### PR TITLE
fix(setup): prevent hang on git clone and show progress

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -65,30 +65,47 @@ for cmd in git bash; do
 done
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# stdin を /dev/tty に再接続（curl パイプ経由のケース）
+#   git が認証プロンプトを出す場合や install.sh の `read -p` が動くために、
+#   git 操作より前に行う。
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+if [ ! -t 0 ] && ( : </dev/tty ) 2>/dev/null; then
+  exec </dev/tty
+fi
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# git 認証プロンプト回避
+#   idd-claude は public repo なので認証は不要。credential helper の誤動作で
+#   プロンプトが出ると `curl | bash` の stdin では応答できず無限待ちになるため、
+#   GIT_TERMINAL_PROMPT=0 でプロンプト自体を無効化して即エラーにする。
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+export GIT_TERMINAL_PROMPT=0
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # クローン（未取得） or 更新（既存）
+#   --progress で進捗を表示（--quiet だと無応答に見えるため）
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 if [ -d "$IDD_CLAUDE_DIR/.git" ]; then
   echo "📦 既存のクローンを更新: $IDD_CLAUDE_DIR (branch=$IDD_CLAUDE_BRANCH)"
-  git -C "$IDD_CLAUDE_DIR" fetch --quiet --depth 1 origin "$IDD_CLAUDE_BRANCH"
-  git -C "$IDD_CLAUDE_DIR" checkout --quiet "$IDD_CLAUDE_BRANCH" 2>/dev/null || true
-  git -C "$IDD_CLAUDE_DIR" reset --hard --quiet "origin/$IDD_CLAUDE_BRANCH"
+  git -C "$IDD_CLAUDE_DIR" fetch --depth 1 origin "$IDD_CLAUDE_BRANCH"
+  git -C "$IDD_CLAUDE_DIR" checkout "$IDD_CLAUDE_BRANCH" 2>/dev/null || true
+  git -C "$IDD_CLAUDE_DIR" reset --hard "origin/$IDD_CLAUDE_BRANCH"
 else
-  echo "📦 idd-claude をクローン: $IDD_CLAUDE_DIR (branch=$IDD_CLAUDE_BRANCH)"
   # 既存の非 git ディレクトリがある場合は安全のため停止
   if [ -e "$IDD_CLAUDE_DIR" ]; then
     echo "Error: '$IDD_CLAUDE_DIR' は git リポジトリではありません。移動または削除してから再実行してください。" >&2
     exit 1
   fi
-  git clone --quiet --depth 1 --branch "$IDD_CLAUDE_BRANCH" \
-    "$IDD_CLAUDE_REPO_URL" "$IDD_CLAUDE_DIR"
-fi
-
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# curl パイプ経由の場合は stdin を /dev/tty に再接続
-#   （install.sh の対話プロンプト `read -r -p` を動作させるため）
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-if [ ! -t 0 ] && ( : </dev/tty ) 2>/dev/null; then
-  exec </dev/tty
+  echo "📦 idd-claude をクローン: $IDD_CLAUDE_DIR (branch=$IDD_CLAUDE_BRANCH)"
+  if ! git clone --progress --depth 1 --branch "$IDD_CLAUDE_BRANCH" \
+       "$IDD_CLAUDE_REPO_URL" "$IDD_CLAUDE_DIR"; then
+    echo "" >&2
+    echo "Error: git clone に失敗しました。" >&2
+    echo "  - ネットワーク接続を確認してください" >&2
+    echo "  - プロキシ設定がある場合は https_proxy 環境変数をセットしてください" >&2
+    echo "  - IDD_CLAUDE_REPO_URL を fork に変えている場合は URL / 認証を確認してください" >&2
+    exit 1
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

`curl | bash` で setup.sh を実行した際、git clone が無応答に見える／実際にハングする問題を修正。

## 症状

ユーザー報告: `curl ... | bash` 実行で `📦 idd-claude をクローン:` まで表示された後、何も進まずハング状態になる。`~/.idd-claude` も作成されない。

## 原因

1. **`git clone --quiet` による出力抑制**: 進捗が一切表示されないため、実際はクローン中であっても体感ハング。実クローン時間が長い環境で特に問題
2. **credential helper 経由の認証プロンプト無限待ち**: public repo でも credential helper が以前の failed token を検出して再認証プロンプトを出すケースがあり、`curl | bash` の消費済み stdin では応答不可

## 修正内容

- `export GIT_TERMINAL_PROMPT=0`: public repo に認証不要なので、誤プロンプトが出ても即エラー終了に（ハング回避）
- `--quiet` を削除し `--progress` を付与: `git clone` / `git fetch` の進捗を常時表示
- `exec </dev/tty` を git 操作より前に移動: 万一プロンプトが必要なケースでも tty から応答できるように
- clone 失敗時のエラーメッセージを拡充: ネットワーク／プロキシ／URL のトラブルシュートヒントを明示

## Test plan

- [x] `bash -n setup.sh` OK
- [x] 実 public URL `https://github.com/hitoshiichikawa/idd-claude.git` を smoke test → Enumerating / Counting / Receiving の進捗が表示され、33 objects を数秒で clone 完了 → install.sh が起動
- [ ] main merge 後に `curl | bash` で end-to-end 確認

## 回避策（修正 merge 前）

```bash
git clone --depth 1 https://github.com/hitoshiichikawa/idd-claude.git ~/.idd-claude
bash ~/.idd-claude/install.sh --all
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)