### PR TITLE
fix(setup): remove exec </dev/tty (hangs on some terminals), gate no-args pipe

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -65,12 +65,32 @@ for cmd in git bash; do
 done
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# stdin を /dev/tty に再接続（curl パイプ経由のケース）
-#   git が認証プロンプトを出す場合や install.sh の `read -p` が動くために、
-#   git 操作より前に行う。
+# 非対話実行（curl パイプ）で引数なしだと install.sh の対話プロンプトに stdin が
+# 届かず即エラー／無応答になる。args なしの curl | bash は早期エラーで停止し、
+# 代替手段を案内する（`bash <(curl ...)` か、手動インストール）。
+#
+# 以前は `exec </dev/tty` で stdin を tty に付け替える実装だったが、tmux / screen /
+# 特定ターミナル環境で `exec </dev/tty` 自体が無応答になるケースが確認されたため削除。
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-if [ ! -t 0 ] && ( : </dev/tty ) 2>/dev/null; then
-  exec </dev/tty
+if [ ! -t 0 ] && [ $# -eq 0 ]; then
+  cat >&2 <<'PIPE_NO_ARGS'
+Error: curl | bash で引数なし実行されました。install.sh が対話プロンプトに入りますが、
+       curl パイプ経由では stdin がすでに消費されているため応答できません。
+
+次のいずれかで再実行してください:
+
+  # 1) 引数を付けて非対話実行（カレントディレクトリに配置 + watcher）
+  curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/setup.sh \
+    | bash -s -- --all
+
+  # 2) プロセス置換でターミナル stdin を保持したまま対話実行
+  bash <(curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/setup.sh)
+
+  # 3) 手動インストール（最も確実）
+  git clone --depth 1 https://github.com/hitoshiichikawa/idd-claude.git ~/.idd-claude
+  bash ~/.idd-claude/install.sh
+PIPE_NO_ARGS
+  exit 2
 fi
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
## 症状

ユーザー報告: \`curl | bash\` で何も出力されず沈黙する。\`bash -x\` トレースで追跡した結果、\`exec </dev/tty\` の行で止まっていることを特定。

\`\`\`
+ '[' '!' -t 0 ']'
+ exec          ← ここで Ctrl+C 待ちになる（exit=130）
\`\`\`

\`( : </dev/tty ) 2>/dev/null\` のテストは通るのに、その後の \`exec </dev/tty\` が無応答になる。tmux / screen / 一部のターミナルエミュレータ / systemd user session など、tty は open できるが stdin への再バインドで blocking するパターン。

## 修正

1. \`exec </dev/tty\` ブロックを**削除**。環境依存で信頼できないため
2. \`curl | bash\` で args なし実行されたら**即 exit 2** で停止し、3 つの代替手段を案内:
   - \`bash -s -- --all\` 等の引数付き非対話実行
   - \`bash <(curl ...)\` のプロセス置換（tty 維持）
   - 手動 clone + \`bash ~/.idd-claude/install.sh\`

これで「pipe 経由で沈黙してハング」という体験は完全に無くなる。非対話利用は args、対話利用は \`bash <(curl ...)\`、という明確な使い分けになる。

## Test plan

- [x] \`bash -n setup.sh\` OK
- [x] \`echo '' | bash setup.sh\` → exit 2、明示的エラーと代替手段 3 種を表示
- [x] \`echo '' | bash setup.sh --help\` → 従来通り install.sh --help を起動

## 回避策（merge 前でも使える）

\`\`\`bash
# 既にクローン済みなので install.sh を直接起動
bash ~/.idd-claude/install.sh --all
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)