### PR TITLE
feat: GitHub ラベル一括作成スクリプト (idd-claude-labels.sh) を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ idd-claude/
 │   └── .github/
 │       ├── ISSUE_TEMPLATE/
 │       │   └── feature.yml          # 自動開発用 Issue テンプレート
+│       ├── scripts/
+│       │   └── idd-claude-labels.sh # ラベル一括作成スクリプト（冪等）
 │       └── workflows/
 │           └── issue-to-pr.yml      # GitHub Actions 版ワークフロー
 │
@@ -168,7 +170,35 @@ git push
 
 ### Step 2. GitHub 側の準備
 
-リポジトリの Settings からラベルを作成する（GitHub CLI からでも可）。
+#### ラベル一括作成（推奨）
+
+Step 1 で同梱される `.github/scripts/idd-claude-labels.sh` を実行すると、必要なラベルを
+冪等に作成できます（既存ラベルはスキップ、`--force` で color / description を上書き）。
+
+```bash
+cd /path/to/your-project
+bash .github/scripts/idd-claude-labels.sh
+
+# 既存ラベルの color / description を更新したい場合
+bash .github/scripts/idd-claude-labels.sh --force
+
+# repo 外から実行する場合
+bash .github/scripts/idd-claude-labels.sh --repo owner/repo
+```
+
+作成されるラベル:
+
+| 名前 | 色 | 用途 |
+|---|---|---|
+| `auto-dev` | 青 | 自動開発対象 |
+| `needs-decisions` | 黄 | 人間の判断が必要 |
+| `awaiting-design-review` | 橙 | 設計 PR レビュー待ち（Architect 発動時） |
+| `claude-picked-up` | 紫 | Claude Code 実行中 |
+| `ready-for-review` | 緑 | 実装 PR 作成完了 |
+| `claude-failed` | 赤 | 自動実行が停止 |
+| `skip-triage` | 灰 | Triage をスキップ |
+
+#### 手動で作成する場合
 
 ```bash
 gh label create auto-dev                --repo owner/repo --color 1f77b4 --description "自動開発対象"
@@ -180,7 +210,7 @@ gh label create claude-failed           --repo owner/repo --color e74c3c --descr
 gh label create skip-triage             --repo owner/repo --color 95a5a6 --description "Triage をスキップ"
 ```
 
-Branch protection も設定しておく。
+#### Branch protection（任意）
 
 ```bash
 gh api -X PUT repos/owner/repo/branches/main/protection \

--- a/install.sh
+++ b/install.sh
@@ -134,12 +134,27 @@ if $INSTALL_REPO; then
   cp -v "$REPO_TEMPLATE_DIR/.github/workflows/issue-to-pr.yml" \
         "$REPO_PATH/.github/workflows/issue-to-pr.yml"
 
-  echo ""
-  echo "  ✅ 配置完了。次の手順:"
-  echo "     1. CLAUDE.md をプロジェクト固有の内容に編集"
-  echo "     2. .github/workflows/issue-to-pr.yml の認証方式を選択"
-  echo "     3. git add / commit / push"
-  echo "     4. GitHub で必要なラベルを作成（README 参照）"
+  mkdir -p "$REPO_PATH/.github/scripts"
+  cp -v "$REPO_TEMPLATE_DIR/.github/scripts/idd-claude-labels.sh" \
+        "$REPO_PATH/.github/scripts/idd-claude-labels.sh"
+  chmod +x "$REPO_PATH/.github/scripts/idd-claude-labels.sh"
+
+  cat <<REPO_HINT
+
+  ✅ 配置完了。次の手順:
+
+     1. CLAUDE.md をプロジェクト固有の内容に編集（技術スタック・規約など）
+     2. .github/workflows/issue-to-pr.yml の認証方式を選択（Local watcher 運用なら不要）
+     3. git add / commit / push
+     4. GitHub ラベルを一括作成:
+          cd $REPO_PATH
+          bash .github/scripts/idd-claude-labels.sh
+        （repo 外から実行する場合は --repo owner/repo を付与）
+     5. Branch protection（任意）:
+          gh api -X PUT repos/<owner>/<repo>/branches/main/protection \\
+            -f required_pull_request_reviews.required_approving_review_count=1 \\
+            -F enforce_admins=false
+REPO_HINT
 fi
 
 # ─────────────────────────────────────────────────────────────

--- a/repo-template/.github/scripts/idd-claude-labels.sh
+++ b/repo-template/.github/scripts/idd-claude-labels.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+# idd-claude: GitHub ラベル一括作成スクリプト
+#
+# 使い方:
+#   cd /path/to/your-project
+#   bash .github/scripts/idd-claude-labels.sh
+#
+#   # 明示的に repo を指定（repo 外から呼ぶ場合）
+#   bash .github/scripts/idd-claude-labels.sh --repo owner/repo
+#
+#   # 既存ラベルの color / description を上書き更新
+#   bash .github/scripts/idd-claude-labels.sh --force
+#
+# 依存: gh CLI（`gh auth login` 済み）
+# =============================================================================
+
+set -euo pipefail
+
+REPO=""
+FORCE=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --force|-f)
+      FORCE="--force"
+      shift
+      ;;
+    -h|--help)
+      sed -n '3,16p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "未知のオプション: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+command -v gh >/dev/null 2>&1 || {
+  echo "Error: 'gh' CLI が必要です。https://cli.github.com" >&2
+  exit 1
+}
+
+REPO_ARG=()
+if [ -n "$REPO" ]; then
+  REPO_ARG=(--repo "$REPO")
+fi
+
+# Label definitions: name|color|description
+LABELS=(
+  "auto-dev|1f77b4|自動開発対象"
+  "needs-decisions|f1c40f|人間の判断が必要"
+  "awaiting-design-review|e67e22|設計 PR レビュー待ち（Architect 発動時）"
+  "claude-picked-up|9b59b6|Claude Code 実行中"
+  "ready-for-review|2ecc71|PR 作成完了"
+  "claude-failed|e74c3c|自動実行が失敗"
+  "skip-triage|95a5a6|Triage をスキップ"
+)
+
+echo "📌 idd-claude ラベルを作成します"
+if [ -n "$REPO" ]; then
+  echo "   対象: $REPO"
+else
+  echo "   対象: カレントディレクトリの git repo（gh auto-detect）"
+fi
+echo ""
+
+CREATED=0
+EXISTS=0
+UPDATED=0
+FAILED=0
+
+for spec in "${LABELS[@]}"; do
+  IFS="|" read -r NAME COLOR DESC <<< "$spec"
+  printf "  %-25s ... " "$NAME"
+  if [ -n "$FORCE" ]; then
+    if gh label create "$NAME" --color "$COLOR" --description "$DESC" --force "${REPO_ARG[@]}" >/dev/null 2>&1; then
+      echo "created/updated"
+      UPDATED=$((UPDATED+1))
+    else
+      echo "FAILED"
+      FAILED=$((FAILED+1))
+    fi
+  else
+    if gh label create "$NAME" --color "$COLOR" --description "$DESC" "${REPO_ARG[@]}" 2>/dev/null; then
+      echo "created"
+      CREATED=$((CREATED+1))
+    else
+      # 既存ラベルかどうか確認
+      if gh label list "${REPO_ARG[@]}" --limit 100 --json name --jq '.[].name' 2>/dev/null | grep -qx "$NAME"; then
+        echo "already exists (skipped; use --force to update)"
+        EXISTS=$((EXISTS+1))
+      else
+        echo "FAILED"
+        FAILED=$((FAILED+1))
+      fi
+    fi
+  fi
+done
+
+echo ""
+echo "== 結果 =="
+echo "  新規作成: $CREATED"
+echo "  既存スキップ: $EXISTS"
+echo "  上書き更新: $UPDATED"
+echo "  失敗: $FAILED"
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

idd-claude で必要な 7 ラベルを 1 コマンドで作成できる冪等なスクリプトを追加。`install.sh` が対象リポジトリにコピー配置し、完了メッセージで実行手順を案内する。

## 使い方

```bash
# Step 1. 対象リポジトリへの配置
curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/setup.sh \
  | bash -s -- --all

# Step 2. ラベル一括作成（新規追加）
cd /path/to/your-project
bash .github/scripts/idd-claude-labels.sh
```

引数:
- `--force` / `-f`: 既存ラベルの color / description を上書き更新
- `--repo owner/repo`: repo 外から実行する場合（省略時は gh が auto-detect）
- `-h` / `--help`: 使い方を表示

## 作成されるラベル

| 名前 | 色 | 用途 |
|---|---|---|
| `auto-dev` | 青 | 自動開発対象 |
| `needs-decisions` | 黄 | 人間の判断が必要 |
| `awaiting-design-review` | 橙 | 設計 PR レビュー待ち（Architect 発動時） |
| `claude-picked-up` | 紫 | Claude Code 実行中 |
| `ready-for-review` | 緑 | 実装 PR 作成完了 |
| `claude-failed` | 赤 | 自動実行が停止 |
| `skip-triage` | 灰 | Triage をスキップ |

## 実装上のポイント

- **冪等**: 既存ラベルは `already exists (skipped)` でスキップ、`--force` で color / description を上書き更新
- **集計出力**: 新規作成 / 既存スキップ / 上書き更新 / 失敗 の件数を最後にサマリ
- **設定の単一ソース化**: ラベル定義は `LABELS` 配列 1 箇所だけに存在（name|color|description の pipe 区切り）
- **repo 配置**: `install.sh --repo` / `--all` 実行時に自動で `.github/scripts/` にコピー（実行権限付き）

## Test plan

- [x] `bash -n idd-claude-labels.sh` OK
- [x] `--help` で使い方を表示
- [x] `install.sh --repo <tmp>` で `.github/scripts/idd-claude-labels.sh` が実行権限付きで配置される
- [x] 配置完了メッセージに `bash .github/scripts/idd-claude-labels.sh` を含む具体的な手順が表示される
- [ ] 実 repo に対する label create（main merge 後に idd-claude 自身に対して smoke test）
- [ ] `--force` で既存ラベル更新
- [ ] `--repo owner/repo` で repo 外からの呼び出し

🤖 Generated with [Claude Code](https://claude.com/claude-code)