### PR TITLE
fix(workflow): Actions ワークフローを IDD_CLAUDE_USE_ACTIONS 変数で明示 opt-in 化

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,12 +331,32 @@ launchctl load  ~/Library/LaunchAgents/com.local.issue-watcher-repo-b.plist
 
 ### Step 3-B. GitHub Actions をセットアップ（代替）
 
-リポジトリの Settings → Secrets and variables → Actions で以下のいずれかを登録する。
+ワークフローファイル `.github/workflows/issue-to-pr.yml` は **デフォルトで無効**です。
+repo 配置直後は何もしないので、ローカル watcher のみで運用する場合は **この Step 全体をスキップしてください**
+（ファイルが repo に残っていても問題ありません）。
+
+Actions 経由で自動開発を動かしたい場合のみ、以下を設定します。
+
+#### 1. Repository variable で opt-in
+
+Settings → Secrets and variables → Actions → **Variables** タブ → "New repository variable"
+
+| 名前 | 値 | 意味 |
+|---|---|---|
+| `IDD_CLAUDE_USE_ACTIONS` | `true` | ワークフロー発火を許可 |
+
+この変数が未設定（または `true` 以外）だと、Issue イベントでワークフローの job が `if:`
+条件でスキップされるため何も走りません。ローカル watcher と Actions の二重起動を防ぐ保険にも
+なっています。
+
+#### 2. Secrets に認証情報を追加
+
+Settings → Secrets and variables → Actions → **Secrets** タブ
 
 - `ANTHROPIC_API_KEY`（Console で発行）
 - または `CLAUDE_CODE_OAUTH_TOKEN`（`claude setup-token` で発行）
 
-`.github/workflows/issue-to-pr.yml` は両方に対応する形でコメントアウトを切り替えるだけで使える。
+`.github/workflows/issue-to-pr.yml` は両方に対応する形でコメントアウトを切り替えるだけで使えます。
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -144,12 +144,19 @@ if $INSTALL_REPO; then
   ✅ 配置完了。次の手順:
 
      1. CLAUDE.md をプロジェクト固有の内容に編集（技術スタック・規約など）
-     2. .github/workflows/issue-to-pr.yml の認証方式を選択（Local watcher 運用なら不要）
-     3. git add / commit / push
-     4. GitHub ラベルを一括作成:
+     2. git add / commit / push
+     3. GitHub ラベルを一括作成:
           cd $REPO_PATH
           bash .github/scripts/idd-claude-labels.sh
         （repo 外から実行する場合は --repo owner/repo を付与）
+     4. 実行基盤の選択:
+        - **ローカル watcher のみ使う場合**: 何もしない（.github/workflows/issue-to-pr.yml は
+          repository variable 未設定なので自動でスキップされます）
+        - **GitHub Actions で回す場合**:
+          a) Settings → Secrets and variables → Actions → **Variables** タブで
+             \`IDD_CLAUDE_USE_ACTIONS=true\` を追加
+          b) Secrets タブで \`ANTHROPIC_API_KEY\` もしくは \`CLAUDE_CODE_OAUTH_TOKEN\` を追加
+          c) 必要に応じて .github/workflows/issue-to-pr.yml の認証方式行を切り替え
      5. Branch protection（任意）:
           gh api -X PUT repos/<owner>/<repo>/branches/main/protection \\
             -f required_pull_request_reviews.required_approving_review_count=1 \\

--- a/repo-template/.github/workflows/issue-to-pr.yml
+++ b/repo-template/.github/workflows/issue-to-pr.yml
@@ -6,6 +6,23 @@ name: Issue-driven Team Development
 # Issue が作成・ラベル付与・ラベル除去されたときに Claude Code を起動して
 # 自動開発を実行する。Local watcher を使わず、GitHub Actions 上で回す場合のテンプレート。
 #
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ★★ 重要: このワークフローはデフォルトで無効 ★★
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 有効化するには、リポジトリ設定で variables（Secrets ではなく Variables）に
+# `IDD_CLAUDE_USE_ACTIONS=true` を追加してください:
+#
+#   Settings → Secrets and variables → Actions → Variables タブ → New variable
+#     Name : IDD_CLAUDE_USE_ACTIONS
+#     Value: true
+#
+# 変数が未設定（または `true` 以外）の場合、Issue イベントが発火しても
+# 本ワークフローの job は条件分岐でスキップされ、何も実行しません。
+#
+# ローカル watcher のみで開発する場合はこの変数を **設定しない** ことで、
+# ファイルがリポジトリにあっても安全にスキップされます。
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
 # 3 つのモードを同一ワークフロー内で自動判別する:
 #   - design        : 初回・Architect 必要 → PM + Architect + PjM（設計 PR 作成ゲート）
 #   - impl          : 初回・Architect 不要 → PM + Developer + PjM（実装 PR 作成）
@@ -38,8 +55,15 @@ permissions:
 
 jobs:
   claude-team-dev:
-    # auto-dev ラベルがあり、かつ停止ラベルが付いていない場合のみ発火
+    # ─────────────────────────────────────────────────────────────
+    # 発火条件:
+    #   1. Repository variable `IDD_CLAUDE_USE_ACTIONS == 'true'`（明示的な opt-in）
+    #   2. auto-dev ラベルがある
+    #   3. 停止系ラベル（needs-decisions / awaiting-design-review /
+    #      claude-picked-up / ready-for-review / claude-failed）が付いていない
+    # ─────────────────────────────────────────────────────────────
     if: |
+      vars.IDD_CLAUDE_USE_ACTIONS == 'true' &&
       contains(github.event.issue.labels.*.name, 'auto-dev') &&
       !contains(github.event.issue.labels.*.name, 'needs-decisions') &&
       !contains(github.event.issue.labels.*.name, 'awaiting-design-review') &&


### PR DESCRIPTION
## Summary

\`.github/workflows/issue-to-pr.yml\` がリポジトリに存在するだけで Issue イベントに反応してしまい、ローカル watcher のみで運用しているユーザーに対して:

- 認証情報（Secret）未設定で毎 Issue ごとに失敗通知を撒く
- Secret が設定されていた場合、ローカル watcher と同時起動してレース

する問題がありました。**Repository variable で明示 opt-in する方式**に変更して、デフォルトでは完全に何もしない状態にします。

## 変更

### ワークフロー

\`\`\`yaml
# Before
jobs:
  claude-team-dev:
    if: |
      contains(github.event.issue.labels.*.name, 'auto-dev') && ...

# After
jobs:
  claude-team-dev:
    if: |
      vars.IDD_CLAUDE_USE_ACTIONS == 'true' &&
      contains(github.event.issue.labels.*.name, 'auto-dev') && ...
\`\`\`

### 使い分け

| 運用モード | 設定 |
|---|---|
| **ローカル watcher のみ** | 何もしなくて良い（変数未設定 → ワークフローは常にスキップ） |
| **GitHub Actions で回す** | Settings → Variables → \`IDD_CLAUDE_USE_ACTIONS=true\` を追加 + Secret も登録 |

### その他ドキュメント

- ワークフローヘッダコメントに「デフォルト無効」「有効化手順」を明記
- install.sh 完了メッセージを 2 ルート（ローカル watcher のみ / Actions 併用）に分岐
- README の Step 3-B を再構成し、Variable opt-in + Secret 登録を 2 小節に分ける

## 既存ユーザーへの影響

- **ローカル watcher のみ利用者**: 完全に透過（むしろ誤発火のリスクが減る）
- **Actions 利用者**: 変数 \`IDD_CLAUDE_USE_ACTIONS=true\` を一度追加すれば従来通り
- レース防止の副次効果: ローカル watcher と Actions を両方使うハイブリッド運用で、どちらを有効にするか明示的に管理できる

## Test plan

- [x] YAML syntax OK（python yaml.safe_load で検証）
- [x] install.sh syntax OK
- [ ] Variable 未設定の repo に Issue を立てても workflow がスキップされる（\`if:\` が false）
- [ ] Variable \`IDD_CLAUDE_USE_ACTIONS=true\` を設定した repo では従来通り発火
- [ ] install.sh 完了メッセージが新ルートを案内

🤖 Generated with [Claude Code](https://claude.com/claude-code)