### PR TITLE
fix(watcher): prepend common install dirs to PATH in issue-watcher.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,8 +566,10 @@ idd-claude は [cc-sdd](https://github.com/gotalab/cc-sdd) の仕様記法・レ
 ### `claude` コマンドが見つからない
 
 cron / launchd は対話シェルのプロファイルを読み込まないため、`PATH` が通っていないことが多い。
-`launchd` なら plist の `EnvironmentVariables` で `PATH` を明示する（同梱の plist では設定済み）。
-cron なら `crontab -e` の先頭に `PATH=...` を書く。
+`issue-watcher.sh` 側で `~/.local/bin` / `/usr/local/bin` / `/opt/homebrew/bin` を冒頭で `PATH` に
+追加しているため、標準的なインストール先であれば追加設定は不要。
+それ以外の場所に `claude` / `gh` がある場合は、launchd なら plist の `EnvironmentVariables`、
+cron なら `crontab -e` の先頭で `PATH=...` を明示する。
 
 ### OAuth 認証が切れた
 

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -23,6 +23,11 @@
 
 set -euo pipefail
 
+# cron / launchd は対話シェルの profile を読まないため PATH が最小限になり、
+# ~/.local/bin や /usr/local/bin にインストールした claude / gh が見つからない。
+# 一般的なインストール先を先頭に足しておき、どの起動経路でも同じ挙動にする。
+export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Config（環境に合わせて書き換える）
 #


### PR DESCRIPTION
## Summary
- cron / launchd は対話シェルの profile を読まないため `PATH` が最小限になり、`~/.local/bin` にインストールされた `claude` が `command -v` で解決できず、冒頭の依存チェックで毎回 `Error: claude が見つかりません。PATH を確認してください。` を吐いて終了していた（実測: 2 分おきの cron で同エラーが連続記録）。
- `issue-watcher.sh` 冒頭で `~/.local/bin` / `/usr/local/bin` / `/opt/homebrew/bin` を `PATH` に prepend し、cron / launchd / 手動実行すべてで同じ解決順にする。
- README のトラブルシューティングを新しい挙動に合わせて更新（標準インストール先なら追加設定不要、それ以外は従来どおり）。

## Test plan
- [x] `env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'export PATH=$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH; command -v claude gh jq flock git'` で 5 コマンドすべて解決することを確認
- [x] `~/bin/issue-watcher.sh` に反映後、次回 cron 実行で `cron.log` に `claude が見つかりません` が出ないこと
- [ ] `awaiting-design-review` / `auto-dev` 付きの Issue がある場合、通常の Triage / 本実装フローが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)