### PR TITLE
fix(#31): make idd-claude-labels.sh idempotent on existing labels

### DIFF
--- a/.github/scripts/idd-claude-labels.sh
+++ b/.github/scripts/idd-claude-labels.sh
@@ -12,7 +12,7 @@
 #   # 既存ラベルの color / description を上書き更新
 #   bash .github/scripts/idd-claude-labels.sh --force
 #
-# 依存: gh CLI（`gh auth login` 済み）
+# 依存: gh CLI（`gh auth login` 済み）, jq
 # =============================================================================
 
 set -euo pipefail
@@ -43,6 +43,11 @@ done
 
 command -v gh >/dev/null 2>&1 || {
   echo "Error: 'gh' CLI が必要です。https://cli.github.com" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || {
+  echo "Error: 'jq' が必要です。" >&2
   exit 1
 }
 
@@ -77,30 +82,53 @@ EXISTS=0
 UPDATED=0
 FAILED=0
 
+# 既存ラベルを 1 回の API コールで全件取得しキャッシュする。
+# `gh label list` のデフォルト件数上限（30）はページネーション境界の取りこぼし
+# を起こすため、`--limit 1000` で十分なマージンを取る（NFR 2.3）。
+# 取得自体に失敗した場合（API 不達 / 認証失敗 / 権限不足等）は、ラベル状態を
+# 確定できないので即座にエラー終了する（Req 2.4）。
+EXISTING_LABELS_JSON=""
+if ! EXISTING_LABELS_JSON=$(gh label list "${REPO_ARG[@]}" --limit 1000 --json name 2>&1); then
+  echo "Error: 既存ラベル一覧の取得に失敗しました: $EXISTING_LABELS_JSON" >&2
+  exit 1
+fi
+
+# 取得結果を name → 1 の連想配列に展開する。
+declare -A EXISTING_LABELS=()
+while IFS= read -r existing_name; do
+  [ -n "$existing_name" ] && EXISTING_LABELS["$existing_name"]=1
+done < <(printf '%s' "$EXISTING_LABELS_JSON" | jq -r '.[].name')
+
 for spec in "${LABELS[@]}"; do
   IFS="|" read -r NAME COLOR DESC <<< "$spec"
   printf "  %-25s ... " "$NAME"
-  if [ -n "$FORCE" ]; then
-    if gh label create "$NAME" --color "$COLOR" --description "$DESC" --force "${REPO_ARG[@]}" >/dev/null 2>&1; then
-      echo "created/updated"
-      UPDATED=$((UPDATED+1))
-    else
-      echo "FAILED"
-      FAILED=$((FAILED+1))
-    fi
-  else
-    if gh label create "$NAME" --color "$COLOR" --description "$DESC" "${REPO_ARG[@]}" 2>/dev/null; then
-      echo "created"
-      CREATED=$((CREATED+1))
-    else
-      # 既存ラベルかどうか確認
-      if gh label list "${REPO_ARG[@]}" --limit 100 --json name --jq '.[].name' 2>/dev/null | grep -qx "$NAME"; then
-        echo "already exists (skipped; use --force to update)"
-        EXISTS=$((EXISTS+1))
+  if [ -n "${EXISTING_LABELS[$NAME]:-}" ]; then
+    # 既存ラベル
+    if [ -n "$FORCE" ]; then
+      if gh label create "$NAME" --color "$COLOR" --description "$DESC" --force "${REPO_ARG[@]}" >/dev/null 2>&1; then
+        echo "created/updated"
+        UPDATED=$((UPDATED+1))
       else
         echo "FAILED"
         FAILED=$((FAILED+1))
       fi
+    else
+      echo "already exists (skipped; use --force to update)"
+      EXISTS=$((EXISTS+1))
+    fi
+  else
+    # 未存在ラベル: 新規作成を試みる
+    if gh label create "$NAME" --color "$COLOR" --description "$DESC" "${REPO_ARG[@]}" >/dev/null 2>&1; then
+      if [ -n "$FORCE" ]; then
+        echo "created/updated"
+        UPDATED=$((UPDATED+1))
+      else
+        echo "created"
+        CREATED=$((CREATED+1))
+      fi
+    else
+      echo "FAILED"
+      FAILED=$((FAILED+1))
     fi
   fi
 done

--- a/docs/specs/31-idd-claude-labels-sh-awaiting-design-rev/impl-notes.md
+++ b/docs/specs/31-idd-claude-labels-sh-awaiting-design-rev/impl-notes.md
@@ -1,0 +1,142 @@
+# 実装ノート — Issue #31 idd-claude-labels.sh の冪等性バグ修正
+
+## 採用した実装方針
+
+`gh label list` を **1 回だけ呼び出して全既存ラベルを連想配列にキャッシュ**するアプローチを採用した。
+
+### 検討した代替案と却下理由
+
+1. **`gh label view <name>` で個別存在判定（PM 推奨案）**
+   - `gh label view` サブコマンドは現行 `gh` CLI に存在しない（`gh label`
+     のサブコマンドは `clone` / `create` / `delete` / `edit` / `list` のみ）。
+     実機検証で全件 FAILED となり棄却。
+2. **`gh api repos/{owner}/{repo}/labels/{name}` で個別取得**
+   - `--repo` 引数なし時に owner/repo を自前で解決する必要があり、複雑化する。
+   - ラベル数 9 件 = API コール 9 回となり、レート制限的にも不利。
+3. **採用案: `gh label list --limit 1000 --json name` を 1 回呼び出してキャッシュ**
+   - API コール 1 回で済む。
+   - `--limit 1000` で件数上限・ページネーション境界の取りこぼし懸念を解消（NFR 2.3）。
+   - 取得自体が失敗したら（API 不達 / 認証失敗 / 権限不足）即座に `exit 1`、
+     真の失敗のみを失敗として扱う契約に合致（Req 2.4）。
+
+### 主な変更点
+
+- `gh label list ... --limit 100 | grep -qx` のフォールバック判定を撤廃。
+- 事前に全既存ラベル名を `declare -A EXISTING_LABELS` の連想配列にキャッシュ。
+- 各ラベルの分岐を「キャッシュ参照 → 既存／未存在」の単純な O(1) 判定に変更。
+- `gh label list` 失敗時は即時 `exit 1` し、stderr にエラーメッセージを出力。
+- 依存に `jq` を明記（CLAUDE.md の前提と一致）。`command -v jq` 事前チェック追加。
+
+### 修正前後の挙動比較
+
+| シナリオ | 修正前（バグあり） | 修正後 |
+|---|---|---|
+| 全ラベル既存・`--force` なし | ラベルにより一部「FAILED」誤分類 → exit 1 | 全件「既存スキップ」 → exit 0 |
+| 一部既存・`--force` なし | 既存ラベルが「FAILED」誤分類リスク | 既存はスキップ、不足分のみ「新規作成」 |
+| 全ラベル既存・`--force` 付き | 「上書き更新」9 → exit 0（変化なし） | 「上書き更新」9 → exit 0 |
+| 真の API 失敗 | `gh label list` 1 回目失敗時に `gh label list` で再試行する 2 段構え | 即時 exit 1 でエラーを stderr に出力 |
+| ページネーション境界（label > 30） | `--limit 100` でも越境すれば取りこぼし | `--limit 1000` で実用上回避 |
+
+## 検証結果
+
+### 静的解析
+
+- `shellcheck` は当該環境にインストール不可（sudo パスワード要求）。
+- 代替として `bash -n` の構文チェックを両ファイルで実行 → OK。
+- 既存規約（`set -euo pipefail`、`"$var"` クォート、配列展開 `"${arr[@]}"`、
+  `command -v`）はすべて維持。新規追加した連想配列展開も適切にクォートしている。
+
+### 同期確認
+
+```
+diff -u .github/scripts/idd-claude-labels.sh \
+        repo-template/.github/scripts/idd-claude-labels.sh
+# → 差分なし（exit 0）
+```
+
+### スモークテスト（実 GitHub API、対象 repo: `hitoshiichikawa/idd-claude`）
+
+| # | シナリオ | 結果 | 担保される AC |
+|---|---|---|---|
+| 1 | 全既存・`--force` なし | 既存スキップ 9 / 失敗 0 / exit 0 | 1.1, 1.4, 1.5, 2.1, 2.3, 4.1-4.4 |
+| 2 | 全既存・`--force` 付き | 上書き更新 9 / 失敗 0 / exit 0 | 3.1, 3.2 |
+| 3 | 未知引数 `--bogus` | stderr エラー + exit 1 | 5.5 |
+| 4 | `--help` | ヘルプ出力 + exit 0 | 5.4 |
+| 5 | `-f` 短エイリアス | `--force` と同じ結果 | 5.3 |
+| 6 | 1 ラベル削除 → 再実行 | 新規作成 1 / 既存スキップ 8 / 失敗 0 / exit 0 | 1.2 |
+| 7 | `--repo owner/name` 引数 | カレント以外の repo を対象に正常動作 | 5.2 |
+| 7' | `--repo` に存在しない repo | stderr エラー + exit 1（`gh label list` 失敗） | 2.2, 2.4 |
+| 8 | 同一引数で連続実行 | 2 回目: 新規作成 0 / 失敗 0 / exit 0 | 1.3, NFR 1.1 |
+
+### コードレベルでの真の失敗時 exit 1 経路
+
+- `gh label list` 失敗時: 行 86 `if ! EXISTING_LABELS_JSON=$(...)` → 行 88 `exit 1`
+- `gh label create` 失敗時: 各分岐内で `FAILED=$((FAILED+1))` 計上 → 末尾 `if [ "$FAILED" -gt 0 ]; then exit 1`
+
+## 後方互換性の確認
+
+| 項目 | 確認結果 |
+|---|---|
+| 引数（`--repo` / `--force` / `-f` / `-h` / `--help`） | 維持（Smoke 3〜7） |
+| 環境変数 | 元から未使用（変更なし） |
+| exit code 意味（0=成功、1=失敗） | 維持。`gh label list` 失敗時の exit 1 を新規追加（要件 Req 2.4 で要請されている振る舞い） |
+| 出力フォーマット | `📌` 装飾、ラベル行 `%-25s ... <status>`、`already exists (skipped; use --force to update)` 文言、`== 結果 ==` 見出し、4 サマリ行（新規作成 / 既存スキップ / 上書き更新 / 失敗）すべて維持 |
+| ラベル定義（名前・色・description） | 9 ラベルを一切改変せず（Req 6.1, 6.3） |
+| sudo 不要 | 維持 |
+| root 配置と template 配置の同期 | `diff` 無差分（Req 6.2） |
+
+### 新規依存
+
+- `jq`: CLAUDE.md 「依存 CLI: `gh`, `jq`, `flock`, `git`」に記載済み。idd-claude
+  プロジェクト全体で前提済みなので新規プラットフォーム要件は発生しない。スクリプト
+  冒頭コメントとヘッダの「依存:」行に追記し、`command -v jq` チェックを追加した。
+
+## 各 AC への対応箇所メモ
+
+| 要件 ID | 対応箇所 |
+|---|---|
+| Req 1.1 | 全既存時 → for ループで全件 EXISTS 計上（行 100-101, 107-108） |
+| Req 1.2 | 既存／未存在の分岐（行 100 / 行 113） |
+| Req 1.3 | 連想配列キャッシュにより 2 回目も同じ結果（NFR 1.1 と同根拠） |
+| Req 1.4 | 既存ラベル分岐は FAILED に到達しない |
+| Req 1.5 | 行 107-108 で EXISTS 加算 |
+| Req 2.1 | 末尾 `if FAILED > 0` 判定で 0 のとき exit 0 |
+| Req 2.2 | `gh label create` 失敗時 / `gh label list` 失敗時の双方で exit 1 |
+| Req 2.3 | 既存スキップは FAILED にならない（旧バグ解消） |
+| Req 2.4 | 行 44-46 (`command -v gh`) と行 86-89（`gh label list` 失敗時） |
+| Req 3.1 | `--force` 分岐で UPDATED 加算（行 102-105） |
+| Req 3.2 | UPDATED のみ加算され FAILED 0 維持 |
+| Req 3.3 | `gh label create --force` 失敗時のみ FAILED 加算 |
+| Req 4.1 | `printf "  %-25s ... " "$NAME"` で行頭整形を維持 |
+| Req 4.2 | `already exists (skipped; use --force to update)` 文言維持 |
+| Req 4.3 | サマリ 4 行のラベル名・順序維持 |
+| Req 4.4 | `== 結果 ==` 見出し維持 |
+| Req 4.5 | `📌` 装飾維持 |
+| Req 5.1〜5.5 | 引数解析ブロックを未変更（行 23-42） |
+| Req 6.1 | LABELS 配列 9 件未変更 |
+| Req 6.2 | root と template を `diff` で同期確認済み |
+| Req 6.3 | LABELS 配列の name / color / description を一切改変せず |
+| NFR 1.1 | Smoke 8 で実証 |
+| NFR 1.2 | for ループで 1 ラベル 1 行出力 |
+| NFR 1.3 | CREATED + EXISTS + UPDATED + FAILED の合算が常に 9 になる構造 |
+| NFR 1.4 | 失敗時に `printf "  %-25s ... " "$NAME"` 後に `echo "FAILED"` |
+| NFR 2.1 | 引数名・env var・exit code 意味を維持 |
+| NFR 2.2 | sudo 不要 |
+| NFR 2.3 | `--limit 1000` で件数上限のマージン確保 |
+
+## 残課題・確認事項
+
+- **shellcheck 未実行**: 当該実行環境にインストールできなかった。CI 等で
+  `shellcheck` が利用可能な環境では PR で再確認することを推奨。
+  既存スクリプトと同じコーディングパターン（`set -euo pipefail`、配列展開、
+  `command -v`、`>/dev/null 2>&1`）を踏襲しているため、新規警告の混入リスクは
+  低いと判断。
+- **`gh label list --limit 1000` の上限**: GitHub の単一ページ取得上限は 100 で、
+  `gh` CLI 内部で paginate される実装。`--limit 1000` は idd-claude の 9 ラベル
+  および一般的な repo のラベル数（数十件）に対して十分な safety margin だが、
+  極端な repo（1000+ ラベル）では取りこぼし可能性が残る。idd-claude の運用上は
+  現実的に発生しないため許容範囲と判断。
+- **真の API 失敗時の挙動シミュレーション**: 不正な repo 名指定（Smoke 7 初回）で
+  `gh label list` 失敗時の exit 1 経路は実機確認できた。認証失敗・レート制限などの
+  シミュレーションはしていないが、いずれも `gh` の非ゼロ exit を伴うため同じ経路
+  に乗る。

--- a/docs/specs/31-idd-claude-labels-sh-awaiting-design-rev/requirements.md
+++ b/docs/specs/31-idd-claude-labels-sh-awaiting-design-rev/requirements.md
@@ -1,0 +1,101 @@
+# Requirements Document
+
+## Introduction
+
+`idd-claude-labels.sh` は idd-claude が利用する GitHub ラベル群を冪等に作成・更新するためのセットアップスクリプトである。本来は何度再実行しても、既存ラベルは「スキップ」、不足ラベルのみ「作成」と分類されるべきだが、現状では特定の既存ラベル（少なくとも `awaiting-design-review` と `ready-for-review` で再現）が「FAILED」と分類され、最終的に exit code 1 で異常終了する。これにより `install.sh` 経由のセットアップ再実行や、CI からの呼び出しが偽陽性で失敗扱いになる。本要件は、スクリプトの冪等性と終了コード契約を本来の仕様に揃え、後方互換性を保ったまま再現バグを解消することを目的とする。
+
+## Requirements
+
+### Requirement 1: 冪等な再実行とラベル分類
+
+**Objective:** As an idd-claude のセットアップ実行者, I want スクリプトを何度再実行しても結果が一貫すること, so that 既存ラベルの有無に関わらず安心して install.sh / セットアップを反復できる
+
+#### Acceptance Criteria
+
+1. When 全ラベルが既に対象 repo に存在する状態でスクリプトが `--force` なしで再実行されたとき, the Label Setup Script shall すべてのラベルを「既存スキップ」として分類する
+2. When 一部のラベルのみ既に存在する状態でスクリプトが `--force` なしで再実行されたとき, the Label Setup Script shall 既存ラベルを「既存スキップ」、不足ラベルを「新規作成」として分類する
+3. When 同一 repo に対してスクリプトを `--force` なしで連続して実行したとき, the Label Setup Script shall 2 回目の実行で `新規作成` 件数と `失敗` 件数の両方を 0 にする
+4. If GitHub 上に存在するラベルが、スクリプト内で定義されたラベル一覧と完全一致しているとき, the Label Setup Script shall `失敗` 件数を 0 として報告する
+5. If あるラベルが GitHub 上に既に存在しているとき, the Label Setup Script shall そのラベルを「既存スキップ」として分類しサマリの `既存スキップ` 件数に計上する
+
+### Requirement 2: 真の失敗のみを失敗として扱う終了コード契約
+
+**Objective:** As an install.sh / CI から呼び出す自動化処理, I want 真の失敗（API 不達・認証エラー等）のときだけ非ゼロ終了すること, so that 既存ラベルの存在による偽陽性で後続処理を中断させない
+
+#### Acceptance Criteria
+
+1. When 全ラベルが既存スキップまたは新規作成または上書き更新で正常に処理されたとき, the Label Setup Script shall exit code 0 で終了する
+2. If 真の失敗（GitHub API 不達・認証失敗・権限不足など、ラベル状態を確定できない事象）が 1 件以上発生したとき, the Label Setup Script shall exit code 1 で終了する
+3. When 全ラベルが既に存在する状態で `--force` なしで再実行されたとき, the Label Setup Script shall exit code 0 で終了する
+4. If `gh` CLI が未インストールまたは未認証であるとき, the Label Setup Script shall ラベル処理に進まずエラーメッセージを標準エラーに出力し非ゼロで終了する
+
+### Requirement 3: `--force` 指定時の上書き更新
+
+**Objective:** As an ラベル定義（color / description）を更新したい運用者, I want `--force` を付ければ既存ラベルも安全に上書きできること, so that ラベル仕様の変更を 1 コマンドで全 repo に反映できる
+
+#### Acceptance Criteria
+
+1. When `--force` 付きで再実行されたとき, the Label Setup Script shall 既存ラベルを「上書き更新」として分類しサマリの `上書き更新` 件数に計上する
+2. When `--force` 付きで実行され、すべてのラベルが既に存在しているとき, the Label Setup Script shall `失敗` を 0 として報告し exit code 0 で終了する
+3. If `--force` 付き実行中に真の失敗（API 不達等）が発生したとき, the Label Setup Script shall そのラベルのみを「FAILED」に計上し exit code 1 で終了する
+
+### Requirement 4: 出力フォーマットの後方互換性
+
+**Objective:** As an 既存の install.sh / 運用ドキュメント / 既稼働 CI の利用者, I want 出力フォーマットが既存の見え方を壊さないこと, so that ログ目視・スクレイピング・ドキュメント参照が引き続き機能する
+
+#### Acceptance Criteria
+
+1. The Label Setup Script shall 各ラベル行を「ラベル名 ... ステータス文字列」の形式で 1 行ずつ標準出力に出力する
+2. The Label Setup Script shall 既存ラベルに対するステータス文字列として `already exists (skipped; use --force to update)` を使用する
+3. The Label Setup Script shall サマリセクションに `新規作成` `既存スキップ` `上書き更新` `失敗` の 4 ラベルを、現行と同じ表示順・同じ日本語ラベル名で出力する
+4. The Label Setup Script shall サマリ見出しを `== 結果 ==` のまま維持する
+5. Where 既存スクリプトが先頭行に絵文字や ASCII 装飾（`📌` 等）を含む見出しを出力している場合, the Label Setup Script shall それらの装飾文字列を維持する
+
+### Requirement 5: 引数・環境変数の後方互換性
+
+**Objective:** As an 既存の呼び出し側（install.sh / 手動運用 / ドキュメント手順）, I want 既存の起動方法をそのまま使い続けられること, so that 修正による回帰（regression）を避けられる
+
+#### Acceptance Criteria
+
+1. The Label Setup Script shall 引数なしの呼び出しを受け付け、カレント repo を対象として動作する
+2. The Label Setup Script shall `--repo owner/name` 形式の引数で対象 repo を明示できる
+3. The Label Setup Script shall `--force` および `-f` の両エイリアスを既存ラベルの上書きフラグとして受け付ける
+4. When `-h` または `--help` が渡されたとき, the Label Setup Script shall ヘルプを出力し exit code 0 で終了する
+5. If 既知でない引数が渡されたとき, the Label Setup Script shall エラーメッセージを標準エラーに出力し非ゼロで終了する
+
+### Requirement 6: 定義済みラベル集合と template 同期
+
+**Objective:** As an idd-claude のテンプレート利用者, I want root 配置と template 配置のラベルスクリプトが同じ挙動であること, so that 既に install 済みの consumer repo にも同じ修正が反映される
+
+#### Acceptance Criteria
+
+1. The Label Setup Script shall `auto-dev` / `needs-decisions` / `awaiting-design-review` / `claude-picked-up` / `ready-for-review` / `claude-failed` / `skip-triage` / `needs-rebase` / `needs-iteration` の 9 ラベルすべてを処理対象に含む
+2. When 本要件を満たす修正が行われたとき, the Label Setup Script shall リポジトリ root 配置版（`.github/scripts/idd-claude-labels.sh`）と template 配置版（`repo-template/.github/scripts/idd-claude-labels.sh`）の両方で同等の挙動になる
+3. The Label Setup Script shall 既存ラベル定義（名前・色・説明文）を本 Issue の修正で改変しない
+
+## Non-Functional Requirements
+
+### NFR 1: 冪等性とログの観測性
+
+1. The Label Setup Script shall 同一 repo・同一引数での 2 回目以降の実行で、`新規作成` および `失敗` の合計件数を 0 にする
+2. The Label Setup Script shall 各ラベルの分類結果（作成 / 既存 / 更新 / 失敗）を 1 ラベルあたり 1 行で標準出力に出力する
+3. The Label Setup Script shall サマリの 4 件数（新規作成 / 既存スキップ / 上書き更新 / 失敗）の合計を、対象ラベル総数（9 件）と一致させる
+4. If ラベル処理中に GitHub API からのエラーが発生したとき, the Label Setup Script shall そのラベル名と「FAILED」を含む 1 行を出力する
+
+### NFR 2: 後方互換性と運用安全性
+
+1. The Label Setup Script shall 既存の引数名・環境変数名・exit code 意味を本 Issue の修正によって変更しない
+2. The Label Setup Script shall 本 Issue の修正後も sudo を要求せず、ユーザー権限のみで動作する
+3. While GitHub 側のラベル取得結果がページネーション境界をまたぐ場合でも, the Label Setup Script shall ラベルの存在判定を取得順や件数上限に依存させず安定して行う
+
+## Out of Scope
+
+- 新規ラベルの追加、既存ラベルの削除、ラベル名・色・説明文の変更
+- スクリプト名・配置先・呼び出し方法の変更
+- `gh` CLI 以外のクライアントへの差し替え
+- `idd-claude-labels.sh` を呼び出していない他スクリプト（`install.sh` / `setup.sh` / `issue-watcher.sh` 等）の挙動変更
+- ラベル運用ポリシーやワークフロー全体の見直し
+
+## Open Questions
+
+- なし（再現条件・期待挙動・後方互換性スコープは Issue 本文と既存スクリプトから決定可能）

--- a/repo-template/.github/scripts/idd-claude-labels.sh
+++ b/repo-template/.github/scripts/idd-claude-labels.sh
@@ -12,7 +12,7 @@
 #   # 既存ラベルの color / description を上書き更新
 #   bash .github/scripts/idd-claude-labels.sh --force
 #
-# 依存: gh CLI（`gh auth login` 済み）
+# 依存: gh CLI（`gh auth login` 済み）, jq
 # =============================================================================
 
 set -euo pipefail
@@ -43,6 +43,11 @@ done
 
 command -v gh >/dev/null 2>&1 || {
   echo "Error: 'gh' CLI が必要です。https://cli.github.com" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || {
+  echo "Error: 'jq' が必要です。" >&2
   exit 1
 }
 
@@ -77,30 +82,53 @@ EXISTS=0
 UPDATED=0
 FAILED=0
 
+# 既存ラベルを 1 回の API コールで全件取得しキャッシュする。
+# `gh label list` のデフォルト件数上限（30）はページネーション境界の取りこぼし
+# を起こすため、`--limit 1000` で十分なマージンを取る（NFR 2.3）。
+# 取得自体に失敗した場合（API 不達 / 認証失敗 / 権限不足等）は、ラベル状態を
+# 確定できないので即座にエラー終了する（Req 2.4）。
+EXISTING_LABELS_JSON=""
+if ! EXISTING_LABELS_JSON=$(gh label list "${REPO_ARG[@]}" --limit 1000 --json name 2>&1); then
+  echo "Error: 既存ラベル一覧の取得に失敗しました: $EXISTING_LABELS_JSON" >&2
+  exit 1
+fi
+
+# 取得結果を name → 1 の連想配列に展開する。
+declare -A EXISTING_LABELS=()
+while IFS= read -r existing_name; do
+  [ -n "$existing_name" ] && EXISTING_LABELS["$existing_name"]=1
+done < <(printf '%s' "$EXISTING_LABELS_JSON" | jq -r '.[].name')
+
 for spec in "${LABELS[@]}"; do
   IFS="|" read -r NAME COLOR DESC <<< "$spec"
   printf "  %-25s ... " "$NAME"
-  if [ -n "$FORCE" ]; then
-    if gh label create "$NAME" --color "$COLOR" --description "$DESC" --force "${REPO_ARG[@]}" >/dev/null 2>&1; then
-      echo "created/updated"
-      UPDATED=$((UPDATED+1))
-    else
-      echo "FAILED"
-      FAILED=$((FAILED+1))
-    fi
-  else
-    if gh label create "$NAME" --color "$COLOR" --description "$DESC" "${REPO_ARG[@]}" 2>/dev/null; then
-      echo "created"
-      CREATED=$((CREATED+1))
-    else
-      # 既存ラベルかどうか確認
-      if gh label list "${REPO_ARG[@]}" --limit 100 --json name --jq '.[].name' 2>/dev/null | grep -qx "$NAME"; then
-        echo "already exists (skipped; use --force to update)"
-        EXISTS=$((EXISTS+1))
+  if [ -n "${EXISTING_LABELS[$NAME]:-}" ]; then
+    # 既存ラベル
+    if [ -n "$FORCE" ]; then
+      if gh label create "$NAME" --color "$COLOR" --description "$DESC" --force "${REPO_ARG[@]}" >/dev/null 2>&1; then
+        echo "created/updated"
+        UPDATED=$((UPDATED+1))
       else
         echo "FAILED"
         FAILED=$((FAILED+1))
       fi
+    else
+      echo "already exists (skipped; use --force to update)"
+      EXISTS=$((EXISTS+1))
+    fi
+  else
+    # 未存在ラベル: 新規作成を試みる
+    if gh label create "$NAME" --color "$COLOR" --description "$DESC" "${REPO_ARG[@]}" >/dev/null 2>&1; then
+      if [ -n "$FORCE" ]; then
+        echo "created/updated"
+        UPDATED=$((UPDATED+1))
+      else
+        echo "created"
+        CREATED=$((CREATED+1))
+      fi
+    else
+      echo "FAILED"
+      FAILED=$((FAILED+1))
     fi
   fi
 done


### PR DESCRIPTION
## 概要

`idd-claude-labels.sh` で `awaiting-design-review` や `ready-for-review` など一部の既存ラベルが「FAILED」に誤分類され、exit code 1 で終了するバグを修正した。

修正アプローチ: `gh label list --limit 1000 --json name` を 1 回呼び出して全既存ラベルを連想配列にキャッシュし、各ラベルの存在判定を O(1) のキャッシュ参照に変更。真の失敗（API 不達・認証失敗等）のみ FAILED として扱い、既存ラベルは正しく「既存スキップ」に分類する。

root 配置版（`.github/scripts/idd-claude-labels.sh`）と template 配置版（`repo-template/.github/scripts/idd-claude-labels.sh`）を同一内容に同期済み（`diff -u` 無差分）。

## 対応 Issue

Closes #31

## 関連 PR

なし（Architect フェーズなし）

## 受入基準チェック

- [x] Req 1.1: 全既存ラベルが存在する状態で `--force` なし再実行 → 全件「既存スキップ」（Smoke 1）
- [x] Req 1.2: 一部既存ラベルのみ → 既存はスキップ、不足分を新規作成（Smoke 6）
- [x] Req 1.3: 連続実行 2 回目で新規作成 0・失敗 0（Smoke 8）
- [x] Req 1.4: 全ラベル既存時、失敗件数 = 0（Smoke 1）
- [x] Req 1.5: 既存ラベルを EXISTS カウントに計上（連想配列キャッシュ参照 → EXISTING 分岐）
- [x] Req 2.1: 全件スキップ・新規作成・更新で exit 0（Smoke 1/8）
- [x] Req 2.2: 真の失敗（`gh label list` 不達、`gh label create` 失敗）で exit 1
- [x] Req 2.3: 全既存・`--force` なし → exit 0（Smoke 1）
- [x] Req 2.4: `gh` 未インストール時は `command -v gh` で即時 exit 1（行 44-46）
- [x] Req 3.1: `--force` 付きで既存ラベル → 「上書き更新」に分類（Smoke 2）
- [x] Req 3.2: `--force` 付き全件更新で失敗 0・exit 0（Smoke 2）
- [x] Req 3.3: `--force` 付き実行中の真の API 失敗 → そのラベルのみ FAILED 計上 → exit 1
- [x] Req 4.1-4.5: `📌` 装飾・ラベル行フォーマット・`already exists (skipped; use --force to update)` 文言・`== 結果 ==` 見出し・4 サマリ行の順序・日本語ラベル名をすべて維持
- [x] Req 5.1-5.5: 引数（`--repo` / `--force` / `-f` / `-h` / `--help` / 未知引数エラー）の挙動維持（Smoke 3-7）
- [x] Req 6.1: 9 ラベルすべて処理対象に含む（LABELS 配列未変更）
- [x] Req 6.2: root 配置と template 配置を `diff -u` 無差分に同期（Smoke 同期確認）
- [x] Req 6.3: ラベルの名前・色・説明文を一切変更しない
- [x] NFR 1: 2 回目実行で新規作成 0・失敗 0、各ラベル 1 行出力、4 件数合計 = 9（Smoke 8）
- [x] NFR 2: 引数・env var・exit code 意味の後方互換性維持、sudo 不要、`--limit 1000` で件数上限マージン確保

## テスト結果

実機 GitHub API を使用（対象 repo: `hitoshiichikawa/idd-claude`）

```
Smoke 1: 全既存・--force なし → 既存スキップ 9 / 新規作成 0 / 失敗 0 / exit 0  PASS
Smoke 2: 全既存・--force 付き → 上書き更新 9 / 失敗 0 / exit 0                  PASS
Smoke 3: 未知引数 --bogus     → stderr エラー + exit 1                            PASS
Smoke 4: --help               → ヘルプ出力 + exit 0                               PASS
Smoke 5: -f 短エイリアス     → --force と同等の結果                               PASS
Smoke 6: 1 ラベル削除後再実行 → 新規作成 1 / 既存スキップ 8 / 失敗 0 / exit 0   PASS
Smoke 7: --repo owner/name    → 指定 repo を正常に対象化                          PASS
Smoke 7': --repo に存在しない repo → gh label list 失敗 → stderr + exit 1        PASS
Smoke 8: 同一引数で連続実行   → 2 回目: 新規作成 0 / 失敗 0 / exit 0             PASS
```

静的解析:
- `bash -n .github/scripts/idd-claude-labels.sh` → OK（構文エラーなし）
- `bash -n repo-template/.github/scripts/idd-claude-labels.sh` → OK
- `diff -u .github/scripts/idd-claude-labels.sh repo-template/.github/scripts/idd-claude-labels.sh` → 無差分

## 後方互換性

| 項目 | 状態 |
|---|---|
| 引数（`--repo` / `--force` / `-f` / `-h` / `--help`） | 維持 |
| 環境変数 | 元から未使用（変更なし） |
| exit code 意味（0=成功 / 1=失敗） | 維持。`gh label list` 失敗時の exit 1 を新規追加（Req 2.4 要請） |
| 出力フォーマット（`📌` / `== 結果 ==` / 4 サマリ行 / `already exists (skipped; use --force to update)` 文言） | 維持 |
| ラベル定義（名前・色・description） | 9 ラベルを一切改変せず |
| sudo 不要 | 維持 |
| 新規依存: `jq` | CLAUDE.md「依存 CLI」に記載済み。スクリプト冒頭に `command -v jq` チェックを追加 |

## 確認事項

- `shellcheck` がローカル実行環境にインストールできなかった（sudo パスワード要求）。CI または shellcheck 利用可能な環境での再確認を希望します
- `gh label list --limit 1000` は idd-claude の 9 ラベル運用では十分なマージンだが、極端な repo（1000+ ラベル）では取りこぼしリスクが残る。本プロジェクトの運用上は現実的に発生しないため許容範囲と判断しているが、必要であれば `--limit` 値の引き上げまたは `--paginate` フラグ採用を検討可（設計変更となるため別 Issue 推奨）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #31 のコメントを参照してください。