### PR TITLE
fix(claude): correct PjM design PR template to require manual label removal

### DIFF
--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -31,7 +31,7 @@ Architect の直後に呼ばれます。`docs/specs/<番号>-<slug>/` 配下の 
 4. Issue へコメントで設計 PR リンクと案内を投稿:
    > 🎨 設計レビュー PR を作成しました: #<design-pr-number>
    >
-   > - 問題なければ **merge** してください。次回のポーリングで Developer が自動起動し、実装 PR が別途作成されます
+   > - 問題なければ **merge** してください。merge 後に Issue から `awaiting-design-review` ラベルを外すと、次回のポーリングで Developer が自動起動し、実装 PR が別途作成されます
    > - 修正が必要な場合: PR に直接 commit / suggest-edit / line comment で指摘してください
    > - 設計をやり直したい場合: PR を close し、この Issue から `awaiting-design-review` ラベルを外すと再 Triage されます
 
@@ -62,7 +62,7 @@ Refs #<issue-number>
 
 ## 次のステップ
 
-- この PR を **merge** すると、次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
+- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
 - 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
 - やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください
 
@@ -73,7 +73,7 @@ Refs #<issue-number>
 ---
 
 🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
-設計レビューゲート: PM → Architect が完了した段階です。実装は merge 後に自動開始します。
+設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から `awaiting-design-review` ラベルを外すと実装が自動開始します。
 ```
 
 ---

--- a/repo-template/.claude/agents/project-manager.md
+++ b/repo-template/.claude/agents/project-manager.md
@@ -31,7 +31,7 @@ Architect の直後に呼ばれます。`docs/specs/<番号>-<slug>/` 配下の 
 4. Issue へコメントで設計 PR リンクと案内を投稿:
    > 🎨 設計レビュー PR を作成しました: #<design-pr-number>
    >
-   > - 問題なければ **merge** してください。次回のポーリングで Developer が自動起動し、実装 PR が別途作成されます
+   > - 問題なければ **merge** してください。merge 後に Issue から `awaiting-design-review` ラベルを外すと、次回のポーリングで Developer が自動起動し、実装 PR が別途作成されます
    > - 修正が必要な場合: PR に直接 commit / suggest-edit / line comment で指摘してください
    > - 設計をやり直したい場合: PR を close し、この Issue から `awaiting-design-review` ラベルを外すと再 Triage されます
 
@@ -62,7 +62,7 @@ Refs #<issue-number>
 
 ## 次のステップ
 
-- この PR を **merge** すると、次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
+- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
 - 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
 - やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください
 
@@ -73,7 +73,7 @@ Refs #<issue-number>
 ---
 
 🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
-設計レビューゲート: PM → Architect が完了した段階です。実装は merge 後に自動開始します。
+設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から `awaiting-design-review` ラベルを外すと実装が自動開始します。
 ```
 
 ---


### PR DESCRIPTION
## Summary

PjM agent template の 3 箇所で「設計 PR を **merge** すれば Developer が自動起動」と
書かれていたが、実際は `awaiting-design-review` ラベルを手動除去しない限り watcher は
当該 Issue を pickup しない（既存実装は `-label:"awaiting-design-review"` で除外）。

README line 384 では既に正しく記載されていたが、PjM agent template (root と repo-template
両方) だけが事実と乖離していたため修正。

修正対象は `.claude/agents/project-manager.md` と `repo-template/.claude/agents/project-manager.md`
の 2 ファイル（diff -q で同一であることを確認済み）、各 3 箇所:

- Issue コメント文面（line 34）
- 設計 PR 本文テンプレ「次のステップ」（line 65）
- 設計 PR 本文テンプレのフッター（line 76）

## Test plan

- [x] grep で「自動起動」「自動開始」「次回のポーリング」が修正後の正しい文面と整合
- [x] root と repo-template が同一内容のままであることを確認（`diff -q`）
- [x] README line 384 の記述と整合

## 関連

- 修正対象は人間の運用ガイドのみ。watcher コードには触れない
- ワークフロー自動化（設計 PR merge 検出 → ラベル自動除去）は別 Issue で起票予定

## 確認事項

- 修正後の文面が冗長すぎないか（「merge 後に Issue から `awaiting-design-review` を外す」を 3 箇所に書いている）
- 既存 open design PR（#34 / #38）への補足コメントは別途投稿します

🤖 Generated with [Claude Code](https://claude.com/claude-code)
