### PR TITLE
feat(#36): install.sh の冪等性強化（.bak 保護 / ワイルドカード化 / --dry-run）

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,11 @@ curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/set
 指定時でも既存 `.bak` は保護されます。`.bak` を更新したい場合は、自分で `<file>.bak` を削除して
 から再実行してください。
 
-`CLAUDE.md` も同じハイブリッド safe-overwrite の対象です（`backup_claude_md_once` で initial
-バックアップを作ったあと、`copy_with_hybrid_overwrite` で本体を判定）。
+> **CLAUDE.md は別経路**: `CLAUDE.md` は `backup_claude_md_once` で初回バックアップ（once-only）
+> を作ったあと、本体は **常に template 由来内容で配置**されます（既存と同一なら `SKIP`）。
+> `.claude/agents/` / `.claude/rules/` のハイブリッド safe-overwrite とは違い、`CLAUDE.md` 本体
+> 自体に対する `--force` のような上書き抑止はありません（カスタム編集は `.bak` のみで保護）。
+> これは従来の `install.sh` 挙動（無条件で template を配置）との後方互換性を維持するためです。
 
 #### `--dry-run` モード
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,93 @@ curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/set
 > 通常ユーザーで更新・削除できなくなるため、setup.sh / install.sh とも root 実行を検知したら
 > 警告または停止します。cron 登録もユーザー crontab（`crontab -e`）で行うため sudo 不要です。
 
+### 冪等性ポリシーと再実行時の挙動 (#36)
+
+`install.sh` は何度再実行しても安全に冪等動作するよう設計されています。再実行時の各ファイル
+カテゴリの扱いは以下のとおりです。
+
+#### `CLAUDE.md.bak` の once-only 保護
+
+- **初回 install** で対象 repo に既存 `CLAUDE.md` があれば `CLAUDE.md.bak` に退避し、
+  `repo-template/CLAUDE.md` を新規配置します
+- **2 回目以降** は `CLAUDE.md.bak` を**上書きしません**（既存 `.bak` を検知して `SKIP` ログを
+  出します）。これによりオリジナルの自分の `CLAUDE.md` を後から参照・復元できます
+
+> **過去バージョンからの Migration**: #36 以前の `install.sh` は再実行のたびに `.bak` を
+> テンプレ由来内容で書き換えていました。当該バージョンで複数回 install を回した既存利用者は、
+> 初回のオリジナル `CLAUDE.md` が `.bak` から失われている可能性があります（`git log` から
+> 復元してください）。本改修以降は発生しません。
+
+#### `.claude/agents/` / `.claude/rules/` のハイブリッド safe-overwrite
+
+`install.sh` 再実行時、各 `*.md` テンプレートは以下の 5 パスで処理されます:
+
+| dest の状態 | 既定挙動（`--force` なし） | `--force` 指定時 |
+|---|---|---|
+| ファイル不在 | `NEW`（無条件配置、template 進化に追従） | `NEW`（同上） |
+| 内容が template と完全一致 | `SKIP`（`.bak` を作らない） | `SKIP`（同上） |
+| 差分あり、`<file>.bak` 不在 | `BACKUP` `<file>.bak` を once-only 退避してから `OVERWRITE` | 同左（`--force` でも once-only） |
+| 差分あり、`<file>.bak` 既存 | `SKIP`（`use --force to overwrite` 警告） | `OVERWRITE`（`.bak` は再退避せず温存） |
+
+**設計意図**: 初回退避された `.bak` を「カスタム編集の最も貴重な世代」として扱うため、`--force`
+指定時でも既存 `.bak` は保護されます。`.bak` を更新したい場合は、自分で `<file>.bak` を削除して
+から再実行してください。
+
+`CLAUDE.md` も同じハイブリッド safe-overwrite の対象です（`backup_claude_md_once` で initial
+バックアップを作ったあと、`copy_with_hybrid_overwrite` で本体を判定）。
+
+#### `--dry-run` モード
+
+`--dry-run` を付けると、ファイルシステムを変更せずに**予定操作のみを列挙**します。出力例:
+
+```text
+$ ./install.sh --repo /path/to/your-project --dry-run
+[DRY-RUN] BACKUP    /path/to/your-project/CLAUDE.md → CLAUDE.md.bak
+[DRY-RUN] OVERWRITE /path/to/your-project/CLAUDE.md
+[DRY-RUN] NEW       /path/to/your-project/.claude/agents/reviewer.md
+[DRY-RUN] SKIP      /path/to/your-project/.claude/agents/developer.md (identical to template)
+[DRY-RUN] BACKUP    /path/to/your-project/.claude/rules/ears-format.md → ears-format.md.bak (custom edits detected)
+[DRY-RUN] OVERWRITE /path/to/your-project/.claude/rules/ears-format.md
+```
+
+| Prefix | 意味 |
+|---|---|
+| `NEW` | 配置先にファイルが存在しない。新規作成 |
+| `OVERWRITE` | 既存ファイルを template 内容で上書き（差分ありまたは `--force`） |
+| `SKIP` | 既存ファイルが template と同一、もしくは `.bak` 既存で上書き抑止 |
+| `BACKUP` | `<file>.bak` を作成（`OVERWRITE` 直前にのみ発生） |
+
+**保証**: `--dry-run` で `NEW` / `OVERWRITE` と分類されたファイルは、`--dry-run` を外して同じ
+引数で再実行すれば**必ず実際に配置されます**（ファイル状態が変化しない限り）。これにより、
+影響範囲を事前確認してから実適用を判断できます。
+
+`--dry-run` は `setup.sh` 経由（`curl | bash`）でも透過されます:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/setup.sh \
+  | bash -s -- --all --dry-run
+```
+
+#### `--force` の使いどころ
+
+既存利用者が再 install するときの推奨フローは以下のとおりです:
+
+1. まず `./install.sh --repo /path --dry-run` で影響範囲を確認
+2. 必要なら `<file>.bak` をコミットして自分のカスタム編集を保護
+3. `./install.sh --repo /path` を実行（既定挙動でカスタム編集は `.bak` once-only 退避される）
+4. **どうしても最新 template を強制適用したい**ファイルだけ `--force` で再実行（`.bak` 既存は
+   尊重される）
+
+通常の運用では `--force` は不要です。
+
+#### 既存利用者向け Migration Note
+
+本改修で必要な追加手順は**ありません**。既存の `install.sh --repo` / `--local` / `--all` 起動は
+そのまま動作し、再実行時に自動的に新しい冪等性ガードが適用されます。env var 名・cron / launchd
+登録文字列・ラベル名・配置先パスは一切変わりません。
+
+---
+
 手動セットアップ（Git clone 経由）の手順は以下のとおりです。
 
 ### Step 1. 対象リポジトリへの配置

--- a/docs/specs/36-refactor-install-install-sh-bak-dry-run/impl-notes.md
+++ b/docs/specs/36-refactor-install-install-sh-bak-dry-run/impl-notes.md
@@ -1,0 +1,216 @@
+# Implementation Notes: install.sh 冪等性バグ修正と配置漏れ予防 (#36)
+
+## 実装サマリ
+
+`install.sh` に以下のヘルパー関数群を追加し、既存の `setup_repo` / `setup_local_watcher` ブロック
+の個別 `cp` 呼び出しをヘルパー経由に置換した。
+
+- 出力／分類層: `log_action` / `files_equal` / `classify_action` / `ensure_dir`
+- ファイル操作層: `copy_template_file` / `copy_glob_to_homebin` / `backup_claude_md_once` /
+  `copy_with_hybrid_overwrite` / `copy_agents_rules`
+- グローバルフラグ: `DRY_RUN` / `FORCE`、CLI フラグ `--dry-run` / `--force` を追加し `-h` / `--help`
+  にも記載
+
+`local-watcher/bin/` 配下の `*.sh` / `*.tmpl` をワイルドカード配置に切り替えたため、新規
+`*.tmpl` / `*.sh` 追加で `install.sh` を書き換えなくて済むようになった。
+
+## 完了タスク
+
+design.md / tasks.md の numeric ID 順に消化:
+
+| Task ID | 内容 | Commit |
+|---|---|---|
+| 1.1 / 1.2 / 1.3 | ヘルパー関数群（出力／分類層 + ファイル操作層 + ハイブリッド safe-overwrite）の追加 | `feat(install): add idempotency helpers (log_action / classify / copy_*)` |
+| 2.1 | `--dry-run` / `--force` 引数パースとヘルプ更新 | `feat(install): add --dry-run / --force flags and update help` |
+| 3.1 | `setup_repo` ブロックの個別 cp をヘルパー呼び出しに置換 | `refactor(install): replace setup_repo cp calls with idempotent helpers` |
+| 4.1 | `setup_local_watcher` ブロックのワイルドカード化 | `refactor(install): wildcard-deploy local-watcher/bin via copy_glob_to_homebin` |
+| 5.1 | `setup.sh` の引数透過確認（修正不要） | （docs only、本ファイルに記録） |
+| 6.1 | README に冪等性ポリシー節を追加 | `docs(readme): document install.sh idempotency policy and --dry-run` |
+| 7.1 | shellcheck と統合スモークテスト | （本ファイル末尾の Test Results 参照） |
+| - | CLAUDE.md ハンドラの design.md 解釈差分修正 | `fix(install): treat CLAUDE.md body as meta-file after once-only backup` |
+
+タスク 8（dogfood E2E、deferrable）は dry-run 経路のみ実施（破壊的変更を本 repo に直接当てたくない
+ため、実 install までは行っていない）。
+
+## 設計判断・解釈の補足
+
+### CLAUDE.md ハンドラを `copy_with_hybrid_overwrite` から `copy_template_file` に変更
+
+design.md 「setup_repo ブロック」セクションでは「CLAUDE.md も agents/rules と同じハイブリッド
+ポリシーで処理する関数を呼ぶ」と記載されていたが、その直後の設計判断で:
+
+> （`<repo>/CLAUDE.md.bak` が既にあるので、ハイブリッド側は `.bak` 退避をスキップしてそのまま
+> OVERWRITE / SKIP のみを行う）
+
+と記述されており、**`backup_claude_md_once` で `.bak` を作った直後に hybrid を呼ぶと、`.bak` 既存
+状態で OVERWRITE が走る**ことを期待していた。
+
+しかし実装上 `copy_with_hybrid_overwrite` は agents/rules 用に「`.bak` 既存 + `--force` なし =
+SKIP（カスタム編集を予告なく失わせない）」という要件 3.1 の精神を実装している。これを CLAUDE.md
+にそのまま適用すると:
+
+- 利用者の既存 CLAUDE.md → `backup_claude_md_once` が `.bak` に退避 → `copy_with_hybrid_overwrite`
+  が「`.bak` 既存」を検知して SKIP（`use --force to overwrite`）→ template 由来 CLAUDE.md が
+  配置されない
+
+これは要件 2.5（CLAUDE.md 不在時はテンプレート由来 CLAUDE.md を新規配置する）および要件 5.4
+（従来配置されていたファイル群を引き続き配置する）に対する後方互換違反となる。
+
+**判断**: design.md の「ハイブリッド側は `.bak` 退避をスキップして OVERWRITE / SKIP のみ」という
+**意図**を、agents/rules とは異なる経路で実現する形に補正した。すなわち CLAUDE.md は:
+
+1. `backup_claude_md_once` で `.bak` once-only 退避（`.bak` がなければ作る、あれば触らない）
+2. `copy_template_file`（meta files 用、`.bak` を作らない、既存と同一なら SKIP / 差分ありなら
+   無条件 OVERWRITE）で本体を配置
+
+これにより、要件 2.x（`.bak` once-only 保護）と要件 5.4（template 由来 CLAUDE.md は常に配置）の
+両方を満たし、design.md の「ハイブリッド側は OVERWRITE / SKIP のみ」の意図とも整合する。
+
+design.md 自体は書き換えていない（人間レビュー済みのため）。本判断は「確認事項」として PR 本文に
+明記する。
+
+### `--dry-run` 中の重複 BACKUP 表記
+
+dogfood dry-run（`./install.sh --repo .`）で、最初の修正前は CLAUDE.md について `[DRY-RUN]
+BACKUP CLAUDE.md → CLAUDE.md.bak` が 2 回出ていた（`backup_claude_md_once` と
+`copy_with_hybrid_overwrite` が両方とも `.bak` 不在を検知したため）。これは上記の CLAUDE.md ハンドラ
+変更で解消した。
+
+### `--dry-run` 後の dry-run で BACKUP のみ残るケース
+
+design.md の「Dry-run Tests 3: 実 install 後の `--dry-run` で SKIP のみ」は理想形だが、初回 install
+後（CLAUDE.md.bak がまだ存在しない状態）で再度 dry-run すると:
+
+```
+[DRY-RUN] BACKUP    /path/CLAUDE.md → CLAUDE.md.bak
+[DRY-RUN] SKIP      /path/CLAUDE.md (identical to template)
+[DRY-RUN] SKIP      /path/.claude/agents/...md (identical to template)
+...
+```
+
+のように `BACKUP` 行が出る。これは「次回実行時に `.bak` を作る」という once-only 規律と整合する
+**想定挙動**。要件 4.5 の本質は「dry-run の `NEW` / `OVERWRITE` 分類が実実行と一致する」ことで、
+これは検証済み。要件 2 や 4 はこの BACKUP 表記を禁じていない。
+
+ただ、CLAUDE.md.bak を含む完全な冪等点に到達するには、対象 repo に最初から CLAUDE.md.bak が
+あれば 2 回目以降は SKIP のみ（BACKUP も出ない）になる。
+
+### `setup.sh` 経由の `--dry-run` 透過
+
+`setup.sh` の最終行 `exec bash "$IDD_CLAUDE_DIR/install.sh" "$@"` が全引数を透過するため、
+`install.sh` 側で `--dry-run` を受理するように追加するだけで `setup.sh --dry-run` も成立する
+（DR-4）。setup.sh 自体の修正は不要。
+
+E2E 検証は `setup.sh` の git clone 部分がネットワーク依存（および本リポジトリ自身を IDD_CLAUDE_DIR
+にすると fetch/checkout 周りで競合する）のため、静的確認 + install.sh 単体動作で代替した。実
+ネット環境での E2E は本実装後の運用で必要に応じて確認する。
+
+## 受入基準達成確認
+
+各 requirement numeric ID をどのテストで担保したかを以下に記す。テストは `/tmp/scratch-*` の
+使い捨て環境での手動スモークテスト（design.md「Integration Tests」「Dry-run Tests」全項目）で
+実施した。
+
+| Req ID | 概要 | 担保テスト |
+|---|---|---|
+| 1.1 | `*.sh` の宣言的配置 | `--local --dry-run` で `issue-watcher.sh` が `(chmod +x)` 付きで列挙 |
+| 1.2 | `*.tmpl` の宣言的配置 | `--local --dry-run` で `triage-prompt.tmpl` / `iteration-prompt.tmpl` が列挙 |
+| 1.3 | 新規 `*.tmpl` 追加で install.sh 修正不要 | `local-watcher/bin/iteration-prompt-design.tmpl` を一時追加 → `--local --dry-run` で `[DRY-RUN] NEW iteration-prompt-design.tmpl` 列挙確認（IT-6） |
+| 1.4 | `*.sh` への chmod +x 一括付与 | `copy_glob_to_homebin --executable` 経路、`(chmod +x)` ノートで観測 |
+| 1.5 | 既存ファイル集合の同等性 | IT-1 で 15 ファイル NEW（CLAUDE.md / agents 6 / rules 5 / .github 3）を全配置確認 |
+| 1.6 | マッチ 0 件で正常終了 | helpers 単体テスト: `copy_glob_to_homebin /tmp/empty "*.nope"` で `SKIP (no files matched)` + exit 0 |
+| 2.1 | 初回バックアップ | IT-2: `BACKUP CLAUDE.md → CLAUDE.md.bak` が観測、`USER_ORIGINAL` が bak に温存 |
+| 2.2 | 既存 .bak は上書きしない | IT-3: 2 回目実行で `SKIP (existing .bak preserved)` + bak 不変 |
+| 2.3 | 保持を標準出力に記録 | `[INSTALL] SKIP CLAUDE.md.bak (existing .bak preserved)` のログ確認 |
+| 2.4 | 連続再実行で .bak 内容不変 | IT-3: md5sum diff で bak 不変を確認 |
+| 2.5 | CLAUDE.md 不在時はバックアップしない | IT-1: scratch 空ディレクトリで `BACKUP` 行が出ないことを確認（`backup_claude_md_once` の no-op 分岐） |
+| 3.1 | 無告知の上書きをしない | IT-4: developer.md カスタム編集 → `BACKUP developer.md → developer.md.bak (custom edits detected)` + `OVERWRITE`、無告知ではない |
+| 3.2 | 不在ファイルは新規配置 | IT-1: agents/rules 全ファイル NEW |
+| 3.3 | NEW/OVERWRITE/SKIP のファイル単位ログ | log_action 単体テスト + IT-1〜5 全工程で観測 |
+| 3.4 | --force opt-in で上書き許可 | IT-5: `--force` で `OVERWRITE` 実行 |
+| 3.5 | 上書き時の事後復元手段（.bak） | IT-4: developer.md.bak が CUSTOM EDIT を保持 |
+| 3.6 | --help でポリシー文書化 | `install.sh --help` 出力に `--dry-run` / `--force` の挙動説明 4 行追記 |
+| 4.1 | --dry-run でファイルシステム不変 | DR-1: `--dry-run` 後の find で 0 件 |
+| 4.2 | 各ファイルパスを stdout に列挙 | DR-1 出力 41 行（agents/rules/.github/CLAUDE.md 全網羅） |
+| 4.3 | NEW/OVERWRITE/SKIP の判別可能な形式 | `[DRY-RUN] <ACTION> <path> [<note>]` 統一フォーマット |
+| 4.4 | dry-run で exit 0 | dry-run スモーク全工程で exit 0 |
+| 4.5 | dry-run と実実行の分類が一致 | DR-2: `grep '^\[DRY-RUN\] NEW'` の集合と `grep '^\[INSTALL\] NEW'` の集合が `diff` で一致 |
+| 4.6 | --help に --dry-run 記載 | install.sh ヘッダコメント 19-20 行に記載 |
+| 5.1 | 既存起動形式の維持 | `--repo` / `--local` / `--all` / `-h` / `--help` 全て従来通り受理（追加フラグのみ） |
+| 5.2 | 既存 env var 名・意味・既定値を変えない | install.sh で env var を新規参照していない（DRY_RUN/FORCE はフラグのみ） |
+| 5.3 | cron / launchd 登録文字列の書き換え不要 | watcher 配置先 `$HOME/bin/issue-watcher.sh` 不変、CRON_HINT 無変更 |
+| 5.4 | 配置ファイル群は従来と同じ | IT-1 で従来同等の 15 ファイル配置を確認、CLAUDE.md ハンドラ修正で template 由来配置を保証 |
+| 5.5 | ラベル定義の名前変更なし | `idd-claude-labels.sh` は本改修で touch しない（copy_template_file で配置するだけ） |
+| 5.6 | sudo 警告の維持 | sudo 検知ブロック（行 24-35）無変更 |
+| 6.1 | README に CLAUDE.md.bak 仕様記載 | README 「冪等性ポリシーと再実行時の挙動」節 |
+| 6.2 | README に agents / rules 上書き挙動記載 | 同上、5 パス決定表 |
+| 6.3 | README に --dry-run 使い方記載 | 同上、出力例 + prefix 表 + setup.sh 経由透過説明 |
+| 6.4 | 既存利用者の追加手順がない／最小である | README Migration Note |
+| NFR 1.1 | 連続再実行で差分なし | IT-3, IT-4 で bak / 配置ファイルの md5 不変を確認 |
+| NFR 1.2 | --dry-run のみで副作用切替 | `DRY_RUN` フラグ一元化、各ヘルパー内分岐 |
+| NFR 2.1 | 各操作の path と分類を stdout 出力 | log_action 統一フォーマット |
+| NFR 2.2 | エラーは stderr + 非ゼロ exit | 既存 `echo ... >&2 + exit 1` 維持、新規エラー（例: `cmp` 不在）は同パターン |
+| NFR 3.1 | $HOME 配下のみで完結 | 配置先は `$HOME/bin` / `$HOME/Library` / `$REPO_PATH` のみ。新規 sudo 不要 |
+
+## Test Results
+
+### 静的解析
+
+```
+$ shellcheck install.sh
+(no warnings)
+
+$ bash -n install.sh
+(no errors)
+```
+
+### Integration Tests（design.md 準拠、6 項目）
+
+| # | テスト | 結果 |
+|---|---|---|
+| IT-1 | 初回 install で全ファイル NEW（CLAUDE.md なし scratch） | OK（15 NEW、副作用は scratch 内のみ） |
+| IT-2 | 既存ユーザ CLAUDE.md → BACKUP+OVERWRITE | OK（USER_ORIGINAL が bak に温存） |
+| IT-3 | 再実行で CLAUDE.md.bak 温存 + agents/rules SKIP | OK（bak preserved + identical to template） |
+| IT-4 | agents/developer.md カスタム → BACKUP+OVERWRITE → 再々実行 SKIP | OK（once-only 規律で SECOND CUSTOM が bak に入らない） |
+| IT-5 | `--force` で OVERWRITE のみ、bak 温存 | OK（bak md5 不変） |
+| IT-6 | `local-watcher/bin/` に新規 `*.tmpl` 追加 → `--local --dry-run` で NEW 列挙 | OK（4 ファイル全部検出） |
+
+### Dry-run Tests（design.md 準拠、4 項目）
+
+| # | テスト | 結果 |
+|---|---|---|
+| DR-1 | `--dry-run` でファイルシステム未変更 | OK（scratch 内 entry 0 件） |
+| DR-2 | dry-run の NEW 集合と実 install の NEW 集合が一致 | OK（diff 結果が空） |
+| DR-3 | 実 install 後の dry-run で NEW なし | OK（残るのは BACKUP（CLAUDE.md.bak がまだ無いケース）と SKIP） |
+| DR-4 | setup.sh 経由透過 | 静的確認 OK（最終行 `exec bash ... "$@"`）+ install.sh 単体で `--dry-run` 動作確認 |
+
+### Dogfood E2E (dry-run only)
+
+```
+$ ./install.sh --repo . --dry-run
+[DRY-RUN] BACKUP    /home/hitoshi/github/idd-claude-watcher/CLAUDE.md → CLAUDE.md.bak
+[DRY-RUN] OVERWRITE /home/hitoshi/github/idd-claude-watcher/CLAUDE.md
+[DRY-RUN] SKIP      ...architect.md (identical to template)
+... (agents 6, rules 5, .github 3 全て SKIP identical to template)
+[DRY-RUN] SKIP      .../idd-claude-labels.sh (identical to template)
+```
+
+self-hosting で agents/rules/.github 系は同期済み、CLAUDE.md は本 repo の `./CLAUDE.md` と
+`repo-template/CLAUDE.md` が異なる（前者がプロジェクト全体ガイド、後者がテンプレート）ため
+`OVERWRITE` 表記が出るのは想定挙動。実 install は破壊的影響を避けるため未実施。
+
+## 確認事項（PR 本文への候補）
+
+PM / Architect / Reviewer に確認したい論点:
+
+1. **CLAUDE.md ハンドラを `copy_with_hybrid_overwrite` から `copy_template_file` に変更**
+   - design.md の文章では「CLAUDE.md も hybrid」と書かれているが、設計意図（「ハイブリッド側は
+     `.bak` 退避をスキップして OVERWRITE / SKIP のみ」）と要件 2.5 / 5.4（template を新規配置 /
+     従来配置を維持）に整合させるため、本実装では別経路（meta files 経路）を採用した
+   - design.md の該当記述を将来の改修で更新するかどうかは Architect 判断
+2. **「`--dry-run` 後 SKIP のみ」の Dry-run Test 3 の解釈**
+   - 初回 install 後の dry-run では `CLAUDE.md.bak` がまだ無いため `BACKUP` 行が出る。これは
+     once-only 規律と整合する想定挙動だが、design.md の Test 3 表現は厳密ではない
+3. **dogfood 実 install の未実施**
+   - 本リポジトリ自身に対する実 install (`./install.sh --repo .`) は dry-run のみ確認した。実 install
+     は別 Issue で本 repo の `repo-template/` 同期作業として走らせるのが安全

--- a/install.sh
+++ b/install.sh
@@ -486,21 +486,20 @@ if $INSTALL_LOCAL; then
   echo ""
   echo "📦 ローカル PC に watcher をインストール"
 
-  mkdir -p "$HOME/bin" "$HOME/.issue-watcher/logs"
-  cp -v "$LOCAL_WATCHER_DIR/bin/issue-watcher.sh"   "$HOME/bin/"
-  cp -v "$LOCAL_WATCHER_DIR/bin/triage-prompt.tmpl" "$HOME/bin/"
-  # PR Iteration Processor (#26) 用テンプレート。既存 watcher で
-  # PR_ITERATION_ENABLED=true にするまで参照されないが、配置のみ常時行う。
-  if [ -f "$LOCAL_WATCHER_DIR/bin/iteration-prompt.tmpl" ]; then
-    cp -v "$LOCAL_WATCHER_DIR/bin/iteration-prompt.tmpl" "$HOME/bin/"
-  fi
-  chmod +x "$HOME/bin/issue-watcher.sh"
+  ensure_dir "$HOME/bin"
+  ensure_dir "$HOME/.issue-watcher/logs"
+
+  # local-watcher/bin/ 配下の *.sh / *.tmpl をワイルドカードで一括配置。
+  # 新規 *.tmpl / *.sh が追加された場合に install.sh を書き換えなくて済む。
+  copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.sh"   "$HOME/bin" --executable
+  copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.tmpl" "$HOME/bin"
 
   # macOS: launchd
   if [ "$(uname)" = "Darwin" ]; then
-    mkdir -p "$HOME/Library/LaunchAgents"
-    cp -v "$LOCAL_WATCHER_DIR/LaunchAgents/com.local.issue-watcher.plist" \
-          "$HOME/Library/LaunchAgents/"
+    ensure_dir "$HOME/Library/LaunchAgents"
+    copy_template_file \
+      "$LOCAL_WATCHER_DIR/LaunchAgents/com.local.issue-watcher.plist" \
+      "$HOME/Library/LaunchAgents/com.local.issue-watcher.plist"
 
     cat <<'LAUNCHD_HINT'
 

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_TEMPLATE_DIR="$SCRIPT_DIR/repo-template"
 LOCAL_WATCHER_DIR="$SCRIPT_DIR/local-watcher"
 
+# 冪等性 / dry-run 制御フラグ（後段の引数パースで上書き可能）
+DRY_RUN=false
+FORCE=false
+
 REPO_PATH=""
 INSTALL_LOCAL=false
 INSTALL_REPO=false
@@ -75,6 +79,305 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# ─────────────────────────────────────────────────────────────
+# ヘルパー関数群
+#   引数パースの後に定義し、後段の setup_repo / setup_local_watcher 相当ブロックから
+#   呼び出される。すべて DRY_RUN / FORCE をグローバル変数として参照する。
+# ─────────────────────────────────────────────────────────────
+
+# log_action <NEW|OVERWRITE|SKIP|BACKUP> <path> [<note>]
+#   配置・上書き・スキップ・バックアップを統一フォーマットで stdout に記録する。
+#   DRY_RUN=true の場合は "[DRY-RUN]" prefix、それ以外は "[INSTALL]" prefix を使う。
+log_action() {
+  local action="$1"
+  local path="$2"
+  local note="${3:-}"
+  local prefix
+  if [ "$DRY_RUN" = "true" ]; then
+    prefix="[DRY-RUN]"
+  else
+    prefix="[INSTALL]"
+  fi
+  if [ -n "$note" ]; then
+    printf '%s %-9s %s %s\n' "$prefix" "$action" "$path" "$note"
+  else
+    printf '%s %-9s %s\n' "$prefix" "$action" "$path"
+  fi
+}
+
+# files_equal <path_a> <path_b>
+#   2 ファイルの内容同一性判定。
+#   return: 0=同一 / 1=差分あり / 2=どちらか不在 or 比較不能
+files_equal() {
+  local a="$1"
+  local b="$2"
+  if [ ! -f "$a" ] || [ ! -f "$b" ]; then
+    return 2
+  fi
+  if cmp -s "$a" "$b"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# classify_action <src> <dest>
+#   stdout に "NEW" / "SKIP" / "OVERWRITE" を返す。
+#   - dest 不在 → NEW
+#   - dest 存在 + 内容同一 → SKIP
+#   - dest 存在 + 内容差分 → OVERWRITE
+classify_action() {
+  local src="$1"
+  local dest="$2"
+  if [ ! -e "$dest" ]; then
+    echo "NEW"
+    return 0
+  fi
+  if files_equal "$src" "$dest"; then
+    echo "SKIP"
+  else
+    echo "OVERWRITE"
+  fi
+}
+
+# ensure_dir <path>
+#   mkdir -p の dry-run 対応版。dry-run 時はディレクトリも作らない。
+ensure_dir() {
+  local path="$1"
+  if [ "$DRY_RUN" = "true" ]; then
+    return 0
+  fi
+  mkdir -p "$path"
+}
+
+# copy_template_file <src> <dest> [--executable]
+#   単一ファイルの NEW / SKIP / OVERWRITE 配置（meta ファイル用、`.bak` は作らない）。
+#   既存があっても内容差分があれば無条件で OVERWRITE する。
+#   --executable 指定時は配置後に `chmod +x` を実行する。
+copy_template_file() {
+  local src="$1"
+  local dest="$2"
+  local executable=false
+  if [ "${3:-}" = "--executable" ]; then
+    executable=true
+  fi
+
+  if [ ! -f "$src" ]; then
+    echo "Error: source file not found: $src" >&2
+    return 1
+  fi
+
+  local action
+  action="$(classify_action "$src" "$dest")"
+
+  local note=""
+  if [ "$executable" = "true" ]; then
+    note="(chmod +x)"
+  fi
+
+  case "$action" in
+    NEW)
+      log_action "NEW" "$dest" "$note"
+      if [ "$DRY_RUN" = "false" ]; then
+        ensure_dir "$(dirname "$dest")"
+        cp "$src" "$dest"
+        if [ "$executable" = "true" ]; then
+          chmod +x "$dest"
+        fi
+      fi
+      ;;
+    SKIP)
+      log_action "SKIP" "$dest" "(identical to template)"
+      ;;
+    OVERWRITE)
+      log_action "OVERWRITE" "$dest" "$note"
+      if [ "$DRY_RUN" = "false" ]; then
+        cp "$src" "$dest"
+        if [ "$executable" = "true" ]; then
+          chmod +x "$dest"
+        fi
+      fi
+      ;;
+  esac
+}
+
+# copy_glob_to_homebin <src_dir> <pattern> <dest_dir> [--executable]
+#   `<src_dir>/<pattern>` にマッチする全ファイルを <dest_dir> に配置する。
+#   nullglob を一時的に有効化し、マッチ 0 件は SKIP ログを出して exit 0 で継続する。
+copy_glob_to_homebin() {
+  local src_dir="$1"
+  local pattern="$2"
+  local dest_dir="$3"
+  local executable_flag=""
+  if [ "${4:-}" = "--executable" ]; then
+    executable_flag="--executable"
+  fi
+
+  ensure_dir "$dest_dir"
+
+  # nullglob を一時的に有効化（マッチ 0 件で空配列扱いにする）
+  local prev_nullglob
+  if shopt -q nullglob; then
+    prev_nullglob=on
+  else
+    prev_nullglob=off
+  fi
+  shopt -s nullglob
+
+  # `$pattern` は意図的に glob 展開させたいためクォートしない
+  # shellcheck disable=SC2206
+  local files=( "$src_dir"/$pattern )
+  local count=${#files[@]}
+
+  if [ "$count" -eq 0 ]; then
+    log_action "SKIP" "$src_dir/$pattern" "(no files matched)"
+  else
+    local src
+    for src in "${files[@]}"; do
+      local dest
+      dest="$dest_dir/$(basename "$src")"
+      if [ -n "$executable_flag" ]; then
+        copy_template_file "$src" "$dest" --executable
+      else
+        copy_template_file "$src" "$dest"
+      fi
+    done
+  fi
+
+  # nullglob を呼び出し前の状態に戻す
+  if [ "$prev_nullglob" = "off" ]; then
+    shopt -u nullglob
+  fi
+}
+
+# backup_claude_md_once <repo_path>
+#   CLAUDE.md.bak を初回 1 回のみ作成し、再実行で内容を変えない once-only 規律を実装。
+#   - CLAUDE.md 不在 → noop
+#   - CLAUDE.md.bak 不在 → BACKUP（初回バックアップ）
+#   - CLAUDE.md.bak 既存 → SKIP（既存 .bak を温存）
+backup_claude_md_once() {
+  local repo_path="$1"
+  local src="$repo_path/CLAUDE.md"
+  local bak="$repo_path/CLAUDE.md.bak"
+
+  if [ ! -f "$src" ]; then
+    return 0
+  fi
+
+  if [ ! -f "$bak" ]; then
+    log_action "BACKUP" "$src" "→ CLAUDE.md.bak"
+    if [ "$DRY_RUN" = "false" ]; then
+      cp "$src" "$bak"
+    fi
+  else
+    log_action "SKIP" "$bak" "(existing .bak preserved)"
+  fi
+}
+
+# copy_with_hybrid_overwrite <src> <dest>
+#   1 ファイル単位のハイブリッド safe-overwrite 処理（agents / rules / CLAUDE.md 共用）。
+#   - dest 不在 → NEW（無条件配置、template 進化に追従）
+#   - dest 存在 + 内容同一 → SKIP `(identical to template)`
+#   - dest 存在 + 内容差分:
+#     - <dest>.bak 不在 → BACKUP `<dest> → <name>.bak` + OVERWRITE
+#     - <dest>.bak 既存 + FORCE=false → SKIP `(existing .bak found, use --force to overwrite)`
+#     - <dest>.bak 既存 + FORCE=true  → SKIP の .bak（once-only 規律保護）+ OVERWRITE
+copy_with_hybrid_overwrite() {
+  local src="$1"
+  local dest="$2"
+
+  if [ ! -f "$src" ]; then
+    echo "Error: source file not found: $src" >&2
+    return 1
+  fi
+
+  local action
+  action="$(classify_action "$src" "$dest")"
+
+  case "$action" in
+    NEW)
+      log_action "NEW" "$dest"
+      if [ "$DRY_RUN" = "false" ]; then
+        ensure_dir "$(dirname "$dest")"
+        cp "$src" "$dest"
+      fi
+      ;;
+    SKIP)
+      log_action "SKIP" "$dest" "(identical to template)"
+      ;;
+    OVERWRITE)
+      local bak="$dest.bak"
+      local bak_name
+      bak_name="$(basename "$dest").bak"
+      if [ ! -f "$bak" ]; then
+        # .bak 不在 → 初回退避してから上書き（once-only）
+        local backup_note
+        if [ "$FORCE" = "true" ]; then
+          backup_note="→ $bak_name (--force)"
+        else
+          backup_note="→ $bak_name (custom edits detected)"
+        fi
+        log_action "BACKUP" "$dest" "$backup_note"
+        if [ "$DRY_RUN" = "false" ]; then
+          cp "$dest" "$bak"
+        fi
+        log_action "OVERWRITE" "$dest"
+        if [ "$DRY_RUN" = "false" ]; then
+          cp "$src" "$dest"
+        fi
+      else
+        # .bak 既存 → once-only 規律で再退避しない
+        if [ "$FORCE" = "true" ]; then
+          log_action "SKIP" "$bak" "(existing .bak preserved even with --force)"
+          log_action "OVERWRITE" "$dest"
+          if [ "$DRY_RUN" = "false" ]; then
+            cp "$src" "$dest"
+          fi
+        else
+          log_action "SKIP" "$dest" "(existing .bak found, use --force to overwrite)"
+        fi
+      fi
+      ;;
+  esac
+}
+
+# copy_agents_rules <src_dir> <dest_dir>
+#   `.claude/agents/*.md` および `.claude/rules/*.md` のハイブリッド safe-overwrite 配置。
+#   各 .md ファイルに対して copy_with_hybrid_overwrite を適用する。
+#   nullglob を一時的に有効化し、マッチ 0 件は SKIP ログを出して exit 0 で継続。
+copy_agents_rules() {
+  local src_dir="$1"
+  local dest_dir="$2"
+
+  ensure_dir "$dest_dir"
+
+  local prev_nullglob
+  if shopt -q nullglob; then
+    prev_nullglob=on
+  else
+    prev_nullglob=off
+  fi
+  shopt -s nullglob
+
+  local files=( "$src_dir"/*.md )
+  local count=${#files[@]}
+
+  if [ "$count" -eq 0 ]; then
+    log_action "SKIP" "$src_dir/*.md" "(no files matched)"
+  else
+    local src
+    for src in "${files[@]}"; do
+      local dest
+      dest="$dest_dir/$(basename "$src")"
+      copy_with_hybrid_overwrite "$src" "$dest"
+    done
+  fi
+
+  if [ "$prev_nullglob" = "off" ]; then
+    shopt -u nullglob
+  fi
+}
 
 # 対話モード（引数なし）
 if ! $INSTALL_LOCAL && ! $INSTALL_REPO; then

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,13 @@
 #   ./install.sh --local                     # ローカル watcher のみインストール
 #   ./install.sh --all                       # カレントディレクトリ + ローカル watcher
 #   ./install.sh --all --repo /path/to/project
+#
+# オプション（既存フラグと組み合わせ可）:
+#   --dry-run        実コピーせず、予定操作を [DRY-RUN] プレフィクスで列挙
+#                    （ファイルシステムを変更しない。出力分類は実実行時と一致）
+#   --force          .claude/agents/ / .claude/rules/ / CLAUDE.md について、
+#                    内容差分があれば再 .bak 退避して強制上書き
+#                    （既存 *.bak は once-only 規律で保護されたまま）
 # =============================================================================
 
 set -euo pipefail
@@ -69,8 +76,16 @@ while [[ $# -gt 0 ]]; do
       INSTALL_REPO=true
       shift
       ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
     -h|--help)
-      sed -n '3,14p' "$0"
+      sed -n '3,21p' "$0"
       exit 0
       ;;
     *)

--- a/install.sh
+++ b/install.sh
@@ -431,12 +431,15 @@ if $INSTALL_REPO; then
   REPO_PATH="$REPO_PATH_ABS"
 
   # CLAUDE.md.bak の once-only 保護（初回 install 時のオリジナルを温存）
+  # → 既存 CLAUDE.md があれば `.bak` に退避（既存 `.bak` は尊重、再退避しない）
   backup_claude_md_once "$REPO_PATH"
 
-  # CLAUDE.md 本体は agents/rules と同じハイブリッド safe-overwrite ポリシーで配置。
-  # backup_claude_md_once が既に CLAUDE.md.bak を保護しているため、ここでの BACKUP は
-  # 「既存 .bak を尊重する」分岐に落ちる（once-only 規律で重複退避を防ぐ）。
-  copy_with_hybrid_overwrite "$REPO_TEMPLATE_DIR/CLAUDE.md" "$REPO_PATH/CLAUDE.md"
+  # CLAUDE.md 本体は backup_claude_md_once が `.bak` 退避を引き受けたあと、
+  # copy_template_file で template を常に配置する（既存と同一なら SKIP）。
+  # → design.md「setup_repo ブロック」設計判断: ハイブリッド側は `.bak` 退避を
+  #   スキップしてそのまま OVERWRITE / SKIP のみを行う、と整合
+  # → 要件 2.5 / 5.4: 既存挙動（無条件で template 由来 CLAUDE.md を配置）を維持
+  copy_template_file "$REPO_TEMPLATE_DIR/CLAUDE.md" "$REPO_PATH/CLAUDE.md"
 
   copy_agents_rules "$REPO_TEMPLATE_DIR/.claude/agents" "$REPO_PATH/.claude/agents"
   copy_agents_rules "$REPO_TEMPLATE_DIR/.claude/rules"  "$REPO_PATH/.claude/rules"

--- a/install.sh
+++ b/install.sh
@@ -430,32 +430,29 @@ if $INSTALL_REPO; then
   echo "📦 対象リポジトリにファイルを配置: $REPO_PATH_ABS"
   REPO_PATH="$REPO_PATH_ABS"
 
-  # CLAUDE.md は既存があればバックアップ
-  if [ -f "$REPO_PATH/CLAUDE.md" ]; then
-    echo "  既存の CLAUDE.md を CLAUDE.md.bak にバックアップ"
-    cp "$REPO_PATH/CLAUDE.md" "$REPO_PATH/CLAUDE.md.bak"
-  fi
+  # CLAUDE.md.bak の once-only 保護（初回 install 時のオリジナルを温存）
+  backup_claude_md_once "$REPO_PATH"
 
-  cp -v "$REPO_TEMPLATE_DIR/CLAUDE.md" "$REPO_PATH/CLAUDE.md"
+  # CLAUDE.md 本体は agents/rules と同じハイブリッド safe-overwrite ポリシーで配置。
+  # backup_claude_md_once が既に CLAUDE.md.bak を保護しているため、ここでの BACKUP は
+  # 「既存 .bak を尊重する」分岐に落ちる（once-only 規律で重複退避を防ぐ）。
+  copy_with_hybrid_overwrite "$REPO_TEMPLATE_DIR/CLAUDE.md" "$REPO_PATH/CLAUDE.md"
 
-  mkdir -p "$REPO_PATH/.claude/agents"
-  cp -v "$REPO_TEMPLATE_DIR/.claude/agents/"*.md "$REPO_PATH/.claude/agents/"
+  copy_agents_rules "$REPO_TEMPLATE_DIR/.claude/agents" "$REPO_PATH/.claude/agents"
+  copy_agents_rules "$REPO_TEMPLATE_DIR/.claude/rules"  "$REPO_PATH/.claude/rules"
 
-  mkdir -p "$REPO_PATH/.claude/rules"
-  cp -v "$REPO_TEMPLATE_DIR/.claude/rules/"*.md "$REPO_PATH/.claude/rules/"
+  copy_template_file \
+    "$REPO_TEMPLATE_DIR/.github/ISSUE_TEMPLATE/feature.yml" \
+    "$REPO_PATH/.github/ISSUE_TEMPLATE/feature.yml"
 
-  mkdir -p "$REPO_PATH/.github/ISSUE_TEMPLATE"
-  cp -v "$REPO_TEMPLATE_DIR/.github/ISSUE_TEMPLATE/feature.yml" \
-        "$REPO_PATH/.github/ISSUE_TEMPLATE/feature.yml"
+  copy_template_file \
+    "$REPO_TEMPLATE_DIR/.github/workflows/issue-to-pr.yml" \
+    "$REPO_PATH/.github/workflows/issue-to-pr.yml"
 
-  mkdir -p "$REPO_PATH/.github/workflows"
-  cp -v "$REPO_TEMPLATE_DIR/.github/workflows/issue-to-pr.yml" \
-        "$REPO_PATH/.github/workflows/issue-to-pr.yml"
-
-  mkdir -p "$REPO_PATH/.github/scripts"
-  cp -v "$REPO_TEMPLATE_DIR/.github/scripts/idd-claude-labels.sh" \
-        "$REPO_PATH/.github/scripts/idd-claude-labels.sh"
-  chmod +x "$REPO_PATH/.github/scripts/idd-claude-labels.sh"
+  copy_template_file \
+    "$REPO_TEMPLATE_DIR/.github/scripts/idd-claude-labels.sh" \
+    "$REPO_PATH/.github/scripts/idd-claude-labels.sh" \
+    --executable
 
   cat <<REPO_HINT
 


### PR DESCRIPTION
## 概要

`install.sh` の冪等性を強化し、再実行時の予期しない上書きを防ぎ、dry-run による事前確認を可能にした。

## 対応 Issue

Closes #36

## 関連 PR

- 設計 PR: #38（merged）

## 実装内容

- (Req 1.x / Task 4.1) `local-watcher/bin/` 配下の `*.sh` / `*.tmpl` をワイルドカード配置に切り替え。新規ファイル追加時に `install.sh` の変更が不要になった
- (Req 2.x / Task 1.3) `backup_claude_md_once` で CLAUDE.md を once-only バックアップ。`.bak` が既にある場合は触らず、利用者のカスタム編集を保護する
- (Req 3.x / Task 3.1) `copy_with_hybrid_overwrite` / `copy_agents_rules` で agents・rules の配置を冪等化。差分がなければ SKIP、カスタム編集があれば `.bak` へ退避後 OVERWRITE（`--force` なしでも告知）
- (Req 4.x / Task 2.1) `--dry-run` フラグを追加。ファイルシステムを変更せず NEW / OVERWRITE / SKIP の予定を標準出力に列挙。分類結果は実実行と一致（DR-2 で確認）
- (Req 6.x / Task 6.1) README に「冪等性ポリシーと再実行時の挙動」節を追加（5 パス決定表・出力フォーマット例・Migration Note）

## 受入基準チェック

- [x] Req 1.1〜1.6: `local-watcher/bin/` 全 glob 宣言的配置 ← IT-6 + helpers 単体テスト
- [x] Req 2.1〜2.5: CLAUDE.md once-only .bak ← IT-1〜IT-4
- [x] Req 3.1〜3.6: agents/rules 無告知上書き防止 / --force opt-in ← IT-4〜IT-5
- [x] Req 4.1〜4.6: --dry-run でファイルシステム不変 / NEW|OVERWRITE|SKIP 分類 ← DR-1〜DR-4
- [x] Req 5.1〜5.6: 後方互換性（既存 CLI / env var / cron 登録文字列）維持 ← IT-1 + 静的確認
- [x] Req 6.1〜6.4: README 更新と Migration Note ← `docs(readme)` コミット
- [x] NFR 1.1〜3.1: 冪等性 / 可観測性 / 権限範囲 ← IT-3 + log_action 統一フォーマット

## テスト結果

```
shellcheck install.sh
  → (no warnings)

bash -n install.sh
  → (no errors)

Integration Tests (IT-1〜IT-6): 全 6 件 pass
Dry-run Tests (DR-1〜DR-4): 全 4 件 pass
Dogfood dry-run (./install.sh --repo . --dry-run): OK（OVERWRITE 1 件は想定内）
```

詳細テスト記録: `docs/specs/36-refactor-install-install-sh-bak-dry-run/impl-notes.md` 参照

## 実装上の判断

- `log_action` / `files_equal` / `classify_action` / `ensure_dir` の出力・分類層を新設し、各コピー操作ヘルパーが統一フォーマットでログを出力する構造に整理した
- `DRY_RUN` / `FORCE` はグローバルフラグとして宣言し、全ヘルパー内で参照する形式を採用（env override は不可、CLI フラグのみ）

## 確認事項 / レビュワーへの依頼

1. **CLAUDE.md ハンドラの設計 vs 実装の解釈差**: design.md では「CLAUDE.md も hybrid ポリシー」と記載されているが、要件 2.5 / 5.4（template 由来 CLAUDE.md を常に配置する）との整合のため、`backup_claude_md_once` + `copy_template_file`（meta files 経路）の組み合わせで実装した。design.md の該当箇所の将来更新要否は Architect 判断にお任せしたい
2. **Dry-run Test 3 の解釈差（要件 4.5 は満たしている）**: design.md の「実 install 後 dry-run で SKIP のみ」は、CLAUDE.md.bak が初回 install 直後には存在しないため `BACKUP` 行が残るケースがある。これは once-only 規律と整合する想定挙動で、要件 4.5（dry-run の NEW/OVERWRITE 分類が実実行と一致する）は DR-2 で確認済み
3. **dogfood 実 install の未実施**: 本リポジトリ自身への実 install (`./install.sh --repo .`) は、`repo-template/CLAUDE.md` と `./CLAUDE.md` の差分があるため dry-run のみ実施した。実 install は別 Issue で `repo-template/` 同期作業として安全に走らせる想定

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #36 のコメントを参照してください。