### PR TITLE
docs(readme): clarify setup.sh idempotency edge cases for IDD_CLAUDE_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/set
 > にユーザースコープで配置します。`sudo` で実行するとファイル所有者が root になり、
 > 通常ユーザーで更新・削除できなくなるため、setup.sh / install.sh とも root 実行を検知したら
 > 警告または停止します。cron 登録もユーザー crontab（`crontab -e`）で行うため sudo 不要です。
+>
+> **`$HOME/.idd-claude` は直接編集しないでください**: setup.sh は再実行時に
+> `git reset --hard origin/<branch>` で upstream 状態に上書きするため、このディレクトリ内の
+> ローカル編集は告知なく失われます。idd-claude の挙動を調整したい場合は、設置先 repo
+> （`repo-template/` のコピー先）か `~/bin/` 配下に配置された watcher スクリプトを編集して
+> ください。なお、clone が中断されるなどして `.git` の無い不完全な状態になった場合、setup.sh
+> は安全のため停止します（自動回復しません）。`rm -rf ~/.idd-claude` で削除してから setup.sh
+> を再実行してください。
 
 ### 冪等性ポリシーと再実行時の挙動 (#36)
 


### PR DESCRIPTION
## Summary

setup.sh **本体は冪等**（再実行で `$HOME/.idd-claude` を upstream HEAD にリセット）だが、ユーザから見えにくい 2 つのエッジケースを README で明示。

1. **`$HOME/.idd-claude` 内のローカル編集は告知なく消える**
   - setup.sh は `git reset --hard origin/<branch>` を毎回実行するため、ユーザが「ここを編集すれば挙動を変えられる」と誤解すると編集が失われる
   - 正しい編集場所（設置先 repo or `~/bin/` watcher スクリプト）を案内

2. **不完全クローン（中断時）は自動回復しない**
   - `.git` 無しディレクトリが残ると setup.sh は安全のため停止
   - ユーザが `rm -rf ~/.idd-claude` してから再実行する必要があることを明記

#36（install.sh 冪等性）の改修とは独立した setup.sh 固有の挙動として、sudo 警告ブロックの直後に追記。コード変更なし、ドキュメントのみ。

## Test plan

- [x] `git diff --stat` で 1 file changed / 8 insertions のみ
- [x] 既存の「冪等性ポリシー (#36)」セクションと内容が重複していないことを確認
- [x] 該当ブロック引用が markdown プレビューで正しく連結される（`>` 継続）

## 確認事項

- 注記の配置位置（既存の sudo 警告の直後）が読み手の自然な動線に合っているか
- 「`$HOME/.idd-claude` を編集してはいけない」という強い表現が、内部実装をいじりたい上級ユーザの誤解を招かないか（趣旨は「setup.sh の挙動を当てにしないで」であり、実装研究自体は禁止していない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
