### PR TITLE
feat(#35): needs-iteration を設計 PR にも対応（spec 書き換え許容モード + head pattern 厳格化）

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,22 +825,37 @@ idd-claude 管理下 PR を fresh context の Claude で反復対応する Proce
 - `needs-iteration` ラベルが付いている open PR
 - `claude-failed` / `needs-rebase` ラベルが付いていない（Phase A と排他）
 - draft 状態ではない
-- **head branch が `PR_ITERATION_HEAD_PATTERN` に合致**（デフォルト `^claude/`、自動生成 PR のみ）
+- **head branch が `PR_ITERATION_HEAD_PATTERN` に合致**（デフォルト
+  `^claude/issue-[0-9]+-impl-`、idd-claude 自動生成の **実装 PR** のみ）
+- もしくは `PR_ITERATION_DESIGN_ENABLED=true` のとき、head branch が
+  `PR_ITERATION_DESIGN_HEAD_PATTERN` に合致（デフォルト
+  `^claude/issue-[0-9]+-design-`、設計 PR のみ）
 - **head repo owner が base repo owner と同一**（fork PR を除外）
+
+> **#35 で既定値を厳格化**: `PR_ITERATION_HEAD_PATTERN` の旧既定値 `^claude/` は
+> idd-claude 規約外の `claude/foo` 形式の branch も拾ってしまう恐れがあったため、
+> `^claude/issue-[0-9]+-impl-` に絞り込みました。旧挙動に戻したい場合は cron 側で
+> `PR_ITERATION_HEAD_PATTERN=^claude/` を指定して override してください
+> （Migration Note 参照）。
 
 ### 挙動
 
 | 状況 | アクション |
 |---|---|
 | 候補 PR を検出 → round < MAX | hidden marker 更新 + 着手表明コメント → fresh context で Claude 起動 |
-| Claude 成功（commit+push or reply-only） | `needs-iteration` 除去 + `ready-for-review` 付与 |
+| **実装 PR** Claude 成功（commit+push or reply-only） | `needs-iteration` 除去 + `ready-for-review` 付与 |
+| **設計 PR** Claude 成功（`PR_ITERATION_DESIGN_ENABLED=true` 時） | `needs-iteration` 除去 + `awaiting-design-review` 付与 |
 | Claude 失敗（exit 非 0、turn 上限、push 失敗等） | `needs-iteration` を残置 + WARN ログ、次サイクルで再試行 |
-| 累計 round が `MAX_ROUNDS` に到達 | `needs-iteration` 除去 + `claude-failed` 付与 + エスカレコメント |
+| 累計 round が `MAX_ROUNDS` に到達（design / impl 共通） | `needs-iteration` 除去 + `claude-failed` 付与 + エスカレコメント |
 | `needs-rebase` 併存 | 本機能は skip（Phase A に処理を委ねる） |
+| branch が design / impl 両 pattern に合致（`ambiguous`） | 当該 PR を skip + WARN ログ（運用上は発生しない想定） |
 | dirty working tree 検知 | サイクル全体で本機能を skip（ERROR ログ）、後続 Issue 処理は継続 |
 
-サイクル終了時に `pr-iteration: サマリ: success=N, fail=N, skip=N, escalated=N, overflow=N`
+サイクル終了時に
+`pr-iteration: サマリ: success=N, fail=N, skip=N, escalated=N, overflow=N (design=N, impl=N)`
 が watcher ログに出力されます（`grep 'pr-iteration:' $HOME/.issue-watcher/logs/...`）。
+個別 PR のログ行には `kind=design|impl` と `round=N/MAX` が含まれるため、
+`grep 'pr-iteration:' ... | grep 'kind=design'` のように kind ごとに集計できます。
 
 ### 環境変数
 
@@ -850,8 +865,11 @@ idd-claude 管理下 PR を fresh context の Claude で反復対応する Proce
 | `PR_ITERATION_DEV_MODEL` | `claude-opus-4-7` | 既存の `DEV_MODEL` と同じ運用方針 | iteration 用の Claude モデル ID |
 | `PR_ITERATION_MAX_TURNS` | `60` | 通常レビュー対応で十分。多い場合は対象 PR が大きすぎる兆候 | 1 iteration の Claude 実行 turn 数上限 |
 | `PR_ITERATION_MAX_PRS` | `3` | watcher 実行間隔と PR 平均量に応じて調整 | 1 サイクルで処理する PR 数の上限。超過分は次回に持ち越し |
-| `PR_ITERATION_MAX_ROUNDS` | `3` | 試行回数を抑えて自動エスカレを早めに | 1 PR あたりの累計 iteration 上限。超過時は `claude-failed` 昇格 |
-| `PR_ITERATION_HEAD_PATTERN` | `^claude/` | 既存ブランチ命名規則に合わせる（Phase A と同値推奨） | 自動 iteration 対象とする head branch の正規表現（jq `test()` 互換） |
+| `PR_ITERATION_MAX_ROUNDS` | `3` | 試行回数を抑えて自動エスカレを早めに | 1 PR あたりの累計 iteration 上限。超過時は `claude-failed` 昇格（design / impl 共通） |
+| `PR_ITERATION_HEAD_PATTERN` | `^claude/issue-[0-9]+-impl-` | idd-claude 自動生成の実装 PR のみを対象とする | 実装 PR の自動 iteration 対象とする head branch の正規表現（jq `test()` 互換）。**#35 で既定厳格化**（旧 `^claude/`） |
+| `PR_ITERATION_DESIGN_ENABLED` | `false` | 設計 PR の自動 iteration を試したい場合のみ `true`（**opt-in**） | 設計 PR 拡張全体の有効化フラグ（**#35 新設**） |
+| `PR_ITERATION_DESIGN_HEAD_PATTERN` | `^claude/issue-[0-9]+-design-` | idd-claude 自動生成の設計 PR を対象とする既定値 | 設計 PR の自動 iteration 対象とする head branch の正規表現（**#35 新設**） |
+| `ITERATION_TEMPLATE_DESIGN` | `$HOME/bin/iteration-prompt-design.tmpl` | install.sh --local が配置するため通常は変更不要 | 設計 PR 用 iteration prompt template の配置先（**#35 新設**） |
 | `PR_ITERATION_GIT_TIMEOUT` | `60`（秒） | watcher 最短実行間隔の半分以内 | 各 git / gh 操作の個別タイムアウト |
 
 cron 例（opt-in する場合）:
@@ -862,6 +880,49 @@ cron 例（opt-in する場合）:
 
 `PR_ITERATION_ENABLED=true` を渡さない限り、本機能は完全に無効化されており、Issue 処理
 フローは導入前と完全に一致します（Phase A も独立した env で opt-in）。
+
+### 設計 PR 拡張 (#35)
+
+`PR_ITERATION_ENABLED=true` に加えて `PR_ITERATION_DESIGN_ENABLED=true` を渡すと、
+`claude/issue-<N>-design-<slug>` 形式の **設計 PR** にも `needs-iteration` 反復対応が
+適用されます。設計 PR iteration では:
+
+- **Architect 役割** で起動され、`docs/specs/<N>-<slug>/` 配下の spec 群（`requirements.md` /
+  `design.md` / `tasks.md`）の **書き換えが許容** されます（実装 PR では禁止のまま）
+- 編集スコープは `docs/specs/<N>-<slug>/` 配下に限定（scope 外の変更は commit せず
+  返信で別 Issue 化を提案するよう template が指示）
+- 自己レビューゲート（`.claude/rules/design-review-gate.md` の Mechanical Checks）を
+  最大 2 パスで実行
+- 成功時は `awaiting-design-review` ラベルに自動遷移（実装 PR は `ready-for-review`）
+- 上限到達時は `claude-failed` 昇格 + エスカレコメント（kind 共通）
+
+設計 PR 対応を有効化する cron 例:
+
+```bash
+*/2 * * * * REPO=owner/your-repo REPO_DIR=$HOME/work/your-repo MERGE_QUEUE_ENABLED=true PR_ITERATION_ENABLED=true PR_ITERATION_DESIGN_ENABLED=true $HOME/bin/issue-watcher.sh >> $HOME/.issue-watcher/cron.log 2>&1
+```
+
+`PR_ITERATION_DESIGN_ENABLED=false`（デフォルト）の場合、設計 PR は対象外として
+candidate 段階で除外され、本機能導入前と完全に同一の挙動を保ちます。
+
+#### 1 PR = design or impl のどちらか（混在禁止）
+
+watcher は branch 名で **kind**（design / impl / 対象外）を判定します:
+
+- `claude/issue-<N>-design-<slug>` → `kind=design`（spec 書き換え許容）
+- `claude/issue-<N>-impl-<slug>` → `kind=impl`（spec 書き換え禁止、既存挙動）
+- 両 pattern に合致する branch（運用上は発生しない想定の保険） → `kind=ambiguous`、skip + WARN
+- どちらにも合致しない branch → `kind=none`、skip + INFO
+
+1 PR の中で spec 編集と実装変更を **同居させない** でください。混在 PR は
+ラベル遷移の意味が曖昧になるため、watcher 側で安全側に倒して skip します。
+
+#### review-notes.md (#20) との関係
+
+設計 PR では Reviewer エージェント（#20 Phase 1 Reviewer Subagent Gate）は
+**起動しません**（impl 系限定の現状仕様）。設計 PR iteration 中に
+`review-notes.md` は生成されません。将来拡張で設計 PR にも Reviewer を
+適用する場合は別 Issue で扱います。
 
 ### `needs-iteration` ラベル
 
@@ -914,34 +975,65 @@ gh pr edit <PR番号> --repo owner/your-repo --add-label needs-iteration
 
 ### Migration Note（既存ユーザー向け）
 
-PR Iteration Processor 導入による後方互換性は以下のとおり保証されます:
+PR Iteration Processor 導入（#26）および設計 PR 拡張（#35）による後方互換性は
+以下のとおり保証されます:
 
-- **既存環境変数は不変**: `REPO`, `REPO_DIR`, `LOG_DIR`, `LOCK_FILE`, `TRIAGE_MODEL`,
-  `DEV_MODEL`, `TRIAGE_MAX_TURNS`, `DEV_MAX_TURNS`, `TRIAGE_TEMPLATE`, `MERGE_QUEUE_*`
-  の名前・意味・デフォルトは変更なし
+- **既存環境変数名は不変**: `REPO`, `REPO_DIR`, `LOG_DIR`, `LOCK_FILE`, `TRIAGE_MODEL`,
+  `DEV_MODEL`, `TRIAGE_MAX_TURNS`, `DEV_MAX_TURNS`, `TRIAGE_TEMPLATE`, `MERGE_QUEUE_*`,
+  `PR_ITERATION_ENABLED`, `PR_ITERATION_DEV_MODEL`, `PR_ITERATION_MAX_TURNS`,
+  `PR_ITERATION_MAX_PRS`, `PR_ITERATION_MAX_ROUNDS`, `PR_ITERATION_GIT_TIMEOUT`,
+  `ITERATION_TEMPLATE` の名前・意味は変更なし
 - **既存ラベルは不変**: `auto-dev` / `claude-picked-up` / `awaiting-design-review` /
-  `ready-for-review` / `claude-failed` / `needs-decisions` / `skip-triage` / `needs-rebase`
-  の名前・意味・付与契約は変更なし
+  `ready-for-review` / `claude-failed` / `needs-decisions` / `skip-triage` / `needs-rebase` /
+  `needs-iteration` の名前・意味・付与契約は変更なし
 - **lock ファイル / ログ出力先 / exit code の意味は不変**: `LOCK_FILE` パス、`LOG_DIR` 配下への
   ログ出力先、watcher の exit code は導入前と同一
 - **本機能はデフォルト無効**: `PR_ITERATION_ENABLED` のデフォルトは `false`（**opt-in**）。
-  既存環境を壊すことなく段階的に有効化できる
+  `PR_ITERATION_DESIGN_ENABLED` のデフォルトも `false`（**opt-in**）。既存環境を壊すことなく
+  段階的に有効化できる
 - **依存コマンドの追加なし**: 既存の `gh` / `jq` / `git` / `flock` / `timeout` / `claude` のみ
   で動作（Phase A で `timeout` は既に依存）
 - **新規ラベル `needs-iteration` は冪等追加**: `idd-claude-labels.sh` を再実行すれば既存環境にも
-  追加されます
+  追加されます。`awaiting-design-review` / `ready-for-review` / `claude-failed` も冪等維持
 
 `PR_ITERATION_ENABLED=false`（デフォルト）の状態では PR Iteration コードパスは完全に skip
 されるため、既存運用への影響はありません。
 
+#### #35 で変更された既定値（破壊的だが override で救済可能）
+
+- **`PR_ITERATION_HEAD_PATTERN` の既定値変更**: 旧 `^claude/` → 新
+  `^claude/issue-[0-9]+-impl-`。idd-claude 規約外の `claude/foo` 形式 branch を誤検知する
+  余地を排除しました
+- **影響範囲**: idd-claude PjM が自動生成した PR
+  （`claude/issue-<N>-impl-<slug>` / `claude/issue-<N>-design-<slug>` 形式）はこれまで通り
+  対象。手書き `claude/<slug>` 形式の PR は対象外になります
+- **救済方法**: 旧挙動が必要な運用者は cron 行に
+  `PR_ITERATION_HEAD_PATTERN=^claude/` を追加して既定値を override してください:
+
+  ```bash
+  */2 * * * * REPO=owner/your-repo REPO_DIR=$HOME/work/your-repo MERGE_QUEUE_ENABLED=true PR_ITERATION_ENABLED=true PR_ITERATION_HEAD_PATTERN='^claude/' $HOME/bin/issue-watcher.sh >> $HOME/.issue-watcher/cron.log 2>&1
+  ```
+
+- **deprecation 期間は設けません**: 影響を受ける運用者は cron 行 1 行追加で旧挙動に戻せるため
+
+#### #35 で新設された env var（opt-in 拡張）
+
+- `PR_ITERATION_DESIGN_ENABLED=true` を cron に追加すると、設計 PR
+  （`claude/issue-<N>-design-<slug>`）にも `needs-iteration` 反復対応が適用されます
+  （詳細は前述「設計 PR 拡張 (#35)」節を参照）
+- `PR_ITERATION_DESIGN_HEAD_PATTERN` を cron に追加すると、設計 PR の head branch
+  pattern を override 可能です
+- 設計 PR 対応 Reviewer エージェント（#20 連携）は本 Issue 範囲外のため未実装です
+
 ### ⚠️ merge 後の再配置が必要
 
 Phase A と同様、watcher 関連ファイルを変更する PR を merge しただけでは
-`$HOME/bin/issue-watcher.sh` および `$HOME/bin/iteration-prompt.tmpl` は古いままです。
+`$HOME/bin/issue-watcher.sh` および `$HOME/bin/iteration-prompt.tmpl` /
+`$HOME/bin/iteration-prompt-design.tmpl`（#35 設計 PR 拡張用）は古いままです。
 反映するには:
 
 ```bash
-# 推奨: install.sh の --local 再実行（iteration-prompt.tmpl も同期される）
+# 推奨: install.sh の --local 再実行（*.tmpl はワイルドカードで一括同期される）
 cd ~/.idd-claude && git pull && ./install.sh --local
 ```
 

--- a/docs/specs/35-feat-watcher-needs-iteration-pr-spec-hea/impl-notes.md
+++ b/docs/specs/35-feat-watcher-needs-iteration-pr-spec-hea/impl-notes.md
@@ -1,0 +1,333 @@
+# 実装ノート: #35 feat(watcher) needs-iteration を設計 PR にも対応
+
+## 実施した変更の要約
+
+| Task | コミット | 主な変更ファイル |
+|------|---------|---------------|
+| 1.1 | `c71491a feat(watcher): add design PR iteration prompt template` | `local-watcher/bin/iteration-prompt-design.tmpl` (新規) |
+| 2.1 | `688bb1f docs(install): note iteration-prompt-design.tmpl auto-placement` | `install.sh`（コメントのみ） |
+| 3.1 | `fda2333 feat(watcher): add design PR iteration config + tighten impl head pattern` | `local-watcher/bin/issue-watcher.sh`（Config + 前提チェック） |
+| 3.2 | `06df887 feat(watcher): add pi_classify_pr_kind / pi_select_template / pi_finalize_labels_design` | `local-watcher/bin/issue-watcher.sh`（3 関数追加） |
+| 3.3 | `69c3652 refactor(watcher): make pi_run_iteration kind-aware (design / impl)` | `local-watcher/bin/issue-watcher.sh`（runner リファクタ） |
+| 3.4 | `6c1a705 feat(watcher): extend candidate fetcher and summary with design / impl breakdown` | `local-watcher/bin/issue-watcher.sh`（candidate filter + summary） |
+| 4 | `bc8b317 docs(claude): document design PR iteration responsibilities` | `repo-template/CLAUDE.md` / `repo-template/.claude/agents/project-manager.md` |
+| 5 | `4c11eb8 docs(readme): document design PR iteration extension and head pattern migration` | `README.md` |
+
+## 各タスクの詳細
+
+### Task 1.1: 設計 PR 用 iteration template の新設
+
+`local-watcher/bin/iteration-prompt-design.tmpl` を新規作成。impl 用 template
+（`iteration-prompt.tmpl`）と awk 注入互換のプレースホルダ
+（`{{REPO}}` / `{{PR_NUMBER}}` 等 14 個）を採用し、内容のみ Architect 役割と spec 書き換え
+許容に書き換えた。
+
+主な差分（impl 用 vs design 用）:
+
+- 役割宣言: Developer → **Architect**
+- 編集許容スコープ: 制約なし → **`{{SPEC_DIR}}` 配下のみ**
+- spec 書き換え条項: 「禁止」→ **「許容」（`docs(specs):` scope を推奨）**
+- 自己レビュー指示: なし → **`.claude/rules/design-review-gate.md` の Mechanical Checks を最大 2 パス**
+- 共通禁止事項（force push / main 直 push / resolve 禁止 / `--resume` 禁止）: 同一基準で記述
+
+### Task 2.1: install.sh / setup.sh の冪等配置動作確認
+
+既存の `copy_glob_to_homebin "*.tmpl"` 経路で `iteration-prompt-design.tmpl` が
+`$HOME/bin/` に自動配置されることを scratch HOME で 2 回連続実行して確認:
+
+- 1 回目: `[INSTALL] NEW       /tmp/.../bin/iteration-prompt-design.tmpl`
+- 2 回目: `[INSTALL] SKIP      /tmp/.../bin/iteration-prompt-design.tmpl (identical to template)`
+
+冪等性確認 OK（NFR 2.1）。`setup.sh` は `install.sh` を `exec` するブートストラッパなので
+変更不要。
+
+`install.sh` のコメントに配置されるテンプレート例として
+`iteration-prompt-design.tmpl (#35 設計 PR 用)` を追記し、メンテナの discoverability を
+改善（コードロジック自体は変更なし）。
+
+### Task 3.1: Config ブロックの拡張
+
+`local-watcher/bin/issue-watcher.sh` の Config ブロック（line 100〜120 付近）に以下を追加:
+
+```bash
+PR_ITERATION_HEAD_PATTERN="${PR_ITERATION_HEAD_PATTERN:-^claude/issue-[0-9]+-impl-}"  # 既定厳格化
+PR_ITERATION_DESIGN_ENABLED="${PR_ITERATION_DESIGN_ENABLED:-false}"
+PR_ITERATION_DESIGN_HEAD_PATTERN="${PR_ITERATION_DESIGN_HEAD_PATTERN:-^claude/issue-[0-9]+-design-}"
+ITERATION_TEMPLATE_DESIGN="${ITERATION_TEMPLATE_DESIGN:-$HOME/bin/iteration-prompt-design.tmpl}"
+```
+
+前提ツールチェック節に「`PR_ITERATION_ENABLED=true` かつ
+`PR_ITERATION_DESIGN_ENABLED=true` のとき `iteration-prompt-design.tmpl` 必須」のチェックを
+追加。
+
+### Task 3.2: 種別判定 / template 選択 / ラベル遷移分岐の 3 関数
+
+| 関数 | 責務 | 戻り値 |
+|------|------|-------|
+| `pi_classify_pr_kind <head_ref>` | branch 名 + env から `design` / `impl` / `none` / `ambiguous` を判定 | stdout に 4 値 |
+| `pi_select_template <kind>` | kind に応じた template path を返す | stdout に path、不在で 1 |
+| `pi_finalize_labels_design <pr_number>` | needs-iteration → awaiting-design-review を原子的遷移 | 0/1 |
+
+ローカルで境界値テスト（impl / design / none / ambiguous / DESIGN_ENABLED on/off /
+旧来 `claude/<slug>` 形式 / 厳格化後の impl 認識）を 11 ケース実施し全 pass を確認。
+
+### Task 3.3: pi_run_iteration の kind-aware 化
+
+`pi_run_iteration` を以下のフローに改修:
+
+1. `pi_classify_pr_kind` で kind 判定（none / ambiguous は skip ログ + return 3）
+2. `pi_select_template` で template path 取得（不在で WARN + return 1）
+3. round counter / 着手表明 / claude 起動は kind 非依存で共有
+4. 成功時の finalize 関数を kind で分岐:
+   - design → `pi_finalize_labels_design` (→ `awaiting-design-review`)
+   - impl → `pi_finalize_labels` (→ `ready-for-review`、既存維持)
+5. ログ書式に `kind=design|impl` を追加
+6. claude 実行ログのファイル名にも `kind` を含める（`pr-iteration-design-12-round2-...`）
+
+`pi_build_iteration_prompt` に template path を引数で渡せるよう拡張。第 4 引数を省略すると
+`$ITERATION_TEMPLATE`（impl 用既定）を使う後方互換を維持。
+
+`process_pr_iteration` の戻り値ハンドリング:
+
+- 0 → success
+- 2 → escalated（kind 共通、上限到達）
+- 3 → skip（kind=none / ambiguous、新設）
+- それ以外 → fail
+
+### Task 3.4: candidate filter + サマリ拡張
+
+`pi_fetch_candidate_prs` の jq filter を:
+
+```jq
+[.[]
+  | select(.isDraft == false)
+  | select((.headRepositoryOwner.login // "") == $owner)
+  | select(
+      (.headRefName | test($impl_pattern))
+      or
+      ($design_enabled == "true" and (.headRefName | test($design_pattern)))
+    )
+]
+```
+
+に変更。`PR_ITERATION_DESIGN_ENABLED=false`（既定）のときは impl pattern のみで絞り込み、
+設計 PR は candidate 段階で完全除外（AC 5.1）。
+
+`process_pr_iteration` のサイクル開始ログに `design_enabled` 値を追加。候補件数ログと
+サマリ行に `(design=N, impl=N, ambiguous=N)` 内訳を追加（NFR 3.1 / 3.2）。
+
+ローカルで jq breakdown / filter のユニットテストを実施し、DESIGN_ENABLED=on/off の両系統で
+期待通り（`design=3 impl=2 / design=0 impl=2`）の集計と filter 結果を得られることを確認。
+
+### Task 4: ドキュメント / エージェントルール更新
+
+- `repo-template/CLAUDE.md`: エージェント連携ルール節に「PR Iteration の責務境界」項目を追加。
+  実装 PR では spec 書き換え禁止 / 設計 PR では `docs/specs/` 配下の書き換え許容 /
+  1 PR = design or impl 混在禁止 / 設計 PR iteration は `PR_ITERATION_DESIGN_ENABLED=true`
+  opt-in が必要、を箇条書きで記述。
+- `repo-template/.claude/agents/project-manager.md`: design-review モード本文の Issue 案内
+  コメントに「`needs-iteration` ラベルでの自動反復」項目を追加。「1 PR = design or impl」
+  独立節を追加。
+
+### Task 5: README 更新
+
+- 「対象 PR の判定」節: `PR_ITERATION_HEAD_PATTERN` 既定厳格化（`^claude/` →
+  `^claude/issue-[0-9]+-impl-`）を強調 quote ブロックで明示。`PR_ITERATION_DESIGN_ENABLED=true`
+  のとき設計 PR pattern もマッチする旨を追加。
+- 「挙動」表に kind 別の遷移先 / ambiguous skip を追加。
+- env var 表に `PR_ITERATION_DESIGN_ENABLED` / `PR_ITERATION_DESIGN_HEAD_PATTERN` /
+  `ITERATION_TEMPLATE_DESIGN` の 3 行を追加。`PR_ITERATION_HEAD_PATTERN` の既定値表記を
+  更新（#35 で既定厳格化 注記）。
+- 新節「設計 PR 拡張 (#35)」: Architect 役割 / 編集スコープ /
+  自己レビューゲート / 成功時 awaiting-design-review 遷移 / opt-in cron 例 /
+  混在禁止 / review-notes.md (#20) との関係を独立節として記述。
+- Migration Note に以下を追加:
+  - `PR_ITERATION_HEAD_PATTERN` 既定値変更の影響範囲と override 救済方法
+    （cron に `PR_ITERATION_HEAD_PATTERN=^claude/` を追加）
+  - deprecation 期間なしの判断（cron 行 1 行追加で旧挙動に戻せるため）
+  - 設計 PR 対応の opt-in 方法
+- merge 後の再配置案内に `iteration-prompt-design.tmpl` を追加。
+
+## スモークテスト結果（Task 6 / DoD Req 7.x）
+
+> 本リポジトリには unit test フレームワークが無いため、static analysis +
+> 候補ゼロ状態の dry run + 関数単位の bash テストで検証。E2E（Req 7.1〜7.4）は
+> watcher を実環境で動かす必要があるため、PR 本文の Test plan に反映する形で
+> リリース時に実施する。
+
+### Static Analysis（全て pass）
+
+```text
+$ shellcheck local-watcher/bin/issue-watcher.sh install.sh setup.sh .github/scripts/*.sh
+（pre-existing SC2012 info 警告 2 件のみ。本変更で増えた警告ゼロ）
+
+$ bash -n local-watcher/bin/issue-watcher.sh && echo OK
+OK
+$ bash -n install.sh && echo OK
+OK
+$ bash -n setup.sh && echo OK
+OK
+```
+
+### cron-like 最小 PATH での依存解決確認
+
+```text
+$ env -i HOME=$HOME PATH=/usr/bin:/bin bash -c '
+    export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+    for cmd in claude gh jq flock git timeout; do command -v "$cmd"; done'
+/home/hitoshi/.local/bin/claude
+/usr/bin/gh / /usr/bin/jq / /usr/bin/flock / /usr/bin/git / /usr/bin/timeout
+```
+
+### install.sh --dry-run --local（NEW として認識）
+
+```text
+$ bash install.sh --dry-run --local | grep tmpl
+[DRY-RUN] NEW       /home/hitoshi/bin/iteration-prompt-design.tmpl
+[DRY-RUN] SKIP      /home/hitoshi/bin/iteration-prompt.tmpl (identical to template)
+[DRY-RUN] SKIP      /home/hitoshi/bin/triage-prompt.tmpl (identical to template)
+```
+
+### install.sh 冪等性（scratch HOME で 2 回連続実行）
+
+```text
+1 回目: NEW       /tmp/.../bin/iteration-prompt-design.tmpl
+2 回目: SKIP      /tmp/.../bin/iteration-prompt-design.tmpl (identical to template)
+```
+
+NFR 2.1 確認。
+
+### 候補 0 件 dry run（opt-out / opt-in 両系統）
+
+```text
+# Smoke 1: PR_ITERATION_ENABLED=false (opt-out, 既定)
+$ ... PR_ITERATION_ENABLED=false bash issue-watcher.sh
+（pr-iteration: ログ行ゼロ。opt-out gate が機能している = AC 5.1 / NFR 1.1 / 7.4）
+
+# Smoke 2: opt-in 両方 true（gh が fake REPO で空配列を返す）
+$ ... PR_ITERATION_ENABLED=true PR_ITERATION_DESIGN_ENABLED=true bash issue-watcher.sh
+[2026-04-28 15:43:41] pr-iteration: サイクル開始 (max_prs=3, max_rounds=3, model=claude-opus-4-7, design_enabled=true, timeout=60s)
+[2026-04-28 15:43:42] pr-iteration: 対象候補 0 件、処理対象 0 件（内訳: design=0, impl=0, ambiguous=0）
+[2026-04-28 15:43:42] pr-iteration: サマリ: success=0, fail=0, skip=0, escalated=0, overflow=0 (design=0, impl=0)
+```
+
+NFR 3.2 / AC 6.3 を満たしていることを確認（design / impl 内訳がログに出る）。
+
+### Smoke 3: PR_ITERATION_HEAD_PATTERN override（NFR 4.2 / Req 5.3）
+
+```text
+$ ... PR_ITERATION_HEAD_PATTERN='^claude/' bash issue-watcher.sh
+（候補 0 件で正常終了。override が設定値として有効）
+```
+
+bash 内テストで `PR_ITERATION_HEAD_PATTERN=^claude/` のとき:
+- `claude/foo-bar` → `impl`（旧来 branch を救済）
+- `claude/issue-35-design-foo` (DESIGN_ENABLED=true) → `ambiguous`（両 pattern が
+  一致、設計通り skip 扱い）
+
+### Classifier ユニットテスト（11 ケース全 pass）
+
+| 入力 | 期待 | 結果 |
+|------|------|------|
+| `claude/issue-35-design-foo` + DESIGN_ENABLED=true | design | PASS |
+| `claude/issue-35-impl-foo` + DESIGN_ENABLED=true | impl | PASS |
+| `claude/issue-35-impl-foo` + DESIGN_ENABLED=false | impl | PASS |
+| `claude/foo-bar` | none | PASS |
+| `main` | none | PASS |
+| `feature/branch` | none | PASS |
+| `claude/issue-35-design-foo` (HEAD_PATTERN=^claude/, DESIGN_ENABLED=true) | ambiguous | PASS |
+| `claude/issue-35-design-foo` + DESIGN_ENABLED=false | none | PASS |
+| `claude/issue-35-design-foo` + DESIGN_ENABLED unset | none | PASS |
+| `claude/issue-26-impl-feat-pr-needs-iteration` | impl | PASS（既存 impl PR 認識） |
+| `claude/some-old-branch` | none | PASS（旧来命名は除外） |
+
+## DoD 4 シナリオの状況
+
+| シナリオ | 検証可否 | 備考 |
+|---------|---------|------|
+| Req 7.1 設計 PR 成功 | **未実施（要 E2E）** | 実環境で `claude/issue-<N>-design-<slug>` 形式の PR に `needs-iteration` を付けて検証する必要あり。リリース時に実施し PR 本文 Test plan に記録 |
+| Req 7.2 設計 PR 上限到達 | **未実施（要 E2E）** | 同上、`MAX_ROUNDS` まで回す必要あり |
+| Req 7.3 実装 PR リグレッション | **dry run で部分確認** | candidate filter / kind classifier が impl pattern を従来通り認識することは bash テストで確認済み。E2E（commit push まで）はリリース時に実施 |
+| Req 7.4 完全 opt-out | **dry run で確認済み** | `PR_ITERATION_DESIGN_ENABLED=false` で `pr-iteration:` ログ行に design_enabled=false が出る、impl pattern の filter は従来同等。完全 opt-out 経路の機能動作を確認 |
+
+E2E（Req 7.1 / 7.2 / 7.3）は本実装 PR の merge 後、運用ステップとして実施し、結果は
+PR 本文の Test plan セクションに記録する想定（リリース時の DoD 完了条件）。
+
+## 確認事項（PR 本文「確認事項」候補）
+
+`design.md` の Open Questions / 確認事項に列挙されていた論点はすべて design 段階で
+Architect が判断確定しており、実装側で再確認すべき論点は以下のみ:
+
+- **AC 2.6 のハード enforce**: design.md は「Claude の指示遵守に任せる」を採用済み。
+  本実装でも同方針で template 内で明示するに留め、watcher 側で `git diff --name-only` を
+  ハード enforce する追加実装は行っていない。reviewer がハード enforce を必要とする場合は
+  別 Issue 化して扱う想定。
+
+design.md / requirements.md への矛盾や疑問は発見されず、書き換え不要。
+
+## 既存テストへの影響
+
+- 本リポジトリには unit test フレームワークが無いため、テストの追加 / 削除なし。
+- shellcheck / actionlint / bash -n は本変更で警告増加なし。
+- 既存スモークテスト経路（候補 0 件 dry run）は引き続き正常終了。
+
+## 後方互換性まとめ（NFR 1.1 / 1.2 / 1.3 / 4.6）
+
+- 既存 env var（`PR_ITERATION_ENABLED`, `PR_ITERATION_DEV_MODEL`,
+  `PR_ITERATION_MAX_TURNS`, `PR_ITERATION_MAX_PRS`, `PR_ITERATION_MAX_ROUNDS`,
+  `PR_ITERATION_GIT_TIMEOUT`, `ITERATION_TEMPLATE`）の名前・意味は不変
+- 既定値変更は `PR_ITERATION_HEAD_PATTERN` のみ（`^claude/` → `^claude/issue-[0-9]+-impl-`）。
+  override で旧挙動に戻せる経路は残しているため、影響を受ける運用者は cron 行 1 行追加で復旧可能
+- 既存ラベル名・lock / log / exit code は完全不変
+- cron / launchd 登録文字列は変更不要（既存設定のまま `install.sh --local` を再実行するだけで
+  本変更が反映される）
+- `PR_ITERATION_DESIGN_ENABLED=false`（既定）かつ `PR_ITERATION_HEAD_PATTERN` を override
+  しない既存ユーザーは、impl PR の検知範囲・ラベル遷移・ログ書式が #26 導入時とほぼ同一
+  （差分: サマリ行に `(design=0, impl=N)` 内訳が末尾追加。grep 互換性あり）
+
+## requirement numeric ID とテストカバレッジの対応
+
+| Req ID | カバレッジ手段 |
+|--------|--------------|
+| 1.1 | classifier ユニット (design pattern + enabled → design) |
+| 1.2 | classifier ユニット (impl pattern → impl) |
+| 1.3 | classifier ユニット (neither → none) |
+| 1.4 | classifier ユニット (両方一致 → ambiguous) |
+| 1.5 | 既存 #26 のフィルタ（fork / draft / failed / rebase）はコード上未変更で温存 |
+| 2.1 | template 新規ファイル存在 + dry run NEW 確認 |
+| 2.2 | install.sh dry run + scratch HOME 冪等性確認 |
+| 2.3〜2.7 | template 内に Architect 役割 / 編集スコープ / 禁止事項を inline 記述（コードレビューで確認） |
+| 3.1 | `pi_finalize_labels_design` 関数追加 + コードレビュー |
+| 3.2 | 既存 `pi_finalize_labels` を温存（コードレビュー） |
+| 3.3 | コードレビュー（`pi_run_iteration` の失敗時パス） |
+| 3.4 | コードレビュー（`pi_escalate_to_failed` を kind 共通で呼ぶ） |
+| 3.5 | `idd-claude-labels.sh` を確認、4 ラベル全て既存（変更なし） |
+| 4.1〜4.3 | Config ブロックの env var 既定値（コードレビュー + bash 内テスト） |
+| 4.4 | classifier ユニット (design pattern + DESIGN_ENABLED=false → none) |
+| 4.5 | コードレビュー（`process_pr_iteration` の opt-in gate） |
+| 4.6 | コードレビュー（既存 env var の名前・既定値が不変） |
+| 5.1 | smoke test（DESIGN_ENABLED=false で `pr-iteration:` ログゼロ） |
+| 5.2 | classifier ユニット (`claude/issue-26-impl-...` が impl と認識される) |
+| 5.3 | bash 内テスト（HEAD_PATTERN=^claude/ override で旧 branch を救済可能） + README 記載 |
+| 5.4〜5.7 | repo-template / README のコードレビュー |
+| 6.1 | コードレビュー（`pi_post_processing_marker` 共有） |
+| 6.2 | コードレビュー（既存 prefix `pr-iteration:` と timestamp 書式維持） |
+| 6.3 | smoke test ログに `kind=` / `round=` / `action=` が出ることを目視確認可能（実 iteration 実行時） |
+| 6.4 | コードレビュー（`pi_escalate_to_failed` を kind 共通で呼ぶ） |
+| 6.5 | コードレビュー（hidden marker は kind 引数を含まない、`pi_read_round_counter` 共有） |
+| 7.1〜7.5 | DoD（リリース時 E2E、PR 本文 Test plan に記録） |
+| NFR 1.1〜1.3 | 既存 env / lock / log / exit code を変更していないことをコードレビューで確認 |
+| NFR 2.1 | scratch HOME 冪等性 smoke test |
+| NFR 2.2 | classifier の純粋関数性（同一入力で同一結果）+ 既存 round counter は不変 |
+| NFR 3.1 / 3.2 | smoke test ログのサマリ / 内訳行を目視確認 |
+| NFR 4.1 | bash 内テスト（cron / shell から DESIGN_ENABLED override 可能） |
+| NFR 4.2 | bash 内テスト（HEAD_PATTERN を override で旧 `^claude/` に戻せる） |
+
+## 派生タスクとして切り出すべき項目
+
+- **設計 PR iteration 用 Reviewer エージェント連携**: 本 Issue は impl 系限定で据え置き。
+  将来的に設計 PR にも独立 review-notes.md を導入する場合は別 Issue 化（design.md にも明記）
+- **AC 2.6 のハード enforce**: 現状 Claude の指示遵守に依存。`git diff --name-only` で
+  scope 外編集を検知して自動 revert する実装が必要なら別 Issue 化
+- **設計 PR / 実装 PR で round counter を別離する仕組み**: 本 Issue では共有のまま運用。
+  混在 PR は `ambiguous` で skip するため運用上は破綻しない

--- a/install.sh
+++ b/install.sh
@@ -494,6 +494,8 @@ if $INSTALL_LOCAL; then
 
   # local-watcher/bin/ 配下の *.sh / *.tmpl をワイルドカードで一括配置。
   # 新規 *.tmpl / *.sh が追加された場合に install.sh を書き換えなくて済む。
+  # 配置されるテンプレート例: triage-prompt.tmpl / iteration-prompt.tmpl /
+  #   iteration-prompt-design.tmpl（#35 設計 PR 用）
   copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.sh"   "$HOME/bin" --executable
   copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.tmpl" "$HOME/bin"
 

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -928,15 +928,17 @@ EOF
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# pi_build_iteration_prompt: iteration-prompt.tmpl に変数を注入
-#   入力: $1=pr_number, $2=pr_json, $3=round
+# pi_build_iteration_prompt: 指定 template に変数を注入
+#   入力: $1=pr_number, $2=pr_json, $3=round, $4=template_path（省略時は impl 用既定）
 #   出力: stdout に prompt 文字列
-#   AC 3.1, 3.2, 3.3, 3.4, 3.5
+#   AC 3.1, 3.2, 3.3, 3.4, 3.5（#26）/ #35 で kind 引数の代わりに template path を受け取る
 # ─────────────────────────────────────────────────────────────────────────────
 pi_build_iteration_prompt() {
   local pr_number="$1"
   local pr_json="$2"
   local round="$3"
+  # #35: template path を呼び出し元から渡す。省略時は impl 用 template を使う（後方互換）。
+  local tmpl_path="${4:-$ITERATION_TEMPLATE}"
 
   local pr_title pr_url head_ref base_ref pr_body
   pr_title=$(echo "$pr_json" | jq -r '.title // ""')
@@ -1003,7 +1005,6 @@ pi_build_iteration_prompt() {
   # 複数行値（LINE_COMMENTS_JSON / GENERAL_COMMENTS_JSON / PR_DIFF / REQUIREMENTS_MD）は
   # awk -v では改行を扱えないため、export 経由で ENVIRON[] から取得し、
   # 「行全体が {{KEY}} のみ」のテンプレ行をブロックごと置換する（template はその前提で書かれている）。
-  local tmpl_path="$ITERATION_TEMPLATE"
   if [ ! -f "$tmpl_path" ]; then
     pi_warn "template not found: $tmpl_path"
     return 1
@@ -1064,8 +1065,10 @@ pi_build_iteration_prompt() {
 # ─────────────────────────────────────────────────────────────────────────────
 # pi_run_iteration: 1 PR 分の iteration を実行（fresh context Claude 起動）
 #   入力: $1=pr_json
-#   戻り値: 0=success(commit+push or reply-only), 1=failure, 2=skipped(round上限到達等)
-#   AC 3.6, 4.x, 5.x, 6.2, 6.3, 7.x, 8.3, 9.2, NFR 1.1, NFR 1.3
+#   戻り値: 0=success(commit+push or reply-only), 1=failure, 2=escalated(round上限到達),
+#           3=skip (kind=none/ambiguous, #35)
+#   AC 3.6, 4.x, 5.x, 6.2, 6.3, 7.x, 8.3, 9.2, NFR 1.1, NFR 1.3 (#26)
+#   #35: kind 判定で design / impl を分岐し、template と finalize 関数を切り替える
 # ─────────────────────────────────────────────────────────────────────────────
 pi_run_iteration() {
   local pr_json="$1"
@@ -1075,25 +1078,52 @@ pi_run_iteration() {
   base_ref=$(echo "$pr_json"  | jq -r '.baseRefName')
   pr_url=$(echo "$pr_json"    | jq -r '.url')
 
+  # #35 AC 1.1〜1.4 / 4.4: kind 判定（design / impl / none / ambiguous）
+  local kind
+  kind=$(pi_classify_pr_kind "$head_ref")
+
+  case "$kind" in
+    none)
+      pi_log "PR #${pr_number}: kind=none head=${head_ref} (does not match design/impl pattern), skip"
+      return 3
+      ;;
+    ambiguous)
+      pi_warn "PR #${pr_number}: kind=ambiguous head=${head_ref} (matches both design and impl pattern), skip"
+      return 3
+      ;;
+    design|impl) : ;;
+    *)
+      pi_warn "PR #${pr_number}: kind=${kind} (unknown), skip"
+      return 3
+      ;;
+  esac
+
+  # #35 AC 2.x: kind に応じた template path を取得
+  local tmpl_path
+  if ! tmpl_path=$(pi_select_template "$kind"); then
+    pi_warn "PR #${pr_number}: kind=${kind} 用 template が取得できず iteration 中止"
+    return 1
+  fi
+
   local round
   round=$(pi_read_round_counter "$pr_number")
 
-  # AC 7.2: 上限到達なら escalate
+  # AC 7.2 (#26): 上限到達なら escalate（kind 共通、#35 AC 3.4 / 6.5）
   if [ "$round" -ge "$PR_ITERATION_MAX_ROUNDS" ]; then
-    pi_log "PR #${pr_number}: round=${round} >= max=${PR_ITERATION_MAX_ROUNDS}, claude-failed に昇格"
+    pi_log "PR #${pr_number}: kind=${kind} round=${round} >= max=${PR_ITERATION_MAX_ROUNDS}, claude-failed に昇格"
     pi_escalate_to_failed "$pr_number" "$round" "$PR_ITERATION_MAX_ROUNDS" || true
     return 2
   fi
 
   local next_round=$((round + 1))
 
-  # AC 6.1: 着手表明（marker 更新 + コメント）
+  # AC 6.1: 着手表明（marker 更新 + コメント、kind 非依存、#35 AC 6.1 / 6.5）
   if ! pi_post_processing_marker "$pr_number" "$next_round"; then
-    pi_warn "PR #${pr_number}: 着手表明に失敗、iteration 中止"
+    pi_warn "PR #${pr_number}: kind=${kind} 着手表明に失敗、iteration 中止"
     return 1
   fi
 
-  pi_log "PR #${pr_number}: round=${next_round}/${PR_ITERATION_MAX_ROUNDS} 着手 (${pr_url})"
+  pi_log "PR #${pr_number}: kind=${kind} round=${next_round}/${PR_ITERATION_MAX_ROUNDS} 着手 (${pr_url})"
 
   # サブシェル + trap で必ず main に戻す（AC 8.3）
   local rc=0
@@ -1112,9 +1142,9 @@ pi_run_iteration() {
       exit 1
     fi
 
-    # prompt を生成
+    # prompt を生成（#35: kind に応じた template path を渡す）
     local prompt
-    if ! prompt=$(pi_build_iteration_prompt "$pr_number" "$pr_json" "$next_round"); then
+    if ! prompt=$(pi_build_iteration_prompt "$pr_number" "$pr_json" "$next_round" "$tmpl_path"); then
       pi_warn "PR #${pr_number}: prompt 組み立てに失敗"
       exit 1
     fi
@@ -1122,7 +1152,7 @@ pi_run_iteration() {
     # AC 3.6: fresh context で起動（--resume / --continue は使わない）
     # NFR 1.1: --max-turns で turn 数上限
     local pi_log_file
-    pi_log_file="$LOG_DIR/pr-iteration-${pr_number}-round${next_round}-$(date +%Y%m%d-%H%M%S).log"
+    pi_log_file="$LOG_DIR/pr-iteration-${kind}-${pr_number}-round${next_round}-$(date +%Y%m%d-%H%M%S).log"
     if ! claude \
         --print "$prompt" \
         --model "$PR_ITERATION_DEV_MODEL" \
@@ -1131,10 +1161,10 @@ pi_run_iteration() {
         --output-format stream-json \
         --verbose \
         >> "$pi_log_file" 2>&1; then
-      pi_warn "PR #${pr_number}: Claude 実行が失敗 (log: ${pi_log_file})"
+      pi_warn "PR #${pr_number}: kind=${kind} Claude 実行が失敗 (log: ${pi_log_file})"
       exit 1
     fi
-    pi_log "PR #${pr_number}: Claude 実行完了 (log: ${pi_log_file})"
+    pi_log "PR #${pr_number}: kind=${kind} Claude 実行完了 (log: ${pi_log_file})"
     exit 0
   )
   rc=$?
@@ -1142,17 +1172,30 @@ pi_run_iteration() {
   git checkout main >/dev/null 2>&1 || true
 
   if [ $rc -eq 0 ]; then
-    # AC 6.2: 成功 → ラベル遷移
-    if pi_finalize_labels "$pr_number"; then
-      pi_log "PR #${pr_number}: round=${next_round} action=success (needs-iteration -> ready-for-review)"
+    # AC 6.2 (#26) / #35 AC 3.1 / 3.2: kind に応じたラベル遷移
+    local finalize_ok=false
+    case "$kind" in
+      design)
+        if pi_finalize_labels_design "$pr_number"; then
+          pi_log "PR #${pr_number}: kind=${kind} round=${next_round} action=success (needs-iteration -> awaiting-design-review)"
+          finalize_ok=true
+        fi
+        ;;
+      impl)
+        if pi_finalize_labels "$pr_number"; then
+          pi_log "PR #${pr_number}: kind=${kind} round=${next_round} action=success (needs-iteration -> ready-for-review)"
+          finalize_ok=true
+        fi
+        ;;
+    esac
+    if [ "$finalize_ok" = "true" ]; then
       return 0
-    else
-      pi_warn "PR #${pr_number}: ラベル遷移失敗、needs-iteration を残置"
-      return 1
     fi
+    pi_warn "PR #${pr_number}: kind=${kind} ラベル遷移失敗、needs-iteration を残置"
+    return 1
   else
-    # AC 6.3: 失敗 → needs-iteration を残し WARN
-    pi_log "PR #${pr_number}: round=${next_round} action=fail (needs-iteration を残置)"
+    # AC 6.3 (#26) / #35 AC 3.3: 失敗 → needs-iteration を残し WARN
+    pi_log "PR #${pr_number}: kind=${kind} round=${next_round} action=fail (needs-iteration を残置)"
     return 1
   fi
 }

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -688,13 +688,22 @@ pi_fetch_candidate_prs() {
   fi
 
   # AC 1.2 / 1.3 / 1.4: クライアント側フィルタ（server filter の保険 + head pattern + fork 除外）
+  # #35 AC 4.4 / 5.1: design pattern は PR_ITERATION_DESIGN_ENABLED=true のときのみ OR 条件に
+  # 含める。false（既定）なら impl pattern のみで絞り込み、設計 PR は candidate 段階で除外される
+  # （= 本機能導入前と完全同一の挙動）。
   echo "$prs_json" | jq \
-    --arg pattern "$PR_ITERATION_HEAD_PATTERN" \
+    --arg impl_pattern "$PR_ITERATION_HEAD_PATTERN" \
+    --arg design_pattern "$PR_ITERATION_DESIGN_HEAD_PATTERN" \
+    --arg design_enabled "$PR_ITERATION_DESIGN_ENABLED" \
     --arg owner "$repo_owner" \
     '[.[]
       | select(.isDraft == false)
-      | select(.headRefName | test($pattern))
       | select((.headRepositoryOwner.login // "") == $owner)
+      | select(
+          (.headRefName | test($impl_pattern))
+          or
+          ($design_enabled == "true" and (.headRefName | test($design_pattern)))
+        )
     ]'
 }
 
@@ -1216,25 +1225,55 @@ process_pr_iteration() {
     return 0
   fi
 
-  pi_log "サイクル開始 (max_prs=${PR_ITERATION_MAX_PRS}, max_rounds=${PR_ITERATION_MAX_ROUNDS}, model=${PR_ITERATION_DEV_MODEL}, timeout=${PR_ITERATION_GIT_TIMEOUT}s)"
+  pi_log "サイクル開始 (max_prs=${PR_ITERATION_MAX_PRS}, max_rounds=${PR_ITERATION_MAX_ROUNDS}, model=${PR_ITERATION_DEV_MODEL}, design_enabled=${PR_ITERATION_DESIGN_ENABLED}, timeout=${PR_ITERATION_GIT_TIMEOUT}s)"
 
   local prs_json
   prs_json=$(pi_fetch_candidate_prs)
   local total
   total=$(echo "$prs_json" | jq 'length')
+
+  # #35 NFR 3.2: 候補 PR の design / impl 内訳をログに記録（kind=ambiguous も含む）。
+  # candidate 段階では impl pattern OR (DESIGN_ENABLED=true AND design pattern) で絞られる
+  # ため、ここでは bash 側で同じ正規表現照合を行って breakdown を出す。
+  local design_count=0
+  local impl_count=0
+  local ambiguous_count=0
+  if [ "$total" -gt 0 ]; then
+    local breakdown
+    breakdown=$(echo "$prs_json" | jq -r \
+      --arg impl_pattern "$PR_ITERATION_HEAD_PATTERN" \
+      --arg design_pattern "$PR_ITERATION_DESIGN_HEAD_PATTERN" \
+      --arg design_enabled "$PR_ITERATION_DESIGN_ENABLED" \
+      '[.[] | .headRefName] as $heads
+       | reduce $heads[] as $h ({"design":0, "impl":0, "ambiguous":0};
+           if ($h | test($impl_pattern)) and ($h | test($design_pattern))
+             then .ambiguous += 1
+           elif ($h | test($design_pattern)) and ($design_enabled == "true")
+             then .design += 1
+           elif ($h | test($impl_pattern))
+             then .impl += 1
+           else . end)
+       | "\(.design) \(.impl) \(.ambiguous)"')
+    # shellcheck disable=SC2086
+    set -- $breakdown
+    design_count="${1:-0}"
+    impl_count="${2:-0}"
+    ambiguous_count="${3:-0}"
+  fi
+
   local target_count="$total"
   local skipped_overflow=0
 
   if [ "$total" -gt "$PR_ITERATION_MAX_PRS" ]; then
     target_count="$PR_ITERATION_MAX_PRS"
     skipped_overflow=$((total - PR_ITERATION_MAX_PRS))
-    pi_log "対象候補 ${total} 件中、上限 ${PR_ITERATION_MAX_PRS} 件のみ処理（${skipped_overflow} 件は次回持ち越し）"
+    pi_log "対象候補 ${total} 件中、上限 ${PR_ITERATION_MAX_PRS} 件のみ処理（${skipped_overflow} 件は次回持ち越し、内訳: design=${design_count}, impl=${impl_count}, ambiguous=${ambiguous_count}）"
   else
-    pi_log "対象候補 ${total} 件、処理対象 ${target_count} 件"
+    pi_log "対象候補 ${total} 件、処理対象 ${target_count} 件（内訳: design=${design_count}, impl=${impl_count}, ambiguous=${ambiguous_count}）"
   fi
 
   if [ "$target_count" -eq 0 ]; then
-    pi_log "サマリ: success=0, fail=0, skip=0, escalated=0, overflow=${skipped_overflow}"
+    pi_log "サマリ: success=0, fail=0, skip=0, escalated=0, overflow=${skipped_overflow} (design=0, impl=0)"
     return 0
   fi
 
@@ -1247,7 +1286,7 @@ process_pr_iteration() {
   pr_iter=$(echo "$prs_json" | jq -c ".[0:${target_count}][]")
 
   if [ -z "$pr_iter" ]; then
-    pi_log "サマリ: success=0, fail=0, skip=0, escalated=0, overflow=${skipped_overflow}"
+    pi_log "サマリ: success=0, fail=0, skip=0, escalated=0, overflow=${skipped_overflow} (design=0, impl=0)"
     return 0
   fi
 
@@ -1257,13 +1296,15 @@ process_pr_iteration() {
     case $rc in
       0)  success=$((success + 1)) ;;
       2)  escalated=$((escalated + 1)) ;;
+      3)  skip=$((skip + 1)) ;;       # #35: kind=none / ambiguous は skip としてカウント
       *)  fail=$((fail + 1)) ;;
     esac
     # 各 PR 処理後に保険で main に戻す
     git checkout main >/dev/null 2>&1 || true
   done <<< "$pr_iter"
 
-  pi_log "サマリ: success=${success}, fail=${fail}, skip=${skip}, escalated=${escalated}, overflow=${skipped_overflow}"
+  # #35 NFR 3.1 / 3.2: サマリにも design / impl 内訳を出して grep 集計可能にする
+  pi_log "サマリ: success=${success}, fail=${fail}, skip=${skip}, escalated=${escalated}, overflow=${skipped_overflow} (design=${design_count}, impl=${impl_count})"
 
   # 念のため最終確認で main に戻す
   git checkout main >/dev/null 2>&1 || true

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -789,6 +789,93 @@ pi_finalize_labels() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# pi_finalize_labels_design: 設計 PR 用のラベル遷移（#35 AC 3.1）
+#   needs-iteration 除去 + awaiting-design-review 付与を 1 コマンドで原子的に発行
+# ─────────────────────────────────────────────────────────────────────────────
+pi_finalize_labels_design() {
+  local pr_number="$1"
+  if ! timeout "$PR_ITERATION_GIT_TIMEOUT" gh pr edit "$pr_number" --repo "$REPO" \
+      --remove-label "$LABEL_NEEDS_ITERATION" \
+      --add-label "$LABEL_AWAITING_DESIGN" >/dev/null 2>&1; then
+    pi_warn "PR #${pr_number}: ラベル遷移 (needs-iteration -> awaiting-design-review) に失敗"
+    return 1
+  fi
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pi_classify_pr_kind: branch 名 + env vars から PR の iteration 種別を判定
+#   入力: $1 = head_ref
+#   出力: stdout に "design" / "impl" / "none" / "ambiguous" のいずれか
+#   返り値: 0
+#
+#   優先順序（#35 AC 1.1〜1.4 / 4.4）:
+#     1. impl pattern と design pattern の両方に合致 → ambiguous
+#     2. design pattern のみ合致 + DESIGN_ENABLED=true → design
+#     3. design pattern のみ合致 + DESIGN_ENABLED!=true → none（opt-out gate）
+#     4. impl pattern のみ合致 → impl
+#     5. どちらにも合致しない → none
+#
+#   副作用なし（純粋関数）。同一入力に対して同一結果。
+# ─────────────────────────────────────────────────────────────────────────────
+pi_classify_pr_kind() {
+  local head_ref="$1"
+  local matches_impl=false
+  local matches_design=false
+
+  if [[ "$head_ref" =~ $PR_ITERATION_HEAD_PATTERN ]]; then
+    matches_impl=true
+  fi
+  if [[ "$head_ref" =~ $PR_ITERATION_DESIGN_HEAD_PATTERN ]]; then
+    matches_design=true
+  fi
+
+  if [ "$matches_impl" = "true" ] && [ "$matches_design" = "true" ]; then
+    echo "ambiguous"
+    return 0
+  fi
+  if [ "$matches_design" = "true" ]; then
+    if [ "$PR_ITERATION_DESIGN_ENABLED" = "true" ]; then
+      echo "design"
+    else
+      echo "none"
+    fi
+    return 0
+  fi
+  if [ "$matches_impl" = "true" ]; then
+    echo "impl"
+    return 0
+  fi
+  echo "none"
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pi_select_template: kind から prompt template ファイルパスを返す（#35 AC 2.x）
+#   入力: $1 = kind ("design" / "impl")
+#   出力: stdout に template ファイルパス
+#   返り値: 0=ok, 1=template 未配置（呼び出し元で iteration を中断）
+# ─────────────────────────────────────────────────────────────────────────────
+pi_select_template() {
+  local kind="$1"
+  local path=""
+  case "$kind" in
+    design) path="$ITERATION_TEMPLATE_DESIGN" ;;
+    impl)   path="$ITERATION_TEMPLATE" ;;
+    *)
+      pi_warn "pi_select_template: 未知の kind=${kind}"
+      return 1
+      ;;
+  esac
+  if [ ! -f "$path" ]; then
+    pi_warn "pi_select_template: template not found for kind=${kind}: ${path}"
+    return 1
+  fi
+  echo "$path"
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # pi_escalate_to_failed: 上限到達時の claude-failed 昇格 + エスカレコメント
 #   入力: $1=pr_number, $2=round, $3=max_rounds
 #   AC 7.2, 7.3

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -95,13 +95,27 @@ PR_ITERATION_MAX_TURNS="${PR_ITERATION_MAX_TURNS:-60}"
 PR_ITERATION_MAX_PRS="${PR_ITERATION_MAX_PRS:-3}"
 # 1 PR あたりの累計 iteration 上限。到達時は claude-failed に昇格（AC 7.2）。
 PR_ITERATION_MAX_ROUNDS="${PR_ITERATION_MAX_ROUNDS:-3}"
-# 自動 iteration を許可する head ref のプレフィックス正規表現。
-# 人間が手書きした PR や fork PR を巻き込まないよう既定 `^claude/`（AC 1.2）。
-PR_ITERATION_HEAD_PATTERN="${PR_ITERATION_HEAD_PATTERN:-^claude/}"
+# 自動 iteration を許可する head ref のプレフィックス正規表現（impl PR 用）。
+# 既定値は #35 で `^claude/` から `^claude/issue-[0-9]+-impl-` に厳格化された。
+# 旧 `^claude/` 挙動に戻したい場合は cron / launchd 側で本変数を override すること
+# （Migration Note は README 参照、AC 4.3 / 5.5 / NFR 4.2）。
+PR_ITERATION_HEAD_PATTERN="${PR_ITERATION_HEAD_PATTERN:-^claude/issue-[0-9]+-impl-}"
 # 各 git / gh 操作の個別タイムアウト（秒、NFR 1.3）。
 PR_ITERATION_GIT_TIMEOUT="${PR_ITERATION_GIT_TIMEOUT:-60}"
-# Iteration プロンプトテンプレートの配置先（install.sh --local が配置）。
+# Iteration プロンプトテンプレートの配置先（install.sh --local が配置、impl PR 用）。
 ITERATION_TEMPLATE="${ITERATION_TEMPLATE:-$HOME/bin/iteration-prompt.tmpl}"
+
+# ─── PR Iteration Processor 設定: 設計 PR 拡張 (#35) ───
+# 設計 PR (`claude/issue-<N>-design-<slug>`) にも `needs-iteration` で反復対応する
+# opt-in フラグ。既定 false で本機能は無効、impl PR の挙動は #26 導入時と完全同一。
+# 有効化するには cron / launchd 側で PR_ITERATION_DESIGN_ENABLED=true を渡す
+# （AC 4.1 / 4.4 / 5.1）。
+PR_ITERATION_DESIGN_ENABLED="${PR_ITERATION_DESIGN_ENABLED:-false}"
+# 設計 PR の head branch pattern（jq の test() 互換 POSIX ERE）。
+# idd-claude PjM テンプレートが作る設計 PR は `claude/issue-<N>-design-<slug>` 形式（AC 4.2）。
+PR_ITERATION_DESIGN_HEAD_PATTERN="${PR_ITERATION_DESIGN_HEAD_PATTERN:-^claude/issue-[0-9]+-design-}"
+# 設計 PR 用 Iteration テンプレートの配置先（install.sh --local が配置）。
+ITERATION_TEMPLATE_DESIGN="${ITERATION_TEMPLATE_DESIGN:-$HOME/bin/iteration-prompt-design.tmpl}"
 
 # ─── Design Review Release Processor 設定 (#40) ───
 # 設計 PR が merge された Issue から `awaiting-design-review` ラベルを自動除去し、
@@ -157,6 +171,15 @@ done
 # 無効化（既定）時は template 未配置でも watcher 全体を起動できるよう、無条件チェックを避ける。
 if [ "$PR_ITERATION_ENABLED" = "true" ] && [ ! -f "$ITERATION_TEMPLATE" ]; then
   echo "Error: Iteration テンプレートが見つかりません: $ITERATION_TEMPLATE" >&2
+  echo "  install.sh --local 再実行で配置されます。" >&2
+  exit 1
+fi
+
+# 設計 PR Iteration が有効化されている時のみ design 用 template を必須化（#35 AC 2.2）。
+if [ "$PR_ITERATION_ENABLED" = "true" ] \
+   && [ "$PR_ITERATION_DESIGN_ENABLED" = "true" ] \
+   && [ ! -f "$ITERATION_TEMPLATE_DESIGN" ]; then
+  echo "Error: 設計 PR 用 Iteration テンプレートが見つかりません: $ITERATION_TEMPLATE_DESIGN" >&2
   echo "  install.sh --local 再実行で配置されます。" >&2
   exit 1
 fi

--- a/local-watcher/bin/iteration-prompt-design.tmpl
+++ b/local-watcher/bin/iteration-prompt-design.tmpl
@@ -1,0 +1,145 @@
+# =============================================================================
+# idd-claude PR Iteration Mode (design) prompt template (#35)
+#
+# 用途: `needs-iteration` ラベル付き **設計 PR** を fresh context の Claude で反復対応する
+# 配置先: ~/bin/iteration-prompt-design.tmpl
+#         （issue-watcher.sh が ITERATION_TEMPLATE_DESIGN で参照）
+# 依存  : gh / git / jq（Claude が呼び出す）
+# 関連  : local-watcher/bin/issue-watcher.sh の process_pr_iteration / pi_build_iteration_prompt
+#         repo-template/.claude/agents/architect.md（Architect 役割の参考）
+#
+# 本 template は **設計 PR 専用** です。実装 PR 用の iteration-prompt.tmpl とは別物で、
+# Architect 役割で起動され、`docs/specs/<N>-<slug>/` 配下の spec 群（requirements /
+# design / tasks）の書き換えが許容されます。
+#
+# プレースホルダ（issue-watcher.sh の awk 置換で展開される。impl 用と互換）:
+#   {{PR_NUMBER}}, {{PR_TITLE}}, {{PR_URL}}, {{HEAD_REF}}, {{BASE_REF}},
+#   {{ROUND}}, {{MAX_ROUNDS}}, {{ISSUE_NUMBER}}, {{SPEC_DIR}},
+#   {{LINE_COMMENTS_JSON}}, {{GENERAL_COMMENTS_JSON}}, {{PR_DIFF}},
+#   {{REQUIREMENTS_MD}}, {{REPO}}
+# =============================================================================
+あなたは idd-claude の **PR Iteration Mode (design)** で起動された Architect エージェントです。
+以下の **設計 PR** のレビューコメントに 1 round で対応し、必要なら spec 群（requirements /
+design / tasks）の修正 commit を head branch に push して、各レビュースレッドに返信してください。
+
+## 対象 PR
+
+- Repo  : {{REPO}}
+- Number: #{{PR_NUMBER}}
+- Title : {{PR_TITLE}}
+- URL   : {{PR_URL}}
+- Head  : {{HEAD_REF}}  ← このブランチに watcher が checkout 済み
+- Base  : {{BASE_REF}}
+- Iteration: round {{ROUND}} / {{MAX_ROUNDS}}
+
+## 関連 Issue（存在する場合のみ）
+
+- Issue #{{ISSUE_NUMBER}}
+- Spec dir: {{SPEC_DIR}}
+- requirements.md は本プロンプト末尾に添付（添付がない場合は spec が無い PR）
+
+## 最新 review の line コメント（JSON 配列）
+
+各要素のスキーマ: `{ id, path, line, user, body }`
+
+```json
+{{LINE_COMMENTS_JSON}}
+```
+
+## @claude mention 付き general コメント（JSON 配列）
+
+各要素のスキーマ: `{ id, user, body, url }`
+
+```json
+{{GENERAL_COMMENTS_JSON}}
+```
+
+## 現在の diff（base..head）
+
+```diff
+{{PR_DIFF}}
+```
+
+## requirements.md（関連 Issue がある場合のみ）
+
+```markdown
+{{REQUIREMENTS_MD}}
+```
+
+---
+
+## あなたの責務（Architect 役割、design PR 用、厳守）
+
+1. **head branch を origin と同期**:
+   - `git fetch origin {{HEAD_REF}}`
+   - `git merge --ff-only origin/{{HEAD_REF}}`
+   - **fast-forward が失敗したら作業を中止して `exit 1`**（後続 PR 処理を止めない）
+2. **各 line コメント / general コメントを精読**し、設計に取り込む価値のある指摘は spec 群を更新する
+   - 編集許容スコープ: **`{{SPEC_DIR}}` 配下のみ**（つまり `docs/specs/<N>-<slug>/` の中だけ）
+   - 編集してよい主なファイル: `requirements.md` / `design.md` / `tasks.md`
+   - **設計 PR では spec 群の書き換えが許容されます**（実装 PR の iteration とはここが異なる）
+   - `requirements.md` の整合修正は **軽微なもの（typo / 文言整合 / AC 1 つの言い換え）に限定**
+   - 大規模な要件再編が必要と判断した場合は commit せず、返信本文で「要件大規模再編が必要 → 別 Issue
+     として PM に差し戻し推奨」と明記する
+3. **修正確定前に design-review-gate の自己レビュー**を最大 2 パスで実行する
+   - 参照: `.claude/rules/design-review-gate.md`
+   - Mechanical Checks（必須）:
+     - **Requirements traceability**: requirements.md の numeric ID（1.1, 2.3 等）が design.md の
+       Requirements Traceability マッピングに全て出現しているか
+     - **File Structure Plan の充填**: 具体的なファイルパスが書かれているか（"TBD" 等のプレースホルダなし）
+     - **orphan component 検出**: design.md Components セクションのコンポーネント名がすべて
+       File Structure Plan の対応ファイルに紐づいているか
+   - 問題が draft 内で閉じるなら修正、最大 2 パスで確定。閉じない場合は当該指摘を「再考が必要」として返信
+4. **修正 commit は通常 commit + 通常 push のみ**
+   - `git push origin HEAD:{{HEAD_REF}}`
+   - **force push は絶対禁止**（`--force` / `--force-with-lease` のいずれも使用しない）
+   - push 失敗時はリトライせず `exit 1` する（リモート先行 = WARN 扱いで次サイクル待ち）
+   - commit メッセージは Conventional Commits に準拠（`docs(specs): ...` を **推奨**、強制ではない）
+5. **line コメントへの返信は同一 review thread に投稿**:
+   ```bash
+   gh api -X POST \
+     "/repos/{{REPO}}/pulls/{{PR_NUMBER}}/comments/<COMMENT_ID>/replies" \
+     -f body="<返信本文>"
+   ```
+   - **1 line comment = 1 reply の 1:1 返信を厳守**（まとめ返信は不可）
+   - 返信本文には「spec のどこを更新したか」または「なぜ取り込まないか」を明記する
+6. **@claude mention 付き general コメントへの返信は同一 PR の一般コメントとして投稿**:
+   ```bash
+   gh pr comment {{PR_NUMBER}} --repo {{REPO}} --body "@<元コメント著者>\n> <引用>\n\n<返信本文>"
+   ```
+   - 引用 quoting で元コメントとリンクすることで、誰の指摘への返信かが明示される
+7. **修正不要時は commit / push を行わず、返信コメントの投稿のみで完了**
+   - すべてのコメントが「対応しない理由の返信」だけで足りるなら、push なしで `exit 0` にする
+8. **返信 API がエラーを返したら WARN として後続コメントの処理は継続**
+   - 全件成功なら `exit 0`、push に失敗したら `exit 1`
+9. **すべての処理が成功したら `exit 0`** で終了する
+
+## 編集許容スコープ違反の取り扱い（重要）
+
+- 設計 PR の iteration では **`{{SPEC_DIR}}` 配下の外側のファイル変更は禁止** です
+- レビュー指摘が「`{{SPEC_DIR}}` 外のファイル（実装コード / watcher / install.sh / README 等）の変更」を
+  要求している場合:
+  1. その変更は **commit せず**、返信本文で「scope 外のため別 Issue 化を推奨」と明記する
+  2. 別 Issue 化が必要な場合は、`gh issue create` を使わず、返信で人間に提案するに留める
+- 誤って scope 外を編集しそうになった場合は、`git restore <path>` で取り消してから commit する
+- 迷ったら **scope 外として扱い、別 Issue 化を推奨**する（安全側に倒す）
+
+## 禁止事項（厳守）
+
+- `git push --force` / `git push --force-with-lease`（force push 全般）
+- `main` ブランチへの直接 push
+- レビュースレッドの resolve / unresolve（`resolveReviewThread` GraphQL も含めて禁止、人間の運用判断を尊重）
+- `{{SPEC_DIR}}` 配下の **外側** のファイル変更（commit せず返信で別 Issue 化を推奨）
+- `requirements.md` の大規模再編（軽微な整合修正のみ許容、大規模再編は別 Issue / 別 PR で扱う）
+- `--resume` / `--continue` / `--session-id` 等で過去セッションを引き継ぐこと（fresh context が前提）
+
+## 補足
+
+- 本プロセスは fresh context で起動されているため、前回 iteration の会話履歴は残っていません
+- 修正の影響範囲は line コメントが指摘する範囲に限定し、無関係な spec 再編は行わないこと
+- 設計 PR では Reviewer エージェント（#20）は起動しません（impl 系限定の現状仕様、本 PR 種別では未実装）
+- review-notes.md は本 iteration では生成しない（Reviewer 連携は将来拡張として README に記載済み）
+- 迷ったときの優先順位:
+  1. **scope 違反を回避**（`{{SPEC_DIR}}` 配下のみ編集）
+  2. **要件整合**（requirements.md と design.md の不整合があれば軽微な範囲で揃える）
+  3. **traceability**（requirements の numeric ID が design / tasks にすべて現れる状態を維持）

--- a/repo-template/.claude/agents/project-manager.md
+++ b/repo-template/.claude/agents/project-manager.md
@@ -33,9 +33,24 @@ Architect の直後に呼ばれます。`docs/specs/<番号>-<slug>/` 配下の 
    >
    > - 問題なければ **merge** してください。merge 後に Issue から `awaiting-design-review` ラベルを外すと、次回のポーリングで Developer が自動起動し、実装 PR が別途作成されます
    > - 修正が必要な場合: PR に直接 commit / suggest-edit / line comment で指摘してください
+   > - **`needs-iteration` ラベルでの自動反復**（idd-claude 側で `PR_ITERATION_DESIGN_ENABLED=true` 有効時）: line コメント / `@claude` mention general コメントを残してから `needs-iteration` ラベルを付与すると、watcher が次サイクルで Architect 役割の iteration を起動し、`docs/specs/<N>-<slug>/` 配下の spec 群を更新する。成功時は `awaiting-design-review` に自動遷移
    > - 設計をやり直したい場合: PR を close し、この Issue から `awaiting-design-review` ラベルを外すと再 Triage されます
    >
    > _注: watcher で `DESIGN_REVIEW_RELEASE_ENABLED=true` を有効化している場合、設計 PR merge 後数分以内に Issue から `awaiting-design-review` が自動除去され、ステータスコメントが投稿されます。手動でのラベル除去は不要です。_
+
+## 1 PR = design or impl のどちらか（混在禁止）
+
+設計 PR と実装 PR は **必ず別 PR** として扱います。1 PR の中で `docs/specs/<N>-<slug>/`
+配下の spec 編集と実装コードの変更を同居させないでください。
+
+- 設計 PR の branch 名は `claude/issue-<N>-design-<slug>`（idd-claude PjM が自動付与）
+- 実装 PR の branch 名は `claude/issue-<N>-impl-<slug>`（idd-claude PjM が自動付与）
+- watcher の PR Iteration Processor は branch 名で **kind**（design / impl / 対象外）を判定する
+  - 両 pattern に合致する branch は `ambiguous` として skip される
+  - 設計 PR iteration では spec 群を書き換えてよい / 実装 PR iteration では spec 書き換え禁止
+  - ラベル遷移先が分岐する（design → `awaiting-design-review` / impl → `ready-for-review`）
+
+混在 PR は **ラベル遷移の意味が曖昧になる** ため、watcher 側で対象外として扱います。
 
 ## 設計 PR 本文テンプレート
 

--- a/repo-template/CLAUDE.md
+++ b/repo-template/CLAUDE.md
@@ -128,7 +128,12 @@
 - Architect は Triage の `needs_architect: true` 判定時のみ PM と Developer の間に挟まれる
 - Architect が起動した Issue では **設計 PR ゲート**を経由する（設計 PR を merge してから実装 PR が別途作られる）
 - Reviewer は impl / impl-resume の Developer 完了直後に **独立 context** で起動され、reject 時は Developer に最大 1 回だけ自動差し戻し、再 reject では `claude-failed` で人間に委ねる（差し戻しループは Reviewer 最大 2 回 / Developer 最大 2 回で打ち切り）
-- Developer は `design.md` / `tasks.md` を書き換えない（設計 PR で人間レビュー済みのため）。矛盾は PR 本文「確認事項」で指摘する
+- Developer は **実装 PR** で `design.md` / `tasks.md` / `requirements.md` を書き換えない（設計 PR で人間レビュー済みのため）。矛盾は PR 本文「確認事項」で指摘する
+- **PR Iteration（`needs-iteration` ラベル）の責務境界**:
+  - **設計 PR (`claude/issue-<N>-design-<slug>`)** で `needs-iteration` が付いた場合、watcher が次サイクルで Architect 役割の iteration を起動する。`docs/specs/<N>-<slug>/` 配下（`requirements.md` / `design.md` / `tasks.md`）の **書き換えは許容** され、成功時 `awaiting-design-review` に遷移する
+  - **実装 PR (`claude/issue-<N>-impl-<slug>`)** で `needs-iteration` が付いた場合、watcher が次サイクルで Developer 役割の iteration を起動する。`docs/specs/<N>-<slug>/` 配下の **spec 書き換えは禁止** で、矛盾は PR 本文「確認事項」で指摘するに留める。成功時 `ready-for-review` に遷移する
+  - **1 PR = design or impl のどちらか**（混在禁止）。1 PR で spec 編集と実装変更を同居させない（branch 名が両 pattern に合致するケースは watcher が `ambiguous` として skip する）
+  - 設計 PR iteration は idd-claude 側で `PR_ITERATION_DESIGN_ENABLED=true` の opt-in が必要
 - 各エージェントの成果物は `docs/specs/<番号>-<slug>/` 配下に保存する（Kiro / cc-sdd 互換）
   - `requirements.md`（PM）— EARS 形式の AC、numeric 階層 ID
   - `design.md`（Architect、条件付き）— File Structure Plan / Components and Interfaces / Traceability


### PR DESCRIPTION
## 概要

`needs-iteration` ラベルによる PR 自動反復（#26 導入済み）を設計 PR（`claude/issue-<N>-design-<slug>`）にも対応させる拡張。Architect 役割で動作する専用 iteration prompt template を新設し、watcher の種別判定・template 選択・ラベル遷移を kind-aware（`design` / `impl` / `none` / `ambiguous`）に改修した。

あわせて `PR_ITERATION_HEAD_PATTERN` の既定値を `^claude/` から `^claude/issue-[0-9]+-impl-` に厳格化し、旧来の曖昧な branch 名による誤 pickup を防止。設計 PR 拡張は `PR_ITERATION_DESIGN_ENABLED=true` の opt-in で有効化する。

## 対応 Issue

Closes #35

## 関連 PR

- 設計 PR: #48 (merged)

## 実装内容

- (Task 1.1 / Req 2.1–2.7) `local-watcher/bin/iteration-prompt-design.tmpl` を新設。Architect 役割・spec 書き換え許容・設計レビューゲート自己チェックを記述
- (Task 3.1–3.4 / Req 1.x 4.x) `issue-watcher.sh` に `pi_classify_pr_kind` / `pi_select_template` / `pi_finalize_labels_design` の 3 関数を追加し、`pi_run_iteration` を kind-aware に改修
- (Task 3.4 / Req 5.1) `pi_fetch_candidate_prs` の jq filter を拡張。`PR_ITERATION_DESIGN_ENABLED=false`（既定）のとき設計 PR を candidate 段階で完全除外
- (Task 4 / Req 5.4–5.7) `repo-template/CLAUDE.md` / `repo-template/.claude/agents/project-manager.md` にエージェント連携上の PR Iteration 責務境界を追記
- (Task 5) `README.md` に `PR_ITERATION_HEAD_PATTERN` 既定値変更の Migration Note、設計 PR 拡張の独立節、env var 表を更新

## 受入基準チェック

- [x] Req 1.1: `When PR の head_ref が 設計 PR パターンにマッチ かつ DESIGN_ENABLED=true のとき, the Watcher shall その PR を kind=design として選択する` ← classifier ユニット 11 ケース中 design pattern ケース pass
- [x] Req 1.2: `When PR の head_ref が 実装 PR パターンにマッチするとき, the Watcher shall その PR を kind=impl として選択する` ← classifier ユニット pass（既存 `claude/issue-26-impl-...` も認識）
- [x] Req 1.3: `When PR の head_ref がいずれのパターンにもマッチしないとき, the Watcher shall その PR を kind=none として skip する` ← classifier ユニット pass
- [x] Req 1.4: `When PR の head_ref が impl pattern / design pattern の双方にマッチするとき, the Watcher shall その PR を kind=ambiguous として skip する` ← classifier ユニット pass
- [x] Req 4.x: 4 つの env var（`PR_ITERATION_DESIGN_ENABLED` / `PR_ITERATION_DESIGN_HEAD_PATTERN` / `ITERATION_TEMPLATE_DESIGN` / 厳格化 `PR_ITERATION_HEAD_PATTERN`）が Config ブロックに追加・override 可能 ← コードレビュー確認
- [x] Req 5.1: `When PR_ITERATION_DESIGN_ENABLED=false のとき, the Watcher shall 設計 PR を candidate 段階で除外する` ← smoke test（opt-out 系統で `pr-iteration:` ログ行に design_enabled=false）

## テスト結果

```
### Static Analysis（全て pass）
$ shellcheck local-watcher/bin/issue-watcher.sh install.sh setup.sh .github/scripts/*.sh
（pre-existing SC2012 info 警告 2 件のみ。本変更で増えた警告ゼロ）

$ bash -n local-watcher/bin/issue-watcher.sh && echo OK
OK

### install.sh 冪等性（scratch HOME で 2 回連続実行）
1 回目: [INSTALL] NEW       /tmp/.../bin/iteration-prompt-design.tmpl
2 回目: [INSTALL] SKIP      /tmp/.../bin/iteration-prompt-design.tmpl (identical to template)

### Classifier ユニットテスト 11 ケース全 pass
claude/issue-35-design-foo + DESIGN_ENABLED=true → design   PASS
claude/issue-35-impl-foo + DESIGN_ENABLED=true   → impl     PASS
claude/issue-35-impl-foo + DESIGN_ENABLED=false  → impl     PASS
claude/foo-bar                                   → none     PASS
main / feature/branch                            → none     PASS
HEAD_PATTERN=^claude/, DESIGN_ENABLED=true       → ambiguous PASS
claude/issue-35-design-foo + DESIGN_ENABLED=false → none    PASS
claude/issue-26-impl-feat-pr-needs-iteration     → impl     PASS

### jq breakdown ユニットテスト
DESIGN_ENABLED=true:  design=3 impl=2 / filter 後 5 件
DESIGN_ENABLED=false: design=0 impl=2 / filter 後 2 件

### 候補 0 件 dry run（opt-in both true）
pr-iteration: サイクル開始 (max_prs=3, max_rounds=3, model=claude-opus-4-7, design_enabled=true, timeout=60s)
pr-iteration: 対象候補 0 件、処理対象 0 件（内訳: design=0, impl=0, ambiguous=0）
pr-iteration: サマリ: success=0, fail=0, skip=0, escalated=0, overflow=0 (design=0, impl=0)
```

E2E 4 件（Req 7.1: 設計 PR 成功 / 7.2: 設計 PR 上限到達 / 7.3: 実装 PR リグレッション / 7.4: 完全 opt-out）は実環境の watcher 稼働が必要なため、リリース後の手動検証扱いとする。

## 実装上の判断

- **AC 2.6 のハード enforce 不採用**: `git diff --name-only` で spec ディレクトリ外の編集を検知して自動 revert する実装は、design.md の判断通り「Claude の指示遵守に任せる」で留めた。ハード enforce が必要な場合は別 Issue 化を想定
- **round counter の design / impl 共有**: 混在 PR は `ambiguous` で skip するため運用上の破綻を避けられる。別離は将来 Issue 化の候補
- **PR_ITERATION_HEAD_PATTERN 既定値変更**: `^claude/` → `^claude/issue-[0-9]+-impl-`。既存ユーザーは cron 行に `PR_ITERATION_HEAD_PATTERN=^claude/` を追加すれば旧挙動に戻せる（README Migration Note に記載済み）

## 確認事項

- **AC 2.6 ハード enforce の要否**: 現状は template 内の指示に依存。spec ディレクトリ外の編集を watcher 側で機械的に検知・revert する実装が必要と判断する場合は別 Issue での対応を依頼
- **PR_ITERATION_HEAD_PATTERN 既定値変更の影響**: 旧来の `claude/<slug>` 形式 branch を使っている運用者は impl iteration が検知されなくなる（Migration Note に override 方法を記載済み）。この変更の影響範囲がどの程度か確認をお願いしたい

## PR 品質チェック

- [x] すべての受入基準に対応する実装がある（Req 1.x / 2.x / 3.x / 4.x / 5.x / 6.x、E2E 4 件はリリース後）
- [x] `shellcheck` がクリーン（pre-existing 警告 2 件のみ、本変更で増加ゼロ）
- [x] 手動スモークテスト結果を PR 本文 Test plan に記載
- [x] 既存 env var 名 / ラベル / cron 登録文字列の後方互換性を確認（NFR 1.1–1.3）
- [x] README / CLAUDE.md / repo-template を更新済み（Task 4 / 5）
- [x] PR_ITERATION_HEAD_PATTERN 既定値変更の Migration Note を README に追加
- [x] PR 本文に「確認事項」セクションあり

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #35 のコメントを参照してください。