### PR TITLE
fix(#76): override REPO_DIR to slot worktree in _slot_run_issue

### DIFF
--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -3855,6 +3855,12 @@ _slot_run_issue() {
     return 1
   fi
 
+  # Issue #76: slot worktree が REPO_DIR の意味を担う。サブシェル内で上書きするため
+  # parent cron / launchd 側の REPO_DIR には伝播せず、後段の parse_review_result /
+  # stage_checkpoint_* / `git -C "$REPO_DIR"` 系すべてが slot worktree を参照するようになる。
+  # 既存 cron 起動文字列を変更する必要はない。
+  REPO_DIR="$WT"
+
   # ── Worktree を origin/main 最新へ強制リセット ──
   if ! _worktree_reset "$WT"; then
     slot_warn "worktree reset に失敗 (path=$WT)"


### PR DESCRIPTION
Closes #76

## Summary

`_slot_run_issue` のサブシェル冒頭、`cd "\$WT"` の直後に **`REPO_DIR="\$WT"` を 1 行追加**するだけ。Phase C 由来の REPO_DIR 経路バグを修正します。

## 根本原因

Phase C (#16) で `_slot_run_issue` は slot worktree (`\$WT`) に `cd` するものの、**`REPO_DIR` env を上書きしていなかった**。このため:

| 関数 / 箇所 | path 構築 | 参照先 |
|---|---|---|
| `parse_review_result` | `\$REPO_DIR/\$SPEC_DIR_REL/review-notes.md` | **cron REPO_DIR**（slot worktree とは別） |
| `stage_checkpoint_has_impl_notes` | 同上 | 同上 |
| `stage_checkpoint_read_review_result` | 同上 | 同上 |
| `git -C "\$REPO_DIR"` 系 | `\$REPO_DIR` | 同上 |

Reviewer subagent が slot worktree に書いた `review-notes.md` を watcher が cron `REPO_DIR` 配下で `[ -f ]` チェック → false → `parse_review_result` rc=2 → `parse-failed` reason → `claude-failed` ラベル付与。

## 過去のインシデント — すべて本バグが根本原因

| Issue | 一見の原因 | 実際の原因 | 復旧方法 |
|---|---|---|---|
| #52 | RESULT 行を inline backtick で書いていた | （結果的に同じだが parser が path 違いで file 不在判定）| 手動復旧 |
| #55 | – | 同上 | 手動復旧 |
| #63 | RESULT 行フォーマット問題（と当初推定） | **本バグ** | 手動復旧（PR #75） |
| #67 | – | **本バグ** | 手動復旧（PR #73） |
| #68 | – | **本バグ** | 手動復旧（PR #74） |

`#63` の手動復旧過程で **parser を直接 grep して RESULT 行が抽出できることが判明**し、ファイル path 解決のほうが原因と特定。

## 修正内容

```diff
   # サブシェル内で worktree に cd（親には伝播しない、Req 3.5）
   if ! cd "\$WT"; then
     slot_warn "worktree への cd に失敗 (path=\$WT)"
     _slot_mark_failed "worktree-cd" "worktree path への cd に失敗しました: \`\$WT\`"
     return 1
   fi

+  # Issue #76: slot worktree が REPO_DIR の意味を担う。サブシェル内で上書きするため
+  # parent cron / launchd 側の REPO_DIR には伝播せず、後段の parse_review_result /
+  # stage_checkpoint_* / \`git -C "\$REPO_DIR"\` 系すべてが slot worktree を参照するようになる。
+  # 既存 cron 起動文字列を変更する必要はない。
+  REPO_DIR="\$WT"
+
   # ── Worktree を origin/main 最新へ強制リセット ──
```

## Test plan

- [x] `bash -n local-watcher/bin/issue-watcher.sh` — syntax OK
- [x] `shellcheck local-watcher/bin/issue-watcher.sh` — 新規警告 0 件（既存 SC2317 (info) 10 件のみ、ベースラインと同一）
- [x] **手動 path 検証**: cron REPO_DIR 配下に Reviewer の review-notes.md が存在しない一方、slot worktree 配下では `RESULT: approve\n` 末尾独立行が parser-safe であることを確認（#63 復旧過程で実証済）
- [ ] **dogfood (E2E)**: 本 PR merge 後、本リポジトリ自身の watcher で次の Reviewer round=1 が `parse-failed` ではなく approve / reject 判定で正常完走するか観測（**最重要 — 本修正の検証は dogfood が決定的**）
- [ ] **Stage Checkpoint dogfood (E2E)**: `STAGE_CHECKPOINT_ENABLED=true` 下で `impl-notes.md tracked=yes` / `review-notes.md tracked=yes result=approve` が正しくログに出ることを観測

## 後方互換性

- 既存 cron / launchd 起動文字列を変更する必要なし
- 既存 env var 名・意味は不変
- 既存ラベルの意味・遷移契約は不変
- exit code 意味、`LOG_DIR` 出力先は不変
- `PARALLEL_SLOTS=1`（既定）/ 2 以上ともに同一挙動（slot 間で REPO_DIR が干渉しない、サブシェル境界で閉じるため）
- `repo-template/**` には変更なし。consumer repo には**再 install (`./install.sh --local`) で反映**

## 確認事項（PR レビュワーへ）

1. **slot 間干渉なし**: `_slot_run_issue` はサブシェル `( _slot_run_issue ) &` で fork されるため、各 slot の `REPO_DIR` 上書きは互いに独立。parent cron / launchd の `REPO_DIR` も不変。
2. **parent cron の REPO_DIR への影響なし**: `_hook_invoke` は `REPO_DIR="\$REPO_DIR"` で hook 子プロセスへ env を継承するが、本 PR の上書きは `cd "\$WT"` の **後** に置いたため、`_hook_invoke` で継承される `REPO_DIR` は **slot worktree path**（`\$WT`）になる。これは意図通り（hook 側も slot context で動くべき、Req 5.x の hook 仕様に整合）。
3. **`_worktree_reset "\$WT"` への影響なし**: `_worktree_reset` の引数で `\$WT` を直接受け取っているため、`REPO_DIR` 経由しない。挙動は不変。
4. **PR 作成系の挙動への影響なし**: PjM の `gh pr create` は cwd 起点で動くため、cwd が slot worktree のままなら問題なし。

## 関連

- 親 Issue: #76
- 影響を受けたインシデント: #52, #55, #63 (PR #75), #67 (PR #73), #68 (PR #74)
- Phase C 親: #16
- Reviewer Gate: #20
- Stage Checkpoint: #68
- umbrella: #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)