### PR TITLE
chore(issues): disable blank issues to force feature.yml template usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# GitHub web UI で Issue を作成する際は必ず ISSUE_TEMPLATE/feature.yml を経由させる。
+# - blank_issues_enabled: false にすると `/issues/new` 直アクセスや「Open a blank issue」リンクが
+#   無効化され、picker（テンプレート 1 件のみなら自動的に feature.yml）に倒れる。
+# - これにより PM Triage が前提とするフィールド構造（問題 / 受入基準 / Out of Scope 等）が
+#   常に埋まる状態で Issue が起票される。
+# - `gh issue create --template feature.yml` 経由なら従来どおり template が使われる。
+#   `gh issue create` を素で叩いた場合は body を手書きするフローでもそのまま通る（CLI 側の挙動）。
+blank_issues_enabled: false

--- a/repo-template/.github/ISSUE_TEMPLATE/config.yml
+++ b/repo-template/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+# GitHub web UI で Issue を作成する際は必ず ISSUE_TEMPLATE/feature.yml を経由させる。
+# - blank_issues_enabled: false にすると `/issues/new` 直アクセスや「Open a blank issue」リンクが
+#   無効化され、picker（テンプレート 1 件のみなら自動的に feature.yml）に倒れる。
+# - これにより PM Triage が前提とするフィールド構造（問題 / 受入基準 / Out of Scope 等）が
+#   常に埋まる状態で Issue が起票される。
+# - `gh issue create --template feature.yml` 経由なら従来どおり template が使われる。
+#   `gh issue create` を素で叩いた場合は body を手書きするフローでもそのまま通る（CLI 側の挙動）。
+blank_issues_enabled: false


### PR DESCRIPTION
## Summary

GitHub web UI で Issue 新規作成時、`/issues/new` 直アクセスやブックマーク経由だと ISSUE_TEMPLATE をバイパスして空白の issue editor が表示される問題を解消するため、`.github/ISSUE_TEMPLATE/config.yml` に `blank_issues_enabled: false` を追加。

## 背景

- idd-claude では PM Triage が `feature.yml` のフィールド構造（問題 / 受入基準 / Out of Scope 等）を前提に要件精査する
- テンプレート無しで起票された Issue は Triage 結果が `needs-decisions` に倒れやすく、人間判断のラリーが増える
- 今回 `/issues/new` 直アクセス時のテンプレート未表示が確認されたため、構造的に強制する

## 変更内容

`.github/ISSUE_TEMPLATE/config.yml`（新規、root + repo-template に同内容）:

```yaml
blank_issues_enabled: false
```

これによりいかなるアクセス方法（`/issues/new` 直 / `/issues/new/choose` / 緑「New issue」ボタン / ブックマーク）でも picker （テンプレート 1 件のみなので自動的に `feature.yml`）に倒れる。

## Test plan

- [x] YAML 構文確認 (`python3 -c "import yaml; yaml.safe_load(open('config.yml'))"`)
- [ ] Web UI dogfood: merge 後に `https://github.com/hitoshiichikawa/idd-claude/issues/new` を直アクセスして `feature.yml` form が表示されることを確認

## 後方互換性

- `gh issue create --template feature.yml` は従来通り動作
- `gh issue create` を素で叩く場合: GitHub CLI 側の挙動は不変（body 手書きで通る）
- consumer repo: `install.sh` 再実行で `repo-template/.github/ISSUE_TEMPLATE/config.yml` がコピーされる
- 既存 Issue / PR / cron / ラベル / env var への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)