### PR TITLE
fix(#80): DRR Processor matches strict issue-number prefix (drop body Refs check)

### DIFF
--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -1946,25 +1946,31 @@ drr_find_merged_design_pr() {
   local prs_json
   # head pattern を server-side クエリで一次絞り込み（in:head + 規約 prefix）。
   # 複数件マッチを許容するため limit=20。
+  # 注意（Issue #80）: GitHub の text search はトークン分解（"claude" / "issue" / "${N}" /
+  # "design" の各語）で他 Issue 用の merged 設計 PR もヒットさせるため、ここでは候補
+  # 取得（noisy）に留め、最終一致判定は後段の jq で issue 番号 fix の strict prefix で行う。
   if ! prs_json=$(timeout "$DRR_GH_TIMEOUT" gh pr list \
       --repo "$REPO" \
       --state merged \
       --search "is:pr is:merged claude/issue-${issue_number}-design- in:head" \
-      --json number,headRefName,body,mergedAt \
+      --json number,headRefName,mergedAt \
       --limit 20 2>/dev/null); then
     return 1
   fi
 
-  # 取得結果が空 / 不正な場合に jq エラーで落ちないよう fail-safe で `// []` を挟む。
-  local pattern="$DESIGN_REVIEW_RELEASE_HEAD_PATTERN"
-  local refs_pattern="(Refs|refs|Ref|ref) #${issue_number}([^0-9]|$)"
+  # Issue #80: head 名を issue 番号で strict 比較する（旧 `^claude/issue-[0-9]+-design-`
+  # では他 Issue 用 PR が通過していた）。body の `Refs #N` 検査は cross-reference
+  # （Architect が design PR 本文で別 Issue を参照する）と衝突して誤検知の原因に
+  # なっていたため drop。head が `claude/issue-${N}-design-<slug>` で始まることを
+  # 唯一の同定条件とする。
+  # 同 issue 番号の merged 設計 PR が複数ある場合（再 design 等）は、PR 番号最大
+  # （= 最新と看做す）を採用。
+  local strict_head_prefix="claude/issue-${issue_number}-design-"
   local pr_number
   pr_number=$(echo "$prs_json" | jq -r \
-    --arg pattern "$pattern" \
-    --arg refs_re "$refs_pattern" \
+    --arg prefix "$strict_head_prefix" \
     '[(. // [])[]
-      | select(.headRefName | test($pattern))
-      | select((.body // "") | test($refs_re))
+      | select(.headRefName | startswith($prefix))
       | .number
     ] | sort | last // ""' 2>/dev/null || echo "")
   echo "$pr_number"


### PR DESCRIPTION
Closes #80

## Summary

`drr_find_merged_design_pr` の同定ロジックを **issue 番号 fix の head strict prefix** に変更し、body `Refs #N` 検査を drop。これで cross-reference 衝突による誤検知（**他 Issue 用 merged 設計 PR を対象 Issue の release 候補と誤認**）を構造的に解消します。

修正は 1 関数のみ、14 行追加 / 8 行削除。

## 根本原因（再掲）

以下 3 点の組み合わせ:

1. **GitHub server-side text search** (`claude/issue-${N}-design- in:head`) が **トークン分解** で他 Issue 用 PR もヒット
2. **client-side jq head pattern** (`^claude/issue-[0-9]+-design-`) が **issue 番号で fix されておらず** `[0-9]+` で泛化
3. **body Refs check** が Architect の **cross-reference (`Refs #65（claude-failed 復旧）` 等)** と衝突

→ Issue #65 dogfood (2026-04-30) で実害発火: PR #78 が GitHub auto-close。詳細は Issue #80 と Issue #65 のコメント参照。

## 修正内容（diff）

```diff
-      --json number,headRefName,body,mergedAt \
+      --json number,headRefName,mergedAt \
       --limit 20 2>/dev/null); then
     return 1
   fi

-  local pattern="$DESIGN_REVIEW_RELEASE_HEAD_PATTERN"
-  local refs_pattern="(Refs|refs|Ref|ref) #${issue_number}([^0-9]|$)"
+  local strict_head_prefix="claude/issue-${issue_number}-design-"
   local pr_number
   pr_number=$(echo "$prs_json" | jq -r \
-    --arg pattern "$pattern" \
-    --arg refs_re "$refs_pattern" \
+    --arg prefix "$strict_head_prefix" \
     '[(. // [])[]
-      | select(.headRefName | test($pattern))
-      | select((.body // "") | test($refs_re))
+      | select(.headRefName | startswith($prefix))
       | .number
     ] | sort | last // ""' 2>/dev/null || echo "")
```

## Test plan

- [x] **inline smoke 6 ケース PASS** (commit message に詳細):
  1. 誤検知防止: `drr_find_merged_design_pr 65` で PR #71 / #69 を返さない（fixture が `Refs #65` を含む状況）
  2-3. 正常検出: `66` → `71`、`68` → `69`
  4. 同 issue 複数 merged 時: PR 番号最大採用
  5. 該当 PR 無し: 空文字
  6. Cross-reference に騙されない: `Refs #65` を含む PR #500 (head=`claude/issue-200-design-...`) でも `65` には返さない
- [x] `bash -n local-watcher/bin/issue-watcher.sh` PASS
- [x] `shellcheck local-watcher/bin/issue-watcher.sh` 新規警告ゼロ（既存 SC2317 (info) 10 件のみ、ベースラインと同一）
- [ ] **dogfood (E2E)**: 本 PR merge + install.sh 再実行 + cron に `DESIGN_REVIEW_RELEASE_ENABLED=true` 復活後、Issue #65 を `auto-dev` 再付与し、設計 PR が作成されたあとも DRR が誤動作しないことを観測

## 後方互換性

- API 契約は不変: `drr_find_merged_design_pr <N>` の戻り値仕様（stdout に PR 番号 / 該当無しなら空文字 / API エラーなら rc=1）は維持
- `DESIGN_REVIEW_RELEASE_HEAD_PATTERN` env var は本 fix では未使用化（後方互換のため env var 自体は残す。次回の clean-up で削除候補）
- `repo-template/**` への変更なし
- `DESIGN_REVIEW_RELEASE_ENABLED=false`（既定）下では本関数は呼ばれない（既存挙動維持）

## 関連

- 親 Issue: #80
- 影響を受けたインシデント: **Issue #65 (2026-04-30 dogfood)** ← 本 PR の起票契機
- 親 DRR Processor: #40
- 暫定対応として cron から削除済の `DESIGN_REVIEW_RELEASE_ENABLED=true` は、本 PR merge + install 後に復活させる

## merge 後の手順

1. `cd ~/.idd-claude && git pull && ./install.sh --local` で `~/bin/issue-watcher.sh` を更新
2. cron に `DESIGN_REVIEW_RELEASE_ENABLED=true` を復活
3. Issue #65 に `auto-dev` ラベル再付与 → dogfood 再開

🤖 Generated with [Claude Code](https://claude.com/claude-code)