### PR TITLE
feat(#85): install.sh --repo で idd-claude ラベルを自動セットアップ

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,40 @@ curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/set
 **カレントディレクトリ (`./`)** にテンプレートを配置します。対話モードでも
 プロンプトで Enter のみ入力すると同じくカレントがデフォルトです。
 
+#### GitHub ラベルの自動セットアップ (#85)
+
+`install.sh --repo` または `install.sh --all` で対象リポジトリに配置した直後、
+同梱の `.github/scripts/idd-claude-labels.sh` を **自動実行**して、idd-claude が
+状態遷移に使う必須ラベル（`auto-dev` / `claude-claimed` / `ready-for-review` 等）を
+冪等作成します。これにより初回 cron / Actions 起動時に watcher が claim ラベル付与に
+失敗する事故を防げます。
+
+- **opt-out**: `--no-labels` フラグまたは `IDD_CLAUDE_SKIP_LABELS=true` 環境変数で
+  ラベル処理を完全に skip できます。CI / 別ツールでラベルを自前管理しているリポジトリで
+  推奨します
+- **fail-soft**: `gh` 未インストール / `gh auth login` 未実施 / 権限なし / API 失敗時は
+  ラベル処理だけを skip し、install 全体は exit 0 で完走します。skip 時は手動 fallback の
+  完全コマンドが出力されるので、それをコピペで実行してください
+- **冪等**: 既存ラベルは name / color / description ともに変更されません（既存値は保護）。
+  色や説明を上書きしたい場合は手動で `bash .github/scripts/idd-claude-labels.sh --force`
+- **`--local` 単独時は走りません**: 対象リポジトリ配置がない場合はラベル処理も発生しません
+- **`--dry-run`**: 実 API 呼び出しせず、これから実行されるコマンドだけを表示します
+
+```bash
+# 通常: 配置 + ラベル自動作成（既存ラベルは保護）
+./install.sh --repo /path/to/your-project
+
+# ラベル処理を完全に skip（自前管理する運用向け）
+./install.sh --repo /path/to/your-project --no-labels
+# あるいは env で
+IDD_CLAUDE_SKIP_LABELS=true ./install.sh --repo /path/to/your-project
+```
+
+`gh auth login` 未実施・private fork で権限が無い等で skip 扱いになった場合は、認証等を
+解消してから手動 fallback として後述の [ラベル一括作成（推奨）](#ラベル一括作成推奨) を
+実行してください。自動実行が成功している場合、手動 step を改めて実行する必要はありません
+（再実行しても既存ラベルが保護されるため、害はありません）。
+
 環境変数で挙動を調整できます（特定タグの検証や fork からのインストール向け）:
 
 | 変数 | デフォルト | 用途 |
@@ -278,6 +312,13 @@ git push
 
 Step 1 で同梱される `.github/scripts/idd-claude-labels.sh` を実行すると、必要なラベルを
 冪等に作成できます（既存ラベルはスキップ、`--force` で color / description を上書き）。
+
+> **既に `install.sh --repo` を使った場合は手動実行は不要です** — install.sh は配置直後に
+> 同じスクリプトを `--repo owner/name` 付きで自動実行します
+> （[GitHub ラベルの自動セットアップ (#85)](#github-ラベルの自動セットアップ-85) 参照）。
+> ここに記載する手動実行は、(a) 手動セットアップ（`cp -r` 経由）を選んだ場合、
+> (b) 自動実行が `gh` 未認証等で skip された場合、(c) 既存リポジトリで `--force` 指定の
+> color / description 更新を行いたい場合の fallback として残しています。
 
 ```bash
 cd /path/to/your-project

--- a/docs/specs/85-feat-install-install-sh-repo-idd-claude/impl-notes.md
+++ b/docs/specs/85-feat-install-install-sh-repo-idd-claude/impl-notes.md
@@ -1,0 +1,279 @@
+# Implementation Notes — Issue #85
+
+## 概要
+
+`install.sh --repo <path>` / `--all` の延長線で、対象リポジトリの GitHub ラベル
+（`auto-dev` / `claude-claimed` / `ready-for-review` 等）を自動セットアップする機能を
+追加した。fail-soft 設計のため認証不足や API 失敗で install 全体は止まらず、
+`--no-labels` / `IDD_CLAUDE_SKIP_LABELS=true` で完全 opt-out 可能。
+
+## 変更ファイル
+
+- `install.sh` — `--no-labels` 引数追加 + ラベル自動セットアップ helper 群追加 + 配置完了直後の hook
+- `README.md` — 「GitHub ラベルの自動セットアップ (#85)」節を追加、既存「ラベル一括作成（推奨）」節に注記
+- `docs/specs/85-feat-install-install-sh-repo-idd-claude/tasks.md` — Developer 自己管理のタスク計画
+- `docs/specs/85-feat-install-install-sh-repo-idd-claude/impl-notes.md` — 本ファイル
+
+`repo-template/.github/scripts/idd-claude-labels.sh` は **未変更**（既存 interface / 集計書式 / LABELS 定義を保つ Req 6.3 / 6.4 のため）。
+
+## 設計上の判断（Open Questions への対応）
+
+### Q1: 対象 repo `owner/repo` の特定方法の優先順位
+
+**採用順序**:
+
+1. `gh repo view --json nameWithOwner -q .nameWithOwner -R "$repo_path"` を最優先（gh が SSH/HTTPS の差異を吸収してくれる）
+2. fallback として `git -C "$repo_path" remote get-url origin` を sed で正規化（SSH `git@github.com:owner/repo.git` / HTTPS `https://github.com/owner/repo.git` 双方を `owner/repo` 形式に）
+3. それも失敗したら skip + 手動コマンド案内（Req 3.5）
+
+**`--repo` 引数の意味**: 既存 install.sh 仕様どおり「ローカルパス」のまま据え置き。`owner/repo` 形式は内部的に解決する。後方互換性（Req 6.1）を壊さない判断。
+
+### Q2: `IDD_CLAUDE_SKIP_LABELS=true` env による opt-out
+
+**採用**。`--no-labels` と同等扱いし、env 値は `true|TRUE|True|1|yes|YES` を opt-out として解釈する。理由:
+
+- `curl | bash` 経由のフローでは引数を渡しにくい場面がある（NFR 1.1 の cron-safe 性に有用）
+- 既存 idd-claude が `IDD_CLAUDE_USE_ACTIONS` / `IDD_CLAUDE_REPO_URL` / `IDD_CLAUDE_BRANCH` / `IDD_CLAUDE_DIR` 等の `IDD_CLAUDE_*` env 命名規則を持つので命名整合性がある
+
+opt-out 経路は両方が `[INSTALL] SKIP [labels] opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS)` という単一メッセージに集約され、認証失敗等の skip と区別できる出力になっている（Req 4.2）。
+
+### Q3: private fork での挙動
+
+要件は **fail-soft 内で完走できれば足りる** としている。`gh repo view` / `gh label list` / `gh label create` のいずれも write 権限を要求する箇所は権限不足で失敗するため、当該失敗は `[INSTALL] FAIL [labels] ...` に集約され install 全体は exit 0 で完走する（Req 3.3）。private fork で成功させるためのベストエフォート対応（owner 切り替え提案等）は本 Issue のスコープ外として未実装。
+
+### Q4: README の手動セットアップ節
+
+**残す + 自動実行との関係を注記**（Req 7.4 への回答）。理由:
+
+- 手動セットアップ経路（`cp -r` で配置するユーザー）が依然存在する
+- 自動実行が `gh` 未認証等で skip された場合の fallback 必要
+- `--force` で color / description を更新したい既存ユーザー向け
+
+冒頭に warning blockquote を追加して「`install.sh --repo` を使った場合は手動実行は不要」と明記。
+
+## 実装上の判断
+
+- **dry-run 中はラベルスクリプトの存在チェックをスキップ**: dry-run はファイルを実際に配置しないので、`repo_path/.github/scripts/idd-claude-labels.sh` がまだ存在しない可能性がある。dry-run の予定表示が「labels script not found」になるのを避けるため、`gh` 不在 → slug 解決 → DRY-RUN return → 認証チェック → スクリプト存在チェック の順序にした。これは UX 上の判断で、AC 5.4 の「これから実行されるラベルセットアップ内容を表示」を素直に満たす書き方
+- **`--force` を渡さない**: Req 2.5 で「既存ラベルの color / description を上書きしない」と明示されているため、自動実行は素の `bash <script> --repo <slug>` で起動し、既存値は保護する
+- **集計行の grep**: `idd-claude-labels.sh` の集計書式（`新規作成: 0` 等の行）を sed でパースして `[INSTALL] OK [labels] created=N exists=N updated=N failed=N` のサマリ 1 行を出している。NFR 2.3 の grep 可能性を意識
+- **call site**: `if $INSTALL_REPO; then ... REPO_HINT ... setup_repo_labels "$REPO_PATH"; fi` の中に配置。`INSTALL_LOCAL` のみ true の経路は通らないため Req 1.3 / 1.5 を構造的に保証
+- **対話モード**: 対話で `INSTALL_REPO=true` になった場合も同じ if ブロックを通るので Req 1.4 を構造的に満たす
+
+## AC → テスト手段マッピング
+
+本リポジトリは bash + markdown が主な成果物のため unit test framework は無し（CLAUDE.md「テスト・検証」節）。AC は **shellcheck + 手動スモークテスト**で担保する。
+
+| Req ID | 内容 | 確認方法 / 結果 |
+|---|---|---|
+| 1.1 | `--repo` 配置成功直後にラベル起動 | スモーク 2 / スモーク 6 で `🏷  GitHub ラベル自動セットアップ` 出力を観測 |
+| 1.2 | `--all --repo <path>` でも起動 | スモーク 8 |
+| 1.3 | `--local` 単独では起動しない | スモーク 1 で「ラベルセットアップ」セクションが出力に現れないことを確認 |
+| 1.4 | 対話モードで repo 選択時に起動 | コード経路上、対話モードも `INSTALL_REPO=true` を立てるため同じ if ブロックを通る（構造的保証） |
+| 1.5 | ラベル対象は対象 repo 1 件 | `setup_repo_labels` は引数 1 つで呼ばれ、内部で 1 つの slug しか解決しない |
+| 2.1 | 必須ラベル全件新規作成 | 既存 `idd-claude-labels.sh` の挙動を委譲（Req 6.3 で interface 不変） |
+| 2.2 | 不足分のみ追加 | 同上（labels.sh が `--force` なしでは既存をスキップ） |
+| 2.3 | 全件存在時は noop | スモーク 6 で `created=0 exists=11 updated=0 failed=0` を観測 |
+| 2.4 | 既存削除/リネームしない | `--force` を渡していない、削除 API も呼ばない |
+| 2.5 | color / description 上書きしない | `--force` を渡していない |
+| 3.1 | gh 不在時 skip | スモーク 7-1（`PATH=/tmp/no-gh-bin` で `gh CLI not found`） |
+| 3.2 | gh 未認証時 skip | スモーク 7-2（`HOME=/tmp/empty-home` で `gh CLI is not authenticated`） |
+| 3.3 | 権限なしで skip | API 失敗パスに集約され `FAIL` で skip。実権限テストは private fork 環境必要のため部分検証 |
+| 3.4 | API 接続失敗時 skip | スモーク 2（`hitoshiichikawa/idd-test-fake` 存在しない repo で `[INSTALL] FAIL ... rc=1`） |
+| 3.5 | skip 時に手動コマンドブロック提示 | スモーク 2 / 7-1 / 7-2 / 9 で `手動でラベル一括作成を実行するには:` ブロック出力 |
+| 3.6 | コピペ可能な完全コマンド | 同上、`bash <path>/.github/scripts/idd-claude-labels.sh --repo <slug>` を出力 |
+| 4.1 | `--no-labels` で完全 skip | スモーク 3 |
+| 4.2 | opt-out と認証失敗の区別 | `opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS)` メッセージ vs `gh CLI is not authenticated` メッセージで区別可能 |
+| 4.3 | `--no-labels` × 他フラグ組み合わせ | スモーク 3 で `--repo` と組み合わせ確認、`--all` / `--dry-run` / `--force` も bool フラグで独立しているため影響なし |
+| 4.4 | 既定値 false | `SKIP_LABELS=false` を初期化、env で変更時のみ true |
+| 5.1 | 成功時要約表示 | スモーク 6 で `[INSTALL] OK [labels] created=0 exists=11 updated=0 failed=0` |
+| 5.2 | skip 時に skip + 手動コマンド | スモーク 2 / 3 / 7-1 / 7-2 / 9 |
+| 5.3 | 出力プレフィクス統一 | `[INSTALL]` prefix を踏襲、`log_label_action` ヘルパーで統一 |
+| 5.4 | dry-run で API 呼ばずに plan 表示 | スモーク 4（`[INSTALL] DRY-RUN [labels] would run: bash ... --repo ...`） |
+| 6.1 | 既存 install.sh フラグ意味不変 | `--repo` / `--local` / `--all` / `-h` / `--help` / `--dry-run` / `--force` の解釈を変更していない（diff 範囲は `--no-labels` 追加と末尾 hook 1 箇所のみ） |
+| 6.2 | 対話モードのプロンプト不変 | 対話モードのコード（`if ! $INSTALL_LOCAL && ! $INSTALL_REPO; then ...`）は無変更 |
+| 6.3 | idd-claude-labels.sh interface 不変 | `repo-template/.github/scripts/idd-claude-labels.sh` は無変更（git diff で確認） |
+| 6.4 | LABELS 定義不変 | 同上 |
+| 6.5 | 再 install で破壊しない | スモーク 5 で 2 回連続実行も同じ挙動 |
+| 7.1 | README に自動実行記載 | `README.md` に「GitHub ラベルの自動セットアップ (#85)」節を追加 |
+| 7.2 | `--no-labels` opt-out 記載 | 同節内で明記 |
+| 7.3 | skip 時の手動 fallback 記載 | 同節末尾と既存「ラベル一括作成（推奨）」節の追記で説明 |
+| 7.4 | 自動と手動の関係を矛盾なく説明 | 既存節冒頭に warning blockquote を追加（自動実行が成功した場合は手動 step 不要） |
+| NFR 1.1 | 追加プロンプトを発行しない | `setup_repo_labels` は `read` を呼ばない |
+| NFR 1.2 | sudo を要求しない | sudo を呼ぶ箇所なし |
+| NFR 2.1 | 30 秒以内 | スモーク 6 で `time` 計測 ≈ 1.2 秒（end-to-end） |
+| NFR 2.2 | タイムアウト時 skip | gh 自体のタイムアウト + シェルの非ゼロ rc を `FAIL` ログに集約。NFR 2.1 の 30s 超に達する API 異常は実観測の機会が無く、構造的保証のみ |
+| NFR 2.3 | grep 可能な書式で記録 | `[INSTALL] (OK|SKIP|DRY-RUN|FAIL) [labels] ...` 形式 |
+| NFR 3.1 | 認証情報を出力しない | gh の出力をそのまま流すが、gh 自体は token を mask する。install.sh 自体では token を扱わない |
+| NFR 3.2 | 追加認証情報入力を要求しない | skip 時は `gh auth login` の案内のみ、対話プロンプトはなし |
+
+## 手動スモークテスト記録（test plan）
+
+実施環境: Linux 6.17.0 / bash 5 / shellcheck 0.10.0 / gh 2.89.0
+
+### 1. shellcheck
+
+```text
+$ shellcheck install.sh repo-template/.github/scripts/idd-claude-labels.sh
+(no output)  # clean
+```
+
+### 2. `--local` 単独でラベル処理が走らない
+
+```text
+$ ./install.sh --local 2>&1 | grep -E "(GitHub ラベル|labels)"
+（出力なし）
+```
+
+→ Req 1.3, 1.5 OK
+
+### 3. `--repo /tmp/idd85-test`（fake remote → API failure）
+
+```text
+$ ./install.sh --repo /tmp/idd85-test
+...
+🏷  GitHub ラベル自動セットアップ
+   対象: hitoshiichikawa/idd-test-fake
+Error: 既存ラベル一覧の取得に失敗しました: GraphQL: Could not resolve to a Repository ...
+[INSTALL] FAIL      [labels] label setup partially failed (created=? failed=?, rc=1)
+   手動でラベル一括作成を実行するには:
+       cd /tmp/idd85-test
+       bash .github/scripts/idd-claude-labels.sh
+     または repo 外から:
+       bash /tmp/idd85-test/.github/scripts/idd-claude-labels.sh --repo hitoshiichikawa/idd-test-fake
+🎉 idd-claude のインストールが完了しました。
+$ echo $?
+0
+```
+
+→ Req 1.1, 3.4, 3.5, 3.6, 5.2, 5.3 OK / install 全体 exit 0
+
+### 4. `--no-labels` opt-out
+
+```text
+$ ./install.sh --repo /tmp/idd85-test --no-labels
+...
+🏷  GitHub ラベル自動セットアップ
+[INSTALL] SKIP      [labels] opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS)
+   手動でラベル一括作成を実行するには:
+       cd /tmp/idd85-test
+       bash .github/scripts/idd-claude-labels.sh
+     または repo 外から:
+       bash /tmp/idd85-test/.github/scripts/idd-claude-labels.sh
+```
+
+→ Req 4.1, 4.2, 4.3 OK
+
+### 5. `IDD_CLAUDE_SKIP_LABELS=true` env による opt-out
+
+```text
+$ IDD_CLAUDE_SKIP_LABELS=true ./install.sh --repo /tmp/idd85-test
+...
+[INSTALL] SKIP      [labels] opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS)
+```
+
+→ Open Question 2 への対応 OK
+
+### 6. `--dry-run`
+
+```text
+$ ./install.sh --repo /tmp/idd85-test --dry-run
+...
+🏷  GitHub ラベル自動セットアップ
+[INSTALL] DRY-RUN   [labels] would run: bash /tmp/idd85-test/.github/scripts/idd-claude-labels.sh --repo hitoshiichikawa/idd-test-fake
+```
+
+→ Req 5.4 OK / 実 API 呼び出しなし（fake remote にもかかわらずエラーが出ない）
+
+### 7-1. gh 不在（PATH に gh が無い環境）
+
+```text
+$ env -i HOME=$HOME PATH=/tmp/no-gh-bin /tmp/no-gh-bin/bash -c './install.sh --repo /tmp/idd85-test'
+...
+[INSTALL] SKIP      [labels] gh CLI not found
+```
+
+→ Req 3.1 OK
+
+### 7-2. gh 未認証
+
+```text
+$ env -i HOME=/tmp/empty-home PATH=/usr/bin:/bin bash -c './install.sh --repo /tmp/idd85-test'
+...
+[INSTALL] SKIP      [labels] gh CLI is not authenticated (run: gh auth login)
+```
+
+→ Req 3.2 OK
+
+### 8. `--all --repo`
+
+```text
+$ ./install.sh --all --repo /tmp/idd85-test 2>&1 | grep -E "(GitHub ラベル|labels)"
+🏷  GitHub ラベル自動セットアップ
+[INSTALL] FAIL      [labels] label setup partially failed (created=? failed=?, rc=1)
+```
+
+→ Req 1.2 OK
+
+### 9. owner/repo 解決失敗（origin remote なし）
+
+```text
+$ rm -rf /tmp/idd85-noremote && mkdir -p /tmp/idd85-noremote && cd /tmp/idd85-noremote && git init -q && cd -
+$ ./install.sh --repo /tmp/idd85-noremote
+...
+[INSTALL] SKIP      [labels] could not resolve owner/repo from /tmp/idd85-noremote
+```
+
+→ slug 解決失敗時の skip 経路 OK
+
+### 10. 実 repo（success path）
+
+```text
+$ git clone --depth 1 https://github.com/hitoshiichikawa/idd-claude /tmp/idd85-real
+$ time ./install.sh --repo /tmp/idd85-real
+...
+🏷  GitHub ラベル自動セットアップ
+   対象: hitoshiichikawa/idd-claude
+📌 idd-claude ラベルを作成します
+   対象: hitoshiichikawa/idd-claude
+
+  auto-dev                  ... already exists (skipped; use --force to update)
+  ...（11 ラベルすべて already exists）
+[INSTALL] OK        [labels] created=0 exists=11 updated=0 failed=0
+🎉 idd-claude のインストールが完了しました。
+
+real    0m1.199s
+```
+
+→ Req 1.1, 2.3, 5.1, NFR 2.1 OK（idempotent / 既存ラベル保護 / 1.2s で完走）
+
+### 11. 冪等性（連続 2 回実行）
+
+```text
+$ ./install.sh --repo /tmp/idd85-test ; ./install.sh --repo /tmp/idd85-test
+（両回とも同じ FAIL ログ + 手動コマンド出力 / install 全体 exit 0）
+```
+
+→ Req 6.5 OK
+
+### 12. `--help` の更新確認
+
+```text
+$ ./install.sh --help
+...
+#   --no-labels      対象リポジトリ配置時に走る GitHub ラベル自動セットアップを完全に skip
+#                    （`IDD_CLAUDE_SKIP_LABELS=true` env でも同等の opt-out が可能）
+```
+
+## 確認事項（PR 本文への転記候補）
+
+1. **`IDD_CLAUDE_SKIP_LABELS` env を採用**: 要件上は `--no-labels` のみ必須だが、`curl | bash` フローでの利便性のため env 経由 opt-out も追加した（Open Question 2）。後方互換性問題は無いが、追加 env 名のレビューをお願いしたい
+2. **slug 解決の優先順位**: `gh repo view` 優先 → `git remote get-url origin` 正規表現 fallback の 2 段。env var `REPO` を解決源として加えるかは保留した（既存 install.sh の `--repo` 引数と意味衝突するため）。今後 watcher との整合のために env を増やす場合は別 Issue で議論したい（Open Question 1）
+3. **private fork の権限不足ケース**: 現状 fail-soft で skip されるが、ベストエフォートで成功させるための owner 切り替え提案等は実装していない（Open Question 3, スコープ外）
+4. **既存 README 「ラベル一括作成（推奨）」節**: 残して fallback 位置付けに格下げ（Open Question 4）。節を削除する案もあったが、手動セットアップ経路ユーザーへの後方互換性を優先した
+5. **テストフレームワーク不在**: 本リポジトリは bash + markdown が主な成果物で unit test framework が無いため、検証は shellcheck + 手動スモークテスト（CLAUDE.md「テスト・検証」節準拠）に依拠している。設計上の妥当性は手動テスト 12 ケースで担保
+
+## 派生タスク候補（次の Issue 候補）
+
+- watcher 側（`local-watcher/bin/issue-watcher.sh`）からのラベル不足検知 + 自動補完（本 Issue では Out of Scope と明示）
+- private fork での owner 切り替え提案（fail-soft 内のベストエフォート向上）
+- `setup.sh` 経由での `--no-labels` 透過確認（実装上は引数透過するが E2E 確認が未実施）

--- a/docs/specs/85-feat-install-install-sh-repo-idd-claude/requirements.md
+++ b/docs/specs/85-feat-install-install-sh-repo-idd-claude/requirements.md
@@ -1,0 +1,135 @@
+# Requirements Document
+
+## Introduction
+
+`install.sh --repo <path>` でテンプレートを配置した直後の対象リポジトリには、idd-claude が
+状態遷移に使う必須ラベル（`auto-dev` / `claude-claimed` / `ready-for-review` 等）がまだ
+存在しない。そのため初回 cron で watcher が claim ラベルの付与に失敗し
+（"claude-claimed ラベル付与に失敗、slot-1 を解放して次 Issue へ" 等）、ユーザーは別途
+`bash .github/scripts/idd-claude-labels.sh` を手動実行する手間を要する。本機能では
+`install.sh --repo` の延長線でラベルセットアップを自動化し、認証不足や API 失敗時にも
+install 全体を止めない fail-soft な挙動と、再実行時の冪等性、`--no-labels` による opt-out を
+提供する。既存の `idd-claude-labels.sh` の interface・既存 `install.sh` オプションの
+後方互換性は破壊しない。
+
+## Requirements
+
+### Requirement 1: ラベル自動セットアップの実行範囲
+
+**Objective:** As a 対象リポジトリにテンプレートを配置するユーザー, I want install 直後に必須ラベルが対象 repo に揃う, so that 初回 cron で watcher がラベル付与に失敗せず Issue を処理できる
+
+#### Acceptance Criteria
+
+1. When `install.sh --repo <path>` がテンプレート配置に成功した直後, the Install Helper shall 対象リポジトリ向けにラベルセットアップ処理を起動する
+2. When `install.sh --all` で対象リポジトリパスが指定されている, the Install Helper shall 対象リポジトリ向けにラベルセットアップ処理を起動する
+3. When `install.sh --local` のみが指定されている, the Install Helper shall ラベルセットアップ処理を起動しない
+4. When `install.sh` を引数なしの対話モードで起動し対話で対象リポジトリ配置を選択した, the Install Helper shall その選択された対象リポジトリ向けにラベルセットアップ処理を起動する
+5. The Install Helper shall ラベルセットアップ処理の対象を対象リポジトリ 1 件に限定する（ローカル watcher の `$HOME` 配下にはラベル概念が存在しないため）
+
+### Requirement 2: 冪等性と既存ラベルの保護
+
+**Objective:** As a 既に idd-claude を導入済みのリポジトリ運用者, I want 再 install してもラベルが破壊されない, so that 既存の Issue / PR に紐づくラベル状態を失わず安全に再 install できる
+
+#### Acceptance Criteria
+
+1. When 対象リポジトリに必須ラベルがまだ 1 件も存在しない状態で初回 install が成功する, the Install Helper shall 必須ラベル全件を新規作成する
+2. When 対象リポジトリに必須ラベルが部分的に存在する, the Install Helper shall 不足しているラベルのみを追加し、既存ラベルは変更しない
+3. When 対象リポジトリに必須ラベル全件が既に存在する, the Install Helper shall 新規作成・更新を行わずに完了する
+4. The Install Helper shall ラベルセットアップ処理の中で既存ラベルを削除またはリネームしない
+5. While ラベル名・色・説明文の上書き更新は本機能のスコープ外, the Install Helper shall 既存ラベルの color / description を上書きしない
+
+### Requirement 3: 認証・権限・API 失敗時の fail-soft 動作
+
+**Objective:** As a `gh` 未認証 / 対象 repo への write 権限なし / API 一時障害下でセットアップを進めたいユーザー, I want ラベル部分が失敗しても install 全体は完走してくれる, so that テンプレート配置という主目的を中断されない
+
+#### Acceptance Criteria
+
+1. If `gh` CLI が `command -v` で見つからない, the Install Helper shall ラベルセットアップを skip し、install 全体は exit 0 で完走する
+2. If `gh` が未認証である, the Install Helper shall ラベルセットアップを skip し、install 全体は exit 0 で完走する
+3. If 対象リポジトリへの label 書き込み権限が無い, the Install Helper shall ラベルセットアップを skip し、install 全体は exit 0 で完走する
+4. If GitHub API への接続失敗 / レート制限 / 一時的エラーで一部または全部のラベル作成が失敗する, the Install Helper shall ラベルセットアップを skip 扱いとし、install 全体は exit 0 で完走する
+5. While ラベルセットアップが skip 扱いとなった, the Install Helper shall 後続の対象リポジトリ手順サマリ出力（既存）の前後いずれかで skip 理由と手動実行コマンドを 1 ブロック以上提示する
+6. If ラベルセットアップが skip 扱いとなった, the Install Helper shall ユーザーがコピー & 貼り付けで再実行できる完全な手動コマンド文字列を出力に含める
+
+### Requirement 4: opt-out オプション
+
+**Objective:** As a CI / 別ツールでラベルを自前管理しているリポジトリ運用者, I want `--no-labels` でラベル処理を完全に止められる, so that 自分の運用と競合させずに install のみ走らせられる
+
+#### Acceptance Criteria
+
+1. When `install.sh --repo <path> --no-labels` が指定される, the Install Helper shall ラベルセットアップ処理を完全に skip する
+2. When `--no-labels` が指定された skip, the Install Helper shall 認証失敗時の skip と区別できる出力（opt-out である旨）を提示する
+3. When `--no-labels` が `--all` / `--repo` / `--dry-run` / `--force` のいずれと組み合わされる, the Install Helper shall 他オプションの挙動を変えずにラベル処理のみを抑止する
+4. The Install Helper shall `--no-labels` を既定値（off）として扱い、無指定時はラベルセットアップを試行する
+
+### Requirement 5: 出力・ユーザー可視性
+
+**Objective:** As a install を眺めているユーザー, I want ラベル処理の結果が他ステップと同じ書式で見える, so that 何が起きたか・次に何をすべきかを 1 画面で把握できる
+
+#### Acceptance Criteria
+
+1. While ラベルセットアップが成功裏に完了する, the Install Helper shall 「ラベルセットアップが完了した」旨と、作成数・既存スキップ数を 1 行以上で要約表示する
+2. While ラベルセットアップが skip 扱いとなる, the Install Helper shall skip した事実を出力し、Requirement 3.5 の手動実行コマンドを併記する
+3. The Install Helper shall ラベルセットアップ部の出力プレフィクスを既存の install ステップ（テンプレート配置等）と統一感のある形式で出力する
+4. While `--dry-run` が指定されている, the Install Helper shall 実 API 呼び出しを行わずに「これから実行されるラベルセットアップ内容」を表示する
+
+### Requirement 6: 後方互換性
+
+**Objective:** As a 既存 `install.sh` / `idd-claude-labels.sh` ユーザー, I want 既存 interface が壊れない, so that 既稼働の consumer repo / cron / CI が無修正で動き続ける
+
+#### Acceptance Criteria
+
+1. The Install Helper shall 既存 `install.sh` オプション `--repo` / `--local` / `--all` / `-h` / `--help` / `--dry-run` / `--force` の意味と挙動を本機能の追加で変更しない
+2. The Install Helper shall 既存の対話モードのプロンプト文言・順序・分岐を本機能の追加で変更しない
+3. The Install Helper shall 既存 `idd-claude-labels.sh` の引数仕様（`--repo` / `--force` / `-h` / `--help`）・exit code 意味・stdout サマリ書式を変更しない
+4. The Install Helper shall 既存 `idd-claude-labels.sh` の `LABELS=(...)` で定義されたラベル名・色・説明文を本機能の追加で変更しない
+5. While 既存 consumer repo に再 install が走る, the Install Helper shall 配置済みファイル・既存ラベルに対して破壊的変更を引き起こさない
+
+### Requirement 7: README ドキュメント反映
+
+**Objective:** As a README を読んで idd-claude を導入する新規ユーザー, I want 自動ラベル作成が走ることがドキュメントに記載されている, so that 手動 step を二重実行したり「ラベルが勝手にできた」と困惑することがなくなる
+
+#### Acceptance Criteria
+
+1. The README shall `install.sh --repo` 経由のセットアップ手順節で、ラベルセットアップが自動実行される旨を明記する
+2. The README shall `--no-labels` で opt-out できる旨と、その推奨ユースケースを明記する
+3. The README shall 認証不足等で skip された場合に手動 fallback 手順（`bash .github/scripts/idd-claude-labels.sh`）に進めばよいことを明記する
+4. While 既存の手動セットアップ節（"ラベル一括作成（推奨）"）が残る, the README shall 自動実行と手動実行の関係（自動が走った場合は手動 step を改めて実行する必要はない）を矛盾なく説明する
+
+## Non-Functional Requirements
+
+### NFR 1: 非対話・cron-safe
+
+1. The Install Helper shall ラベルセットアップ部で標準入力からの追加プロンプトを発行しない（`curl | bash` 経由・非 TTY 環境で停止しない）
+2. The Install Helper shall ラベルセットアップに伴って sudo / 管理者権限を要求しない
+
+### NFR 2: パフォーマンスと観測性
+
+1. While ラベルセットアップを実行する, the Install Helper shall 既存の対象リポジトリ全体 install 1 回あたりの所要時間に対し、ラベルセットアップが正常終了する場合は 30 秒以内で完了する（GitHub API 通常応答時を想定）
+2. If GitHub API 応答が NFR 2.1 の上限を超えそうな状況になる, the Install Helper shall タイムアウトまたはエラー扱いで skip し、install 全体を停滞させない
+3. The Install Helper shall ラベルセットアップ結果（成功 / skip / 失敗カテゴリ）を grep 可能な書式で stdout または stderr に記録する
+
+### NFR 3: セキュリティ
+
+1. The Install Helper shall API 認証情報（token 等）を stdout / stderr / ログに出力しない
+2. The Install Helper shall ラベルセットアップが skip された場合に、`gh auth login` を促す案内以外の追加認証情報入力を要求しない
+
+## Out of Scope
+
+- Watcher 側（`local-watcher/bin/issue-watcher.sh` / GitHub Actions workflow）からのラベル自動補完
+- `setup.sh`（curl パイプ用 bootstrap）独自のラベル処理。`setup.sh` は最終的に `install.sh` を exec するので、本機能の対象は `install.sh` 側のみ
+- `idd-claude-labels.sh` 自体の機能拡張（色変更・説明文更新・ラベル削除等）
+- 既存ラベルの color / description の上書き更新（`--force` の自動付与）
+- GitHub Actions 経由の install フロー対応
+- ラベルセット定義の追加・変更（必須ラベル一覧は `idd-claude-labels.sh` 側の真実源を踏襲）
+- private fork など、対象リポジトリの種別ごとの個別最適化（fail-soft の枠内で動けば足りるとする）
+
+## Open Questions
+
+以下の点は Issue 本文 "判断を委ねたい点" として作成者が明示的に挙げており、要件定義段階での
+推測ではなく **設計フェーズ（Architect）または人間判断** に委ねます。
+
+- 対象リポジトリ `owner/repo` の特定方法の優先順位（`git -C <path> remote get-url origin` パース / 環境変数 `REPO` / `--repo owner/name` 形式の引数導入のいずれを優先するか）。なお現在の `install.sh --repo` は **ローカルパス** を受け取る仕様であり、`owner/repo` 形式の引数導入は後方互換性検討が必要
+- `--no-labels` の代替として `IDD_CLAUDE_SKIP_LABELS=true` env var でも opt-out 可能にすべきか（現要件では `--no-labels` のみを必須としている）
+- private fork で `gh label create --repo "$REPO"` がそのまま機能するかの検証範囲（fail-soft で skip されれば要件上は満たせるが、ベストエフォートで成功させる対応をどこまで取り込むか）
+- 自動ラベルセットアップが成功した場合の README 既存「手動でラベル一括作成」節の扱い（節を残す / 「fallback として」と注記する / 削除する のいずれにするか）

--- a/docs/specs/85-feat-install-install-sh-repo-idd-claude/review-notes.md
+++ b/docs/specs/85-feat-install-install-sh-repo-idd-claude/review-notes.md
@@ -1,0 +1,69 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-04-30T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-85-impl-feat-install-install-sh-repo-idd-claude
+- HEAD commit: e9fde7a5d16c9071f62b926e370b26fcb0c5a421
+- Compared to: main..HEAD
+- Feature Flag Protocol 採否: opt-out（CLAUDE.md に節なし → 通常の 3 カテゴリ判定のみ）
+
+差分概要:
+
+- `install.sh`: `--no-labels` 引数 + `IDD_CLAUDE_SKIP_LABELS` env 解釈 + helper 群（`log_label_action` / `print_label_manual_command` / `resolve_repo_slug` / `setup_repo_labels`）追加 + `INSTALL_REPO=true` 経路末尾で `setup_repo_labels "$REPO_PATH"` 呼び出し。help 表示も更新（`sed -n '3,23p'`）
+- `README.md`: 「GitHub ラベルの自動セットアップ (#85)」節を追加、既存「ラベル一括作成（推奨）」節に warning blockquote 注記
+- `repo-template/.github/scripts/idd-claude-labels.sh`: 未変更（`git diff main..HEAD -- repo-template/.github/scripts/idd-claude-labels.sh` が空。Req 6.3 / 6.4 を満たす）
+- spec docs（requirements.md / tasks.md / impl-notes.md）新規
+
+## Verified Requirements
+
+- 1.1 — `install.sh:667` で `INSTALL_REPO=true` 経路の末尾に `setup_repo_labels "$REPO_PATH"`。スモーク 3 / 10 で `🏷  GitHub ラベル自動セットアップ` 出力を確認
+- 1.2 — `--all --repo` でも `INSTALL_REPO=true` を立てる引数パース（install.sh:85-89）。スモーク 8 で確認
+- 1.3 — call-site が `if $INSTALL_REPO; then ... fi` に閉じており、`INSTALL_LOCAL` 単独経路には呼出なし。スモーク 2 で出力にラベル節が出ないことを確認
+- 1.4 — 対話モードも `INSTALL_REPO=true` を立てる既存実装に乗るため同じ if ブロックを通る（構造的保証）
+- 1.5 — `setup_repo_labels` が引数 1 個（`repo_path`）で受け、内部で 1 つの slug のみ解決。複数 repo を扱わない
+- 2.1〜2.5 — `idd-claude-labels.sh` の挙動委譲。`--force` を渡さないため既存 color / description は保護される（install.sh:566-572 のコメント参照）。スモーク 6 で `created=0 exists=11 updated=0 failed=0` を確認
+- 3.1 — `command -v gh` で不在検知 → `log_label_action SKIP "gh CLI not found"` + `print_label_manual_command`（install.sh:489-494）。スモーク 7-1 で確認
+- 3.2 — `gh auth status` で未認証検知 → SKIP（install.sh:516-520）。スモーク 7-2 で確認
+- 3.3, 3.4 — `bash <labels_script> --repo <slug>` の rc != 0 を `FAIL` ログに集約 + 手動コマンド出力 + `return 0` で fail-soft（install.sh:545-573）。スモーク 3 / 8 で `[INSTALL] FAIL ... rc=1` + install 全体 exit 0 を確認
+- 3.5 — `print_label_manual_command` で skip / fail 時に手動コマンドを 1 ブロック提示（install.sh:435-450）
+- 3.6 — `bash <repo_path>/.github/scripts/idd-claude-labels.sh${repo:+ --repo $repo}` の完全文字列を出力（install.sh:444-449）
+- 4.1 — `--no-labels` で `SKIP_LABELS=true` → `setup_repo_labels` 冒頭で SKIP（install.sh:483-487）。スモーク 4 で確認
+- 4.2 — opt-out 専用メッセージ `opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS)` で認証失敗 SKIP と区別可能
+- 4.3 — `SKIP_LABELS` は他フラグと独立した bool で、`--all` / `--dry-run` / `--force` の挙動を変更しない
+- 4.4 — `SKIP_LABELS=false` で初期化、env / フラグで明示的に true に変える場合のみ opt-out（install.sh:58）
+- 5.1 — 成功時 `[INSTALL] OK [labels] created=N exists=N updated=N failed=N` を 1 行で出力（install.sh:566-568）。スモーク 10 で確認
+- 5.2 — skip / fail 時に skip 理由 + `print_label_manual_command` の手動コマンドブロック（install.sh:484-486 / 514-518 等）
+- 5.3 — `[INSTALL] STATUS [labels] ...` のプレフィクス書式を `log_label_action` で統一
+- 5.4 — `DRY_RUN=true` 時に `log_label_action DRY-RUN "would run: bash ... --repo ..."` で API 呼び出さず予定表示（install.sh:507-510）。スモーク 6 で確認
+- 6.1 — `--repo` / `--local` / `--all` / `-h` / `--help` / `--dry-run` / `--force` のパース分岐は無変更（diff は `--no-labels` 追加 1 ケースと help 行範囲 `3,21p`→`3,23p` のみ）
+- 6.2 — 対話モード分岐 `if ! $INSTALL_LOCAL && ! $INSTALL_REPO; then ...` は無変更（diff 範囲外）
+- 6.3, 6.4 — `repo-template/.github/scripts/idd-claude-labels.sh` の git diff main..HEAD が空（未変更）。`bash <script> --repo <slug>` 形式で既存 interface を呼び出す
+- 6.5 — `--force` を渡さない + skip / fail 時も exit 0 のため、再 install で破壊しない。スモーク 11（連続 2 回実行）で確認
+- 7.1 — README.md の「GitHub ラベルの自動セットアップ (#85)」節で自動実行を明記
+- 7.2 — 同節内で `--no-labels` / `IDD_CLAUDE_SKIP_LABELS=true` の opt-out と推奨ユースケースを記載
+- 7.3 — 同節末尾で skip 時の手動 fallback 案内（既存「ラベル一括作成（推奨）」節への参照）を記載
+- 7.4 — 既存「ラベル一括作成（推奨）」節冒頭に warning blockquote を追加し、自動実行成功時は手動 step 不要であることを明記
+- NFR 1.1 — `setup_repo_labels` は `read` を呼ばず非対話
+- NFR 1.2 — sudo を呼ぶ箇所なし
+- NFR 2.1 — スモーク 10 で `time` 計測 ≈ 1.2 秒
+- NFR 2.2 — gh のタイムアウト + 非ゼロ rc を `FAIL` ログに集約（構造的保証）
+- NFR 2.3 — `[INSTALL] (OK|SKIP|DRY-RUN|FAIL) [labels] ...` の grep 可能書式
+- NFR 3.1 — install.sh 自体は token を扱わず、gh 出力をそのまま流す（gh 自体が token を mask）
+- NFR 3.2 — skip 時は `gh auth login` 案内のみ、追加プロンプトなし
+
+## Findings
+
+なし
+
+## Summary
+
+`install.sh` の `INSTALL_REPO=true` 経路に fail-soft なラベル自動セットアップ helper を追加し、
+`--no-labels` / `IDD_CLAUDE_SKIP_LABELS` opt-out、dry-run 透過、手動コマンドブロック出力、
+冪等性、既存 `idd-claude-labels.sh` interface 不変（diff で確認）まで全 AC をカバー。
+shellcheck もクリーン。本リポジトリは bash + markdown 主体で unit test framework が無いため
+（CLAUDE.md「テスト・検証」節）、検証は impl-notes.md の手動スモークテスト 12 ケースに依拠
+しており、各 AC への紐付けが明示されている。boundary 逸脱なし。
+
+RESULT: approve

--- a/docs/specs/85-feat-install-install-sh-repo-idd-claude/tasks.md
+++ b/docs/specs/85-feat-install-install-sh-repo-idd-claude/tasks.md
@@ -1,0 +1,49 @@
+# Tasks
+
+> Developer self-managed work plan for Issue #85.
+> Architect was not invoked for this Issue, so this tasks.md is a lightweight working plan.
+
+## 設計判断（Open Questions への暫定回答）
+
+- **対象 repo `owner/repo` の特定**: 第 1 候補 = `gh repo view --json nameWithOwner -q .nameWithOwner` を REPO_PATH の中で実行（fail-soft）。第 2 候補 = `git -C "$REPO_PATH" remote get-url origin` から正規表現で `owner/repo` を抽出。env var `REPO` は将来導入余地として残し、本 Issue では使用しない（install.sh 既存の `--repo` 引数とは別軸の env var を増やすと混乱するため）
+- **`IDD_CLAUDE_SKIP_LABELS` env**: 採用する。`--no-labels` と同様 opt-out として扱う（NFR 1.1 の cron-safe 性に有用）
+- **既存「手動でラベル一括作成」README 節**: 残す + 自動実行が走る旨と fallback 関係を明示（Req 7.4）
+
+## タスク
+
+- [ ] 1. `install.sh` に `--no-labels` 引数パースを追加
+  - 引数パース部に `--no-labels` を追加し、bool flag `SKIP_LABELS` を導入
+  - `IDD_CLAUDE_SKIP_LABELS=true` env でも opt-out 可能にする
+  - ヘルプ文（先頭コメント）を更新
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+- [ ] 2. ラベルセットアップ実行ヘルパー関数 `run_label_setup_for_repo` を実装
+  - 対象 repo を `gh repo view` → `git remote` 順で解決（fail-soft）
+  - `gh` 不在 / 未認証 / 権限不足 / API 失敗 → skip + 手動コマンド案内（Req 3.1〜3.6）
+  - `--dry-run` 時は LABELS_DRY_RUN_PLAN を表示し API 呼び出ししない
+  - 既存 `idd-claude-labels.sh` を `--repo owner/name` で呼び出す（既存 interface 不変）
+  - skip 理由はカテゴリを区別したログ書式で stdout に出力（grep 可能）
+  - _Requirements: 1.1, 1.5, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 5.1, 5.2, 5.3, 5.4, 6.3, NFR 2.3, NFR 3.1_
+
+- [ ] 3. 配置完了直後にラベルセットアップを呼び出す
+  - `INSTALL_REPO=true` のとき、配置完了後・`REPO_HINT` 出力後に run_label_setup_for_repo
+  - `INSTALL_LOCAL=true` のみのときは呼ばない（Req 1.3, 1.5）
+  - `SKIP_LABELS=true` のときは opt-out 旨の skip ログのみ出力（Req 4.2）
+  - 対話モードで対象リポジトリを選んだ場合も自動的に走る（Req 1.4）
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 4.2, 4.3, 5.1, 5.3, 6.1, 6.2_
+
+- [ ] 4. README.md にラベル自動セットアップの記載を追加
+  - install.sh 経由のセットアップ手順節に自動実行の旨を追記（Req 7.1）
+  - `--no-labels` の opt-out 説明と推奨ユースケース（Req 7.2）
+  - skip 時の手動 fallback 案内（Req 7.3）
+  - 既存「ラベル一括作成（推奨）」節は残し、自動と手動の関係を注記（Req 7.4）
+  - _Requirements: 7.1, 7.2, 7.3, 7.4_
+
+- [ ] 5. 手動スモークテストと impl-notes.md 記録
+  - shellcheck install.sh / idd-claude-labels.sh
+  - `/tmp/idd85-test` で配置 + ラベル成功・skip・冪等再実行
+  - `--local` でラベル処理が走らないこと
+  - `--no-labels` で opt-out 経路
+  - `--dry-run` で API 呼び出しなしの plan 表示
+  - 結果を impl-notes.md に記録
+  - _Requirements: 全要件のテスト確認_

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,8 @@
 #   --force          .claude/agents/ / .claude/rules/ / CLAUDE.md について、
 #                    内容差分があれば再 .bak 退避して強制上書き
 #                    （既存 *.bak は once-only 規律で保護されたまま）
+#   --no-labels      対象リポジトリ配置時に走る GitHub ラベル自動セットアップを完全に skip
+#                    （`IDD_CLAUDE_SKIP_LABELS=true` env でも同等の opt-out が可能）
 # =============================================================================
 
 set -euo pipefail
@@ -48,6 +50,15 @@ LOCAL_WATCHER_DIR="$SCRIPT_DIR/local-watcher"
 # 冪等性 / dry-run 制御フラグ（後段の引数パースで上書き可能）
 DRY_RUN=false
 FORCE=false
+
+# ラベル自動セットアップ opt-out 制御
+#   true: ラベルセットアップを完全に skip（`--no-labels` または
+#         `IDD_CLAUDE_SKIP_LABELS=true` env で有効化）
+#   false: 既定（対象リポジトリ配置時にラベルセットアップを試行する）
+SKIP_LABELS=false
+case "${IDD_CLAUDE_SKIP_LABELS:-}" in
+  true|TRUE|True|1|yes|YES) SKIP_LABELS=true ;;
+esac
 
 REPO_PATH=""
 INSTALL_LOCAL=false
@@ -84,8 +95,12 @@ while [[ $# -gt 0 ]]; do
       FORCE=true
       shift
       ;;
+    --no-labels)
+      SKIP_LABELS=true
+      shift
+      ;;
     -h|--help)
-      sed -n '3,21p' "$0"
+      sed -n '3,23p' "$0"
       exit 0
       ;;
     *)
@@ -394,6 +409,171 @@ copy_agents_rules() {
   fi
 }
 
+# ─────────────────────────────────────────────────────────────
+# ラベル自動セットアップ（Issue #85）
+#   テンプレート配置完了直後に対象リポジトリ向けラベルを冪等作成する。
+#   gh 不在 / 未認証 / 権限なし / API 失敗時は skip し install 全体を止めない（fail-soft）。
+#   `--no-labels` または `IDD_CLAUDE_SKIP_LABELS=true` で完全 opt-out。
+#   `--dry-run` 時は API 呼び出しせず、これから走る予定だけを表示する。
+# ─────────────────────────────────────────────────────────────
+
+# log_label_action <STATUS> <message>
+#   ラベルセットアップ系の出力を grep 可能な統一書式で記録する（NFR 2.3）。
+#   STATUS は OK / SKIP / DRY-RUN / FAIL のいずれか。
+log_label_action() {
+  local status="$1"
+  local message="$2"
+  printf '%s %-9s [labels] %s\n' "[INSTALL]" "$status" "$message"
+}
+
+# print_label_manual_command <repo_or_path>
+#   skip 時にユーザーが手動実行できる完全コマンド文字列を 1 ブロックで提示する（Req 3.5, 3.6）。
+#   引数:
+#     - owner/repo 形式が解決できていれば --repo 付き、解決できていなければ
+#       repo path に cd してからの実行例の両方を出す
+print_label_manual_command() {
+  local repo="$1"
+  local repo_path="$2"
+  cat <<MANUAL
+   手動でラベル一括作成を実行するには:
+       cd $repo_path
+       bash .github/scripts/idd-claude-labels.sh
+     または repo 外から:
+       bash $repo_path/.github/scripts/idd-claude-labels.sh${repo:+ --repo $repo}
+MANUAL
+}
+
+# resolve_repo_slug <repo_path>
+#   対象 repo path から `owner/repo` を解決する（fail-soft）。
+#   解決順序:
+#     1. gh repo view --json nameWithOwner
+#     2. git -C remote get-url origin → 正規表現抽出
+#   いずれも失敗したら空文字列を stdout に返す（呼び出し側で skip 判断）。
+resolve_repo_slug() {
+  local repo_path="$1"
+  local slug=""
+
+  if command -v gh >/dev/null 2>&1; then
+    if slug=$(gh repo view --json nameWithOwner -q .nameWithOwner -R "$repo_path" 2>/dev/null); then
+      if [ -n "$slug" ]; then
+        printf '%s' "$slug"
+        return 0
+      fi
+    fi
+  fi
+
+  # gh が解決できない / repo path 内が clone 済みでない場合: git remote から推測
+  local remote=""
+  if remote=$(git -C "$repo_path" remote get-url origin 2>/dev/null); then
+    # SSH / HTTPS / git 形式すべて対応
+    # 例: git@github.com:owner/repo.git → owner/repo
+    #     https://github.com/owner/repo.git → owner/repo
+    slug=$(printf '%s\n' "$remote" \
+      | sed -E -e 's#^[^:]+://[^/]+/##' \
+              -e 's#^git@[^:]+:##' \
+              -e 's#\.git$##' \
+              -e 's#/$##')
+    if printf '%s' "$slug" | grep -Eq '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
+      printf '%s' "$slug"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# setup_repo_labels <repo_path>
+#   対象 repo へのラベル一括作成を起動する。fail-soft 設計のため、エラーが起きても
+#   exit 0 で戻る。出力は log_label_action / print_label_manual_command に集約する。
+setup_repo_labels() {
+  local repo_path="$1"
+  local labels_script="$repo_path/.github/scripts/idd-claude-labels.sh"
+
+  echo ""
+  echo "🏷  GitHub ラベル自動セットアップ"
+
+  # opt-out: --no-labels / IDD_CLAUDE_SKIP_LABELS
+  if [ "$SKIP_LABELS" = "true" ]; then
+    log_label_action "SKIP" "opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS)"
+    print_label_manual_command "" "$repo_path"
+    return 0
+  fi
+
+  # gh 未インストール → skip
+  #   dry-run でも gh 不在を可視化したいので最初に判定する
+  if ! command -v gh >/dev/null 2>&1; then
+    log_label_action "SKIP" "gh CLI not found"
+    print_label_manual_command "" "$repo_path"
+    return 0
+  fi
+
+  # 対象 repo slug 解決（Req 1.1, 1.5）
+  #   dry-run でも実 git remote から解決可能なので先に行う
+  local repo_slug=""
+  if ! repo_slug=$(resolve_repo_slug "$repo_path"); then
+    repo_slug=""
+  fi
+  if [ -z "$repo_slug" ]; then
+    log_label_action "SKIP" "could not resolve owner/repo from $repo_path"
+    print_label_manual_command "" "$repo_path"
+    return 0
+  fi
+
+  # dry-run: 実 API 呼び出しせず、予定を表示する（Req 5.4）
+  #   dry-run 下ではラベルスクリプト自体は配置されない可能性があるため、ここで早期 return
+  if [ "$DRY_RUN" = "true" ]; then
+    log_label_action "DRY-RUN" "would run: bash $labels_script --repo $repo_slug"
+    return 0
+  fi
+
+  # gh 認証チェック（Req 3.2）
+  if ! gh auth status >/dev/null 2>&1; then
+    log_label_action "SKIP" "gh CLI is not authenticated (run: gh auth login)"
+    print_label_manual_command "" "$repo_path"
+    return 0
+  fi
+
+  # 配置されたラベルスクリプトの存在確認（自分自身が配置したはずだが念のため）
+  if [ ! -f "$labels_script" ]; then
+    log_label_action "SKIP" "labels script not found: $labels_script"
+    return 0
+  fi
+
+  # 実行: 既存 idd-claude-labels.sh の interface を変更せず呼び出す（Req 6.3）
+  #   - --repo owner/name を渡す
+  #   - --force は付けない（既存ラベルの color/description を上書きしない）（Req 2.5）
+  #   - bash で起動（実行ビット欠落でも動かせる保険）
+  echo "   対象: $repo_slug"
+  local labels_output=""
+  local labels_rc=0
+  if labels_output=$(bash "$labels_script" --repo "$repo_slug" 2>&1); then
+    labels_rc=0
+  else
+    labels_rc=$?
+  fi
+
+  # 全行をユーザーに見せる
+  printf '%s\n' "$labels_output"
+
+  # 集計行を取り出して要約（Req 5.1）
+  local created exists updated failed
+  created=$(printf '%s\n' "$labels_output" | sed -n 's/^[[:space:]]*新規作成:[[:space:]]*//p' | tail -n1)
+  exists=$(printf '%s\n' "$labels_output" | sed -n 's/^[[:space:]]*既存スキップ:[[:space:]]*//p' | tail -n1)
+  updated=$(printf '%s\n' "$labels_output" | sed -n 's/^[[:space:]]*上書き更新:[[:space:]]*//p' | tail -n1)
+  failed=$(printf '%s\n' "$labels_output" | sed -n 's/^[[:space:]]*失敗:[[:space:]]*//p' | tail -n1)
+
+  if [ "$labels_rc" -eq 0 ]; then
+    log_label_action "OK" "created=${created:-?} exists=${exists:-?} updated=${updated:-?} failed=${failed:-0}"
+    return 0
+  fi
+
+  # rc != 0: API / 権限 / レート制限などで一部または全部失敗（Req 3.3, 3.4）
+  log_label_action "FAIL" "label setup partially failed (created=${created:-?} failed=${failed:-?}, rc=$labels_rc)"
+  print_label_manual_command "$repo_slug" "$repo_path"
+  # fail-soft: install 全体は止めない
+  return 0
+}
+
 # 対話モード（引数なし）
 if ! $INSTALL_LOCAL && ! $INSTALL_REPO; then
   echo "=== idd-claude install ==="
@@ -463,10 +643,9 @@ if $INSTALL_REPO; then
 
      1. CLAUDE.md をプロジェクト固有の内容に編集（技術スタック・規約など）
      2. git add / commit / push
-     3. GitHub ラベルを一括作成:
-          cd $REPO_PATH
-          bash .github/scripts/idd-claude-labels.sh
-        （repo 外から実行する場合は --repo owner/repo を付与）
+     3. GitHub ラベルを一括作成: 直後にこの install.sh が自動実行します
+        （skip 時のメッセージが出た場合のみ手動 fallback してください。
+         opt-out したい場合は --no-labels を付けて再実行）
      4. 実行基盤の選択:
         - **ローカル watcher のみ使う場合**: 何もしない（.github/workflows/issue-to-pr.yml は
           repository variable 未設定なので自動でスキップされます）
@@ -480,6 +659,12 @@ if $INSTALL_REPO; then
             -f required_pull_request_reviews.required_approving_review_count=1 \\
             -F enforce_admins=false
 REPO_HINT
+
+  # ラベル自動セットアップ（Issue #85）
+  #   - 配置完了直後にラベルを冪等作成して、初回 cron で claim ラベル付与に
+  #     失敗しないようにする
+  #   - fail-soft: 失敗・skip しても install 全体は exit 0 で完走する
+  setup_repo_labels "$REPO_PATH"
 fi
 
 # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要

`install.sh --repo <path>` でテンプレートを配置した直後の対象リポジトリに、idd-claude の状態遷移に必要なラベル（`auto-dev` / `claude-claimed` / `ready-for-review` 等）が存在しない問題を解消する。

- `install.sh --repo` / `--all` の配置完了直後に `idd-claude-labels.sh` を自動起動するよう拡張
- 認証不足・権限不足・API 失敗時でも install 全体は exit 0 で完走する fail-soft 設計
- `--no-labels` フラグおよび `IDD_CLAUDE_SKIP_LABELS=true` env による完全 opt-out に対応
- skip 時は手動実行コマンドをコピー & ペーストできる形式で出力
- 既存 `install.sh` オプション・既存 `idd-claude-labels.sh` の interface・ラベル定義は無変更

## 対応 Issue

Closes #85

## 関連 PR

なし

## 実装内容

- (Req 1.1 / Task 1) `install.sh` に `setup_repo_labels` helper を追加し、`INSTALL_REPO=true` 経路の配置完了直後に呼び出す
- (Req 3 / Task 2) `--no-labels` フラグと `IDD_CLAUDE_SKIP_LABELS` env を追加し、fail-soft な skip ロジック（gh 不在 / 未認証 / API 失敗）を実装
- (Req 4 / Task 3) slug 解決（`gh repo view` 優先 → `git remote get-url origin` fallback）と opt-out フラグ解析を実装
- (Req 5 / Task 4) `[INSTALL] OK|SKIP|DRY-RUN|FAIL [labels] ...` のプレフィクス統一出力、dry-run 時の plan 表示
- (Req 7 / Task 5) README に「GitHub ラベルの自動セットアップ」節を追加、既存「ラベル一括作成（推奨）」節に warning blockquote を追記

## 受入基準チェック

- [x] Req 1.1: When `--repo` 配置に成功した直後, the Install Helper shall ラベルセットアップを起動する ← スモーク 3 / 10 で `🏷  GitHub ラベル自動セットアップ` 出力を確認
- [x] Req 3.1: If `gh` が見つからない, the Install Helper shall skip し exit 0 で完走する ← スモーク 7-1 で `SKIP gh CLI not found` を確認
- [x] Req 3.2: If gh 未認証, the Install Helper shall skip し exit 0 で完走する ← スモーク 7-2 で `SKIP gh CLI is not authenticated` を確認
- [x] Req 4.1: When `--no-labels` が指定される, the Install Helper shall ラベル処理を完全 skip する ← スモーク 4 で確認
- [x] Req 5.1: ラベル成功時は `created=N exists=N updated=N failed=N` の 1 行要約を出力する ← スモーク 10 で `[INSTALL] OK [labels] created=0 exists=11 updated=0 failed=0` を確認
- [x] Req 6.1: 既存 `install.sh` フラグの意味・挙動が変わらない ← diff は `--no-labels` 追加と末尾 hook 1 箇所のみ
- [x] Req 6.3: `idd-claude-labels.sh` の interface / exit code が不変 ← git diff main..HEAD で当該ファイルの変更なし
- [x] NFR 2.1: ラベルセットアップが 30 秒以内で完了する ← スモーク 10 で time ≈ 1.2 秒

## テスト結果

```
$ shellcheck install.sh repo-template/.github/scripts/idd-claude-labels.sh
(no output)  # clean

# 手動スモークテスト: 12 ケース（impl-notes.md 参照）
# スモーク 10（実 repo success path）:
$ time ./install.sh --repo /tmp/idd85-real
🏷  GitHub ラベル自動セットアップ
   対象: hitoshiichikawa/idd-claude
[INSTALL] OK        [labels] created=0 exists=11 updated=0 failed=0
🎉 idd-claude のインストールが完了しました。
real    0m1.199s

# shellcheck clean / 12 ケース pass / NFR 2.1 OK
```

詳細な各 AC→スモーク番号のマッピングは `docs/specs/85-feat-install-install-sh-repo-idd-claude/impl-notes.md` を参照。

## 実装上の判断

- **slug 解決の優先順位**: `gh repo view` 優先 → `git remote get-url origin` 正規表現 fallback の 2 段。env var `REPO` との衝突を避けるため env は解決源に含めない（impl-notes.md: Q1）
- **`IDD_CLAUDE_SKIP_LABELS` env を追加採用**: `--no-labels` のみ必須要件だが、`curl | bash` フローでの利便性と既存 `IDD_CLAUDE_*` 命名規則との整合性から追加（impl-notes.md: Q2）
- **`--force` を渡さない**: Req 2.5 で既存 color / description の上書き禁止が明示されているため、自動実行は素の `--repo <slug>` で起動
- **dry-run 中はラベルスクリプト存在チェックをスキップ**: dry-run はファイルを実際に配置しないため、スクリプト不在を避けて先に DRY-RUN return するよう順序を調整

## 確認事項 / レビュワーへの依頼

1. `IDD_CLAUDE_SKIP_LABELS` env 名の採用（要件上は `--no-labels` のみ必須、追加 env 名のレビューをお願いしたい）
2. slug 解決に env var `REPO` を使わない判断（既存 install.sh の `--repo` 引数との意味衝突回避）
3. private fork での権限不足は fail-soft で skip されるのみ（ベストエフォート対応はスコープ外）
4. 既存 README「ラベル一括作成（推奨）」節は残して fallback 位置付けに格下げ（節削除案もあったが手動セットアップ経路ユーザーへの互換性を優先）
5. 独立レビュー結果: `docs/specs/85-feat-install-install-sh-repo-idd-claude/review-notes.md`（RESULT: approve）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #85 のコメントを参照してください。
