### PR TITLE
refactor(install): 既存 CLAUDE.md を上書きせず template を .org として並置

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,17 +204,55 @@ IDD_CLAUDE_SKIP_LABELS=true ./install.sh --repo /path/to/your-project
 `install.sh` は何度再実行しても安全に冪等動作するよう設計されています。再実行時の各ファイル
 カテゴリの扱いは以下のとおりです。
 
-#### `CLAUDE.md.bak` の once-only 保護
+#### `CLAUDE.md` の `.org` 並置 (#87)
 
-- **初回 install** で対象 repo に既存 `CLAUDE.md` があれば `CLAUDE.md.bak` に退避し、
-  `repo-template/CLAUDE.md` を新規配置します
-- **2 回目以降** は `CLAUDE.md.bak` を**上書きしません**（既存 `.bak` を検知して `SKIP` ログを
-  出します）。これによりオリジナルの自分の `CLAUDE.md` を後から参照・復元できます
+`CLAUDE.md` は技術スタック・規約・プロジェクト固有メタを利用者が手で書き込む
+プロジェクト憲章であるため、**install.sh は既存 `CLAUDE.md` を上書きしません**。
+代わりに最新 template を `CLAUDE.md.org` として並置します（差分があるときのみ）。
 
-> **過去バージョンからの Migration**: #36 以前の `install.sh` は再実行のたびに `.bak` を
-> テンプレ由来内容で書き換えていました。当該バージョンで複数回 install を回した既存利用者は、
-> 初回のオリジナル `CLAUDE.md` が `.bak` から失われている可能性があります（`git log` から
-> 復元してください）。本改修以降は発生しません。
+| 対象 repo の状態 | 既定挙動（`--force` なし） | `--force` 指定時 |
+|---|---|---|
+| `CLAUDE.md` 不在 | `NEW` `CLAUDE.md`（template をそのまま配置、`.org` は作らない） | `NEW`（同上） |
+| `CLAUDE.md` ありかつ template と同一 | `SKIP`（`.org` も `.bak` も作らない） | `SKIP`（同上） |
+| `CLAUDE.md` ありかつ差分あり、`.org` 不在 | `SKIP CLAUDE.md` + `NEW CLAUDE.md.org`（既存据え置き、template を並置） | `BACKUP CLAUDE.md → CLAUDE.md.bak` + `OVERWRITE CLAUDE.md`（`.org` は触らない） |
+| `CLAUDE.md` ありかつ差分あり、`.org` 既存 + 内容同一 | `SKIP CLAUDE.md` + `SKIP CLAUDE.md.org` | `OVERWRITE CLAUDE.md`（`.bak` 既存は once-only で温存、`.org` は触らない） |
+| `CLAUDE.md` ありかつ差分あり、`.org` 既存 + 差分あり | `SKIP CLAUDE.md` + `OVERWRITE CLAUDE.md.org`（最新 template に追従） | `OVERWRITE CLAUDE.md`（`.org` は触らない） |
+
+**`CLAUDE.md.org` の merge 手順**: install 直後にこのファイルが新規作成・更新された
+場合、`install.sh` がコンソール末尾に merge ガイドを表示します。基本フロー:
+
+```bash
+# 差分確認
+diff CLAUDE.md CLAUDE.md.org
+
+# 対話的に merge
+vimdiff CLAUDE.md CLAUDE.md.org
+
+# 必要な箇所を CLAUDE.md に取り込んだら .org は削除して構いません。
+# 次回 install で template が更新されていれば再作成されます。
+rm CLAUDE.md.org
+```
+
+**`CLAUDE.md.bak` の once-only 保護（`--force` 経路）**:
+
+- `--force` 指定時のみ、既存 `CLAUDE.md` を `CLAUDE.md.bak` に退避してから template で
+  上書きします
+- 既存 `CLAUDE.md.bak` は **`--force` 経路でも上書きしません**（once-only 規律）。これに
+  よりオリジナルの自分の `CLAUDE.md` を後から参照・復元できます
+- `--force` なしの通常経路では `.bak` を作成・更新しません（既存 `.bak` も触りません）
+
+> **過去バージョンからの Migration**:
+> - #87 以前は `--force` なしでも `CLAUDE.md` が template で上書きされる挙動でした。
+>   再 install 時に `.bak` once-only に退避はされていましたが、本体側はカスタム編集が
+>   毎回 template に置き換わる UX でした。本改修以降は **既定で既存 `CLAUDE.md` を据え置き**、
+>   `CLAUDE.md.org` を参照用に並置する形に変更されました。従来の上書き挙動が必要な場合は
+>   `--force` を明示してください
+> - #36 以前の `install.sh` は再実行のたびに `.bak` をテンプレ由来内容で書き換えていました。
+>   当該バージョンで複数回 install を回した既存利用者は、初回のオリジナル `CLAUDE.md` が
+>   `.bak` から失われている可能性があります（`git log` から復元してください）。#36 以降は
+>   発生しません
+> - 既存 `CLAUDE.md.bak` は `CLAUDE.md.org` に **自動マイグレーションしません**。`.bak` の
+>   内容を `.org` に取り込みたい場合は手動でコピーしてください
 
 #### `.claude/agents/` / `.claude/rules/` のハイブリッド safe-overwrite
 
@@ -231,11 +269,11 @@ IDD_CLAUDE_SKIP_LABELS=true ./install.sh --repo /path/to/your-project
 指定時でも既存 `.bak` は保護されます。`.bak` を更新したい場合は、自分で `<file>.bak` を削除して
 から再実行してください。
 
-> **CLAUDE.md は別経路**: `CLAUDE.md` は `backup_claude_md_once` で初回バックアップ（once-only）
-> を作ったあと、本体は **常に template 由来内容で配置**されます（既存と同一なら `SKIP`）。
-> `.claude/agents/` / `.claude/rules/` のハイブリッド safe-overwrite とは違い、`CLAUDE.md` 本体
-> 自体に対する `--force` のような上書き抑止はありません（カスタム編集は `.bak` のみで保護）。
-> これは従来の `install.sh` 挙動（無条件で template を配置）との後方互換性を維持するためです。
+> **CLAUDE.md は別経路**: `CLAUDE.md` は #87 以降 **`.org` 並置方式**で扱われます。
+> `--force` なしでは既存 `CLAUDE.md` を据え置き、template を `CLAUDE.md.org` として
+> 並置します。`--force` 指定時のみ従来の上書き挙動（`.bak` once-only 退避＋ template
+> で上書き）に切り替わります。詳細は本節先頭の「`CLAUDE.md` の `.org` 並置 (#87)」を
+> 参照してください。
 
 #### `--dry-run` モード
 
@@ -243,12 +281,20 @@ IDD_CLAUDE_SKIP_LABELS=true ./install.sh --repo /path/to/your-project
 
 ```text
 $ ./install.sh --repo /path/to/your-project --dry-run
-[DRY-RUN] BACKUP    /path/to/your-project/CLAUDE.md → CLAUDE.md.bak
-[DRY-RUN] OVERWRITE /path/to/your-project/CLAUDE.md
+[DRY-RUN] SKIP      /path/to/your-project/CLAUDE.md (existing kept, template placed as CLAUDE.md.org)
+[DRY-RUN] NEW       /path/to/your-project/CLAUDE.md.org
 [DRY-RUN] NEW       /path/to/your-project/.claude/agents/reviewer.md
 [DRY-RUN] SKIP      /path/to/your-project/.claude/agents/developer.md (identical to template)
 [DRY-RUN] BACKUP    /path/to/your-project/.claude/rules/ears-format.md → ears-format.md.bak (custom edits detected)
 [DRY-RUN] OVERWRITE /path/to/your-project/.claude/rules/ears-format.md
+```
+
+`--force` を付けると CLAUDE.md は従来挙動（`.bak` 退避 + 上書き）に戻ります:
+
+```text
+$ ./install.sh --repo /path/to/your-project --dry-run --force
+[DRY-RUN] BACKUP    /path/to/your-project/CLAUDE.md → CLAUDE.md.bak
+[DRY-RUN] OVERWRITE /path/to/your-project/CLAUDE.md (--force)
 ```
 
 | Prefix | 意味 |

--- a/docs/specs/87-refactor-install-claude-md-template-org/impl-notes.md
+++ b/docs/specs/87-refactor-install-claude-md-template-org/impl-notes.md
@@ -1,0 +1,187 @@
+# Implementation Notes — #87 refactor(install): CLAUDE.md.org 並置
+
+## 採用方針
+
+**案 2（CLAUDE.md 専用関数 `copy_claude_md_with_org` の新設）** を採用しました。
+
+### 案 1（`copy_with_hybrid_overwrite` にモードフラグ追加）を採らなかった理由
+
+- 既存の `copy_with_hybrid_overwrite` は `.claude/agents/` `.claude/rules/` で使われ、
+  Issue #36 の「ハイブリッド safe-overwrite 規律」（`.bak` once-only + `--force` での
+  上書き）を実現する責務に集中している。Req NFR 3.1 で本 Issue のスコープは CLAUDE.md
+  単一ファイルに限定されており、共有関数にモード分岐を増やすと両系統の責務が交錯する
+- CLAUDE.md は Req 2 / Req 6 で `.org` 並置 / merge ガイド表示など固有の挙動が多く、
+  独立関数として `copy_claude_md_with_org` に閉じ込めたほうが、bash の可読性とテスト容易性
+  （シナリオ別に挙動を独立にトレース可能）が高い
+- `--force` 経路では従来挙動（`backup_claude_md_once` + `.bak` 退避 + template 上書き）を
+  そのまま再利用したい。新関数は `FORCE=true` 時に `classify_action` ベースの NEW / SKIP /
+  OVERWRITE 経路だけ持ち、`.bak` は呼び出し側の `backup_claude_md_once` に委譲する設計とした
+
+### 動作仕様（実装した分岐）
+
+`copy_claude_md_with_org <src> <dest>` の状態遷移:
+
+| dest 状態 | template 差分 | FORCE | 挙動 |
+|---|---|---|---|
+| 不在 | — | any | `NEW dest`（`.org` 作らず）— Req 1.1 / 1.2 |
+| 存在 | 同一 | any | `SKIP dest`（`.org` 作らず）— Req 2.5 |
+| 存在 | 差分 | false | `SKIP dest` + `.org` 並置（NEW / SKIP / OVERWRITE） — Req 2.1〜2.4 |
+| 存在 | 差分 | true | 既存 OVERWRITE 経路（`.org` 触らず） — Req 3.1, 3.4 |
+
+`.org` 側の冪等経路（FORCE=false / 差分あり）:
+
+- `.org` 不在 → `NEW dest.org`
+- `.org` 既存 + 内容同一 → `SKIP dest.org`
+- `.org` 既存 + 差分あり → `OVERWRITE dest.org (refresh from template)`
+
+`CLAUDE_MD_ORG_TOUCHED` グローバルフラグを `NEW` / `OVERWRITE` 時のみ true に立て、
+配置完了サマリ末尾の merge ガイドメッセージ表示判定に使う（Req 6.1, 6.2）。
+
+`--force` 経路では `backup_claude_md_once` を呼んでから `copy_claude_md_with_org` を呼ぶ。
+`backup_claude_md_once` 自体は #36 の once-only 規律をそのまま保持しており（既存 `.bak` を
+SKIP）、Req 4.1 / Req 3.3 を満たす。
+
+## 変更ファイル
+
+| ファイル | 内容 |
+|---|---|
+| `install.sh` | ヘッダの `--force` 説明更新 / 新関数 `copy_claude_md_with_org` 追加 / `setup_repo` 内の CLAUDE.md 配置経路を新関数に切替 / 配置完了サマリ末尾に CLAUDE.md.org merge ガイド追加（条件付き） |
+| `README.md` | 「CLAUDE.md.bak の once-only 保護」節を「CLAUDE.md の `.org` 並置 (#87)」に再構成 / dry-run 出力例を新挙動に更新 / `--force --dry-run` 例を追加 / 「CLAUDE.md は別経路」注記を `.org` 並置方式に書き換え / Migration note を 2 段階構成（#87 と #36）に拡張 |
+| `docs/specs/87-refactor-install-claude-md-template-org/impl-notes.md` | 本ファイル（新規） |
+
+`backup_claude_md_once` / `copy_with_hybrid_overwrite` / `copy_template_file` /
+`copy_agents_rules` / `setup_repo_labels` 等の既存関数は **interface 不変**（NFR 1）。
+env var 名・cron 登録文字列・exit code・既存フラグの意味も無変更（NFR 1.1〜1.4）。
+
+## Test Plan（手動スモークテスト結果）
+
+すべて `IDD_CLAUDE_SKIP_LABELS=true ./install.sh ...` で実行（ラベル自動セットアップは
+本 Issue 範囲外なので opt-out）。
+
+### シナリオ A: CLAUDE.md 不在 → NEW 配置
+
+- 実行: `./install.sh --repo /tmp/scratch-a`（CLAUDE.md 不在の scratch dir）
+- 結果: `[INSTALL] NEW /tmp/scratch-a/CLAUDE.md` のみ。`.org` 不在、`.bak` 不在、merge ガイド非表示
+- AC: Req 1.1 / 1.2 / 1.3 ✅
+
+### シナリオ B: 既存 CLAUDE.md（差分あり） → 据え置き + .org 並置
+
+- 実行: 既存 CLAUDE.md（"# My Project Custom..."）配置後 `./install.sh --repo /tmp/scratch-b`
+- 結果:
+  - `[INSTALL] SKIP /tmp/scratch-b/CLAUDE.md (existing kept, template placed as CLAUDE.md.org)`
+  - `[INSTALL] NEW /tmp/scratch-b/CLAUDE.md.org`
+  - 既存 CLAUDE.md は **sha256 hash 完全一致**（preserve）
+  - `.org` の内容は template と完全一致
+  - `.bak` は作成されず
+  - merge ガイド `📝 CLAUDE.md.org（最新 template 並置）の merge ガイド:` 表示
+- AC: Req 2.1 / 2.2 / 6.1 ✅
+
+### シナリオ C: シナリオ B 状態で再 install（`.org` の冪等性）
+
+- C-1（template 同一の状態で再実行）:
+  - `[INSTALL] SKIP /tmp/scratch-b/CLAUDE.md (existing kept, ...)`
+  - `[INSTALL] SKIP /tmp/scratch-b/CLAUDE.md.org (identical to template)`
+  - merge ガイド非表示（Req 6.1: `.org` を NEW / OVERWRITE していないため）
+  - 既存 CLAUDE.md / .org のハッシュ不変
+- C-2（`.org` を手動で stale 化 → 再実行）:
+  - `[INSTALL] OVERWRITE /tmp/scratch-b/CLAUDE.md.org (refresh from template)`
+  - merge ガイド表示
+  - 再実行後 `.org` は再び template と完全一致、CLAUDE.md は不変
+- AC: Req 2.3 / 2.4 / 5.1 / 6.1 / 6.2 ✅
+
+### シナリオ D: 既存 CLAUDE.md と template 同一 → SKIP
+
+- 実行: template を CLAUDE.md として配置後 `./install.sh --repo /tmp/scratch-d`
+- 結果: `[INSTALL] SKIP /tmp/scratch-d/CLAUDE.md (identical to template)` のみ
+- `.org` 不在、`.bak` 不在、merge ガイド非表示
+- AC: Req 2.5 ✅
+
+### シナリオ E: シナリオ B 状態 + `--force`
+
+- 実行: 既存カスタム CLAUDE.md (`.bak` 不在) で `./install.sh --repo /tmp/scratch-e --force`
+- 結果:
+  - `[INSTALL] BACKUP /tmp/scratch-e/CLAUDE.md → CLAUDE.md.bak`
+  - `[INSTALL] OVERWRITE /tmp/scratch-e/CLAUDE.md (--force)`
+  - `.bak` の内容はカスタム CLAUDE.md（"# My Project Custom CLAUDE.md (E)..."）と一致
+  - 上書き後の CLAUDE.md は template と一致
+  - `.org` 不在、merge ガイド非表示
+- AC: Req 3.1 / 3.2 / 3.4 ✅
+
+### シナリオ F: 既存 .bak ありの状態で再 install
+
+- F-1（`--force` なし、既存 `.bak` あり、CLAUDE.md カスタム）:
+  - `[INSTALL] SKIP /tmp/scratch-f/CLAUDE.md (existing kept, ...)`
+  - `[INSTALL] NEW /tmp/scratch-f/CLAUDE.md.org`
+  - 既存 .bak は `a14125c0...` のまま不変（Req 4.1）
+  - 既存 CLAUDE.md は据え置き（Req 4.3）
+- F-2（`--force` あり、既存 `.bak` あり）:
+  - `[INSTALL] SKIP /tmp/scratch-f/CLAUDE.md.bak (existing .bak preserved)`
+  - `[INSTALL] OVERWRITE /tmp/scratch-f/CLAUDE.md (--force)`
+  - 既存 .bak は once-only 規律で温存（Req 3.3）
+  - CLAUDE.md は template で上書き
+- AC: Req 3.3 / 4.1 / 4.2 / 4.3 ✅
+
+### 追加検証 1: `--dry-run` の整合性
+
+- シナリオ A の状態で `--dry-run` 実行 → `[DRY-RUN] SKIP CLAUDE.md (existing kept...)` /
+  `[DRY-RUN] NEW CLAUDE.md.org` を表示、ファイルシステムは不変
+- シナリオ B の状態で `--dry-run --force` 実行 → `[DRY-RUN] SKIP CLAUDE.md.bak (existing .bak preserved)` /
+  `[DRY-RUN] OVERWRITE CLAUDE.md (--force)`、FS 不変
+- AC: Req 5.2 / 5.3 ✅
+
+### 追加検証 2: 既存 .bak と .org の独立運用
+
+- 既存 CLAUDE.md (custom) + 既存 CLAUDE.md.bak ありの状態で `--force` なし install
+- `.bak` は不変、`.org` は新規作成、本体は据え置き → Req 4.3 ✅
+
+### 静的解析
+
+- `shellcheck install.sh` → クリーン（warning ゼロ）
+
+## 受入基準と担保テストの対応表
+
+| Req ID | 内容 | 担保テスト |
+|---|---|---|
+| 1.1 | 不在時 template を CLAUDE.md として配置 | シナリオ A |
+| 1.2 | 不在時 .org を作らない | シナリオ A |
+| 1.3 | 不在時 NEW ログを 1 行出力 | シナリオ A |
+| 2.1 | 既存 CLAUDE.md (差分) を変更しない | シナリオ B |
+| 2.2 | .org 不在時に NEW 配置 | シナリオ B |
+| 2.3 | .org 既存 + 同一 → SKIP | シナリオ C-1 |
+| 2.4 | .org 既存 + 差分 → 更新 | シナリオ C-2 |
+| 2.5 | CLAUDE.md と template 同一 → 何もしない | シナリオ D |
+| 2.6 | .org の判定は agents/rules と独立 | シナリオ B/C 全体（agents/rules 配下と独立に動作することを目視） |
+| 3.1 | --force 時 既存を template で上書き | シナリオ E |
+| 3.2 | --force + .bak 不在 → 退避してから上書き | シナリオ E |
+| 3.3 | --force + .bak 既存 → .bak 不変 | シナリオ F-2 |
+| 3.4 | --force 時 .org を作成・更新しない | シナリオ E / F-2 |
+| 3.5 | --force の意味を変更しない | シナリオ E（従来挙動と同じ BACKUP/OVERWRITE シーケンス） |
+| 4.1 | 既存 .bak の中身を変更しない | シナリオ F-1, F-2 |
+| 4.2 | .bak を .org に自動マイグレーションしない | シナリオ F-1（.bak はそのまま、.org は template から新規作成） |
+| 4.3 | .bak 有無に関わらず .org 並置ロジック適用 | シナリオ F-1 / 追加検証 2 |
+| 5.1 | 同一入力で 2 回連続実行しても等価状態 | シナリオ C-1 |
+| 5.2 | --dry-run で FS 不変・予定操作を表示 | 追加検証 1 |
+| 5.3 | --dry-run の出力分類が実実行と一致 | 追加検証 1（NEW / SKIP / OVERWRITE / BACKUP すべて [DRY-RUN] prefix で対応） |
+| 6.1 | .org 新規/更新時に merge ガイド表示 | シナリオ B / C-2 |
+| 6.2 | CLAUDE.md 不在で .org を作らなかった場合は merge ガイド非表示 | シナリオ A / D |
+| 6.3 | README に `.org` 並置仕様 1 セクション | README.md「CLAUDE.md の `.org` 並置 (#87)」節 |
+| 6.4 | README に旧挙動からの移行 note | README.md Migration note 2 段構成 |
+| NFR 1.1〜1.4 | 既存 env var / フラグ / sudo 不要 / exit code 不変 | install.sh 引数パース・関数 interface 不変、shellcheck pass |
+| NFR 2.1 | 操作種別と対象パスを 1 行ログ出力 | 各シナリオの `[INSTALL]` ログ |
+| NFR 2.2 | 既存 agents 配置ログとカラム整合 | `printf '%s %-9s %s %s\n'` のフォーマットを共有 (`log_action`) |
+| NFR 3.1 | 範囲外ファイル（agents/rules/workflows/ISSUE_TEMPLATE/scripts）の取り扱い不変 | `setup_repo` の他関数呼び出しに変更なし、シナリオ全体で agents/rules が従来通り NEW |
+
+## 確認事項
+
+なし。要件は明確で、実装上の判断点（`--force` 経路の `.bak` 一段呼び出し、merge ガイド
+表示判定の global flag、`.org` の更新時メッセージ）はすべて Req に従って一意に決まった。
+
+ただし、Reviewer に注意してほしい設計判断:
+
+- `CLAUDE_MD_ORG_TOUCHED` をグローバル変数として導入した。Bash 関数間の戻り値伝達は
+  exit code か stdout になるが、`copy_claude_md_with_org` は他の `copy_*` 関数同様に
+  ログ出力に stdout を使うため、副作用としてのフラグはグローバルで持つほうが直感的と判断。
+  単一の `setup_repo` 内でのみ使われ、副作用は配置完了サマリ表示の 1 箇所に閉じる
+- README の Migration note を 2 段（#87 と既存の #36）に拡張した。Issue #87 の挙動変更が
+  「既存ユーザにとって既定動作の変化」になるため、`--force` で従来挙動を取り戻せる旨を
+  明示した。Req 6.4 の趣旨に沿う

--- a/docs/specs/87-refactor-install-claude-md-template-org/requirements.md
+++ b/docs/specs/87-refactor-install-claude-md-template-org/requirements.md
@@ -1,0 +1,161 @@
+# Requirements Document
+
+## Introduction
+
+`install.sh` は対象 repo に `repo-template/CLAUDE.md` を配置する際、既存 `CLAUDE.md` があると
+`CLAUDE.md.bak` に退避してから template で上書きする「上書き優先」挙動を採っている。しかし
+`CLAUDE.md` は技術スタック・規約・プロジェクト固有メタなど、利用者が手で書き込んだ重要な
+プロジェクト憲章であり、再 install のたびに本体が template に置き換わる UX は破壊的である。
+
+本要件は、`CLAUDE.md` に限り「ユーザーの記述が主、template は参考」という関係に反転する。
+既存 `CLAUDE.md` は active のまま据え置き、template 由来のコンテンツは同ディレクトリの
+`CLAUDE.md.org` として並置することで、利用者がいつでも最新 template と差分比較・手動 merge
+できるようにする。後方互換性のため、従来の上書き挙動は `--force` で escape hatch として残す。
+
+スコープは `CLAUDE.md` の単一ファイル取り扱いに限定する。`.claude/agents/` `.claude/rules/`
+`.github/workflows/` `.github/ISSUE_TEMPLATE/` の取り扱いは本 Issue では変更しない。
+
+## Requirements
+
+### Requirement 1: CLAUDE.md の不在時配置
+
+**Objective:** As an idd-claude を初めて install するユーザー, I want template の CLAUDE.md が
+そのまま配置されること, so that 初回セットアップではプロジェクトガイドの雛形を即座に得られる
+
+#### Acceptance Criteria
+
+1. When 対象 repo に `CLAUDE.md` が存在せず install.sh が実行される, the install Script shall
+   `repo-template/CLAUDE.md` を `CLAUDE.md` として配置する
+2. When 上記 1 の配置が行われる, the install Script shall `CLAUDE.md.org` を作成しない
+3. When 上記 1 の配置が行われる, the install Script shall 当該配置を `NEW` 種別のログとして 1 行出力する
+
+### Requirement 2: 既存 CLAUDE.md の据え置きと .org 並置
+
+**Objective:** As 既存の CLAUDE.md を編集済みのユーザー, I want 自分の CLAUDE.md が install で
+上書きされず、最新 template だけ参照可能な形で並置されること, so that 安全に再 install
+できつつ template の差分も確認できる
+
+#### Acceptance Criteria
+
+1. When 対象 repo に既存 `CLAUDE.md` が存在し、かつ template と内容が異なり、`--force` が
+   指定されていない状態で install.sh が実行される, the install Script shall 既存 `CLAUDE.md`
+   を変更しない
+2. When 上記 1 の条件が成立し、`CLAUDE.md.org` が存在しない, the install Script shall
+   `repo-template/CLAUDE.md` を `CLAUDE.md.org` として配置する
+3. When 上記 1 の条件が成立し、既存 `CLAUDE.md.org` の内容が template と同一である, the install
+   Script shall `CLAUDE.md.org` を変更せず、SKIP 種別のログを 1 行出力する
+4. When 上記 1 の条件が成立し、既存 `CLAUDE.md.org` の内容が template と異なる, the install
+   Script shall `CLAUDE.md.org` を template の最新内容で更新する
+5. When 既存 `CLAUDE.md` と template の内容が完全に一致する, the install Script shall
+   `CLAUDE.md` を変更せず、`CLAUDE.md.org` を作成しない
+6. The install Script shall `CLAUDE.md.org` の作成・更新・スキップを `.claude/agents/` /
+   `.claude/rules/` 配下のファイル配置と独立に判定する
+
+### Requirement 3: --force 指定時の従来挙動
+
+**Objective:** As 最新 template を強制適用したい運用者, I want `--force` で従来通り template
+で上書きできる escape hatch があること, so that 後方互換性が保たれ、強制更新が必要な場面に
+対応できる
+
+#### Acceptance Criteria
+
+1. When 対象 repo に既存 `CLAUDE.md` が存在し、かつ template と内容が異なり、`--force` が
+   指定された状態で install.sh が実行される, the install Script shall 既存 `CLAUDE.md` を
+   template の内容で上書きする
+2. While `--force` 指定の上書きが発生する場合、対象 repo に `CLAUDE.md.bak` が存在しない,
+   the install Script shall 上書き直前の `CLAUDE.md` を `CLAUDE.md.bak` として退避してから
+   上書きする
+3. While `--force` 指定の上書きが発生する場合、対象 repo に既に `CLAUDE.md.bak` が存在する,
+   the install Script shall 既存 `CLAUDE.md.bak` を再退避せず温存したまま `CLAUDE.md` を上書きする
+4. When `--force` 指定により `CLAUDE.md` の上書きが行われた, the install Script shall
+   `CLAUDE.md.org` を作成・更新しない
+5. The install Script shall `--force` の意味（差分ありファイルへの強制上書き）を本要件以外で
+   変更しない
+
+### Requirement 4: 既存 .bak ファイルの保護
+
+**Objective:** As 過去 install で `.bak` を取得済みのユーザー, I want 過去の `.bak` が今回の
+install で消えたり中身が変わったりしないこと, so that オリジナルの編集履歴を失わない
+
+#### Acceptance Criteria
+
+1. While 対象 repo に既存 `CLAUDE.md.bak` が存在する, the install Script shall 既存
+   `CLAUDE.md.bak` の中身を変更しない
+2. While 対象 repo に既存 `CLAUDE.md.bak` が存在する, the install Script shall 既存
+   `CLAUDE.md.bak` を `CLAUDE.md.org` に自動マイグレーションしない
+3. The install Script shall 既存 `CLAUDE.md.bak` の有無に関係なく、Requirement 2 の
+   `CLAUDE.md.org` 並置ロジックを適用する
+
+### Requirement 5: 冪等性
+
+**Objective:** As 定期的に install.sh を再実行する運用者, I want 何度実行しても予測可能で
+破壊的でない動作であること, so that update を恐れずに最新 template を取り込める
+
+#### Acceptance Criteria
+
+1. When install.sh が同一の入力（同じ対象 repo・同じ template バージョン・同じフラグ）で
+   2 回連続実行される, the install Script shall 2 回目で `CLAUDE.md` および `CLAUDE.md.org`
+   の内容を 1 回目終了時点と等価な状態に保つ
+2. When install.sh が `--dry-run` で実行される, the install Script shall ファイルシステムを
+   変更せず、`CLAUDE.md` および `CLAUDE.md.org` に対する予定操作を `[DRY-RUN]` プレフィクス付き
+   ログとして表示する
+3. The install Script shall `--dry-run` での出力分類（NEW / SKIP / OVERWRITE / BACKUP 等）を
+   実実行時の分類と一致させる
+
+### Requirement 6: ユーザー向け merge ガイダンス
+
+**Objective:** As 並置された `CLAUDE.md.org` を初めて見るユーザー, I want 何のファイルか・
+どう使うかが install 完了直後にわかること, so that template との差分マージ作業に着手できる
+
+#### Acceptance Criteria
+
+1. When install.sh の対象 repo 配置ブロックが `CLAUDE.md.org` を新規作成または更新した,
+   the install Script shall 配置完了サマリの末尾に `CLAUDE.md.org` の意味と
+   `diff CLAUDE.md CLAUDE.md.org` 等の merge 手順を案内するメッセージを 1 ブロック表示する
+2. Where 対象 repo に `CLAUDE.md` が存在しなかったために `CLAUDE.md.org` が作られなかった
+   ケース, the install Script shall 上記 1 の merge ガイドメッセージを表示しない
+3. The README shall `CLAUDE.md.org` 並置仕様（不在時 NEW / 既存据え置き / `.org` 更新 / 同一時
+   SKIP / `--force` での従来挙動）と利用者向け merge 手順を 1 セクションで説明する
+4. The README shall 旧挙動（`.bak` 退避＋ template 上書き）から新挙動への移行 note を提示する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The install Script shall 既存環境変数名（`REPO`, `REPO_DIR`, `LOG_DIR`, `LOCK_FILE`,
+   `IDD_CLAUDE_SKIP_LABELS` 等）の解釈を変更しない
+2. The install Script shall 既存フラグ（`--repo`, `--local`, `--all`, `--dry-run`, `--force`,
+   `--no-labels`）の意味を本 Issue 範囲外で変更しない
+3. The install Script shall sudo 不要のユーザースコープ install 前提を維持する
+4. The install Script shall exit code の意味（0=成功 / 非 0=失敗）を変更しない
+
+### NFR 2: 観測可能性
+
+1. When `CLAUDE.md` または `CLAUDE.md.org` に対する操作が行われる, the install Script shall
+   操作種別（NEW / SKIP / OVERWRITE / BACKUP）と対象パスを 1 行ログとして標準出力に書き出す
+2. The install Script shall ログ行のフォーマットを既存の `.claude/agents/` 配置ログと
+   視覚的に整合させる（同一カラム整列・同一プレフィクス規約）
+
+### NFR 3: 範囲限定の安全性
+
+1. The install Script shall 本要件で規定しないファイル（`.claude/agents/**`,
+   `.claude/rules/**`, `.github/workflows/**`, `.github/ISSUE_TEMPLATE/**`,
+   `.github/scripts/**`）の取り扱いを変更しない
+
+## Out of Scope
+
+- `.claude/agents/` `.claude/rules/` `.github/workflows/` `.github/ISSUE_TEMPLATE/`
+  `.github/scripts/` 配下のファイルへの `.org` 並置方式の適用（将来検討）
+- 自動 merge / 自動 diff 表示（`diff` や `git merge-file` の自動実行）
+- install 完了後の `git add` / `git commit` / `git push` の自動化
+- 既存 `CLAUDE.md.bak` の `CLAUDE.md.org` への自動マイグレーション
+- `CLAUDE.md.org` 拡張子と emacs org-mode の衝突回避機構
+- `CLAUDE.md.org` を git で追跡するか・無視するか（`.gitignore` への追記等）の方針決定
+- ユーザーの `CLAUDE.md` を解析して衝突箇所をハイライトする機能
+- `--force` 以外の新規フラグ追加（例: `--no-org`, `--org-only` 等）
+
+## Open Questions
+
+- なし（Issue 本文で判断委ね事項として挙がった 3 点はすべて要件側で確定済み:
+  拡張子は `.org` で固定 / `.bak` の自動マイグレーションはしない / agents・rules への
+  同種改修は本 Issue スコープ外）

--- a/docs/specs/87-refactor-install-claude-md-template-org/review-notes.md
+++ b/docs/specs/87-refactor-install-claude-md-template-org/review-notes.md
@@ -1,0 +1,56 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-01T04:53:08Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-87-impl-refactor-install-claude-md-template-org
+- HEAD commit: bc0a0e3c6abe2a59e875208005893191f3330095
+- Compared to: main..HEAD
+- Feature Flag Protocol: 採否節なし → opt-out 解釈（flag 観点の追加チェックは適用せず、通常 3 カテゴリ判定のみ）
+
+## Verified Requirements
+
+すべて Reviewer 自身による `/tmp/review87-XXXX` への scratch repo 配置スモークテストで再検証済み（impl-notes.md のシナリオ A〜F + dry-run 4 種を独立に再実行）。
+
+- 1.1 — `install.sh:483-490` (`copy_claude_md_with_org` の NEW 分岐) / 検証: 不在状態で `[INSTALL] NEW <repo>/CLAUDE.md` を観測、内容は template と sha256 一致
+- 1.2 — `install.sh:483-490` (NEW 分岐で `.org` を作らない) / 検証: 不在からの NEW 配置後 `CLAUDE.md.org` 不在を確認
+- 1.3 — `install.sh:486` (`log_action "NEW" "$dest"`) / 検証: NEW ログ 1 行のみ出力
+- 2.1 — `install.sh:496-499` (OVERWRITE 経路で本体は SKIP として明示、cp しない) / 検証: 既存カスタム CLAUDE.md（"# My Project Custom..."）が install 前後で sha256 完全一致
+- 2.2 — `install.sh:502-508` (`.org` 不在 → NEW 並置) / 検証: `[INSTALL] NEW <repo>/CLAUDE.md.org` を観測、`.org` の内容は template と sha256 一致
+- 2.3 — `install.sh:512-515` (`.org` 既存 + 内容同一 → SKIP) / 検証: 再 install で `[INSTALL] SKIP <repo>/CLAUDE.md.org (identical to template)` を観測
+- 2.4 — `install.sh:516-523` (`.org` 既存 + 差分 → OVERWRITE + `CLAUDE_MD_ORG_TOUCHED=true`) / 検証: stale `.org` を手動配置後 `[INSTALL] OVERWRITE <repo>/CLAUDE.md.org (refresh from template)`、再実行後 `.org` ハッシュは template と一致
+- 2.5 — `install.sh:492-494` (SKIP 分岐で `.org` 触らず) / 検証: 既存 CLAUDE.md = template の repo に対し `[INSTALL] SKIP <repo>/CLAUDE.md (identical to template)` のみ、`.org` 不在
+- 2.6 — `install.sh:745-750` (`copy_claude_md_with_org` と `copy_agents_rules` が直列で独立呼び出し、共有状態は `CLAUDE_MD_ORG_TOUCHED` のみで agents/rules 経路に影響しない) / 検証: シナリオ B / D の双方で `.claude/agents/` `.claude/rules/` が NEW 配置され、`.org` 判定は CLAUDE.md 単独で確定
+- 3.1 — `install.sh:453-475` (FORCE=true 分岐の OVERWRITE 経路 `(--force)` 注記) / 検証: `--force` 指定で `[INSTALL] OVERWRITE <repo>/CLAUDE.md (--force)`、本体ハッシュが template と一致
+- 3.2 — `install.sh:742-744` (FORCE=true 時のみ `backup_claude_md_once` を呼ぶ) + `backup_claude_md_once` (291-308) / 検証: `.bak` 不在から `[INSTALL] BACKUP <repo>/CLAUDE.md → CLAUDE.md.bak` を観測、`.bak` の内容は上書き前 CLAUDE.md と sha256 一致
+- 3.3 — `install.sh:300-307` (既存 `.bak` あれば `SKIP (existing .bak preserved)`) / 検証: 既存 .bak ありで `--force` 実行、`[INSTALL] SKIP <repo>/CLAUDE.md.bak (existing .bak preserved)` + `.bak` ハッシュ不変
+- 3.4 — `install.sh:453-475` (FORCE 分岐は `.org` を触らない) / 検証: シナリオ E / F-2 共に install 後 `.org` 不在
+- 3.5 — `copy_with_hybrid_overwrite` (318-375) は変更なし、agents/rules への `--force` の意味（差分時に強制 OVERWRITE、`.bak` once-only 温存）は不変。`copy_claude_md_with_org` 内の `(--force)` 注記は Req 3 範囲内 / 検証: git diff 上 318-375 行範囲に変更なし
+- 4.1 — `install.sh:300-307` (once-only 規律で既存 `.bak` を変更しない) + 通常経路では `backup_claude_md_once` を呼ばない (`install.sh:742-744`) / 検証: シナリオ F-1 / F-2 共に既存 `.bak` ハッシュ不変
+- 4.2 — `copy_claude_md_with_org` 内に `.bak` 参照なし（grep で確認） / 検証: 既存 `.bak` を入力にしても `.org` 内容は template そのもの（`.bak` のコピーではない）
+- 4.3 — `install.sh:737-747` (FORCE=false 時 `backup_claude_md_once` をスキップし、`copy_claude_md_with_org` のみを呼ぶ。後者は `.bak` 有無に関係なく `.org` 並置を判定) / 検証: シナリオ F-1 で既存 .bak ありの状態でも `.org` が NEW 配置される
+- 5.1 — シナリオ C-1 (再 install で `[INSTALL] SKIP CLAUDE.md` + `[INSTALL] SKIP CLAUDE.md.org`、両ファイルのハッシュが 1 回目終了時点と一致)
+- 5.2 — `install.sh:124-139` (DRY_RUN=true で `[DRY-RUN]` prefix) + 各 `cp` を `if [ "$DRY_RUN" = "false" ]` でガード / 検証: dry-run 4 シナリオ全てで `.org` / `.bak` / `CLAUDE.md` のハッシュ不変・ファイル新設なし
+- 5.3 — Reviewer 検証: `--dry-run`（NEW / SKIP / OVERWRITE）と `--dry-run --force`（BACKUP / OVERWRITE / SKIP）の組合せで実実行と同じ 4 分類が `[DRY-RUN]` prefix 付きで出力されることを確認
+- 6.1 — `install.sh:791-808` (`CLAUDE_MD_ORG_TOUCHED=true` 時のみ heredoc で merge ガイド表示) + `install.sh:508`, `install.sh:522` (NEW / OVERWRITE 時のみ true 化) / 検証: シナリオ B（`.org` NEW）と C-2（`.org` OVERWRITE）でガイド表示
+- 6.2 — シナリオ A（CLAUDE.md NEW）/ D（CLAUDE.md SKIP）/ C-1（`.org` SKIP）でガイド非表示を観測
+- 6.3 — `README.md:207-255` (`#### CLAUDE.md の .org 並置 (#87)` 節 1 つで NEW / SKIP / OVERWRITE / BACKUP / `--force` 経路と merge 手順を網羅)
+- 6.4 — `README.md:244-254` (Migration note を `#87` と `#36` の 2 段構成に拡張、新規定→従来挙動への戻し方として `--force` を案内)
+- NFR 1.1 — git diff 上、env var 名（`REPO`, `REPO_DIR`, `LOG_DIR`, `LOCK_FILE`, `IDD_CLAUDE_SKIP_LABELS`）の解釈変更なし
+- NFR 1.2 — 既存フラグ（`--repo`, `--local`, `--all`, `--dry-run`, `--force`, `--no-labels`）の意味変更なし。`--force` の挙動は CLAUDE.md 経路で本 Issue が定義する範囲（Req 3）に閉じ、agents/rules への意味（`copy_with_hybrid_overwrite`）は無変更
+- NFR 1.3 — sudo 検知ブロック (`install.sh:35-46`) は無変更
+- NFR 1.4 — exit code の意味（0=成功 / 非 0=失敗）変更なし。新規 `Error: $org exists but is not a regular file` 経路 (`install.sh:524-528`) のみ追加だが、これは既存の `Error: source file not found` (`install.sh:198-201`, `install.sh:444-446`) と同じく異常時の `return 1` なので意味的整合
+- NFR 2.1 — `log_action "NEW|SKIP|OVERWRITE|BACKUP" <path> [<note>]` を 1 行ログとして stdout に出力、各シナリオで観測
+- NFR 2.2 — `log_action` (`install.sh:124-139`) は `printf '%s %-9s %s %s\n'` で agents/rules 配置ログと同一フォーマット
+- NFR 3.1 — `setup_repo` 内で `copy_agents_rules` / `copy_template_file`（ISSUE_TEMPLATE / workflows / scripts）の呼び出しは無変更（git diff 上 749-763 行に変更なし）
+
+## Findings
+
+なし。
+
+## Summary
+
+要件 1.1〜6.4 + NFR 1〜3 全項目を独立 scratch repo でのスモークテスト（A〜F + dry-run 4 種 + 独立性検証）で再検証し、`install.sh:411-534` の `copy_claude_md_with_org` 実装、`install.sh:737-747` の `setup_repo` 内呼び出し切替、`install.sh:791-808` の merge ガイド分岐、README の `.org` 節と Migration note 2 段構成いずれも要件と一致した。`shellcheck install.sh` クリーン、env var / フラグ / exit code / sudo 不要 / 範囲外ファイル取り扱いの後方互換性も維持されている。Reject 該当なし。
+
+RESULT: approve

--- a/install.sh
+++ b/install.sh
@@ -16,9 +16,11 @@
 # オプション（既存フラグと組み合わせ可）:
 #   --dry-run        実コピーせず、予定操作を [DRY-RUN] プレフィクスで列挙
 #                    （ファイルシステムを変更しない。出力分類は実実行時と一致）
-#   --force          .claude/agents/ / .claude/rules/ / CLAUDE.md について、
-#                    内容差分があれば再 .bak 退避して強制上書き
-#                    （既存 *.bak は once-only 規律で保護されたまま）
+#   --force          .claude/agents/ / .claude/rules/ について、内容差分があれば
+#                    .bak once-only 退避して強制上書き（既存 *.bak は保護）。
+#                    CLAUDE.md は --force 指定時のみ従来挙動（.bak 退避＋ template
+#                    で上書き）。--force なしでは既存 CLAUDE.md は据え置き、
+#                    template を CLAUDE.md.org として並置（差分時のみ）。
 #   --no-labels      対象リポジトリ配置時に走る GitHub ラベル自動セットアップを完全に skip
 #                    （`IDD_CLAUDE_SKIP_LABELS=true` env でも同等の opt-out が可能）
 # =============================================================================
@@ -409,6 +411,128 @@ copy_agents_rules() {
   fi
 }
 
+# CLAUDE_MD_ORG_TOUCHED
+#   `copy_claude_md_with_org` が `CLAUDE.md.org` を NEW / OVERWRITE した場合に
+#   "true" を立てるグローバルフラグ（Req 6.1）。配置完了サマリ末尾の merge
+#   ガイドメッセージ表示判定に使う。SKIP / 既存 CLAUDE.md 不在 / `--force`
+#   経路では立てない（Req 6.2）。
+CLAUDE_MD_ORG_TOUCHED=false
+
+# copy_claude_md_with_org <src> <dest>
+#   CLAUDE.md 専用の安全配置ロジック（Issue #87）。
+#   既存 CLAUDE.md が編集済みであることを前提に、template を `.org` として
+#   並置することで「ユーザー記述が主、template は参考」という関係に反転する。
+#
+#   - dest 不在 + FORCE=any                 → NEW（template を CLAUDE.md として配置、.org は作らない）
+#   - dest 存在 + 内容同一                  → SKIP（.org も作らない）
+#   - dest 存在 + 差分あり + FORCE=false:
+#     - dest.org 不在                       → NEW dest.org（template を並置、本体は据え置き）
+#     - dest.org 存在 + 内容同一            → SKIP dest.org
+#     - dest.org 存在 + 差分あり            → OVERWRITE dest.org（最新 template に追従）
+#   - dest 存在 + 差分あり + FORCE=true:
+#     既存 backup_claude_md_once の挙動に委譲（.bak once-only 退避 + template で上書き）。
+#     `.org` は触らない（Req 3.4）。
+#
+#   既存 `CLAUDE.md.bak` は本関数では一切触らない（Req 4.1, 4.2）。
+copy_claude_md_with_org() {
+  local src="$1"
+  local dest="$2"
+  local org="$dest.org"
+  local org_name
+  org_name="$(basename "$dest").org"
+
+  if [ ! -f "$src" ]; then
+    echo "Error: source file not found: $src" >&2
+    return 1
+  fi
+
+  # FORCE 指定時は従来挙動（NFR 1.2 / Req 3.1〜3.4）。
+  # backup_claude_md_once → copy_template_file 相当のシーケンスを再現するため、
+  # 呼び出し側で backup_claude_md_once を先に呼ぶ前提を保ち、本関数では
+  # template で上書きするだけに留める。
+  if [ "$FORCE" = "true" ]; then
+    # `.org` は --force 経路では作らない / 触らない（Req 3.4）
+    local action
+    action="$(classify_action "$src" "$dest")"
+    case "$action" in
+      NEW)
+        log_action "NEW" "$dest"
+        if [ "$DRY_RUN" = "false" ]; then
+          ensure_dir "$(dirname "$dest")"
+          cp "$src" "$dest"
+        fi
+        ;;
+      SKIP)
+        log_action "SKIP" "$dest" "(identical to template)"
+        ;;
+      OVERWRITE)
+        log_action "OVERWRITE" "$dest" "(--force)"
+        if [ "$DRY_RUN" = "false" ]; then
+          cp "$src" "$dest"
+        fi
+        ;;
+    esac
+    return 0
+  fi
+
+  # 通常経路（--force なし）
+  local action
+  action="$(classify_action "$src" "$dest")"
+
+  case "$action" in
+    NEW)
+      # CLAUDE.md 不在: template を CLAUDE.md としてそのまま配置。
+      # `.org` は作らない（Req 1.2）。
+      log_action "NEW" "$dest"
+      if [ "$DRY_RUN" = "false" ]; then
+        ensure_dir "$(dirname "$dest")"
+        cp "$src" "$dest"
+      fi
+      ;;
+    SKIP)
+      # 既存 CLAUDE.md が template と同一: 何も触らない（Req 2.5）。
+      log_action "SKIP" "$dest" "(identical to template)"
+      ;;
+    OVERWRITE)
+      # 既存 CLAUDE.md は据え置き、template を `.org` として並置（Req 2.1）。
+      # 本体側は変更しないので OVERWRITE ログは出さず、SKIP として明示する。
+      log_action "SKIP" "$dest" "(existing kept, template placed as $org_name)"
+
+      local org_action
+      if [ ! -e "$org" ]; then
+        # `.org` 不在: 新規並置（Req 2.2）
+        log_action "NEW" "$org"
+        if [ "$DRY_RUN" = "false" ]; then
+          cp "$src" "$org"
+        fi
+        CLAUDE_MD_ORG_TOUCHED=true
+      else
+        org_action="$(classify_action "$src" "$org")"
+        case "$org_action" in
+          SKIP)
+            # `.org` 既存 + 内容同一（Req 2.3）
+            log_action "SKIP" "$org" "(identical to template)"
+            ;;
+          OVERWRITE)
+            # `.org` 既存 + 差分あり: template の最新内容で更新（Req 2.4）
+            log_action "OVERWRITE" "$org" "(refresh from template)"
+            if [ "$DRY_RUN" = "false" ]; then
+              cp "$src" "$org"
+            fi
+            CLAUDE_MD_ORG_TOUCHED=true
+            ;;
+          NEW)
+            # 通常 to-here ない経路だが念のため（org が存在するのに NEW 判定なら
+            # ファイルではなくディレクトリの可能性 → 安全側でエラー）
+            echo "Error: $org exists but is not a regular file" >&2
+            return 1
+            ;;
+        esac
+      fi
+      ;;
+  esac
+}
+
 # ─────────────────────────────────────────────────────────────
 # ラベル自動セットアップ（Issue #85）
 #   テンプレート配置完了直後に対象リポジトリ向けラベルを冪等作成する。
@@ -610,16 +734,17 @@ if $INSTALL_REPO; then
   echo "📦 対象リポジトリにファイルを配置: $REPO_PATH_ABS"
   REPO_PATH="$REPO_PATH_ABS"
 
-  # CLAUDE.md.bak の once-only 保護（初回 install 時のオリジナルを温存）
-  # → 既存 CLAUDE.md があれば `.bak` に退避（既存 `.bak` は尊重、再退避しない）
-  backup_claude_md_once "$REPO_PATH"
-
-  # CLAUDE.md 本体は backup_claude_md_once が `.bak` 退避を引き受けたあと、
-  # copy_template_file で template を常に配置する（既存と同一なら SKIP）。
-  # → design.md「setup_repo ブロック」設計判断: ハイブリッド側は `.bak` 退避を
-  #   スキップしてそのまま OVERWRITE / SKIP のみを行う、と整合
-  # → 要件 2.5 / 5.4: 既存挙動（無条件で template 由来 CLAUDE.md を配置）を維持
-  copy_template_file "$REPO_TEMPLATE_DIR/CLAUDE.md" "$REPO_PATH/CLAUDE.md"
+  # CLAUDE.md は Issue #87 で挙動を分岐：
+  #   - `--force` あり: 従来挙動（`.bak` once-only 退避 + template で上書き）
+  #   - `--force` なし: 既存 CLAUDE.md は据え置き、template を `CLAUDE.md.org` として並置
+  # `.bak` once-only 退避は `--force` 経路でのみ意味があるため、その時だけ呼ぶ。
+  # 既存 `CLAUDE.md.bak` は通常経路では一切触らない（Req 4.1, 4.2）。
+  if [ "$FORCE" = "true" ]; then
+    backup_claude_md_once "$REPO_PATH"
+  fi
+  copy_claude_md_with_org \
+    "$REPO_TEMPLATE_DIR/CLAUDE.md" \
+    "$REPO_PATH/CLAUDE.md"
 
   copy_agents_rules "$REPO_TEMPLATE_DIR/.claude/agents" "$REPO_PATH/.claude/agents"
   copy_agents_rules "$REPO_TEMPLATE_DIR/.claude/rules"  "$REPO_PATH/.claude/rules"
@@ -659,6 +784,28 @@ if $INSTALL_REPO; then
             -f required_pull_request_reviews.required_approving_review_count=1 \\
             -F enforce_admins=false
 REPO_HINT
+
+  # CLAUDE.md.org の merge ガイド（Req 6.1, 6.2）
+  #   `.org` を NEW / OVERWRITE した場合のみ表示。既存 CLAUDE.md 不在で
+  #   `.org` を作らなかったケースや、SKIP しかなかったケースでは表示しない。
+  if [ "$CLAUDE_MD_ORG_TOUCHED" = "true" ]; then
+    cat <<'CLAUDE_MD_ORG_HINT'
+
+  📝 CLAUDE.md.org（最新 template 並置）の merge ガイド:
+
+     既存の CLAUDE.md は変更されていません。最新 template を CLAUDE.md.org
+     として並置しました。差分を確認して必要な箇所だけ手動で取り込んでください。
+
+       diff CLAUDE.md CLAUDE.md.org              # 差分確認
+       diff -u CLAUDE.md.org CLAUDE.md           # template を base に左右反転
+       vimdiff CLAUDE.md CLAUDE.md.org           # 対話的に merge
+       # merge 完了後、必要なら CLAUDE.md.org は削除して構いません
+       #   （次回 install で template が更新されていれば再作成されます）
+
+     どうしても template で完全上書きしたい場合は、`./install.sh --repo <path> --force`
+     を使用してください（既存 CLAUDE.md は CLAUDE.md.bak に once-only 退避されます）。
+CLAUDE_MD_ORG_HINT
+  fi
 
   # ラベル自動セットアップ（Issue #85）
   #   - 配置完了直後にラベルを冪等作成して、初回 cron で claim ラベル付与に


### PR DESCRIPTION
## 概要

`install.sh` が対象 repo に `CLAUDE.md` を配置する際、既存ファイルを上書きせず
template を `CLAUDE.md.org` として並置する挙動に変更する。

- 既存 `CLAUDE.md` は変更せず据え置き（ユーザーのプロジェクト憲章を保護）
- `CLAUDE.md.org` として最新 template を並置し、ユーザーが差分確認・手動 merge できるように
- `--force` 指定時は従来挙動（`.bak` 退避 + template 上書き）を escape hatch として維持
- 配置完了サマリの末尾に merge ガイドメッセージを条件付き表示

## 対応 Issue

Closes #87

## 関連 PR

なし

## 実装内容

- (Req 1 / Task 1) `copy_claude_md_with_org` 関数を新設し、CLAUDE.md 不在時は NEW 配置、存在時は据え置き + `.org` 並置の分岐を実装
- (Req 2 / Task 2) `.org` の冪等経路（不在→NEW / 既存同一→SKIP / 既存差分→OVERWRITE）を実装
- (Req 3 / Task 3) `--force` 経路は `backup_claude_md_once` + template 上書きの従来挙動を維持（`.org` 触らず）
- (Req 4 / Task 4) 既存 `.bak` は once-only 規律で温存（自動マイグレーションなし）
- (Req 5 / Task 5) 同一入力での 2 回連続実行で等価状態を保証（冪等性）
- (Req 6 / Task 6) `.org` NEW / OVERWRITE 時のみ merge ガイドメッセージをサマリ末尾に表示
- (NFR 1) 既存 env var 名・フラグ・exit code・sudo 不要前提を維持
- README に `.org` 並置仕様セクションと Migration note（2 段構成）を追加

## 受入基準チェック

- [x] Req 1.1: When CLAUDE.md 不在で install.sh が実行される ← シナリオ A
- [x] Req 1.2: When 上記 1 の配置が行われる → .org を作成しない ← シナリオ A
- [x] Req 1.3: When 上記 1 の配置が行われる → NEW ログ 1 行出力 ← シナリオ A
- [x] Req 2.1: When 既存 CLAUDE.md(差分) + --force なし → 既存を変更しない ← シナリオ B
- [x] Req 2.2: When .org 不在 → NEW 並置 ← シナリオ B
- [x] Req 2.3: When .org 既存 + 内容同一 → SKIP ← シナリオ C-1
- [x] Req 2.4: When .org 既存 + 差分 → OVERWRITE ← シナリオ C-2
- [x] Req 2.5: When CLAUDE.md と template が同一 → 何もしない ← シナリオ D
- [x] Req 3.1〜3.5: --force 時の従来挙動維持 ← シナリオ E
- [x] Req 4.1〜4.3: 既存 .bak 保護 ← シナリオ F-1 / F-2
- [x] Req 5.1〜5.3: 冪等性・dry-run ← シナリオ C-1 / 追加検証 1
- [x] Req 6.1〜6.4: merge ガイド表示 / README 更新 ← シナリオ B / C-2

## テスト結果

```
shellcheck install.sh → クリーン（warning ゼロ）

スモークテスト（/tmp/scratch-* への install.sh 実行）:
  シナリオ A: CLAUDE.md 不在 → NEW 配置 ✅
  シナリオ B: 既存 CLAUDE.md(差分) → 据え置き + .org 並置 ✅
  シナリオ C-1: 再 install → SKIP CLAUDE.md / SKIP .org ✅
  シナリオ C-2: .org stale 化 → OVERWRITE .org + merge ガイド表示 ✅
  シナリオ D: CLAUDE.md = template → SKIP のみ、.org 不作成 ✅
  シナリオ E: --force + .bak 不在 → BACKUP + OVERWRITE ✅
  シナリオ F-1: 既存 .bak + --force なし → .bak 不変 + .org NEW ✅
  シナリオ F-2: 既存 .bak + --force → .bak once-only 保護 + CLAUDE.md 上書き ✅
  dry-run 4 種 → FS 不変・予定操作を [DRY-RUN] prefix 付きで表示 ✅
  独立性検証: .org 判定は agents/rules 経路に影響しない ✅

Reviewer による独立 scratch repo 再検証: 全 AC pass (RESULT: approve)
```

## 実装上の判断

- `CLAUDE.md` 専用関数 `copy_claude_md_with_org` を新設し、既存の `copy_with_hybrid_overwrite`（agents/rules で使用）に手を入れない設計を採用（Req NFR 3.1 への適合）
- `CLAUDE_MD_ORG_TOUCHED` グローバルフラグで `.org` の NEW / OVERWRITE を配置完了サマリ表示判定に使用（bash 関数間の戻り値は exit code か stdout に限られるため、副作用フラグはグローバルで持つ）
- `--force` 経路では `backup_claude_md_once` を呼び出してから `copy_claude_md_with_org` に渡す構造により、`.bak` の once-only 規律（Req 3.3 / 4.1）を既存関数に委譲

詳細は `impl-notes.md` を参照。

## 確認事項

- Reviewer の approve 判定を確認済み（全 AC pass、Findings なし）
- Reviewer 判定の詳細は [docs/specs/87-refactor-install-claude-md-template-org/review-notes.md](docs/specs/87-refactor-install-claude-md-template-org/review-notes.md) を参照

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #87 のコメントを参照してください。
