### PR TITLE
fix(watcher): rate_limit_event detection と Stage C PR verify を修正 (Closes #104)

### DIFF
--- a/docs/specs/104-bug-watcher-rate-limit-event-detection-b/impl-notes.md
+++ b/docs/specs/104-bug-watcher-rate-limit-event-detection-b/impl-notes.md
@@ -1,0 +1,153 @@
+# 実装ノート: Issue #104
+
+## 概要
+
+Issue #104 の 3 つの bug（quota 枯渇時の虚偽成功）を修正した。実装の詳細・
+テスト・後方互換性に関する所見を記載する。
+
+## 実装したタスク
+
+### Bug 1: 現行スキーマの quota 検出（Req 1.1〜1.4, 2.1〜2.2）
+
+`local-watcher/bin/issue-watcher.sh` の `qa_detect_rate_limit()` を書き換え、
+3 種の検出経路を 1 つの jq filter に統合した:
+
+| detection_path | スキーマ判定式 |
+|---|---|
+| `rate_limit_event_v2` | `type=="rate_limit_event"` かつ `rate_limit_info.status=="rejected"` |
+| `rate_limit_event_v1` | `type=="rate_limit_event"` かつ `status=="exceeded"`（旧スキーマ） |
+| `synthetic_429_result` | `type=="result"` かつ `is_error==true` かつ `api_error_status==429` |
+
+reset 時刻フィールド探索順:
+
+1. ネスト位置: `.rate_limit_info.resetsAt / .resets_at / .reset_at`（現行スキーマ / Req 1.3）
+2. top-level: `.resetsAt / .reset_at / .resets_at`（旧スキーマ / Req 2.2）
+
+出力フォーマットを `<detection_path>\t<epoch_or_empty>` の TSV 1 検出 1 行に変更。
+これによって NFR 2.1（どの検出経路で発火したか識別可能）を満たす。
+
+### Bug 2: synthetic 429 result 行の検出（Req 3.1〜3.4）
+
+Bug 1 と同じ jq filter で同居検出する。`qa_run_claude_stage()` 側のロジックを
+更新し、検出 TSV から「epoch を持つ最新検出」を優先採用する形に変更:
+
+- epoch あり検出が 1 件以上 → exit 99 + reset_file 永続化（既存契約と等価）
+- 検出はあるが epoch ゼロ → claude_rc 透過 + warn ログ（Req 1.4 / Req 3.2 の fallback）
+- 検出ゼロ → claude_rc 透過
+
+### Bug 3: Stage C の PR 実在 verify（Req 4.1〜4.4）
+
+`run_impl_pipeline()` の Stage C 完了処理 (`case 0)`) に `gh pr view --head "$BRANCH"`
+verify を追加。PR URL が空 / gh が非 0 のいずれの場合も
+`mark_issue_failed "stageC-pr-missing" ...` で claude-failed 化する。
+
+### 副次修正: PIPESTATUS preservation（latent bug 修正）
+
+`qa_run_claude_stage()` の pipeline `... | tee | qa_detect_rate_limit ... || true`
+において `|| true` が PIPESTATUS を 0 で上書きしてしまう挙動が判明。
+`set +e/-e` で囲って PIPESTATUS を即座に配列コピーする形に修正した。
+
+これは Issue #66 由来の latent bug であり、quota-aware 経路で claude が非 0 終了
+した場合に常に rc=0 として扱われていた。Issue #104 のスコープ拡張として併せて修正。
+影響: Issue #66 の opt-in 経路 (QUOTA_AWARE_ENABLED=true) でのみ発現する欠陥。
+
+## 受入基準カバレッジ
+
+| Req ID | 担保テスト | テストファイル |
+|---|---|---|
+| 1.1 | `v2-rate-limit-event-rejected (all)` / `v2-numeric-epoch` / wrapper 経由 `v2-rate-limit-event-rejected` | `qa_detect_rate_limit_test.sh` / `qa_run_claude_stage_test.sh` |
+| 1.2 | wrapper 経由 `v2-rate-limit-event-rejected (rc=99 + reset_file=epoch)` | `qa_run_claude_stage_test.sh` |
+| 1.3 | `v2-rate-limit-event-rejected` / `v2-numeric-epoch`（ネスト位置 reset 抽出） | `qa_detect_rate_limit_test.sh` |
+| 1.4 | `v2-no-reset` / wrapper 経由 `v2-no-reset (claude_rc 透過 / reset_file 空)` | 両方 |
+| 2.1 | `v1-rate-limit-event-exceeded` / wrapper 経由 同じ | 両方 |
+| 2.2 | `v1-reset-at-snake`（旧スキーマ snake_case 受理） | 両方 |
+| 3.1 | `synthetic-429-result` (path + epoch) / wrapper 経由 (rc=99) | 両方 |
+| 3.2 | `synthetic-429-no-reset` (path のみ epoch 空) / wrapper 経由 (claude_rc 透過 + warn) | 両方 |
+| 3.3 | wrapper の `qa_warn "stage detected without reset ... path=..."` ログ出力（実装 / テストでは warn 文字列出力経路を確認） | 実装 review |
+| 3.4 | `normal-success`（is_error:false / allowed のみ）→ 検出ゼロ + rc=0 | 両方 |
+| 4.1 | `PR 実在あり: rc=0` | `stagec_pr_verify_test.sh` |
+| 4.2 | `PR 不在 (空 URL): mark_issue_failed=stageC-pr-missing` | `stagec_pr_verify_test.sh` |
+| 4.3 | `PR 実在あり: mark_issue_failed 未呼出` + 成功 echo | `stagec_pr_verify_test.sh` + 実装 review |
+| 4.4 | `gh 失敗 (rc=1)` / `gh timeout (rc=124)` 両ケース | `stagec_pr_verify_test.sh` |
+| 5.1 | fixture `v2-rate-limit-event-rejected.jsonl` 配置済 | `local-watcher/test/fixtures/qa_detect_rate_limit/` |
+| 5.2 | fixture `v1-rate-limit-event-exceeded.jsonl` 配置済 | 同上 |
+| 5.3 | fixture `synthetic-429-result.jsonl` 配置済 | 同上 |
+| 5.4 | 上記 3 fixture ＋ wrapper 経由 (rc=99) すべて緑 | `qa_detect_rate_limit_test.sh` / `qa_run_claude_stage_test.sh` |
+| 5.5 | 既存 `parse_review_result_test.sh` (19 PASS) | `parse_review_result_test.sh` |
+| NFR 1.1 | `opt-out v2 input rc=0` / `opt-out reset_file untouched` / `opt-out preserves claude rc=7` | `qa_run_claude_stage_test.sh` |
+| NFR 1.2 | `normal-success with claude rc=2` (NFR 1.2 既存 rc 透過) + opt-out 透過 | `qa_run_claude_stage_test.sh` |
+| NFR 2.1 | 実装の `qa_log "... path=${_path} reset_epoch=..."` で経路 + stage label を grep 可能 | 実装 review |
+| NFR 2.2 | Stage C 失敗時 `qa_warn "stageC PR verify failed issue=#... branch=... verify_rc=..."` + Issue コメントで原因情報 | 実装 review |
+| NFR 3.1 | 全テストはローカル `bash + jq` のみで完結（Claude API / GitHub API 不要、fake gh / fake claude を使用） | `*_test.sh` |
+
+## 追加した fixture（local-watcher/test/fixtures/qa_detect_rate_limit/）
+
+| ファイル | 用途 / 対応 Req |
+|---|---|
+| `v2-rate-limit-event-rejected.jsonl` | 現行 rate_limit_event + 後続 synthetic 429（rate_limit_info なし）の代表ケース / Req 5.1 |
+| `v2-numeric-epoch.jsonl` | 現行 rate_limit_event + 数値型 epoch / Req 1.1, 1.3 |
+| `v2-no-reset.jsonl` | 現行 rate_limit_event だが reset 欠落 / Req 1.4 |
+| `v1-rate-limit-event-exceeded.jsonl` | 旧スキーマ単独ケース / Req 5.2 |
+| `v1-reset-at-snake.jsonl` | 旧スキーマ snake_case reset_at / Req 2.2 |
+| `synthetic-429-result.jsonl` | synthetic 429 + 同居 rate_limit_info / Req 5.3 |
+| `synthetic-429-no-reset.jsonl` | synthetic 429 のみで reset 不在 / Req 3.2 |
+| `normal-success.jsonl` | 通常成功 + allowed の rate_limit_event / Req 3.4 |
+| `v2-rate-limit-malformed-line.jsonl` | malformed 1 行混入でも以後の検出を継続 / Req 5.4 / NFR resilience |
+
+## 実行したテストコマンドと結果
+
+```bash
+$ bash local-watcher/test/qa_detect_rate_limit_test.sh
+PASS: 10, FAIL: 0
+
+$ bash local-watcher/test/qa_run_claude_stage_test.sh
+PASS: 23, FAIL: 0
+
+$ bash local-watcher/test/stagec_pr_verify_test.sh
+PASS: 8, FAIL: 0
+
+$ bash local-watcher/test/parse_review_result_test.sh
+PASS: 19, FAIL: 0
+
+$ shellcheck local-watcher/bin/*.sh install.sh setup.sh .github/scripts/*.sh
+（warning なし。info-level SC2012 / SC2317 のみ。すべて pre-existing で
+ 本 PR の変更行には新規発生なし）
+```
+
+## 後方互換性に関する所見
+
+- `QUOTA_AWARE_ENABLED != "true"`（既定）では `qa_run_claude_stage` の opt-out 早期 return
+  経路を保持。test 側で opt-out reset_file untouched / claude rc=7 透過を確認済（NFR 1.1）
+- 旧スキーマ（top-level `status=="exceeded"`）も `rate_limit_event_v1` 経路で引き続き検出。
+  reset フィールド名 `resetsAt` / `reset_at` / `resets_at` のいずれも従来どおり受理する
+  （Req 2.2）
+- exit code 契約（0 / 99 / その他）は変更なし。reset_file の中身も「empty または epoch 1 行」の
+  契約を維持（呼び出し側の `cat "$_qa_reset_file_X"` は変更不要）
+- `qa_detect_rate_limit` の出力フォーマットは TSV に変更したが、本関数は `qa_run_claude_stage`
+  の内部からのみ呼ばれているため外部影響なし。reset_file 自体は引き続き epoch 1 行
+- 環境変数名（`QUOTA_AWARE_ENABLED`, `REPO`, `BRANCH`, `LOG`, `NUMBER` 等）は不変
+- ラベル名（`needs-quota-wait`, `claude-failed`）も不変
+
+## 確認事項（Reviewer / 人間レビュー向け）
+
+1. **PIPESTATUS preservation 修正のスコープ**: 本来は別 Issue 切り出しが妥当な
+   latent bug 修正だが、Issue #104 のテストで露見したため併せて修正した。
+   既存運用への影響は「quota-aware opt-in 時に claude 非 0 終了が正しく検出されるようになる」
+   方向のみで、副作用なし
+2. **Req 3.1 と Req 3.2 の解釈**: Req 3.1 は「synthetic 429 検出 → 終了コード 99」、
+   Req 3.2 は「synthetic 429 検出 + reset 欠落 → 既存 fallback」。両者は「reset 時刻が
+   取得できた時のみ exit 99、取れなければ既存フロー透過」と解釈し実装した。Stage C は
+   PR verify が後段で false-success を捕捉するので、reset 欠落 synthetic 429 でも
+   最終的に虚偽成功は出ない設計
+3. **Bug 3 の PR 実在 verify は Stage C のみ**: 要件 Out of Scope のとおり Stage A/B には
+   verify を入れていない。PIPESTATUS 修正により Stage A/B の claude 非 0 終了は通常の
+   失敗パスに乗るため、Stage A/B の false-success リスクは（既存空成果物を除いて）解消した
+4. **fixture の epoch 値**: `2026-05-15T05:00:00Z` → `1778821200`（GNU date で確認）。
+   テスト assertion 値はこれにハードコード
+
+## 派生タスク候補
+
+- Stage A / Stage B の return code 0 + 空成果物パターンの verify 強化（要件 Out of Scope。
+  本 Issue で PIPESTATUS bug を直したため、空成果物パターン以外は捕捉される）
+- `qa_detect_rate_limit` のさらなるスキーマ追加（CLI バージョン更新時のリグレッション
+  予防のため、定期的に fixture と filter を peer review する運用を README に追記する案）

--- a/docs/specs/104-bug-watcher-rate-limit-event-detection-b/requirements.md
+++ b/docs/specs/104-bug-watcher-rate-limit-event-detection-b/requirements.md
@@ -1,0 +1,159 @@
+# Requirements Document
+
+## Introduction
+
+Claude Max の 5 時間 quota が watcher 実行中に枯渇した際、本来は `needs-quota-wait` ラベルで
+休止し reset 後に resume すべきところを、watcher が「Stage C 完了 / PR 作成済み」と虚偽の成功
+報告を返してしまう不具合が観測されている（再現例: `hitoshiichikawa/KeyNest` Issue #29、Claude
+CLI v2.1.139 環境で local worktree に 12 個の orphan commit が滞留）。
+
+原因は 3 つの bug の連鎖である:
+
+1. `qa_detect_rate_limit` の jq filter が現行 Claude CLI の `rate_limit_event` スキーマ
+   （`rate_limit_info.status == "rejected"`）に追従しておらず、旧スキーマ（top-level
+   `.status == "exceeded"`）しか検出できない。
+2. Claude CLI が quota 枯渇時に `subtype:"success"` / `is_error:true` /
+   `api_error_status:429` を含む synthetic な `result` 行を返したうえで exit code 0 で終了する
+   ケースがあり、return code のみを見る既存判定をすり抜ける。
+3. Stage C 完了報告時に PR の実在を `gh pr view` で verify しておらず、PjM サブエージェントが
+   1 turn で空転終了しても成功と宣言される。
+
+本要件定義は、上記 3 bug を修正しつつ、旧スキーマとの後方互換性および既存テスト群の
+グリーンを維持することをスコープとする。
+
+## Requirements
+
+### Requirement 1: 現行スキーマでの quota 検出
+
+**Objective:** As a watcher 運用者, I want Claude CLI の現行スキーマで送られてくる
+`rate_limit_event` を確実に quota 枯渇として検出したい, so that quota 超過時に虚偽成功を
+出さずに `needs-quota-wait` で正しく休止できる
+
+#### Acceptance Criteria
+
+1. When Claude CLI が `rate_limit_info.status == "rejected"` を含む `rate_limit_event` 行を
+   stream に出力したとき, the Quota-Aware Watcher Module shall それを quota 枯渇として
+   検出し、当該 stage の終了コードを 99 として呼び出し側に返す
+2. When `rate_limit_event` 行から quota 検出がトリガーされたとき, the Quota-Aware Watcher
+   Module shall 当該 event の reset 時刻情報を epoch 秒の整数として `reset_file` に書き出す
+3. While reset 時刻情報が現行スキーマでネスト位置（`rate_limit_info` 配下相当）にある場合,
+   the Quota-Aware Watcher Module shall そのネスト位置から reset 時刻を取得する
+4. If `rate_limit_event` 行は出力されたが reset 時刻情報が欠落または非数値の場合, the
+   Quota-Aware Watcher Module shall 既存フローへの委譲（quota 検出なし扱い）に fallback し、
+   その旨を warn ログへ記録する
+
+### Requirement 2: 旧スキーマとの後方互換性
+
+**Objective:** As a watcher 運用者, I want 旧 Claude CLI スキーマ（top-level `.status ==
+"exceeded"`）も引き続き検出できる状態を保ちたい, so that CLI のバージョン差や将来の rollback
+時にも quota 検出が機能する
+
+#### Acceptance Criteria
+
+1. When Claude CLI が旧スキーマ形式（top-level `.status == "exceeded"`）の `rate_limit_event`
+   行を出力したとき, the Quota-Aware Watcher Module shall 現行スキーマと同様に quota 枯渇と
+   して検出し、終了コード 99 を返す
+2. When 旧スキーマと現行スキーマの両方で reset 時刻フィールド名が異なる場合, the
+   Quota-Aware Watcher Module shall 既存実装が受理してきたフィールド名群（`resetsAt` /
+   `reset_at` / `resets_at` 等）を引き続き受理する
+
+### Requirement 3: synthetic 429 result 行の検出
+
+**Objective:** As a watcher 運用者, I want Claude CLI が exit code 0 で返しても output 内に
+synthetic な 429 エラーが含まれる場合は quota 枯渇として扱いたい, so that CLI の return code
+ベース判定では拾えない quota 超過パターンも `needs-quota-wait` に正しく遷移できる
+
+#### Acceptance Criteria
+
+1. When Claude CLI が `type:"result"` かつ `is_error:true` かつ `api_error_status:429` を持つ
+   行を stream に出力したとき, the Quota-Aware Watcher Module shall 当該 stage を quota 枯渇
+   として扱い、終了コード 99 を呼び出し側に返す
+2. When synthetic 429 result 行が検出されたが reset 時刻情報が同一 stream 内に得られない場合,
+   the Quota-Aware Watcher Module shall 既存の reset 時刻欠落時フォールバック（warn ログ +
+   既存フロー委譲）と同等の挙動を取る
+3. When synthetic 429 result 行が検出されたとき, the Quota-Aware Watcher Module shall 「CLI
+   の return code は 0 だが synthetic 429 を検出したため quota 枯渇扱いに格上げした」旨を
+   warn または info レベルでログへ記録する
+4. While Claude CLI が `type:"result"` かつ `is_error:false`（通常成功）の行を返している場合,
+   the Quota-Aware Watcher Module shall それを quota 枯渇として扱わず、従来どおり成功として
+   呼び出し側に返す
+
+### Requirement 4: Stage C 完了の PR 実在検証
+
+**Objective:** As a watcher 運用者, I want Stage C 完了を宣言する前に対象ブランチに impl PR
+が実在することを verify したい, so that PjM サブエージェントが空転終了しても虚偽成功で
+終わらず `claude-failed` として人間に正しくエスカレーションできる
+
+#### Acceptance Criteria
+
+1. When Stage C の Claude 実行が return code 0 かつ quota 枯渇検出なしで終了したとき, the
+   Stage C Pipeline shall 完了宣言の前に当該 Issue 用ブランチに対応する impl PR の存在を
+   GitHub 側で確認する
+2. If Stage C 終了時に対応 PR が存在しないと判定された場合, the Stage C Pipeline shall 当該
+   Issue を `claude-failed` として `mark_issue_failed "stageC" ...` 経路で扱い、虚偽の成功
+   メッセージを出力しない
+3. When Stage C 終了時に対応 PR の存在が確認できた場合, the Stage C Pipeline shall 従来どおり
+   「Stage C 完了 / PR 作成済み」を成功ログに出力し、終了コード 0 で返す
+4. If Stage C 終了時の PR 存在確認自体が GitHub API 障害など一時的な原因で失敗した場合, the
+   Stage C Pipeline shall PR 不在と同等の安全側判定（虚偽成功を出さない）に倒し、原因を
+   ログへ記録する
+
+### Requirement 5: テストフィクスチャとリグレッションテスト
+
+**Objective:** As a watcher 開発者, I want 現行 / 旧スキーマおよび synthetic 429 のサンプル
+出力をフィクスチャとして保持し検証したい, so that 将来の Claude CLI スキーマ変更で同種
+リグレッションが再発した際に CI/手動テストで早期検知できる
+
+#### Acceptance Criteria
+
+1. The Test Suite shall 現行スキーマ（`rate_limit_info.status == "rejected"`）の
+   `rate_limit_event` 行サンプルを `local-watcher/test/fixtures/` 配下のフィクスチャとして
+   保持する
+2. The Test Suite shall 旧スキーマ（top-level `.status == "exceeded"`）の `rate_limit_event`
+   行サンプルを `local-watcher/test/fixtures/` 配下のフィクスチャとして保持する
+3. The Test Suite shall synthetic 429 result 行（`subtype:"success"` / `is_error:true` /
+   `api_error_status:429`）のサンプルを `local-watcher/test/fixtures/` 配下のフィクスチャと
+   して保持する
+4. When 上記 3 種フィクスチャに対する quota 検出テストを実行したとき, the Test Suite shall
+   いずれのケースでも検出成功（exit 99 相当の判定）を観測できる
+5. The Test Suite shall 既存の `local-watcher/test/` 配下テスト群（`parse_review_result_test.sh`
+   ほか）が本変更後も pass し続ける
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性とフラグ既定値
+
+1. The Quota-Aware Watcher Module shall `QUOTA_AWARE_ENABLED != "true"` での opt-out 既定挙動
+   （tee も解析も走らず素通し実行）を本変更後も維持する
+2. The Quota-Aware Watcher Module shall 既存の環境変数名（`QUOTA_AWARE_ENABLED` 等）と既存の
+   stage 終了コード意味（0 = 成功 / 99 = quota 検出 / それ以外 = 既存失敗）を変更しない
+
+### NFR 2: 観測性
+
+1. When quota 枯渇検出（現行スキーマ / 旧スキーマ / synthetic 429 のいずれか）が発火した
+   とき, the Quota-Aware Watcher Module shall どの検出経路で発火したかを `$LOG` から事後に
+   識別可能な粒度（経路名 + stage label を含むログ行）で記録する
+2. If Stage C で PR 不在による `claude-failed` 化が発生した場合, the Stage C Pipeline shall
+   人間が原因を特定できる粒度（Issue 番号、対象ブランチ、PR 不在の判定根拠）でログを残す
+
+### NFR 3: 検証コスト
+
+1. The Test Suite shall フィクスチャベースの quota 検出テストを外部ネットワーク呼び出し
+   （Claude API / GitHub API への live 呼び出し）なしで実行できる
+
+## Out of Scope
+
+- Claude CLI のスキーマ自体を upstream で修正する作業（CLI ベンダー側の責務）
+- `needs-quota-wait` 検出後の reset 時刻計算ロジックや resume タイミング制御の見直し
+  （Issue #66 の既存設計を踏襲）
+- Stage A / Stage B の return code 0 + 空成果物パターンに対する同種の verify 強化
+  （本 Issue は Stage C の PR 実在 verify に閉じる。Stage A / B 側の検証強化が必要であれば
+  別 Issue として切り出す）
+- `qa_persist_reset_time` 等 reset 時刻永続化系の挙動変更
+- Quota-Aware Watcher の opt-in / opt-out 既定値の変更
+- Reviewer / PjM サブエージェントのプロンプト本文の改修
+- 自動 CI ジョブの新設（テストフィクスチャ追加と既存スモークテスト経路の維持に閉じる）
+
+## Open Questions
+
+- なし

--- a/docs/specs/104-bug-watcher-rate-limit-event-detection-b/review-notes.md
+++ b/docs/specs/104-bug-watcher-rate-limit-event-detection-b/review-notes.md
@@ -1,0 +1,72 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-15T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-104-impl-bug-watcher-rate-limit-event-detection-b
+- HEAD commit: fb267b0
+- Compared to: main..HEAD
+- Round: 1 (PREV_RESULT: none — 前 Reviewer は HTTP 529 で即落ち、review-notes.md 未作成)
+- Feature Flag Protocol: opt-out（対象 repo idd-claude `CLAUDE.md` で宣言確認。flag 観点の細目チェックは適用しない）
+- Architect 不起動につき `tasks.md` / `design.md` なし。`_Boundary:_` 制約は適用対象外
+- 変更ファイル: `local-watcher/bin/issue-watcher.sh` / `local-watcher/test/qa_detect_rate_limit_test.sh` (新規) / `local-watcher/test/qa_run_claude_stage_test.sh` (新規) / `local-watcher/test/stagec_pr_verify_test.sh` (新規) / `local-watcher/test/fixtures/qa_detect_rate_limit/*.jsonl` (新規 9 件) / `docs/specs/104-.../requirements.md` / `docs/specs/104-.../impl-notes.md`
+
+## Verified Requirements
+
+- **1.1** — `qa_detect_rate_limit` jq filter に `rate_limit_event_v2` 経路（`type=="rate_limit_event"` かつ `rate_limit_info.status=="rejected"`）を実装。`qa_run_claude_stage` で epoch 付き検出時に exit 99 を返す（`local-watcher/bin/issue-watcher.sh:362-411, 442-486`）。検証: `qa_detect_rate_limit_test.sh` `v2-rate-limit-event-rejected (all)` / `qa_run_claude_stage_test.sh` rc=99
+- **1.2** — `qa_run_claude_stage` の epoch 採用ブランチで `printf '%s\n' "$_epoch" > "$reset_file"`（`issue-watcher.sh:474`）。検証: `qa_run_claude_stage_test.sh` `v2-rate-limit-event-rejected reset_file == 1778821200`
+- **1.3** — jq filter で `$nested = .rate_limit_info | (.resetsAt // .resets_at // .reset_at)` を top-level より優先（`issue-watcher.sh:381-388`）。検証: `v2-numeric-epoch` (ネスト位置 numeric epoch 1747375200) / `v2-rate-limit-event-rejected` (ネスト位置 ISO 8601)
+- **1.4** — 検出 TSV に epoch なし行のみある場合、`qa_warn "stage detected without reset ..."` を出力し `claude_rc` 透過、`reset_file` を空に戻す（`issue-watcher.sh:481-487`）。検証: `v2-no-reset` rc=0 / reset_file=""
+- **2.1** — `rate_limit_event_v1` 経路（`status=="exceeded"` top-level）が jq filter の elif 分岐に存在（`issue-watcher.sh:368-371`）。検証: `v1-rate-limit-event-exceeded` rc=99 + epoch=1778821200
+- **2.2** — top-level 探索順 `.resetsAt // .reset_at // .resets_at` が保持される（`issue-watcher.sh:389-392`）。検証: `v1-reset-at-snake` (`reset_at` snake_case) rc=99 + epoch=1778821200
+- **3.1** — `synthetic_429_result` 経路（`type=="result"` かつ `is_error==true` かつ `api_error_status==429`）を jq filter に追加（`issue-watcher.sh:372-376`）。検証: `synthetic-429-result` rc=99 + epoch=1778821200（同居 `rate_limit_info` から epoch 抽出）
+- **3.2** — synthetic 429 単独で reset 欠落時は detect TSV に path のみ残り、`qa_warn ... path=synthetic_429_result` 経由で既存フロー透過（`issue-watcher.sh:482-484`）。検証: `synthetic-429-no-reset` rc=0 / reset_file=""
+- **3.3** — quota 検出 / fallback のいずれの経路でも `qa_log` / `qa_warn` に `path=${_path}` および `label=$stage_label` を含むログ行を出力（`issue-watcher.sh:475, 484`）。grep 可能な経路名 `rate_limit_event_v2` / `rate_limit_event_v1` / `synthetic_429_result` のいずれかが付与される
+- **3.4** — 通常 result（`is_error:false`）+ `allowed` only の rate_limit_event は jq filter の selector いずれにも match せず detect TSV 空 → `claude_rc` 透過。検証: `normal-success` rc=0 / detect 出力空
+- **4.1** — Stage C `case 0)` 内に `gh pr view --repo "$REPO" --head "$BRANCH" --json url --jq '.url'` を実装（`issue-watcher.sh:3450-3454`）。検証: `stagec_pr_verify_test.sh` PR 実在ケース rc=0
+- **4.2** — `_stagec_pr_url` が空 / `_stagec_verify_rc != 0` の場合 `mark_issue_failed "stageC-pr-missing" ...` を呼ぶ（`issue-watcher.sh:3461-3463`）。検証: `stagec_pr_verify_test.sh` 空 URL ケース `mark_issue_failed == "stageC-pr-missing"`
+- **4.3** — PR 実在時のみ `echo "✅ ... Stage C 完了 / PR 作成済み (${_stagec_pr_url})"` + `return 0`（`issue-watcher.sh:3455-3458`）。検証: `stagec_pr_verify_test.sh` `mark_issue_failed 未呼出`
+- **4.4** — `gh` rc != 0 ケースも同じ false-success 防止経路（`_stagec_verify_rc -eq 0 && -n "$_stagec_pr_url"` の AND 条件）でカバー。検証: `stagec_pr_verify_test.sh` `gh rc=1` / `gh rc=124` 両ケースで `stageC-pr-missing` mark + rc=1
+- **5.1** — `local-watcher/test/fixtures/qa_detect_rate_limit/v2-rate-limit-event-rejected.jsonl` 配置済
+- **5.2** — `v1-rate-limit-event-exceeded.jsonl` 配置済
+- **5.3** — `synthetic-429-result.jsonl` 配置済
+- **5.4** — 上記 3 種 fixture + `qa_run_claude_stage_test.sh` wrapper 経由でいずれも exit 99 相当を観測（PASS）
+- **5.5** — 既存 `parse_review_result_test.sh` を実行し 19 PASS / 0 FAIL を確認
+- **NFR 1.1** — `qa_run_claude_stage` 冒頭で `QUOTA_AWARE_ENABLED != "true"` 時の opt-out 早期 return 経路は保持（diff の `qa_run_claude_stage()` 関数頭部は変更外、`local-watcher/bin/issue-watcher.sh` 既存実装）。検証: `qa_run_claude_stage_test.sh` opt-out セクション全 3 PASS（rc=0 透過 / reset_file untouched / claude rc=7 透過）
+- **NFR 1.2** — `QUOTA_AWARE_ENABLED` 名・exit code 契約（0/99/その他）変更なし。`return "$claude_rc"` で claude 非 0 rc を透過。検証: `qa_run_claude_stage_test.sh` `normal-success with claude rc=2`
+- **NFR 2.1** — 経路名 + stage_label を含むログ行（`qa_log "stage detected exceeded label=$stage_label path=${_path} reset_epoch=$_epoch"` / `qa_warn "stage detected without reset label=$stage_label path=${_path} ..."`）が grep 可能
+- **NFR 2.2** — Stage C 不在 verify 時 `qa_warn "stageC PR verify failed issue=#$NUMBER branch=$BRANCH verify_rc=$_stagec_verify_rc pr_url='${_stagec_pr_url:-(empty)}'"` + Issue コメント本文に branch / verify_rc を含める（`issue-watcher.sh:3464-3465`）
+- **NFR 3.1** — 全テストはローカル `bash + jq + awk` のみで完結。`fake_claude` / `fake gh` で外部 API を遮断（`qa_run_claude_stage_test.sh:95-100` / `stagec_pr_verify_test.sh:71-72`）
+
+## 副次修正（PIPESTATUS preservation / impl-notes.md 確認事項 1）
+
+`qa_run_claude_stage` で `... | tee | qa_detect_rate_limit ... || true` が PIPESTATUS を 0 で上書きする latent bug を `set +e` / `_qa_pipestatus=("${PIPESTATUS[@]}")` / `set -e` パターンに置換（`issue-watcher.sh:451-455`）。これは Issue #66 由来の既存欠陥で、本 Issue のテスト導入時に露見した。Req に直接対応する項目ではないが、Req 1.4 / 3.2 の「claude_rc 透過」を実際に正しく動作させる前提条件であり、修正範囲としては合理的。
+
+## テスト実行結果（Reviewer 環境で再実行）
+
+```
+$ bash local-watcher/test/qa_detect_rate_limit_test.sh
+PASS: 10, FAIL: 0
+
+$ bash local-watcher/test/qa_run_claude_stage_test.sh
+PASS: 23, FAIL: 0
+
+$ bash local-watcher/test/stagec_pr_verify_test.sh
+PASS: 8, FAIL: 0
+
+$ bash local-watcher/test/parse_review_result_test.sh
+PASS: 19, FAIL: 0
+```
+
+Total 60 PASS / 0 FAIL。impl-notes.md 記載の結果と一致。
+
+## Findings
+
+なし
+
+## Summary
+
+Requirements 1.1〜1.4 / 2.1〜2.2 / 3.1〜3.4 / 4.1〜4.4 / 5.1〜5.5 / NFR 1.1〜3.1 のすべての numeric ID に対して、対応する実装（`local-watcher/bin/issue-watcher.sh` の jq filter 3 経路統合・detect TSV 解釈ロジック・Stage C PR verify 分岐）とテスト（新規 3 ファイル 41 ケース + 既存 1 ファイル 19 ケース）が紐づけられ、Reviewer 環境での再実行も green。副次の PIPESTATUS 修正は Req 1.4 / 3.2 の動作前提として合理的かつ後方互換性ありで、Out of Scope の Stage A/B verify 強化や opt-in / opt-out 既定値変更には踏み込んでいない。境界逸脱・AC 未カバー・missing test のいずれも検出されず。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -324,16 +324,34 @@ qa_format_iso8601() {
   printf '%s' "$epoch"
 }
 
-# stdin の stream-json（1 行 1 JSON）を fold し、`type=="rate_limit_event"` かつ
-# `status=="exceeded"` の最新 reset epoch を stdout に出力する（Req 2.1, 2.2, 2.3,
-# 2.4, 2.5, 2.6）。
+# stdin の stream-json（1 行 1 JSON）を fold し、quota 枯渇イベントを検出して
+# `<detection_path>\t<reset_epoch>` 形式の TSV を 1 検出 1 行で stdout に出力する
+# （Req 1.1〜1.4, 2.1〜2.2, 3.1〜3.4, 5.1〜5.4 / Issue #66 Req 2.x との後方互換）。
 #
-# - 解析失敗（非 JSON / schema 違い）の行は無視して継続（Req 2.5）
-# - allowed のみは無視（Req 2.6）
-# - 同一 stream に複数 exceeded があれば最終行（最新）の epoch のみ stdout（Req 2.4）
-# - reset 時刻フィールド名は claude CLI のスキーマ揺れを考慮して
-#   `.resetsAt` / `.reset_at` / `.resets_at` の順に試す
-# - 値が ISO 8601 文字列の場合は `fromdateiso8601` で epoch 化、数値はそのまま採用
+# 検出経路（detection_path フィールド値）:
+#   - `rate_limit_event_v2`  : 現行 Claude CLI スキーマ
+#                              `type==rate_limit_event` かつ
+#                              `rate_limit_info.status == "rejected"`
+#                              （Issue #104 Bug 1 / Req 1.1）
+#   - `rate_limit_event_v1`  : 旧スキーマ
+#                              `type==rate_limit_event` かつ `status == "exceeded"`
+#                              （Req 2.1 / Issue #66 互換維持）
+#   - `synthetic_429_result` : quota 枯渇直撃時の synthetic result 行
+#                              `type==result` かつ `is_error == true` かつ
+#                              `api_error_status == 429`
+#                              （Issue #104 Bug 2 / Req 3.1）
+#
+# Reset 時刻フィールド探索順（現行 / 旧スキーマ揺れと synthetic 429 同居を許容）:
+#   1) .rate_limit_info.resetsAt / .resets_at / .reset_at  （現行スキーマ ネスト位置 / Req 1.3）
+#   2) .resetsAt / .reset_at / .resets_at                  （旧スキーマ top-level / Req 2.2）
+#   値の型が数値ならそのまま epoch、ISO 8601 文字列なら `fromdateiso8601` で epoch 化。
+#   いずれも取得できなければ空（呼び出し側で reset 欠落 fallback / Req 1.4, 3.2）。
+#
+# 出力契約:
+#   - 1 検出 1 行: `<detection_path>\t<epoch_or_empty>`
+#   - 解析失敗（非 JSON / schema 違い）の行は無視して継続（Req 2.5 / Issue #66）
+#   - allowed のみ / 通常 result（is_error:false）は無視（Req 3.4）
+#   - 同一 stream に複数検出があっても全件出力（呼び出し側で `tail -1` 等を選択）
 #
 # 実装メモ: jq は default だと stdin を "concatenated JSON" として一括 parse する
 # ため、無効な 1 行があると stream 全体が fatal で止まる。stream を停止させない
@@ -341,20 +359,54 @@ qa_format_iso8601() {
 # `try fromjson catch null` で個別 parse する。
 qa_detect_rate_limit() {
   jq -R -r '
+    # 入力 1 行を JSON object に折りたたむ。fromjson 失敗 / 非 object は捨てる。
     . as $line
     | (try ($line | fromjson) catch null)
-    | select(type == "object")
-    | select(.type? == "rate_limit_event")
-    | select(.status? == "exceeded")
-    | (.resetsAt // .reset_at // .resets_at // empty)
+    | select(type == "object") as $j
+
+    # detection_path を 3 経路で識別（先頭で優先度を決定し、最初に match した
+    # 経路を採用）。マッチしなければ empty で当該行を捨てる。
     | (
-        if type == "number" then (. | floor)
-        elif type == "string" then
-          (try (. | fromdateiso8601) catch (try (. | tonumber) catch empty))
-        else empty end
-      )
-  ' 2>/dev/null \
-    | tail -1
+        if ($j.type? == "rate_limit_event")
+           and (($j.rate_limit_info? // {}).status? == "rejected") then
+          "rate_limit_event_v2"
+        elif ($j.type? == "rate_limit_event")
+             and ($j.status? == "exceeded") then
+          "rate_limit_event_v1"
+        elif ($j.type? == "result")
+             and ($j.is_error? == true)
+             and ($j.api_error_status? == 429) then
+          "synthetic_429_result"
+        else
+          empty
+        end
+      ) as $path
+
+    # reset epoch 候補値: 現行スキーマ ネスト → 旧スキーマ top-level の順で探索。
+    # 値が無ければ null を bind（empty を bind すると jq 仕様により当該行が消える）。
+    | (
+        ($j.rate_limit_info? // {})
+        | (.resetsAt // .resets_at // .reset_at // null)
+      ) as $nested
+    | (
+        $j
+        | (.resetsAt // .reset_at // .resets_at // null)
+      ) as $top
+    | (if $nested != null then $nested else $top end) as $raw
+
+    # epoch 化: number はそのまま floor、string は ISO 8601 → epoch、それ以外は空。
+    | (
+        if $raw == null then ""
+        elif ($raw | type) == "number" then ($raw | floor | tostring)
+        elif ($raw | type) == "string" then
+          (try ($raw | fromdateiso8601 | tostring)
+            catch (try ($raw | tonumber | floor | tostring) catch ""))
+        else "" end
+      ) as $epoch_str
+
+    # 出力: <detection_path>\t<epoch_or_empty>
+    | "\($path)\t\($epoch_str)"
+  ' 2>/dev/null
 }
 
 # 既存 6 stage の claude 呼び出しを横断ラップする Stage Wrapper（Req 1.1, 1.2,
@@ -386,26 +438,53 @@ qa_run_claude_stage() {
 
   # opt-in: stream-json を tee で 2 系統に分岐
   #   系統 1: 既存 $LOG への append（観測ログを破壊しない）
-  #   系統 2: qa_detect_rate_limit への pipe → reset epoch を $reset_file に書き出し
+  #   系統 2: qa_detect_rate_limit への pipe → 検出 TSV を中間ファイルに書き出し
   : > "$reset_file"
+  local detect_file="${reset_file}.detect"
+  : > "$detect_file"
   qa_log "stage start label=$stage_label"
 
-  # set -e / pipefail 配下で個別の非 0 exit を握り潰すため、|| true で確実に到達
-  # PIPESTATUS で claude 本体（pipeline 先頭）の exit code を後段で取り出す。
-  "$@" 2>&1 | tee -a "$LOG" | qa_detect_rate_limit > "$reset_file" || true
-  local claude_rc="${PIPESTATUS[0]:-0}"
+  # set -e / pipefail 配下で個別の非 0 exit を握り潰すため、PIPESTATUS を即座に
+  # 配列コピーしてから判断する。`|| true` は PIPESTATUS を 0 で上書きしてしまう
+  # ため使えない（Issue #104 で発覚 / 既存 Issue #66 実装の latent bug 修正）。
+  # set +e/-e で囲って pipefail 起因の即時 exit を一時的に抑止し、
+  # PIPESTATUS[0] = claude 本体 exit code を確実に取り出す。
+  local claude_rc=0
+  set +e
+  "$@" 2>&1 | tee -a "$LOG" | qa_detect_rate_limit > "$detect_file"
+  local _qa_pipestatus=("${PIPESTATUS[@]}")
+  set -e
+  claude_rc="${_qa_pipestatus[0]:-0}"
 
-  if [ -s "$reset_file" ]; then
-    local _epoch
-    _epoch=$(tr -d '[:space:]' < "$reset_file")
-    if [[ "$_epoch" =~ ^[0-9]+$ ]]; then
-      qa_log "stage detected exceeded label=$stage_label reset_epoch=$_epoch"
+  # 検出 TSV を解釈する。
+  # 優先順位:
+  #   1) epoch を持つ検出のうち最新行を採用 → exit 99 経路（reset 永続化に必要）
+  #   2) 1 が無く epoch なし検出のみある場合 → 既存フロー fallback + warn
+  #      （quota 枯渇は事実だが reset 不明では Resume Processor が機能しないため、
+  #      claude_rc を透過。Stage C は別途 PR 実在 verify で虚偽成功を防ぐ /
+  #      Req 1.4 / Req 3.2 / Issue #66 後方互換）
+  #   3) 検出ゼロ → claude_rc 透過
+  if [ -s "$detect_file" ]; then
+    local _epoch_line _path _epoch
+    _epoch_line=$(awk -F '\t' 'NF >= 2 && $2 ~ /^[0-9]+$/ { last = $0 } END { print last }' "$detect_file")
+    if [ -n "$_epoch_line" ]; then
+      _path="${_epoch_line%%$'\t'*}"
+      _epoch="${_epoch_line#*$'\t'}"
+      _epoch=$(printf '%s' "$_epoch" | tr -d '[:space:]')
+      printf '%s\n' "$_epoch" > "$reset_file"
+      qa_log "stage detected exceeded label=$stage_label path=${_path} reset_epoch=$_epoch"
+      rm -f "$detect_file"
       return 99
     fi
-    # 非数値だった場合は検出失敗扱い → 既存フローに委譲（Req 2.5）
-    qa_warn "stage detected non-numeric reset value label=$stage_label value=$_epoch (既存フローに委譲)"
+
+    # epoch 付き検出ゼロだが、検出経路だけは観測できたケース
+    local _last_line
+    _last_line=$(tail -1 "$detect_file")
+    _path="${_last_line%%$'\t'*}"
+    qa_warn "stage detected without reset label=$stage_label path=${_path} (既存フローに委譲 / claude_rc=$claude_rc)"
     : > "$reset_file"
   fi
+  rm -f "$detect_file"
   return "$claude_rc"
 }
 
@@ -3364,9 +3443,24 @@ run_impl_pipeline() {
       >> "$LOG" 2>&1 || _qa_rc_c=$?
   case "$_qa_rc_c" in
     0)
-      echo "✅ #$NUMBER: Stage C 完了 / PR 作成済み" | tee -a "$LOG"
+      # Issue #104 Bug 3 / Req 4.1〜4.4: claude RC=0 + quota 検出なし時点では
+      # 「PR が実際に作成されたか」が未確認。PjM サブエージェントが 1 turn で
+      # 空転終了しても claude RC=0 を返すため、PR 実在を gh で verify する。
       rm -f "$_qa_reset_file_c"
-      return 0
+      local _stagec_pr_url _stagec_verify_rc=0
+      _stagec_pr_url=$(gh pr view --repo "$REPO" --head "$BRANCH" \
+                          --json url --jq '.url' 2>/dev/null) || _stagec_verify_rc=$?
+      if [ "$_stagec_verify_rc" -eq 0 ] && [ -n "$_stagec_pr_url" ]; then
+        # Req 4.3: PR 実在確認できた場合は従来どおり成功
+        echo "✅ #$NUMBER: Stage C 完了 / PR 作成済み (${_stagec_pr_url})" | tee -a "$LOG"
+        return 0
+      fi
+      # Req 4.2 / 4.4: PR 不在または gh 失敗は安全側に倒し claude-failed 化
+      # （NFR 2.2: 人間が原因を特定できる粒度のログを残す）
+      echo "❌ #$NUMBER: Stage C 完了報告だが対応 PR 不在 → claude-failed (branch=$BRANCH verify_rc=$_stagec_verify_rc)" | tee -a "$LOG"
+      qa_warn "stageC PR verify failed issue=#$NUMBER branch=$BRANCH verify_rc=$_stagec_verify_rc pr_url='${_stagec_pr_url:-(empty)}'"
+      mark_issue_failed "stageC-pr-missing" "Stage C の Claude 実行は return code 0 で終了しましたが、対応する impl PR が GitHub 側に検出できませんでした（branch=\`$BRANCH\`）。PjM サブエージェントが 1 turn で空転終了した可能性 / GitHub API 一時障害の可能性のいずれかです。\`$LOG\` を確認してください。"
+      return 1
       ;;
     99)
       local _qa_epoch_c

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/normal-success.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/normal-success.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Implemented feature"}]}}
+{"type":"rate_limit_event","timestamp":"2026-05-15T01:00:00Z","rate_limit_info":{"status":"allowed","tier":"5h"}}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":5678}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/synthetic-429-no-reset.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/synthetic-429-no-reset.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"start"}]}}
+{"type":"result","subtype":"success","is_error":true,"api_error_status":429,"duration_ms":1234}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/synthetic-429-result.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/synthetic-429-result.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"start"}]}}
+{"type":"result","subtype":"success","is_error":true,"api_error_status":429,"duration_ms":1234,"rate_limit_info":{"status":"rejected","resetsAt":"2026-05-15T05:00:00Z"}}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/v1-rate-limit-event-exceeded.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/v1-rate-limit-event-exceeded.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Hi"}]}}
+{"type":"rate_limit_event","status":"exceeded","resetsAt":"2026-05-15T05:00:00Z"}
+{"type":"result","subtype":"error","is_error":true}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/v1-reset-at-snake.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/v1-reset-at-snake.jsonl
@@ -1,0 +1,1 @@
+{"type":"rate_limit_event","status":"exceeded","reset_at":"2026-05-15T05:00:00Z"}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/v2-no-reset.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/v2-no-reset.jsonl
@@ -1,0 +1,1 @@
+{"type":"rate_limit_event","rate_limit_info":{"status":"rejected"}}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/v2-numeric-epoch.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/v2-numeric-epoch.jsonl
@@ -1,0 +1,1 @@
+{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":1747375200}}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/v2-rate-limit-event-rejected.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/v2-rate-limit-event-rejected.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Working on it"}]}}
+{"type":"rate_limit_event","timestamp":"2026-05-15T01:00:00Z","rate_limit_info":{"status":"rejected","resetsAt":"2026-05-15T05:00:00Z","tier":"5h"}}
+{"type":"result","subtype":"error","is_error":true,"api_error_status":429,"error":"rate_limited"}

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/v2-rate-limit-malformed-line.jsonl
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/v2-rate-limit-malformed-line.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init"}
+this is not json at all and should not break the stream
+{"type":"rate_limit_event","rate_limit_info":{"status":"rejected","resetsAt":"2026-05-15T05:00:00Z"}}
+{"type":"result","subtype":"success","is_error":false}

--- a/local-watcher/test/qa_detect_rate_limit_test.sh
+++ b/local-watcher/test/qa_detect_rate_limit_test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh の Quota-Aware 検出関数
+#       (qa_detect_rate_limit) を fixture で検証するスモークテスト。
+#       Issue #104 で導入。
+#
+#       検出経路:
+#         - rate_limit_event_v2  : 現行スキーマ（rate_limit_info.status==rejected）
+#         - rate_limit_event_v1  : 旧スキーマ（top-level status==exceeded）
+#         - synthetic_429_result : type==result/is_error==true/api_error_status==429
+#
+# 配置先: local-watcher/test/qa_detect_rate_limit_test.sh
+# 依存:   bash 4+, awk, jq, diff
+# 実行:   bash local-watcher/test/qa_detect_rate_limit_test.sh
+# 前提:   このスクリプトは local-watcher/bin/issue-watcher.sh から
+#         qa_detect_rate_limit 関数 1 つだけを sed で切り出して eval で読み込み、
+#         issue-watcher.sh のトップレベル副作用は回避する。
+#
+# 期待動作: 全 fixture が Req どおりの結果を返せば PASS、1 件でも失敗すれば
+#           exit 1 で全体失敗。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+FIXTURE_DIR="$SCRIPT_DIR/fixtures/qa_detect_rate_limit"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 2
+fi
+
+# issue-watcher.sh から qa_detect_rate_limit() のみを抽出する。
+# awk で「関数開始行」から最初の単独 `}` までを抜き出す。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit")"
+
+if ! declare -F qa_detect_rate_limit >/dev/null; then
+  echo "ERROR: qa_detect_rate_limit not loaded" >&2
+  exit 2
+fi
+
+# ─── アサーションヘルパ ───
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# fixture を qa_detect_rate_limit に流し、最終検出行（または "$path<TAB>$epoch"）を返す。
+# 検出が無ければ空文字列を返す。
+detect_last_line() {
+  local fx="$1"
+  qa_detect_rate_limit < "$FIXTURE_DIR/$fx" | tail -n 1
+}
+
+# 検出全行を返す（複数検出を assert したい時用）。
+detect_all_lines() {
+  local fx="$1"
+  qa_detect_rate_limit < "$FIXTURE_DIR/$fx"
+}
+
+# ─── テストケース ───
+
+echo "--- qa_detect_rate_limit cases ---"
+
+# Req 1.1, 1.3: 現行スキーマ（rate_limit_info.status=rejected, ISO 8601 reset） →
+#               rate_limit_event_v2 + epoch
+# 注: このフィクスチャは末尾に synthetic 429 result も含み、result 行に rate_limit_info
+# は付かない（実 CLI 挙動の代表ケース）。tail -1 は synthetic_429_result + 空 epoch。
+out=$(detect_last_line "v2-rate-limit-event-rejected.jsonl")
+assert_eq "v2-rate-limit-event-rejected (tail-1) (Req 3.1, 3.2)" \
+  "$(printf 'synthetic_429_result\t')" \
+  "$out"
+
+all=$(detect_all_lines "v2-rate-limit-event-rejected.jsonl" | tr '\n' ';')
+assert_eq "v2-rate-limit-event-rejected (all) (Req 1.1, 1.3, 3.1)" \
+  "rate_limit_event_v2	1778821200;synthetic_429_result	;" \
+  "$all"
+
+# Req 1.1: numeric epoch（ネスト位置にある数値型 reset 値）も受理する
+out=$(detect_last_line "v2-numeric-epoch.jsonl")
+assert_eq "v2-numeric-epoch (Req 1.1, 1.3)" \
+  "$(printf 'rate_limit_event_v2\t1747375200')" \
+  "$out"
+
+# Req 1.4: 現行スキーマで reset 時刻が欠落 → path のみ、epoch 空
+out=$(detect_last_line "v2-no-reset.jsonl")
+assert_eq "v2-no-reset (Req 1.4)" \
+  "$(printf 'rate_limit_event_v2\t')" \
+  "$out"
+
+# Req 2.1: 旧スキーマ（top-level status==exceeded） → rate_limit_event_v1 + epoch
+out=$(detect_last_line "v1-rate-limit-event-exceeded.jsonl")
+assert_eq "v1-rate-limit-event-exceeded (Req 2.1)" \
+  "$(printf 'rate_limit_event_v1\t1778821200')" \
+  "$out"
+
+# Req 2.2: 旧スキーマで reset_at（snake case）も受理する
+out=$(detect_last_line "v1-reset-at-snake.jsonl")
+assert_eq "v1-reset-at-snake (Req 2.2)" \
+  "$(printf 'rate_limit_event_v1\t1778821200')" \
+  "$out"
+
+# Req 3.1: synthetic 429 result（rate_limit_info 同居） → synthetic_429_result + epoch
+out=$(detect_last_line "synthetic-429-result.jsonl")
+assert_eq "synthetic-429-result (Req 3.1)" \
+  "$(printf 'synthetic_429_result\t1778821200')" \
+  "$out"
+
+# Req 3.2: synthetic 429 result で reset 不在 → path のみ、epoch 空
+out=$(detect_last_line "synthetic-429-no-reset.jsonl")
+assert_eq "synthetic-429-no-reset (Req 3.2)" \
+  "$(printf 'synthetic_429_result\t')" \
+  "$out"
+
+# Req 3.4: 通常 result（is_error:false） + allowed の rate_limit_event は検出されない
+out=$(detect_last_line "normal-success.jsonl")
+assert_eq "normal-success (Req 3.4)" "" "$out"
+
+# Req 5.1〜5.4: 解析失敗の混入行があっても以後の検出は継続する（既存 Req 2.5 互換）
+out=$(detect_last_line "v2-rate-limit-malformed-line.jsonl")
+assert_eq "v2-rate-limit-malformed-line (Req 5.4 / NFR resilience)" \
+  "$(printf 'rate_limit_event_v2\t1778821200')" \
+  "$out"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/local-watcher/test/qa_run_claude_stage_test.sh
+++ b/local-watcher/test/qa_run_claude_stage_test.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh の Quota-Aware Stage Wrapper
+#       (qa_run_claude_stage) を fixture で end-to-end 検証する。
+#       Issue #104 で導入。
+#
+#       検証観点（Req と対応付け）:
+#         - 現行スキーマ rate_limit_event_v2 検出 → exit 99 + reset_file = epoch
+#           (Req 1.1, 1.2, 5.4)
+#         - 旧スキーマ rate_limit_event_v1 検出 → exit 99 + reset_file = epoch
+#           (Req 2.1, 5.4)
+#         - synthetic 429 result（rate_limit_info 同居） → exit 99 + reset_file = epoch
+#           (Req 3.1, 3.3, 5.4)
+#         - 通常成功（detection なし） → exit 0
+#           (Req 3.4)
+#         - synthetic 429 のみで reset 不在 → claude_rc 透過 + warn
+#           (Req 3.2)
+#         - opt-out (QUOTA_AWARE_ENABLED!=true) → 素通し
+#           (NFR 1.1)
+#
+# 配置先: local-watcher/test/qa_run_claude_stage_test.sh
+# 依存:   bash 4+, awk, jq
+# 実行:   bash local-watcher/test/qa_run_claude_stage_test.sh
+# 前提:   issue-watcher.sh から関数 2 つ（qa_log/qa_warn/qa_error と
+#         qa_detect_rate_limit / qa_run_claude_stage）を切り出して読み込む。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+FIXTURE_DIR="$SCRIPT_DIR/fixtures/qa_detect_rate_limit"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# 一時 LOG ファイル（qa_run_claude_stage は $LOG に tee する）
+TMPDIR_TEST=$(mktemp -d)
+LOG="$TMPDIR_TEST/test.log"
+export LOG
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# 必要な関数だけを抽出して eval で読み込む。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# qa_log / qa_warn / qa_error は qa_run_claude_stage が呼ぶので必ず loaded する
+# shellcheck disable=SC1090
+eval "$(extract_function "$WATCHER_SH" "qa_log")"
+# shellcheck disable=SC1090
+eval "$(extract_function "$WATCHER_SH" "qa_warn")"
+# shellcheck disable=SC1090
+eval "$(extract_function "$WATCHER_SH" "qa_error")"
+# shellcheck disable=SC1090
+eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit")"
+# shellcheck disable=SC1090
+eval "$(extract_function "$WATCHER_SH" "qa_run_claude_stage")"
+
+for fn in qa_log qa_warn qa_error qa_detect_rate_limit qa_run_claude_stage; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# ─── アサーションヘルパ ───
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# fake-claude: fixture を stdout にダンプし、指定された exit code を返す。
+# qa_run_claude_stage は "$@" を実行するため、引数として fixture と rc を受け取る。
+fake_claude() {
+  local fx_path="$1"
+  local rc="${2:-0}"
+  cat "$fx_path"
+  return "$rc"
+}
+
+# テスト 1 件を実行する補助関数。
+# Args: <test_label> <expected_rc> <expected_reset_file_content> <fixture> [fake_claude_rc]
+# QUOTA_AWARE_ENABLED は呼び出し側で export する想定。
+run_case() {
+  local label="$1"
+  local expected_rc="$2"
+  local expected_reset="$3"
+  local fx="$4"
+  local fake_rc="${5:-0}"
+
+  local reset_file
+  reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+  local rc=0
+  qa_run_claude_stage "TestStage" "$reset_file" -- \
+    fake_claude "$FIXTURE_DIR/$fx" "$fake_rc" >/dev/null 2>&1 || rc=$?
+
+  local actual_reset
+  actual_reset=$(cat "$reset_file" 2>/dev/null || true)
+  rm -f "$reset_file" "${reset_file}.detect"
+
+  assert_eq "$label rc" "$expected_rc" "$rc"
+  assert_eq "$label reset_file" "$expected_reset" "$actual_reset"
+}
+
+# ─── テストケース ───
+
+echo "--- qa_run_claude_stage cases (opt-in) ---"
+export QUOTA_AWARE_ENABLED="true"
+
+# Req 1.1, 1.2, 5.4: 現行スキーマ単独 → exit 99 + epoch 永続化
+# 注: v2-rate-limit-event-rejected は末尾に reset 無し synthetic 429 を含むが、
+# epoch 付き検出を優先採用するため exit 99 + 1778821200 が期待値。
+run_case "v2-rate-limit-event-rejected (Req 1.1, 1.2, 5.4)" \
+  99 "1778821200" "v2-rate-limit-event-rejected.jsonl" 0
+
+# Req 1.1, 1.3 numeric epoch
+run_case "v2-numeric-epoch (Req 1.1, 1.3)" \
+  99 "1747375200" "v2-numeric-epoch.jsonl" 0
+
+# Req 1.4: 現行スキーマで reset 欠落 → claude_rc 透過 (fake rc=0) + warn
+run_case "v2-no-reset (Req 1.4)" \
+  0 "" "v2-no-reset.jsonl" 0
+
+# Req 2.1, 5.4: 旧スキーマ → exit 99 + epoch
+run_case "v1-rate-limit-event-exceeded (Req 2.1, 5.4)" \
+  99 "1778821200" "v1-rate-limit-event-exceeded.jsonl" 0
+
+# Req 2.2: 旧スキーマ snake-case reset_at
+run_case "v1-reset-at-snake (Req 2.2)" \
+  99 "1778821200" "v1-reset-at-snake.jsonl" 0
+
+# Req 3.1, 5.4: synthetic 429 (rate_limit_info 同居) → exit 99 + epoch
+run_case "synthetic-429-result (Req 3.1, 5.4)" \
+  99 "1778821200" "synthetic-429-result.jsonl" 0
+
+# Req 3.2: synthetic 429 単独 + reset 不在 → claude_rc 透過 + warn
+run_case "synthetic-429-no-reset (Req 3.2)" \
+  0 "" "synthetic-429-no-reset.jsonl" 0
+
+# Req 3.4: 通常成功 → claude_rc=0 透過、reset_file 空
+run_case "normal-success (Req 3.4)" \
+  0 "" "normal-success.jsonl" 0
+
+# 補助: claude が非 0 で終了する場合は素通し（quota 検出なし時）
+run_case "normal-success with claude rc=2 (NFR 1.2 既存 rc 透過)" \
+  2 "" "normal-success.jsonl" 2
+
+# Req 5.4: malformed line 混入でも検出を継続
+run_case "v2-rate-limit-malformed-line (Req 5.4)" \
+  99 "1778821200" "v2-rate-limit-malformed-line.jsonl" 0
+
+echo ""
+echo "--- qa_run_claude_stage cases (opt-out) ---"
+export QUOTA_AWARE_ENABLED="false"
+
+# NFR 1.1: opt-out 時は tee も解析も走らず素通し
+# Req 1.1 / NFR 1.1 で claude_rc を完全透過、reset_file は touch されない
+reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+rm -f "$reset_file"  # opt-out 時は touch されないことを確認するため事前削除
+rc=0
+qa_run_claude_stage "TestStage" "$reset_file" -- \
+  fake_claude "$FIXTURE_DIR/v2-rate-limit-event-rejected.jsonl" 0 >/dev/null 2>&1 || rc=$?
+assert_eq "opt-out v2 input rc=0 (NFR 1.1)" "0" "$rc"
+if [ ! -e "$reset_file" ]; then
+  echo "PASS: opt-out reset_file untouched (NFR 1.1)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: opt-out reset_file unexpectedly created"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# opt-out で claude rc を透過
+reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+rm -f "$reset_file"
+rc=0
+qa_run_claude_stage "TestStage" "$reset_file" -- \
+  fake_claude "$FIXTURE_DIR/normal-success.jsonl" 7 >/dev/null 2>&1 || rc=$?
+assert_eq "opt-out preserves claude rc=7 (NFR 1.1, 1.2)" "7" "$rc"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/local-watcher/test/stagec_pr_verify_test.sh
+++ b/local-watcher/test/stagec_pr_verify_test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh の Stage C 完了処理に追加された
+#       「PR 実在 verify」分岐 (Issue #104 Bug 3 / Req 4.1〜4.4) を
+#       fake gh と fake mark_issue_failed で検証するスモークテスト。
+#
+#       検証観点（Req と対応付け）:
+#         - PR 実在ありなら成功 echo + return 0      (Req 4.1, 4.3)
+#         - PR 不在（gh OK + 空文字）なら claude-failed 化 (Req 4.2)
+#         - gh 失敗（rc != 0）なら claude-failed 化 (Req 4.4)
+#
+# 配置先: local-watcher/test/stagec_pr_verify_test.sh
+# 依存:   bash 4+
+# 実行:   bash local-watcher/test/stagec_pr_verify_test.sh
+# 前提:   このスクリプトは issue-watcher.sh の Stage C `case 0)` ブロックを
+#         意味的に再現した小ルーチンを評価する（ソース全体を eval すると
+#         グローバル副作用が走るため、対象ブロックの仕様を最小再現で検証）。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# スモークテストのスコープ: Stage C 完了 case 0) ブロック内の PR 実在 verify ロジック。
+# 直接 `qa_run_claude_stage` の呼び出し直後 case "$_qa_rc_c" in 0) を切り出すと
+# run_impl_pipeline 関数全体に依存してしまうため、本テストでは仕様レベルの再現
+# 関数 `_test_stagec_complete` を定義して同じロジックパスを評価する。
+#
+# 本仕様再現が issue-watcher.sh と divergent しないよう、issue-watcher.sh 側の
+# 該当ブロック（grep で "stageC-pr-missing" を含む行が存在することで担保）を
+# サニティチェックする。
+if ! grep -q "stageC-pr-missing" "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh に stageC-pr-missing ハンドラが見つからない" >&2
+  exit 2
+fi
+if ! grep -q "gh pr view --repo \"\$REPO\" --head \"\$BRANCH\"" "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh に PR 実在 verify (gh pr view --head) が見つからない" >&2
+  exit 2
+fi
+
+# 仕様再現: 実装の Stage C `case 0)` ブロックと等価ロジック。
+# fake gh / fake mark_issue_failed / fake echo で副作用を全テストプロセスに閉じ込める。
+_test_stagec_complete() {
+  local _qa_reset_file_c="/tmp/qa-reset-stagec-test"  # 削除対象だけのダミー
+  : > "$_qa_reset_file_c"
+
+  rm -f "$_qa_reset_file_c"
+  local _stagec_pr_url _stagec_verify_rc=0
+  _stagec_pr_url=$(gh pr view --repo "$REPO" --head "$BRANCH" \
+                      --json url --jq '.url' 2>/dev/null) || _stagec_verify_rc=$?
+  if [ "$_stagec_verify_rc" -eq 0 ] && [ -n "$_stagec_pr_url" ]; then
+    echo "Stage C 完了 / PR 作成済み"
+    return 0
+  fi
+  echo "Stage C 完了報告だが対応 PR 不在 verify_rc=$_stagec_verify_rc"
+  mark_issue_failed "stageC-pr-missing" "PR 不在のため失敗"
+  return 1
+}
+
+# fake mark_issue_failed: 引数を $LAST_MARK_FAILED_STAGE / $LAST_MARK_FAILED_BODY に保存
+mark_issue_failed() {
+  LAST_MARK_FAILED_STAGE="$1"
+  LAST_MARK_FAILED_BODY="$2"
+}
+
+# fake gh: 実装は test ごとに上書きする
+gh() { :; }
+
+# ─── アサーションヘルパ ───
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# 共通 env（実装側の echo / qa_warn は本テストの仕様再現関数に含めていないため
+# NUMBER は未参照になる。実装側ログのフォーマットには含まれることを覚書として残す）
+# shellcheck disable=SC2034
+NUMBER="123"
+REPO="owner/test"
+BRANCH="claude/issue-123-impl-foo"
+LOG="/tmp/test-watcher.log"
+: > "$LOG"
+
+# ─── テストケース ───
+
+echo "--- Stage C PR verify cases ---"
+
+# Req 4.1, 4.3: gh が PR URL を返す → return 0
+gh() {
+  # gh pr view --repo X --head Y --json url --jq '.url'
+  echo "https://github.com/owner/test/pull/45"
+  return 0
+}
+LAST_MARK_FAILED_STAGE=""
+# shellcheck disable=SC2034  # 本テストでは body は未検証だが将来検証用に保持
+LAST_MARK_FAILED_BODY=""
+rc=0
+# サブシェル経由（$()）だと global 代入が消えるため、リダイレクト経由で stdout を捨て
+# call は current shell で実行する
+_test_stagec_complete >/dev/null 2>&1 || rc=$?
+assert_eq "PR 実在あり: rc=0 (Req 4.1, 4.3)" "0" "$rc"
+assert_eq "PR 実在あり: mark_issue_failed 未呼出 (Req 4.3)" "" "$LAST_MARK_FAILED_STAGE"
+
+# Req 4.2: gh は成功 (rc=0) だが URL が空（--head に対応 PR が無い） → claude-failed
+gh() {
+  # gh は対応 PR 無しでも成功で終了するが --jq '.url' が空文字列 / null になる
+  # （gh pr view は head に該当 PR が無いと exit 1 を返すケースもあるが、
+  # gh 1.x の挙動差を吸収するため空文字 + 成功も同等に扱う）
+  echo ""
+  return 0
+}
+LAST_MARK_FAILED_STAGE=""
+# shellcheck disable=SC2034  # 本テストでは body は未検証だが将来検証用に保持
+LAST_MARK_FAILED_BODY=""
+rc=0
+# サブシェル経由（$()）だと global 代入が消えるため、リダイレクト経由で stdout を捨て
+# call は current shell で実行する
+_test_stagec_complete >/dev/null 2>&1 || rc=$?
+assert_eq "PR 不在 (空 URL): rc=1 (Req 4.2)" "1" "$rc"
+assert_eq "PR 不在 (空 URL): mark_issue_failed 呼出 (Req 4.2)" "stageC-pr-missing" "$LAST_MARK_FAILED_STAGE"
+
+# Req 4.4: gh が非 0 終了 (API 障害シミュレーション) → claude-failed
+gh() {
+  return 1
+}
+LAST_MARK_FAILED_STAGE=""
+# shellcheck disable=SC2034  # 本テストでは body は未検証だが将来検証用に保持
+LAST_MARK_FAILED_BODY=""
+rc=0
+# サブシェル経由（$()）だと global 代入が消えるため、リダイレクト経由で stdout を捨て
+# call は current shell で実行する
+_test_stagec_complete >/dev/null 2>&1 || rc=$?
+assert_eq "gh 失敗 (rc=1): _test_stagec_complete rc=1 (Req 4.4)" "1" "$rc"
+assert_eq "gh 失敗 (rc=1): mark_issue_failed 呼出 (Req 4.4)" "stageC-pr-missing" "$LAST_MARK_FAILED_STAGE"
+
+# Req 4.4: gh が timeout 相当の rc=124 → claude-failed
+gh() {
+  return 124
+}
+LAST_MARK_FAILED_STAGE=""
+# shellcheck disable=SC2034  # 本テストでは body は未検証だが将来検証用に保持
+LAST_MARK_FAILED_BODY=""
+rc=0
+# サブシェル経由（$()）だと global 代入が消えるため、リダイレクト経由で stdout を捨て
+# call は current shell で実行する
+_test_stagec_complete >/dev/null 2>&1 || rc=$?
+assert_eq "gh timeout (rc=124): _test_stagec_complete rc=1 (Req 4.4)" "1" "$rc"
+assert_eq "gh timeout (rc=124): mark_issue_failed 呼出 (Req 4.4)" "stageC-pr-missing" "$LAST_MARK_FAILED_STAGE"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Issue #104 の 3 つの bug を修正。Claude CLI rate_limit_event の現行スキーマ対応、synthetic 429 result line の検出経路追加、Stage C で gh pr view による PR 実在 verify を導入。

Closes #104

## 経緯（人手復旧 PR）

idd-claude watcher の通常フローで Stage A (Developer, 4 commits, 60 PASS) は成功しましたが、続く Reviewer 起動時に **HTTP 529 Overloaded** (transient server overload) で reviewer agent が即終了し、`review-notes.md` が書かれず `parse_review_result: parse-failed` で `claude-failed` 昇格しました。

その後、人手で:
1. slot-1 worktree の commit を origin に push
2. 独立 context で Reviewer サブエージェントを手動起動 → approve 判定
3. review-notes.md を commit して PjM の代わりに本 PR を作成

という流れで復旧しています。Reviewer の判定内容は `docs/specs/104-.../review-notes.md` を参照。

## 修正内容

### Bug 1: rate_limit_event スキーマ不一致

- 現行 v2 schema (`rate_limit_info.status == \"rejected\"`) を主検出経路に
- 旧 v1 schema (`status == \"exceeded\"`) も後方互換で並走
- reset 時刻は `.rate_limit_info.resetsAt` / `.resetsAt` の順で探索

### Bug 2: synthetic 429 result line

- `type == \"result\"`, `is_error == true`, `api_error_status == 429` の検出経路を追加
- session が rate_limit_event を吐かず result line のみで死ぬパターンをカバー

### Bug 3: Stage C PR 実在 verify

- Stage C 完了処理に `gh pr view --head <branch>` で PR 存在確認
- 不在時は `mark_issue_failed \"stageC-pr-missing\"` で claude-failed に escalate

### 副次: PIPESTATUS bug fix

`qa_run_claude_stage` の latent bug を修正（claude RC の透過性確保）。Issue #66 由来の問題で、本 Issue で発見・対処。

## 検証

- shellcheck 警告ゼロ
- 既存テスト + 新規テスト合計 **60 PASS / 0 FAIL**
- 新規 fixture: 9 種 (v2/v1 schema, synthetic 429, normal-success, reset-missing, malformed-line)
- 新規 test scripts:
  - `local-watcher/test/qa_detect_rate_limit_test.sh`
  - `local-watcher/test/qa_run_claude_stage_test.sh`
  - `local-watcher/test/stagec_pr_verify_test.sh`

## レビュー

Reviewer round=1 で **approve**。判定詳細は `docs/specs/104-.../review-notes.md` 参照。AC カバレッジ / missing test / boundary 逸脱の 3 カテゴリすべてクリア。

Closes #104

🤖 Restored after Reviewer 529 Overloaded transient failure