### PR TITLE
feat(#118): pr-iteration round の quota soft-fail 自動退避と pre-cycle dirty 回復

### DIFF
--- a/docs/specs/118-bug-watcher-pr-iteration-round-five-hour/impl-notes.md
+++ b/docs/specs/118-bug-watcher-pr-iteration-round-five-hour/impl-notes.md
@@ -1,0 +1,159 @@
+# 実装ノート: #118 bug(watcher): pr-iteration round が five_hour quota の allowed_warning で中途終了し、作業ツリー dirty を残して以降の cycle が沈黙失敗する
+
+## 変更ファイル
+
+- `local-watcher/bin/issue-watcher.sh`
+  - 新規 helper 3 つを `pi_run_iteration` の直前に追加
+    - `pi_detect_quota_soft_fail` (L1885〜): stream-json から `rate_limit_event` + `status == "allowed_warning"` + `surpassedThreshold >= 0.9` を検出する jq folder。`qa_detect_rate_limit` と独立、`QUOTA_AWARE_ENABLED` 設定に依存しない
+    - `pi_branch_is_claude_pr_head` (L1922〜): `^claude/issue-[0-9]+-` 命名規約一致判定。auto-commit 発火ガード
+    - `pi_auto_commit_and_push` (L1942〜): `git add -A` + `git commit -m "<msg>\n\nCo-Authored-By: Claude <noreply@anthropic.com>"` + `git push origin <branch>` の 3 段
+  - `pi_run_iteration` のサブシェルを書き換え (L2025〜2231)
+    - claude 出力を `tee -a $pi_log_file | pi_detect_quota_soft_fail > $pi_soft_fail_file` に分岐
+    - `PIPESTATUS[0]` で claude 本体の rc を保持しつつ、tee / jq の rc を握り潰さない
+    - subshell 終端で `git status --porcelain` 判定 → soft-fail / post-round-dirty / 差分なし の 3 系統で `pi_recover_file` に結果を書き出す
+    - 親 (pi_run_iteration の subshell 外) は recover_file を読み取り、`soft-fail-commit:ok` の場合は `pi_finalize_labels*` を呼ばずに return 1（needs-iteration 据え置き）
+  - `process_pr_iteration` の冒頭 dirty check を書き換え (L2247〜2284)
+    - dirty 検出時に current branch / dirty paths / 派生 issue 番号をログ出力
+    - `claude/issue-<N>-` 規約一致なら `pi_auto_commit_and_push` で `pre-cycle-recover` 経路 → 成功で本処理継続、失敗で ERROR + skip
+    - 規約不一致は ERROR + skip（既存挙動と同等の安全側）
+- `local-watcher/test/pi_detect_quota_soft_fail_test.sh` (新規)
+  - `pi_detect_quota_soft_fail` の検出条件と `pi_branch_is_claude_pr_head` の境界条件を fixture + assert で検証する 13 件のテスト
+- `local-watcher/test/fixtures/pi_detect_quota_soft_fail/*.jsonl` (新規 6 件)
+  - top-level / ネスト位置 / threshold 境界 / rejected 非対象 / 通常成功 / malformed 行混入 を網羅
+
+## 設計判断と根拠
+
+### 1. `pi_detect_quota_soft_fail` を `qa_detect_rate_limit` と分離した理由
+
+要件 5 で `QUOTA_AWARE_ENABLED` と独立に動作することが必須。`qa_detect_rate_limit` は `status="rejected"` / `status="exceeded"` 系を検出して dispatcher 経由で `needs-quota-wait` 付与する流れに紐づいているため、`allowed_warning` の検出ロジックを混ぜると "dispatcher 連携なし"（Req 5.3）の境界が曖昧になる。同一ファイル内に並列配置して両方ともサブシェルで個別の jq folder を呼ぶ構成にした。
+
+### 2. soft-fail 検出と post-round-dirty 検出を 1 経路に統合した理由
+
+要件 2.5 で「soft-fail の commit message を優先」と明記されているため、`subshell 内で has_dirty + soft_fail_observed の 2 値で commit message を分岐」させると要件 1 と要件 2 の経路を共通化できる。要件 1 のみが auto-commit を発火させると、quota 警告は出たが dirty が無いケースで finalize に進んでしまい Req 1.4（needs-iteration 据え置き）が崩れるため、`差分なし + soft-fail` ケースも `soft-fail-commit:ok` 扱いにして finalize を抑止する。
+
+### 3. branch ガードを 2 箇所に重ねた理由
+
+`pi_run_iteration` のサブシェル内では既に `head_ref` を `git checkout` 済みなので通常は claude/issue-... に居る。しかし claude 失敗時 / fetch 失敗時など、想定外の branch（BASE_BRANCH に居る場合等）にいる可能性がある。そのため `pi_branch_is_claude_pr_head` で防御し、不一致なら `post-round-commit:fail` を書き出して finalize を抑止する。`process_pr_iteration` の cycle 冒頭でも独立に同じ guard を掛けて、前 cycle 由来の dirty を回復するか skip するかを判断する。
+
+### 4. push 戦略を `git push origin <branch>` （force なし）にした理由
+
+`pi_run_iteration` で round 開始時に `git checkout -B "$head_ref" "origin/${head_ref}"` で **必ず origin に追従して fresh start** している（既存 AC 4.4）。したがって round 中に出来た commit を push する時点では origin と divergent していないため、plain push で fast-forward できる。force 系を使うと別経路 race で本要件 scope 外の事故を引き起こすため避けた。push 衝突は失敗扱いで needs-iteration 残置（Req 1.5 / 2.4）。
+
+### 5. pre-cycle-recover の log で PR 番号を branch 名から派生させた
+
+Req 4.2 で「PR 番号 / branch / 種別 / 結果」をログ出力することが指定されている。pre-cycle dirty 検出時点では PR 候補リスト取得前なので PR 番号は未知だが、branch 名 `claude/issue-<N>-<slug>` から正規表現で issue 番号を抜き出して `issue=#<N>` として埋め込んだ。grep 集計時の整合性のため。
+
+### 6. claude 失敗時も post-round-recover に進む
+
+claude が exit code 非 0 で終わったとしても、その時点で edit が部分的に残っている可能性は高い（むしろ rate-limit 中途終了は claude 失敗 + dirty として現れる可能性がある）。Req 2 は「round 終了時点で未コミット差分が残っていれば自動退避」と書かれており、claude 成功条件が前提ではないため、claude rc にかかわらず dirty 退避は実行する。退避結果が `post-round-commit:fail` でも上位は WARN + needs-iteration 据え置きの安全側に倒れる。
+
+## 各 AC への対応箇所マッピング
+
+| AC | 担保箇所 | テスト |
+|---|---|---|
+| Req 1.1 | `pi_detect_quota_soft_fail` の jq folder（L1885〜） + `pi_run_iteration` の tee pipe（L2086） | `pi_detect_quota_soft_fail_test.sh` の 6 ケース (top-level / nested / 境界値 / rejected 除外 / 通常成功 / malformed) |
+| Req 1.2 | `pi_run_iteration` subshell の `has_dirty=true && soft_fail_observed=true` 分岐（L2131〜2139） | 設計判断 #2、`pi_auto_commit_and_push` の git ops は手動 smoke test で確認（後述） |
+| Req 1.3 | `pi_auto_commit_and_push` の `Co-Authored-By` 行付与（L1955〜1957） + commit message format（L2134） | 手動 smoke: `/tmp/pi-autocommit-test` で commit message format を検証 |
+| Req 1.4 | recover_status `soft-fail-commit:ok` 分岐で `pi_finalize_labels*` を呼ばず return 1（L2176〜2180） | `pi_finalize_labels` 関連の既存テストが通っていること + 設計判断 #2 |
+| Req 1.5 | recover_status `soft-fail-commit:fail` 分岐で `pi_warn` + return 1（L2181〜2185） | 手動: `pi_auto_commit_and_push` を read-only directory 等で失敗させると WARN が出ることを設計上保証 |
+| Req 1.6 | 本変更は `gh issue edit ... --add-label needs-quota-wait` を一切呼ばない（grep でも 0 件）。`qa_handle_quota_exceeded` 呼び出しも追加していない | grep 検索: 新規追加 hunk に `needs-quota-wait` / `qa_handle_quota_exceeded` 文字列なし |
+| Req 2.1 | `pi_run_iteration` subshell の `has_dirty=$([git status --porcelain] ? true : false)` 判定（L2111〜2114） | 設計判断 #2 |
+| Req 2.2 | `has_dirty=true && soft_fail_observed=false` で post-round-commit 経路（L2141〜2148） | 手動 smoke で auto-commit + push 成功確認 |
+| Req 2.3 | commit message format `docs(specs): recover uncommitted round-${next_round} output (auto)` (L2143) + `Co-Authored-By` (L1955〜1957) | 手動 smoke で message format 確認 |
+| Req 2.4 | recover_status `post-round-commit:fail` 分岐で `pi_warn` + return 1（L2190〜2194） | 設計上保証（`pi_auto_commit_and_push` のいずれかのステップ失敗で発火） |
+| Req 2.5 | `if soft_fail_observed=true` の分岐を `else (post-round)` より先に評価する制御フロー（L2131） | コードレビューで構造的に保証 |
+| Req 3.1 | `pi_log "pre-cycle dirty 検出 issue=#... branch=... paths=..."` (L2257) | 手動 smoke: `/tmp` の test repo で `pre-cycle dirty 検出` ログが出ることを確認 |
+| Req 3.2 | `pi_branch_is_claude_pr_head` 一致時に `pi_auto_commit_and_push` で `pre-cycle-recover` (L2259〜2271) | `pi_detect_quota_soft_fail_test.sh` の `pi_branch_is_claude_pr_head` 4 ケース + 手動 smoke の `auto-commit: OK` |
+| Req 3.3 | commit message format `docs(specs): recover pre-cycle dirty state on ${_pi_pre_branch} (auto)` (L2261) + Co-Authored-By | 手動 smoke: `git log -1 --format='%B'` で確認済み |
+| Req 3.4 | `pi_branch_is_claude_pr_head` 不一致なら `pi_error` + return 0（L2272〜2276） | `pi_detect_quota_soft_fail_test.sh` の `branch=main / develop / human-...` 3 ケース |
+| Req 3.5 | `pi_auto_commit_and_push` 失敗時に `pi_error` + return 0（L2267〜2271） | 設計上保証（`pi_auto_commit_and_push` のいずれかのステップ失敗で発火） |
+| Req 4.1 | `pi_log "PR #... quota-soft-fail utilization=... action=auto-commit+keep-label"` (L2178) | コードレビュー、`pi_log` プレフィクスは既存通り |
+| Req 4.2 | `pi_log "...post-round-recover branch=... action=success"` (L2188) + `pi_log "pre-cycle-recover issue=#... branch=... action=success"` (L2266) | コードレビューで形式確認 |
+| Req 4.3 | `pi_warn` / `pi_error` はそれぞれ `>&2` に出力（pi_log/pi_warn/pi_error の既存定義） | 既存定義そのまま |
+| Req 5.1 | `pi_detect_quota_soft_fail` は `QUOTA_AWARE_ENABLED` を一切参照しない | grep: `pi_detect_quota_soft_fail` 周辺に `QUOTA_AWARE_ENABLED` 文字列なし |
+| Req 5.2 | `process_pr_iteration` 冒頭の dirty 検出 + 回復ロジックも `QUOTA_AWARE_ENABLED` 非依存 | grep: 該当 hunk に `QUOTA_AWARE_ENABLED` なし |
+| Req 5.3 | 新規 hunk に `needs-quota-wait` / `qa_handle_quota_exceeded` の呼び出しなし | grep で確認済み |
+| NFR 1.1 | 既存 needs-iteration → ready-for-review / awaiting-design-review 遷移は recover_status="none:" の場合のみ通過する original path（L2204〜2231） | 既存テスト 178 件が全て通ること |
+| NFR 1.2 | `pi_log` / `pi_warn` / `pi_error` の関数本体は無変更。新規ログも同じ prefix を使う | `pi_log` 関数定義 (L1145〜1153) は無変更 |
+| NFR 1.3 | 既存 env var に追加変更なし（`PR_ITERATION_ENABLED` / `PR_ITERATION_MAX_ROUNDS` / `PR_ITERATION_GIT_TIMEOUT` / `QUOTA_AWARE_ENABLED` をそのまま参照） | Config ブロック (L52〜244) は無変更 |
+| NFR 2.1 | fixture ベースのテストで 4 分岐を独立検証可能（detection の有無 × branch 規約一致の有無） | `pi_detect_quota_soft_fail_test.sh` 13 ケース + 設計判断 #3 |
+| NFR 2.2 | 既存テスト 178 件が全て通る | `for f in local-watcher/test/*_test.sh; do bash $f; done` で確認済み |
+| NFR 3.1 | `pi_log` の `[YYYY-MM-DD HH:MM:SS] pr-iteration: ...` 形式を維持 | `pi_log` 関数定義無変更 |
+| NFR 3.2 | `quota-soft-fail` 行は 1 PR 1 行（`pi_log "PR #${pr_number}: ... quota-soft-fail utilization=... action=..."`）で出力される | grep で集計可能な形式 |
+
+## テスト結果
+
+### shellcheck
+
+```
+$ shellcheck -S warning local-watcher/bin/issue-watcher.sh
+$ echo $?
+0
+```
+
+`-S info` を付けても、追加した新規 hunk からの新規警告は 0 件（pre-existing な SC2317 / SC2012 は私の改修で増減なし）。
+
+### 既存 + 新規テスト
+
+```
+normalize_slug_test.sh:                                      rc=0 PASS: 11, FAIL: 0
+parse_review_result_test.sh:                                 rc=0 PASS: 19, FAIL: 0
+pi_detect_quota_soft_fail_test.sh:                           rc=0 PASS: 13, FAIL: 0   <- 新規
+qa_detect_rate_limit_test.sh:                                rc=0 PASS: 10, FAIL: 0
+qa_run_claude_stage_test.sh:                                 rc=0 PASS: 23, FAIL: 0
+slug_match_guard_test.sh:                                    rc=0 PASS: 13, FAIL: 0
+stagec_pr_verify_fallback_test.sh:                           rc=0 PASS: 35, FAIL: 0
+stagec_pr_verify_retry_test.sh:                              rc=0 PASS: 42, FAIL: 0
+stagec_pr_verify_test.sh:                                    rc=0 PASS: 8, FAIL: 0
+verify_pushed_or_retry_test.sh:                              rc=0 PASS: 17, FAIL: 0
+```
+
+合計 191 ケース全て PASS。新規 13 ケースは Req 1.1 と Req 3.2 / 3.4 の境界条件を網羅。
+
+### 手動 smoke test: pi_auto_commit_and_push の E2E
+
+```bash
+# Setup: /tmp/pi-autocommit-test に git init + bare clone を作って
+# claude/issue-118-impl-foo branch を作り a に編集を加える
+# Extract: pi_log, pi_warn, pi_error, pi_branch_is_claude_pr_head, pi_auto_commit_and_push
+
+branch=claude/issue-118-impl-foo dirty= M a
+guard: OK
+auto-commit: OK
+after: dirty=                       # ← clean state に戻った
+last commit message:
+docs(specs): recover pre-cycle dirty state on claude/issue-118-impl-foo (auto)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+bare clone 側にも commit が push されていることを `git log -1 --format='%H %s' claude/issue-118-impl-foo` で確認。
+
+### 構文チェック
+
+```
+$ bash -n local-watcher/bin/issue-watcher.sh
+syntax OK
+```
+
+### cron-like 最小 PATH での依存解決
+
+```
+$ env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'command -v gh jq flock git timeout'
+/usr/bin/gh
+/usr/bin/jq
+/usr/bin/flock
+/usr/bin/git
+/usr/bin/timeout
+```
+
+claude CLI は `$HOME/.local/bin` に居る前提（既存挙動、本変更で変えていない）。
+
+## 確認事項（レビュワー向け）
+
+1. **claude 失敗時の post-round-recover について**: Req 2 は「Claude セッションが終了したとき」と書かれているのみで、claude rc が 0 / 非 0 を区別していない。実装では claude rc にかかわらず `git status --porcelain` 判定を行い、dirty なら退避する方針にした（設計判断 #6）。これは Req 1 の `allowed_warning` 検知時に claude が exit code 非 0 で抜けるケース（CLI 実装次第）も拾うため必要だが、もし PM 側が「claude rc=0 のときだけ自動回復したい」意図であれば指摘してください。
+2. **branch ガードの round-内版**: `pi_run_iteration` のサブシェル末尾で `pi_branch_is_claude_pr_head` で current branch を再評価しているのは防御的措置。通常経路は `git checkout -B "$head_ref" "origin/${head_ref}"` 直後なので一致するはずだが、`set +e` 配下で稀に checkout が失敗していると BASE_BRANCH に居る可能性を排除できないため。Req 1 / 2 には書かれていないがエラーケース対策として入れた。問題があれば指摘してください。
+3. **`pi_log` の 1 行集計性 (NFR 3.2)**: `quota-soft-fail utilization=0.92 action=auto-commit+keep-label` を 1 行で出すことで `grep 'quota-soft-fail'` で件数集計可能にしている。`utilization` フィールドは `surpassedThreshold` の小数値そのまま。`utilization=0.92` の形式で問題なければよし、`utilization=92%` 等のフォーマットが好ましければ指摘してください。
+4. **pre-cycle-recover の force push 非利用**: 通常 fast-forward で push 可能と想定（subshell 終端でも origin と divergent でない前提）。万一 push 失敗（divergent / 権限）した場合は WARN + skip で次サイクルに委ねる方針。force-with-lease を使うべきか否かは PM 判断に委ねる。
+5. **fixture テストの代替性**: 本リポジトリは unit test framework なしで fixture ベースの shell test を採用している。`pi_run_iteration` 全体の E2E は claude CLI / `gh` への副作用を含むため fixture 化していない。NFR 2.1 で要求される 4 分岐独立検証は `pi_detect_quota_soft_fail_test.sh` の 6 ケース + `pi_branch_is_claude_pr_head` の 7 ケースで担保したつもりだが、より大きなテストハーネス（subshell + git stub）が必要なら次 Issue で切り出すべきかもしれない。
+6. **Out of Scope の遵守**: dispatcher Resume Processor / `needs-quota-wait` ラベル / Stage A / B / C / Triage への波及はなし。本改修は `process_pr_iteration` / `pi_run_iteration` の 2 関数のみ。`qa_*` 関数や `process_quota_resume` は触っていない。

--- a/docs/specs/118-bug-watcher-pr-iteration-round-five-hour/requirements.md
+++ b/docs/specs/118-bug-watcher-pr-iteration-round-five-hour/requirements.md
@@ -1,0 +1,119 @@
+# Requirements Document
+
+## Introduction
+
+`pr-iteration` Processor で 1 round 分の Claude セッションを実行している最中に Claude Max の
+5 時間ローリング quota の警告閾値（`rate_limit_event` の `status == "allowed_warning"` かつ
+`surpassedThreshold >= 0.9`）に到達すると、Claude セッションがファイル編集の途中で打ち切られ、
+commit / push に到達せずに終了する事例が観測されている。watcher は Claude CLI の exit code が 0
+で返ることから「成功」と判定して `needs-iteration` ラベルを外し（あるいは finalize 失敗で残置し）
+ながら、作業ツリーには未コミット変更（dirty）を残す。次サイクルでは `process_pr_iteration` 冒頭の
+dirty 検知で Processor 全体がスキップされるか、`git checkout` が衝突して以後の cycle が沈黙失敗する。
+
+本要件は、`pr-iteration` round の中で quota 警告を検知して「soft-fail」として扱い、未コミット変更を
+自動 commit / push して以降の cycle が継続できる clean state に戻すこと、および dirty が残った
+状態で次サイクルが始まった場合の最小限の自動回復ガードを定義する。`needs-quota-wait` 経由の
+Resume Processor 統合などの大規模な再設計は本要件のスコープ外で、観測実例で session 中断していた
+事象に対する**最小ガード（auto-commit + `needs-iteration` 据え置き）**に範囲を絞る。
+
+## Requirements
+
+### Requirement 1: Round 実行中の quota 警告検知と soft-fail 化
+
+**Objective:** As a idd-claude 運用者, I want `pr-iteration` round 中に Claude Max quota の
+警告閾値到達を検知して soft-fail として扱い未コミット変更を退避してほしい, so that quota 起因で
+途中終了した round の差分が失われたり次サイクルを沈黙失敗させたりしない。
+
+#### Acceptance Criteria
+
+1. When PR Iteration Round の Claude セッション出力に `type == "rate_limit_event"` かつ `status == "allowed_warning"` かつ `surpassedThreshold >= 0.9` を満たすイベントが現れたとき, the PR Iteration Processor shall その round を `quota-soft-fail` として記録する
+2. When `quota-soft-fail` を検出した round が終了したとき, the PR Iteration Processor shall 未コミットの差分があれば head branch に対して自動で commit と push を行う
+3. When `quota-soft-fail` の round で auto-commit を実施するとき, the PR Iteration Processor shall commit message を `docs(specs): partial round-<N> output before quota cutoff (auto-recovered)` 形式とし、`Co-Authored-By: Claude <noreply@anthropic.com>` 行を含める
+4. When `quota-soft-fail` を検出した round が終了したとき, the PR Iteration Processor shall 対象 PR の `needs-iteration` ラベルをそのまま残置し、`ready-for-review` / `awaiting-design-review` への昇格は行わない
+5. If `quota-soft-fail` round の auto-commit や push に失敗したとき, the PR Iteration Processor shall その失敗を WARN ログに記録した上で `needs-iteration` を残置して当該 PR の処理を終了する
+6. The PR Iteration Processor shall `quota-soft-fail` 検知時に対象 PR に `needs-quota-wait` ラベルを付与しない（dispatcher の Resume Processor との連携は本要件スコープ外）
+
+### Requirement 2: Round 終了後の未コミット差分の自動回復
+
+**Objective:** As a idd-claude 運用者, I want quota 警告の有無にかかわらず round 終了時点で
+作業ツリーに未コミット差分が残っていれば自動で退避してほしい, so that 次サイクルが dirty 検知で
+スキップされたり `git checkout` 衝突で停止したりしない。
+
+#### Acceptance Criteria
+
+1. When PR Iteration Round の Claude セッションが終了したとき, the PR Iteration Processor shall 作業ツリーが clean かどうかを判定する
+2. When Round 終了時に未コミット差分が残存しているとき, the PR Iteration Processor shall head branch に対して自動で commit と push を行い作業ツリーを clean state に戻す
+3. When Requirement 2.2 に該当して auto-commit を実施するとき, the PR Iteration Processor shall commit message を `docs(specs): recover uncommitted round-<N> output (auto)` 形式とし、`Co-Authored-By: Claude <noreply@anthropic.com>` 行を含める
+4. If Round 終了後の auto-commit / push に失敗したとき, the PR Iteration Processor shall その失敗を WARN ログに記録した上で当該 PR の処理を終了する
+5. When Round 終了時の dirty 状態が Requirement 1（quota-soft-fail）と Requirement 2（quota 非起因の dirty）の両方の条件を満たすとき, the PR Iteration Processor shall Requirement 1 の commit message と挙動を優先して適用する
+
+### Requirement 3: サイクル開始時の dirty 状態の最小ガード
+
+**Objective:** As a idd-claude 運用者, I want 前 cycle で dirty を残したまま新 cycle が開始した場合に
+作業ツリーを安全に復旧してほしい, so that 過去 round の中間生成物に起因して Processor が
+無期限にスキップされ続けない。
+
+#### Acceptance Criteria
+
+1. When PR Iteration Processor が cycle 冒頭で作業ツリーの dirty を検出したとき, the PR Iteration Processor shall 現在チェックアウトされている branch 名と dirty なパス一覧をログに記録する
+2. When dirty 検出時の current branch が `claude/issue-<番号>-<slug>` 命名規約に一致するとき, the PR Iteration Processor shall 当該 branch に対して未コミット差分を自動 commit / push して作業ツリーを clean state に戻し、Processor の本処理を継続する
+3. When Requirement 3.2 に該当して auto-commit を実施するとき, the PR Iteration Processor shall commit message を `docs(specs): recover pre-cycle dirty state on <branch> (auto)` 形式とし、`Co-Authored-By: Claude <noreply@anthropic.com>` 行を含める
+4. If dirty 検出時の current branch が `claude/issue-<番号>-<slug>` 命名規約に一致しないとき, the PR Iteration Processor shall ERROR ログを残した上で当該 cycle の PR Iteration Processor をスキップして終了する
+5. If 自動回復の commit / push に失敗したとき, the PR Iteration Processor shall ERROR ログを残した上で当該 cycle の PR Iteration Processor をスキップして終了する
+
+### Requirement 4: ログとオブザーバビリティ
+
+**Objective:** As a idd-claude 運用者, I want quota soft-fail と自動回復の発生をログから識別可能に
+してほしい, so that cron 出力の grep で発生件数や対象 PR を機械的に集計できる。
+
+#### Acceptance Criteria
+
+1. When `quota-soft-fail` を検知したとき, the PR Iteration Processor shall `pi_log` プレフィクス付きで PR 番号 / round / utilization / action（`auto-commit+keep-label` など）を 1 行にまとめてログ出力する
+2. When Requirement 2 または Requirement 3 の自動回復を実行したとき, the PR Iteration Processor shall `pi_log` プレフィクス付きで PR 番号 / branch / 種別（`post-round-recover` / `pre-cycle-recover`）/ 結果（success/fail）をログ出力する
+3. The PR Iteration Processor shall 自動回復に伴う commit / push の失敗を WARN または ERROR レベルで `>&2` に出力する
+
+### Requirement 5: 既存 quota-aware 機構との独立性
+
+**Objective:** As a idd-claude 運用者, I want 本要件の検知 / 回復ガードが既存の
+`QUOTA_AWARE_ENABLED` opt-out 設定とは独立に動作してほしい, so that dispatcher の Resume Processor
+を採用していない運用環境でも round 途中終了からの自動回復が機能する。
+
+#### Acceptance Criteria
+
+1. While `QUOTA_AWARE_ENABLED` が `false` に設定されているとき, the PR Iteration Processor shall Requirement 1 の `rate_limit_event` 検知と soft-fail 化を有効のまま動作させる
+2. While `QUOTA_AWARE_ENABLED` が `false` に設定されているとき, the PR Iteration Processor shall Requirement 2 および Requirement 3 の自動回復ガードを有効のまま動作させる
+3. The PR Iteration Processor shall 本要件で追加する検知・回復処理の中で `needs-quota-wait` ラベルの付与や `qa_handle_quota_exceeded` 相当の dispatcher 連携を行わない
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The PR Iteration Processor shall 本要件導入前から存在する PR 番号 / round / kind ベースのラベル遷移挙動（quota 警告が発生しない round における `needs-iteration` → `ready-for-review` / `awaiting-design-review`）を変更しない
+2. The PR Iteration Processor shall 既存の `pi_log` / `pi_warn` / `pi_error` ログ出力形式と既存のログ行プレフィクスを変更しない
+3. The PR Iteration Processor shall 既存の環境変数（`PR_ITERATION_ENABLED` / `PR_ITERATION_MAX_ROUNDS` / `PR_ITERATION_GIT_TIMEOUT` / `QUOTA_AWARE_ENABLED` ほか）の意味と既定値を変更しない
+
+### NFR 2: テスト可能性
+
+1. The PR Iteration Processor shall Requirement 1 〜 3 の各分岐（quota 警告検知 / round 後 dirty / cycle 開始 dirty + branch 一致 / cycle 開始 dirty + branch 不一致）をそれぞれ独立に検証できる fixture を提供する
+2. The PR Iteration Processor shall 既存テストスイートが本要件導入後も成功する状態を維持する
+
+### NFR 3: 観測性とアラート
+
+1. The PR Iteration Processor shall `quota-soft-fail` 行・自動回復行を含むログ出力を、`pi_log` の既存タイムスタンプ形式（`[YYYY-MM-DD HH:MM:SS] pi: ...`）で記録する
+2. The PR Iteration Processor shall 1 回の cycle 中に発生した `quota-soft-fail` の件数を、その cycle のサマリログから集計可能にする（PR 番号付きで 1 行 1 件として出力する）
+
+## Out of Scope
+
+- dispatcher 側 Resume Processor（`process_quota_resume` / `qa_handle_quota_exceeded`）の改修や、`needs-quota-wait` ラベル経由での自動再 trigger 連携
+- Stage A / B / C / Reviewer / Triage など `pr-iteration` 以外のステージにおける同種の round 途中終了対策（本要件は `pr-iteration` round に限定する）
+- Claude Max quota 枯渇の予測抑制（utilization が閾値未満であっても予防的に round を遅延・分割する仕組み）
+- Claude CLI 側で `allowed_warning` 受信後にツール実行を継続する挙動の修正・回避（upstream 課題）
+- 既存 `needs-quota-wait` ラベル / `quota-reset` hidden marker の意味変更
+- auto-commit 対象とする branch 命名規約の拡張（`claude/issue-<番号>-<slug>` 以外の branch を回復対象とすること）
+
+## Open Questions
+
+- なし（Issue 本文の「仮案・判断を委ねたい点」は、本要件で以下の通り採用した:
+  - `needs-quota-wait` ラベル付与は今回スコープ外とし、最小ガード（auto-commit + `needs-iteration` 据え置き）に留める → Requirement 1.6 / 5.3 / Out of Scope に明記
+  - `allowed_warning` 単独で soft-fail とする conservative な扱いを採用 → Requirement 1.1 で `surpassedThreshold >= 0.9` を併用条件として明文化
+  - auto-commit message は `Co-Authored-By: Claude <noreply@anthropic.com>` を含む既存慣習に従う → Requirement 1.3 / 2.3 / 3.3 に明記）

--- a/docs/specs/118-bug-watcher-pr-iteration-round-five-hour/review-notes.md
+++ b/docs/specs/118-bug-watcher-pr-iteration-round-five-hour/review-notes.md
@@ -1,0 +1,91 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-20T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-118-impl-bug-watcher-pr-iteration-round-five-hour
+- HEAD commit: 589a0d4643ad5a8884e7f80fb649c01ad7120c1e
+- Compared to: main..HEAD
+- 変更ファイル:
+  - `local-watcher/bin/issue-watcher.sh`（+275/-6）
+  - `local-watcher/test/pi_detect_quota_soft_fail_test.sh`（新規 +160）
+  - `local-watcher/test/fixtures/pi_detect_quota_soft_fail/*.jsonl`（新規 6 件）
+  - `docs/specs/118-bug-watcher-pr-iteration-round-five-hour/{requirements.md,impl-notes.md}`
+- 注: 本 spec には `tasks.md` / `design.md` が存在しない（PM のみフロー）。`_Boundary:_` の
+  明示は無いが、requirements.md の Out of Scope で `pr-iteration` Processor 限定が明記されており、
+  実装は `pi_run_iteration` / `process_pr_iteration` の 2 関数のみに収束しているため、
+  境界逸脱は検出されない。
+
+## Verified Requirements
+
+- **1.1** — `pi_detect_quota_soft_fail` jq folder（issue-watcher.sh L1885〜）が
+  `type==rate_limit_event` かつ `status==allowed_warning`（top-level / `rate_limit_info` ネスト
+  両対応）かつ `surpassedThreshold>=0.9` で検出。`pi_run_iteration` 内で claude stdout を tee
+  経由で `pi_soft_fail_file` に書き出し、`soft_fail_observed` フラグで参照。テスト 6 ケース
+  （top-level / nested / 境界値 0.85 不検出 / rejected 不検出 / 通常成功 / malformed 行混入）。
+- **1.2** — `pi_run_iteration` subshell L2131〜で `has_dirty=true && soft_fail_observed=true`
+  分岐 → `pi_auto_commit_and_push` で `git add -A && git commit && git push origin <branch>`。
+- **1.3** — `pi_auto_commit_and_push` が `Co-Authored-By: Claude <noreply@anthropic.com>` を
+  常時付与。soft-fail commit message は `docs(specs): partial round-${next_round} output before
+  quota cutoff (auto-recovered)` 形式（要件と完全一致）。
+- **1.4** — 親側 case で `soft-fail-commit:ok` を受けた場合は `pi_finalize_labels*` を呼ばず
+  `return 1` を返すため、`needs-iteration` は外れず `ready-for-review` への昇格も行われない。
+- **1.5** — `soft-fail-commit:fail` 分岐で `pi_warn` 出力 + `return 1`（needs-iteration 残置）。
+- **1.6** — 新規 hunk に `needs-quota-wait` / `qa_handle_quota_exceeded` の追加呼び出しなし
+  （grep 確認: 0 matches）。
+- **2.1** — round 終了直後に `git status --porcelain` で has_dirty を判定（L2120〜）。
+- **2.2** — `has_dirty=true && soft_fail_observed=false` で `post-round-commit` 経路。
+- **2.3** — commit message `docs(specs): recover uncommitted round-${next_round} output (auto)`
+  + Co-Authored-By 付与（要件と完全一致）。
+- **2.4** — `post-round-commit:fail` 分岐で `pi_warn` + `return 1`。
+- **2.5** — `if soft_fail_observed=true` が先に評価され、`else (post-round)` に落ちる制御
+  フローで優先順位を構造的に保証。
+- **3.1** — `process_pr_iteration` 冒頭の dirty 検出時に
+  `pi_log "pre-cycle dirty 検出 issue=#... branch=... paths=..."` を出力（一致 / 不一致
+  双方の経路で出力）。
+- **3.2** — `pi_branch_is_claude_pr_head` 一致時に `pi_auto_commit_and_push` 実行 → 成功で
+  BASE_BRANCH に戻して本処理継続。テスト 2 ケース（`claude/issue-118-impl-foo` /
+  `claude/issue-42-design-bar`）で正規表現マッチ確認。
+- **3.3** — commit message `docs(specs): recover pre-cycle dirty state on ${_pi_pre_branch}
+  (auto)` + Co-Authored-By（要件と完全一致）。
+- **3.4** — `pi_branch_is_claude_pr_head` 不一致時に `pi_error` + `return 0`（skip）。テスト
+  4 ケース（main / develop / hitoshi/manual-work / `claude/no-issue-prefix` / 空文字列）。
+- **3.5** — `pi_auto_commit_and_push` 失敗時に `pi_error "pre-cycle-recover ... action=fail"`
+  + `return 0`。
+- **4.1** — `pi_log "PR #${pr_number}: kind=${kind} round=${next_round} quota-soft-fail
+  utilization=${soft_fail_summary} action=auto-commit+keep-label"` 1 行出力（grep 集計可能）。
+- **4.2** — `pi_log "...post-round-recover branch=... action=success"` および
+  `pi_log "pre-cycle-recover issue=#... branch=... action=success"` の 1 行ログ出力。
+- **4.3** — `pi_warn` / `pi_error` は既存定義のまま `>&2` 出力（NFR 1.2）。
+- **5.1** — `pi_detect_quota_soft_fail` は `QUOTA_AWARE_ENABLED` を参照せず、tee pipe で常時
+  起動（QUOTA_AWARE_ENABLED の有無にかかわらず動作）。
+- **5.2** — `process_pr_iteration` 冒頭の dirty 自動回復ロジックも QUOTA_AWARE_ENABLED 非依存。
+- **5.3** — 新規 hunk に dispatcher 連携（`needs-quota-wait` / `qa_handle_quota_exceeded`）の
+  追加なし（grep 0 matches）。
+- **NFR 1.1** — `recover_status="none:"` の original path で従来の `pi_finalize_labels*`
+  呼び出しがそのまま通過する制御フロー。既存ラベル遷移は保持。
+- **NFR 1.2** — `pi_log` / `pi_warn` / `pi_error` の関数定義は無変更。新規ログも同 prefix。
+- **NFR 1.3** — `PR_ITERATION_*` / `QUOTA_AWARE_ENABLED` ほか既存 env var の意味と既定値変更なし。
+- **NFR 2.1** — fixture ベースの独立テスト（6 検出ケース + 7 branch ガードケース）で 4 分岐
+  検証可能。
+- **NFR 2.2** — `shellcheck -S warning local-watcher/bin/issue-watcher.sh` rc=0 / 191 テスト
+  ケース全 PASS（impl-notes 記載、reviewer 側でも `pi_detect_quota_soft_fail_test.sh` を
+  再実行し 13/13 PASS を確認）。
+- **NFR 3.1** — `pi_log` の既存タイムスタンプ形式維持。
+- **NFR 3.2** — `quota-soft-fail` 行は PR 番号付き 1 行で grep 集計可能。
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric ID（1.1〜5.3 / NFR 1.1〜3.2）について実装またはテストが対応。
+shellcheck warning ゼロ、新規 13 ケース PASS、既存 178 ケース PASS（impl-notes 記載、reviewer
+側で `pi_detect_quota_soft_fail_test.sh` を再実行し PASS=13 確認）。本 spec は PM のみフロー
+で `tasks.md` / `design.md` が無いが、Out of Scope 節で `pr-iteration` Processor 限定が
+明記されており、実装は `pi_run_iteration` / `process_pr_iteration` の 2 関数のみに収束、
+`needs-quota-wait` / `qa_handle_quota_exceeded` の追加呼び出しもなく境界逸脱は検出されない。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -1863,6 +1863,104 @@ pi_build_iteration_prompt() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# pi_detect_quota_soft_fail: stream-json から Claude Max 5h quota の警告閾値到達を検知
+#   入力: stdin に Claude `--output-format stream-json` の出力（1 行 1 JSON）
+#   出力: stdout に検出 1 件 1 行（タブ区切り）。検出無しなら無出力。
+#         形式: <detection_path>\t<surpassed_threshold>
+#           detection_path: 現状 `rate_limit_warning` 固定
+#           surpassed_threshold: 検出時の surpassedThreshold 値（小数文字列）
+#   返り値: 0 固定（解析失敗行・非該当行は無視して継続。`qa_detect_rate_limit` と同じ
+#           resilience 設計 / Req 5.4 互換）
+#
+#   検出条件 (#118 Req 1.1):
+#     - `type == "rate_limit_event"` かつ
+#     - `status == "allowed_warning"`（top-level）または
+#       `rate_limit_info.status == "allowed_warning"`（ネスト位置）かつ
+#     - `surpassedThreshold >= 0.9`（top-level の `surpassedThreshold` または
+#       `rate_limit_info.surpassedThreshold` のどちらかが 0.9 以上）
+#
+#   この関数は `QUOTA_AWARE_ENABLED` 設定とは独立に呼ばれる（Req 5.1）。
+#   `qa_detect_rate_limit` とは独立した関数として配置（Req 5.3: dispatcher 連携なし）。
+# ─────────────────────────────────────────────────────────────────────────────
+pi_detect_quota_soft_fail() {
+  jq -R -r '
+    . as $line
+    | (try ($line | fromjson) catch null)
+    | select(type == "object") as $j
+
+    # status を top-level / ネスト位置の両方で探索
+    | (
+        ($j.status? // ($j.rate_limit_info? // {}).status? // "")
+      ) as $status
+
+    # surpassedThreshold を top-level / ネスト位置の両方で探索
+    | (
+        ($j.surpassedThreshold? // ($j.rate_limit_info? // {}).surpassedThreshold? // null)
+      ) as $threshold
+
+    # type == "rate_limit_event" かつ status == "allowed_warning" かつ
+    # threshold が数値かつ >= 0.9 のときのみ出力
+    | select(
+        $j.type? == "rate_limit_event"
+        and $status == "allowed_warning"
+        and ($threshold | type) == "number"
+        and $threshold >= 0.9
+      )
+
+    | "rate_limit_warning\t\($threshold)"
+  ' 2>/dev/null
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pi_branch_is_claude_pr_head: branch 名が auto-commit 許可規約に一致するか判定
+#   入力: $1 = branch 名
+#   返り値: 0 = 一致（`claude/issue-<N>-<slug>` 形式）/ 1 = 不一致
+#
+#   人間の branch に対する誤 auto-commit 防止のガード（#118 Req 3.2 / 3.4）。
+#   現状は `^claude/issue-[0-9]+-` で固定（Out of Scope: branch 命名規約拡張）。
+# ─────────────────────────────────────────────────────────────────────────────
+pi_branch_is_claude_pr_head() {
+  local branch="${1:-}"
+  [[ "$branch" =~ ^claude/issue-[0-9]+- ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pi_auto_commit_and_push: 指定 branch に対して未コミット差分を `git add -A` →
+#   `git commit -m "$msg"` → `git push origin <branch>` で退避する
+#   入力: $1 = commit message（1 行目）。本文 + Co-Authored-By を関数側で付与する。
+#         $2 = branch 名（push 先 / safety 用に呼び出し時点の current branch と一致前提）
+#   返り値: 0 = 成功 / 1 = 失敗（add / commit / push のいずれか）
+#
+#   設計判断:
+#     - `git add -A` で削除も含む全変更を取り込む（中途終了時の意図不明差分を漏らさない）。
+#     - commit には `Co-Authored-By: Claude <noreply@anthropic.com>` を含める
+#       （#118 Req 1.3 / 2.3 / 3.3 で固定）。
+#     - push は plain `git push origin <branch>`（force 系を使わない）。push 失敗は
+#       上位で WARN 扱い（Req 1.5 / 2.4 / 3.5）。
+#     - 呼び出し前に `pi_branch_is_claude_pr_head` でガードする責務は呼び出し元。
+# ─────────────────────────────────────────────────────────────────────────────
+pi_auto_commit_and_push() {
+  local msg="$1"
+  local branch="$2"
+  local full_msg
+  full_msg=$(printf '%s\n\nCo-Authored-By: Claude <noreply@anthropic.com>\n' "$msg")
+
+  if ! timeout "$PR_ITERATION_GIT_TIMEOUT" git add -A >/dev/null 2>&1; then
+    pi_warn "auto-commit: git add -A に失敗 (branch=${branch})"
+    return 1
+  fi
+  if ! timeout "$PR_ITERATION_GIT_TIMEOUT" git commit -m "$full_msg" >/dev/null 2>&1; then
+    pi_warn "auto-commit: git commit に失敗 (branch=${branch})"
+    return 1
+  fi
+  if ! timeout "$PR_ITERATION_GIT_TIMEOUT" git push origin "$branch" >/dev/null 2>&1; then
+    pi_warn "auto-commit: git push origin ${branch} に失敗"
+    return 1
+  fi
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # pi_run_iteration: 1 PR 分の iteration を実行（fresh context Claude 起動）
 #   入力: $1=pr_json
 #   戻り値: 0=success(commit+push or reply-only), 1=failure, 2=escalated(round上限到達),
@@ -1925,6 +2023,19 @@ pi_run_iteration() {
 
   pi_log "PR #${pr_number}: kind=${kind} round=${next_round}/${PR_ITERATION_MAX_ROUNDS} 着手 (${pr_url})"
 
+  # #118 Req 1.1 / 2.1: soft-fail 検知用 / 自動回復結果のサブシェル <-> 親 通信用に
+  # tmpfile を 2 つ用意する。
+  #   - $pi_soft_fail_file : 検出 1 件 1 行（`pi_detect_quota_soft_fail` の出力）
+  #   - $pi_recover_file   : サブシェル終端で書き出す自動回復結果の 1 行。
+  #                          書式: `<kind>:<result>` 例: `soft-fail-commit:ok`,
+  #                                `post-round-commit:ok`, `post-round-commit:fail`,
+  #                                `none:` （回復不要 / dirty なし）
+  local pi_soft_fail_file pi_recover_file
+  pi_soft_fail_file=$(mktemp -t "pi-softfail-${pr_number}-XXXXXX" 2>/dev/null || mktemp)
+  pi_recover_file=$(mktemp -t "pi-recover-${pr_number}-XXXXXX" 2>/dev/null || mktemp)
+  : > "$pi_soft_fail_file"
+  : > "$pi_recover_file"
+
   # サブシェル + trap で必ず base branch に戻す（AC 8.3）
   local rc=0
   (
@@ -1953,23 +2064,142 @@ pi_run_iteration() {
     # NFR 1.1: --max-turns で turn 数上限
     local pi_log_file
     pi_log_file="$LOG_DIR/pr-iteration-${kind}-${pr_number}-round${next_round}-$(date +%Y%m%d-%H%M%S).log"
-    if ! claude \
+
+    # #118 Req 1.1 / 5.1: claude の stream-json 出力を tee で 2 系統に分岐。
+    #   - 系統 1: 既存通り $pi_log_file へ append（観測ログを壊さない / NFR 1.2）。
+    #   - 系統 2: pi_detect_quota_soft_fail で `allowed_warning` イベントを検出し
+    #            $pi_soft_fail_file に書き出す。QUOTA_AWARE_ENABLED とは独立に動作する
+    #            （Req 5.1）。
+    # set -e / pipefail 配下で `tee` や `jq` の非 0 exit を握り潰さないよう、
+    # PIPESTATUS を即座にコピーしてから claude 本体の exit code を取り出す。
+    local claude_rc=0
+    set +e
+    claude \
         --print "$prompt" \
         --model "$PR_ITERATION_DEV_MODEL" \
         --permission-mode bypassPermissions \
         --max-turns "$PR_ITERATION_MAX_TURNS" \
         --output-format stream-json \
         --verbose \
-        >> "$pi_log_file" 2>&1; then
+        2>&1 \
+      | tee -a "$pi_log_file" \
+      | pi_detect_quota_soft_fail \
+      > "$pi_soft_fail_file"
+    local _pi_pipestatus=("${PIPESTATUS[@]}")
+    set -e
+    claude_rc="${_pi_pipestatus[0]:-0}"
+
+    if [ "$claude_rc" -ne 0 ]; then
       pi_warn "PR #${pr_number}: kind=${kind} Claude 実行が失敗 (log: ${pi_log_file})"
+      # claude 失敗時も round 中に部分編集が残っている可能性があるため、後段の自動回復に
+      # 続ける。検出 file の有無にかかわらず post-round-recover 経路で dirty を退避する。
+    else
+      pi_log "PR #${pr_number}: kind=${kind} Claude 実行完了 (log: ${pi_log_file})"
+    fi
+
+    # #118 Req 1.2 / 2.1 / 2.2: round 終了時点の dirty 判定と自動回復。
+    # 設計判断:
+    #   - 「soft-fail を検出 かつ 差分あり」「soft-fail なし かつ 差分あり」「差分なし」の 3 系統。
+    #   - soft-fail 検出が優先（Req 2.5）。
+    #   - branch ガードは pi_branch_is_claude_pr_head で実施（人間 branch には auto-commit しない）。
+    local current_branch
+    current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    local soft_fail_observed=false
+    if [ -s "$pi_soft_fail_file" ]; then
+      soft_fail_observed=true
+    fi
+    local has_dirty=false
+    if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+      has_dirty=true
+    fi
+
+    # branch ガード（Req 3.2 / 3.4 の round-内版）: 想定外 branch に居る場合は
+    # auto-commit せず WARN（claude 失敗時の subshell 早期 exit や fetch/checkout 失敗で
+    # current_branch が head_ref と乖離するシナリオを安全側に倒す）。
+    if [ "$has_dirty" = "true" ] && ! pi_branch_is_claude_pr_head "$current_branch"; then
+      pi_warn "PR #${pr_number}: kind=${kind} round=${next_round} 想定外 branch '${current_branch}' に dirty 検出 (auto-commit 抑止)"
+      printf '%s' "post-round-commit:fail" > "$pi_recover_file"
+      if [ "$claude_rc" -ne 0 ]; then
+        exit 1
+      fi
+      # claude 成功なのに branch 不一致は構造上ほぼ起きない（防御的）。後続で finalize しないよう fail を返す。
       exit 1
     fi
-    pi_log "PR #${pr_number}: kind=${kind} Claude 実行完了 (log: ${pi_log_file})"
-    exit 0
+
+    local recover_status="none:"
+    if [ "$has_dirty" = "true" ]; then
+      if [ "$soft_fail_observed" = "true" ]; then
+        # Req 1.2 / 1.3 / 2.5: soft-fail 時の commit message
+        if pi_auto_commit_and_push \
+            "docs(specs): partial round-${next_round} output before quota cutoff (auto-recovered)" \
+            "$current_branch"; then
+          recover_status="soft-fail-commit:ok"
+        else
+          recover_status="soft-fail-commit:fail"
+        fi
+      else
+        # Req 2.2 / 2.3: 通常 dirty 時の commit message
+        if pi_auto_commit_and_push \
+            "docs(specs): recover uncommitted round-${next_round} output (auto)" \
+            "$current_branch"; then
+          recover_status="post-round-commit:ok"
+        else
+          recover_status="post-round-commit:fail"
+        fi
+      fi
+    elif [ "$soft_fail_observed" = "true" ]; then
+      # 差分は無いが soft-fail を観測した（差分前に round が打ち切られた稀ケース）
+      recover_status="soft-fail-commit:ok"
+    fi
+    printf '%s' "$recover_status" > "$pi_recover_file"
+
+    # claude 自体の rc を引き継ぐ（失敗は呼び出し元で WARN + needs-iteration 残置に倒れる）
+    exit "$claude_rc"
   )
   rc=$?
   # 保険: 呼び出し元でも base branch に戻す
   git checkout "$BASE_BRANCH" >/dev/null 2>&1 || true
+
+  # #118 Req 1.1 / 4.1 / 4.2: 自動回復結果を読み取ってログ + 後続挙動を分岐
+  local recover_status="none:"
+  if [ -s "$pi_recover_file" ]; then
+    recover_status=$(cat "$pi_recover_file")
+  fi
+  local soft_fail_summary=""
+  if [ -s "$pi_soft_fail_file" ]; then
+    # 検出が複数行ある場合は最後の値を採用（最新 utilization）。tab 区切り 2 列目。
+    soft_fail_summary=$(awk -F '\t' 'NF >= 2 { last = $2 } END { print last }' "$pi_soft_fail_file")
+  fi
+  rm -f "$pi_soft_fail_file" "$pi_recover_file"
+
+  case "$recover_status" in
+    soft-fail-commit:ok)
+      # Req 1.1 / 1.2 / 1.4 / 4.1: soft-fail 検出 + auto-commit 成功 → needs-iteration 据え置き
+      pi_log "PR #${pr_number}: kind=${kind} round=${next_round} quota-soft-fail utilization=${soft_fail_summary} action=auto-commit+keep-label"
+      return 1
+      ;;
+    soft-fail-commit:fail)
+      # Req 1.5: auto-commit / push 失敗 → WARN + needs-iteration 据え置き
+      pi_warn "PR #${pr_number}: kind=${kind} round=${next_round} quota-soft-fail utilization=${soft_fail_summary} action=auto-commit-failed (needs-iteration を残置)"
+      return 1
+      ;;
+    post-round-commit:ok)
+      # Req 2.1 / 2.2 / 4.2: 通常 dirty + auto-commit 成功 → 通常 finalize に進む
+      pi_log "PR #${pr_number}: kind=${kind} round=${next_round} post-round-recover branch=${head_ref} action=success"
+      ;;
+    post-round-commit:fail)
+      # Req 2.4 / 4.3: auto-commit / push 失敗 → WARN + 終了
+      pi_warn "PR #${pr_number}: kind=${kind} round=${next_round} post-round-recover branch=${head_ref} action=fail"
+      return 1
+      ;;
+    none:|"")
+      : # 回復不要（dirty なし）
+      ;;
+    *)
+      pi_warn "PR #${pr_number}: kind=${kind} 未知の recover_status='${recover_status}' (needs-iteration を残置)"
+      return 1
+      ;;
+  esac
 
   if [ $rc -eq 0 ]; then
     # AC 6.2 (#26) / #35 AC 3.1 / 3.2: kind に応じたラベル遷移
@@ -2011,9 +2241,42 @@ process_pr_iteration() {
   fi
 
   # NFR 2.3 / AC 8.5: dirty working tree 検知
+  # #118 Req 3.1〜3.5: 前 cycle で round が途中終了して dirty を残した場合、
+  # current branch が `claude/issue-<N>-<slug>` 命名規約に合致するときは auto-commit /
+  # push で clean state に戻し、Processor の本処理を継続する。合致しない branch では
+  # ERROR + skip（既存挙動と同じ安全側）。QUOTA_AWARE_ENABLED とは独立（Req 5.2）。
   if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
-    pi_error "dirty working tree を検出しました。PR Iteration Processor をスキップします。"
-    return 0
+    local _pi_pre_branch _pi_dirty_paths _pi_pre_issue
+    _pi_pre_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+    # dirty 一覧は `git status --porcelain` の `XY path` 列を末尾だけ取り出し、コンマ区切り化
+    _pi_dirty_paths=$(git status --porcelain 2>/dev/null | awk '{
+      $1=""; sub(/^ /, ""); printf "%s%s", (NR>1?",":""), $0
+    }')
+    # branch 名から PR 番号を派生（Req 4.2: PR 番号 / branch / 種別 / 結果 を出力）
+    _pi_pre_issue=$(echo "$_pi_pre_branch" | grep -oE 'issue-[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+    # Req 3.1: branch 名と dirty パス一覧をログに記録（recover/skip 双方の経路で出力）
+    pi_log "pre-cycle dirty 検出 issue=#${_pi_pre_issue:-?} branch=${_pi_pre_branch} paths=${_pi_dirty_paths}"
+
+    if pi_branch_is_claude_pr_head "$_pi_pre_branch"; then
+      # Req 3.2 / 3.3: 規約一致 branch に対して auto-commit / push して継続
+      if pi_auto_commit_and_push \
+          "docs(specs): recover pre-cycle dirty state on ${_pi_pre_branch} (auto)" \
+          "$_pi_pre_branch"; then
+        # 本処理は BASE_BRANCH で動かすため、回復後に BASE_BRANCH に戻す。
+        # `set -e` 配下なので checkout 失敗時は次の git ops で検出され ERROR に倒れる。
+        git checkout "$BASE_BRANCH" >/dev/null 2>&1 || true
+        # Req 4.2: PR 番号 / branch / 種別 / 結果 を 1 行で出力
+        pi_log "pre-cycle-recover issue=#${_pi_pre_issue:-?} branch=${_pi_pre_branch} action=success"
+      else
+        # Req 3.5: 自動回復失敗は ERROR + skip（次サイクルで再評価）
+        pi_error "pre-cycle-recover issue=#${_pi_pre_issue:-?} branch=${_pi_pre_branch} action=fail (PR Iteration Processor をスキップします)"
+        return 0
+      fi
+    else
+      # Req 3.4: claude/issue-<N>-<slug> 規約外の branch では auto-commit せず skip
+      pi_error "dirty working tree を検出しました（branch=${_pi_pre_branch} は claude/issue-<N>-<slug> 規約外）。PR Iteration Processor をスキップします。"
+      return 0
+    fi
   fi
 
   pi_log "サイクル開始 (max_prs=${PR_ITERATION_MAX_PRS}, max_rounds=${PR_ITERATION_MAX_ROUNDS}, model=${PR_ITERATION_DEV_MODEL}, design_enabled=${PR_ITERATION_DESIGN_ENABLED}, timeout=${PR_ITERATION_GIT_TIMEOUT}s)"

--- a/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-below-threshold.jsonl
+++ b/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-below-threshold.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"rate_limit_event","status":"allowed_warning","surpassedThreshold":0.85,"resetsAt":"2026-05-15T05:00:00Z"}
+{"type":"result","subtype":"success","is_error":false}

--- a/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-malformed-line.jsonl
+++ b/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-malformed-line.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+this is not a valid json line
+{"type":"rate_limit_event","status":"allowed_warning","surpassedThreshold":0.92,"resetsAt":"2026-05-15T05:00:00Z"}
+{"type":"result","subtype":"success","is_error":false}

--- a/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-nested.jsonl
+++ b/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-nested.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"rate_limit_event","timestamp":"2026-05-15T01:00:00Z","rate_limit_info":{"status":"allowed_warning","surpassedThreshold":0.95,"tier":"5h","resetsAt":"2026-05-15T05:00:00Z"}}
+{"type":"result","subtype":"success","is_error":false}

--- a/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-top-level.jsonl
+++ b/local-watcher/test/fixtures/pi_detect_quota_soft_fail/allowed-warning-top-level.jsonl
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"Working"}]}}
+{"type":"rate_limit_event","status":"allowed_warning","surpassedThreshold":0.9,"resetsAt":"2026-05-15T05:00:00Z"}
+{"type":"result","subtype":"success","is_error":false}

--- a/local-watcher/test/fixtures/pi_detect_quota_soft_fail/normal-success.jsonl
+++ b/local-watcher/test/fixtures/pi_detect_quota_soft_fail/normal-success.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"OK"}]}}
+{"type":"result","subtype":"success","is_error":false}

--- a/local-watcher/test/fixtures/pi_detect_quota_soft_fail/rejected-not-warning.jsonl
+++ b/local-watcher/test/fixtures/pi_detect_quota_soft_fail/rejected-not-warning.jsonl
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","tools":["Read","Edit"],"model":"claude-opus-4-7"}
+{"type":"rate_limit_event","timestamp":"2026-05-15T01:00:00Z","rate_limit_info":{"status":"rejected","surpassedThreshold":1.0,"resetsAt":"2026-05-15T05:00:00Z"}}

--- a/local-watcher/test/pi_detect_quota_soft_fail_test.sh
+++ b/local-watcher/test/pi_detect_quota_soft_fail_test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh の PR Iteration 用 quota 警告検知関数
+#       (pi_detect_quota_soft_fail) を fixture で検証するスモークテスト。
+#       Issue #118 で導入。
+#
+#       検出条件:
+#         - type == "rate_limit_event"
+#         - status == "allowed_warning"（top-level または rate_limit_info ネスト位置）
+#         - surpassedThreshold >= 0.9（top-level または rate_limit_info ネスト位置）
+#
+# 配置先: local-watcher/test/pi_detect_quota_soft_fail_test.sh
+# 依存:   bash 4+, awk, jq
+# 実行:   bash local-watcher/test/pi_detect_quota_soft_fail_test.sh
+# 前提:   issue-watcher.sh から pi_detect_quota_soft_fail() のみを awk で切り出して
+#         eval で読み込み、トップレベル副作用は回避する。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+FIXTURE_DIR="$SCRIPT_DIR/fixtures/pi_detect_quota_soft_fail"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 2
+fi
+
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "pi_detect_quota_soft_fail")"
+
+if ! declare -F pi_detect_quota_soft_fail >/dev/null; then
+  echo "ERROR: pi_detect_quota_soft_fail not loaded" >&2
+  exit 2
+fi
+
+# ─── アサーションヘルパ ───
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+detect_all() {
+  local fx="$1"
+  pi_detect_quota_soft_fail < "$FIXTURE_DIR/$fx"
+}
+
+detect_last_line() {
+  local fx="$1"
+  pi_detect_quota_soft_fail < "$FIXTURE_DIR/$fx" | tail -n 1
+}
+
+# ─── テストケース ───
+
+echo "--- pi_detect_quota_soft_fail cases (Issue #118 Req 1.1) ---"
+
+# Req 1.1: status と surpassedThreshold が top-level にある現代スキーマ →
+# rate_limit_warning + threshold 値を出力
+out=$(detect_last_line "allowed-warning-top-level.jsonl")
+assert_eq "Req 1.1: top-level status/threshold で検出" \
+  "$(printf 'rate_limit_warning\t0.9')" \
+  "$out"
+
+# Req 1.1: status と surpassedThreshold が rate_limit_info ネスト位置にあるスキーマ →
+# 同様に検出
+out=$(detect_last_line "allowed-warning-nested.jsonl")
+assert_eq "Req 1.1: rate_limit_info ネスト位置でも検出" \
+  "$(printf 'rate_limit_warning\t0.95')" \
+  "$out"
+
+# Req 1.1: surpassedThreshold が 0.9 未満 → 検出しない（境界値）
+out=$(detect_all "allowed-warning-below-threshold.jsonl")
+assert_eq "Req 1.1: surpassedThreshold < 0.9 は検出しない" "" "$out"
+
+# Req 1.1 / Req 5.3: status=rejected は本関数の対象外（dispatcher 連携を避ける）
+out=$(detect_all "rejected-not-warning.jsonl")
+assert_eq "Req 5.3: status=rejected は pi_detect_quota_soft_fail では検出しない" "" "$out"
+
+# Req 1.1: 通常の成功 stream には検出ゼロ
+out=$(detect_all "normal-success.jsonl")
+assert_eq "NFR 1.1: 通常成功 stream は検出ゼロ" "" "$out"
+
+# NFR resilience: 不正 JSON 行が混入しても以降の検出を継続する
+# （`qa_detect_rate_limit` と同じ try/catch 設計）
+out=$(detect_last_line "allowed-warning-malformed-line.jsonl")
+assert_eq "NFR resilience: 不正行を skip して後続を検出" \
+  "$(printf 'rate_limit_warning\t0.92')" \
+  "$out"
+
+echo ""
+
+# ─── pi_branch_is_claude_pr_head の確認 ───
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "pi_branch_is_claude_pr_head")"
+
+if ! declare -F pi_branch_is_claude_pr_head >/dev/null; then
+  echo "ERROR: pi_branch_is_claude_pr_head not loaded" >&2
+  exit 2
+fi
+
+echo "--- pi_branch_is_claude_pr_head cases (Issue #118 Req 3.2 / 3.4) ---"
+
+rc=0; pi_branch_is_claude_pr_head "claude/issue-118-impl-foo" || rc=$?
+assert_eq "Req 3.2: claude/issue-<N>-<slug> は一致 (return 0)" "0" "$rc"
+
+rc=0; pi_branch_is_claude_pr_head "claude/issue-42-design-bar" || rc=$?
+assert_eq "Req 3.2: claude/issue-<N>-design-... も一致" "0" "$rc"
+
+rc=0; pi_branch_is_claude_pr_head "main" || rc=$?
+assert_eq "Req 3.4: main は不一致 (return 1)" "1" "$rc"
+
+rc=0; pi_branch_is_claude_pr_head "develop" || rc=$?
+assert_eq "Req 3.4: develop は不一致" "1" "$rc"
+
+rc=0; pi_branch_is_claude_pr_head "hitoshi/manual-work" || rc=$?
+assert_eq "Req 3.4: 人間の作業 branch は不一致" "1" "$rc"
+
+rc=0; pi_branch_is_claude_pr_head "claude/no-issue-prefix" || rc=$?
+assert_eq "Req 3.4: claude/ で始まっても issue-<N>- がなければ不一致" "1" "$rc"
+
+rc=0; pi_branch_is_claude_pr_head "" || rc=$?
+assert_eq "NFR safety: 空文字列は不一致" "1" "$rc"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

- `pr-iteration` round 中に Claude Max 5 時間ローリング quota の `allowed_warning`（`surpassedThreshold >= 0.9`）を検知し、round を `quota-soft-fail` として記録して未コミット差分を自動 commit / push する機能を追加した
- round 終了時点で quota 警告の有無にかかわらず dirty が残っていた場合の自動回復（post-round-recover）を追加した
- サイクル冒頭で前回 cycle 由来の dirty を検出した場合、`claude/issue-<N>-<slug>` 命名規約一致なら自動回復（pre-cycle-recover）して本処理を継続し、不一致なら安全側の skip にする処理を追加した

## 対応 Issue

Closes #118

## 関連 PR

なし（設計 PR は走っていない。PM のみフロー）

## 変更内容

### `local-watcher/bin/issue-watcher.sh`（+275 / -6）

- **`pi_detect_quota_soft_fail`（新規）**: claude stdout を tee 経由で受け取り、`type==rate_limit_event` かつ `status==allowed_warning` かつ `surpassedThreshold>=0.9` を jq folder で検出する。`QUOTA_AWARE_ENABLED` や `qa_detect_rate_limit` と独立
- **`pi_branch_is_claude_pr_head`（新規）**: `^claude/issue-[0-9]+-` 命名規約に一致するか判定する auto-commit 発火ガード
- **`pi_auto_commit_and_push`（新規）**: `git add -A` + `git commit -m "<msg>\n\nCo-Authored-By: Claude <noreply@anthropic.com>"` + `git push origin <branch>` の 3 段 helper
- **`pi_run_iteration` 改修**: claude 出力を tee で `pi_soft_fail_file` に分岐し、subshell 終端の `git status --porcelain` で dirty を判定。soft-fail / post-round-dirty / 差分なし の 3 系統で recover_file に書き出し、親側が読み取って finalize か needs-iteration 据え置きかを決定
- **`process_pr_iteration` 改修**: cycle 冒頭の dirty 検出時に branch 名・パスをログ出力し、命名規約一致なら pre-cycle-recover を実行して本処理継続、不一致は ERROR + skip

### `local-watcher/test/pi_detect_quota_soft_fail_test.sh`（新規 +160）

- `pi_detect_quota_soft_fail` の 6 検出ケース（top-level / nested / 境界値 0.85 不検出 / rejected 除外 / 通常成功 / malformed 行混入）
- `pi_branch_is_claude_pr_head` の 7 境界ケース（命名規約一致 2 件 / 不一致 5 件）

### `local-watcher/test/fixtures/pi_detect_quota_soft_fail/`（新規 6 件）

- 各検出ケースに対応する JSONL fixture

## 受入基準チェック

- [x] Req 1.1: `rate_limit_event` + `allowed_warning` + `surpassedThreshold >= 0.9` 検出 ← `pi_detect_quota_soft_fail_test.sh`
- [x] Req 1.2〜1.5: quota-soft-fail 時の auto-commit / needs-iteration 据え置き / 失敗 WARN ← 設計判断 #2、手動 smoke
- [x] Req 1.6: `needs-quota-wait` ラベル付与なし ← grep 0 件確認
- [x] Req 2.1〜2.5: round 終了時の dirty 判定と post-round-recover ← 手動 smoke
- [x] Req 3.1〜3.5: pre-cycle dirty 検出・命名規約一致ガード・auto-commit / skip ← `pi_branch_is_claude_pr_head` テスト + 手動 smoke
- [x] Req 4.1〜4.3: `pi_log` 1 行ログ出力と grep 集計性 ← コードレビュー
- [x] Req 5.1〜5.3: `QUOTA_AWARE_ENABLED` 非依存・dispatcher 連携なし ← grep 確認
- [x] NFR 1.1〜1.3: 後方互換性（既存ラベル遷移・ログ形式・env var 不変） ← 既存テスト 178 件 PASS
- [x] NFR 2.1〜2.2: テスト可能性（新規 13 件 + 既存 178 件 全 PASS）
- [x] NFR 3.1〜3.2: `pi_log` タイムスタンプ形式維持・quota-soft-fail 1 行集計性

## テスト結果

```
normalize_slug_test.sh:                PASS: 11, FAIL: 0
parse_review_result_test.sh:           PASS: 19, FAIL: 0
pi_detect_quota_soft_fail_test.sh:     PASS: 13, FAIL: 0  <- 新規
qa_detect_rate_limit_test.sh:          PASS: 10, FAIL: 0
qa_run_claude_stage_test.sh:           PASS: 23, FAIL: 0
slug_match_guard_test.sh:              PASS: 13, FAIL: 0
stagec_pr_verify_fallback_test.sh:     PASS: 35, FAIL: 0
stagec_pr_verify_retry_test.sh:        PASS: 42, FAIL: 0
stagec_pr_verify_test.sh:             PASS: 8,  FAIL: 0
verify_pushed_or_retry_test.sh:        PASS: 17, FAIL: 0

合計: 191 ケース全 PASS
shellcheck -S warning local-watcher/bin/issue-watcher.sh: rc=0（新規 hunk からの新規警告 0 件）
```

Reviewer (`claude-opus-4-7`) による独立レビューも approve 済み。

## 確認事項

- **claude rc 非 0 時の post-round-recover**: Req 2 は claude rc を条件にしていないため、rc 非 0 でも dirty があれば自動回復する実装にした（設計判断 #6 in impl-notes.md）。`claude rc=0 のときだけ回復したい` という意図であれば修正検討
- **pre-cycle-recover の push 戦略**: force 系を使わず plain push（fast-forward 前提）。divergent 時は WARN + skip で次サイクルに委ねる。`--force-with-lease` が必要か否かは PM 判断
- **utilization フィールドの形式**: `utilization=0.92`（小数値そのまま）。`utilization=92%` が好ましければ指摘してください
- **Reviewer の詳細な所見**: `docs/specs/118-bug-watcher-pr-iteration-round-five-hour/review-notes.md` を参照してください

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
関連 Issue の決定事項の履歴は #118 のコメントを参照してください。