### PR TITLE
spec(#15): Phase B promote pipeline + ST 連携の設計（base→target 自動昇格・ST 観測）

### DIFF
--- a/docs/specs/15-phase-b-promote-pipeline-st-base-branch/design.md
+++ b/docs/specs/15-phase-b-promote-pipeline-st-base-branch/design.md
@@ -220,7 +220,7 @@ docs/specs/
 | `local-watcher/bin/issue-watcher.sh` | 1. Config ブロック（既存 `BASE_BRANCH` 直後）に 6 つの env var 追加: `PROMOTE_PIPELINE_ENABLED` / `PROMOTION_TARGET_BRANCH` / `ST_CHECK_RUN_NAME` / `PROMOTE_MODE` / `PROMOTE_CRON` / `PROMOTE_FAIL_NOTIFY_ISSUE`<br>2. `PROMOTE_PIPELINE_ENABLED` を「`=true` を明示した場合のみ有効、それ以外は無効」の opt-in セマンティクス（既存 `MERGE_QUEUE_ENABLED` の opt-out とは逆）として正規化（Req 1.1, NFR 1.1）<br>3. `process_promote_pipeline()` 関数群（ロガー pp_log/pp_warn/pp_error、サブ関数 pp_resolve_target_branch / pp_get_st_state / pp_handle_st_success / pp_handle_st_failure / pp_do_revert / pp_do_promote / pp_match_cron / pp_notify_promote_failure 等）を追加<br>4. Phase A 本体（`process_merge_queue`）の直後に `process_promote_pipeline \|\| pp_warn "..."` を 1 行追加 | Promote Pipeline Processor / 全サブコンポーネント |
 | `repo-template/.github/scripts/idd-claude-labels.sh` | `LABELS=(...)` 配列に `"st-failed\|d73a4a\|【Issue 用】 ST failure 検知後 revert 済み（Phase B Promote Pipeline が付与）"` を 1 行追加。既存ループが新ラベルも同一処理で作成するため、`st-failed` 追加に伴う冪等性は既存実装に内在（Req 4.1） | Labels Setup Script（consumer 用） |
 | `.github/scripts/idd-claude-labels.sh`（self-hosting） | 同上（Req 4.1.3 で「self-hosting と consumer 配布で同一の名前・色・description」を要求しているため、両ファイルに同一行を追加） | Labels Setup Script（self-hosting 用） |
-| `README.md` | (a) 環境変数表に Phase B env 6 種を追加（既存 `MERGE_QUEUE_*` 表と同じ書式）<br>(b) ラベル一覧表に `st-failed` を追加（「適用先」「付与主」「意味」3 列）<br>(c) Phase B Promote Pipeline 概要セクション（目的・対象・タイミング）<br>(d) ラベル状態遷移節に Phase B 補助フロー（`staged-for-release` 自動付与 → ST polling → revert / promote）を追記<br>(e) Migration Note（`PROMOTE_PIPELINE_ENABLED` 未設定時は既存挙動完全保持） | README 全般 |
+| `README.md` | (a) 環境変数表に Phase B env 6 種を追加（既存 `MERGE_QUEUE_*` 表と同じ書式）<br>(b) ラベル一覧表に `st-failed` を追加（「適用先」「付与主」「意味」3 列）<br>(c) Phase B Promote Pipeline 概要セクション（目的・対象・タイミング）= **利用方法ガイド**<br>(d) ラベル状態遷移節に Phase B 補助フロー（`staged-for-release` 自動付与 → ST polling → revert / promote）を追記（**状態遷移表 + Mermaid 図** の両方を併記）<br>(e) Migration Note（`PROMOTE_PIPELINE_ENABLED` 未設定時は既存挙動完全保持）<br>**具体的な挿入位置と内容スケルトンは「Documentation Set / README 編集ブループリント」節を参照** | README 全般 |
 | `CLAUDE.md`（本 repo） | 「idd-claude 特有の設計上の注意」節に Phase B 関連の留意点 1 行追加（opt-in gate / 2-branch model 前提 / 人間付与 `staged-for-release` との共存） | Project Guide |
 | `repo-template/CLAUDE.md` | 必要に応じて Phase B 機能の説明を追加（consumer 向けには「opt-in 制」と明記。Feature Flag Protocol 節とは別の文脈） | Consumer Project Guide |
 | `QUICK-HOWTO.md` | 「作成されるラベル」一覧に `st-failed` を追加（Req 6.2.1, 6.2.2） | Quick HOWTO |
@@ -689,7 +689,7 @@ LABELS=(
 
 | Field | Detail |
 |-------|--------|
-| Intent | Phase B の opt-in 環境変数・ラベル一覧・状態遷移・後方互換性方針を operator が README から読み取れるようにする |
+| Intent | Phase B の opt-in 環境変数・**利用方法**（operator が opt-in 後にどう振る舞うか）・**ラベル状態遷移**（自動付与 → ST polling → success/failure 分岐）・後方互換性方針を operator が README から読み取れるようにする |
 | Requirements | 6.1, 6.2 |
 
 **Responsibilities & Constraints**
@@ -698,8 +698,171 @@ LABELS=(
 - `st-failed` を全ドキュメントで lowercase / ハイフン区切りで完全一致表記する（Req 6.2.2）
 - 既存 `staged-for-release`（#100）と Phase B 自動付与の `staged-for-release` が同一ラベルを
   共有する旨を README に明記する（Req 6.1.5）
+- 「README を最新化する」の具体内容は次節「README 編集ブループリント」に確定形で書き出す
+  （Architect レビュー時点で抽象表現 "README を更新する" のままにせず、Developer が迷わず
+  追記できる粒度まで落とす）
 
 **Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [ ]
+
+##### README 編集ブループリント
+
+Developer が `README.md` を編集するときの具体的な追加・修正位置と内容スケルトンを以下に
+示す。本ブループリントは Req 6.1 の AC を 1 対 1 で満たすための骨子であり、文言は実装時に
+既存スタイル（敬体／表 / 箇条書きの混在パターン）と整合させて微調整して構わない。
+
+###### 1. 概要（目的・対象・タイミング）セクション追加 — Req 6.1.1
+
+挿入位置: README.md 既存「Merge Queue Processor (Phase A)」セクションの直後 / 新規 h2 として。
+
+```markdown
+## Promote Pipeline Processor (Phase B)
+
+multi-branch（例: `BASE_BRANCH=develop` / リリースブランチ=`main`）運用のリポジトリで、
+Phase A により `BASE_BRANCH` に merge された変更を System Test（ST）結果に応じて
+リリースブランチへ自動昇格、または revert する Processor です。**`PROMOTE_PIPELINE_ENABLED=true`
+を明示したリポジトリでのみ起動**し、未設定 / `false` のリポジトリは導入前と完全に同一の挙動です。
+
+### 目的
+- approved PR の `BASE_BRANCH` merge 後 → `staged-for-release` 自動付与
+- `staged-for-release` 付き Issue の ST check-run を watcher サイクル内でポーリング
+- ST success → ラベル除去 + 昇格対象集合へ（PROMOTE_MODE に応じて昇格タイミング制御）
+- ST failure → `git revert -m 1` + Issue reopen + `st-failed` 付与（fail-continue）
+
+### 対象
+- `BASE_BRANCH != PROMOTION_TARGET_BRANCH` の 2-branch model リポジトリのみ
+- single-branch（`BASE_BRANCH` 未設定 = `main` のみ）リポジトリでは no-op
+
+### タイミング
+- watcher サイクル冒頭、Phase A `process_merge_queue` の直後
+- 1 サイクル = `BASE_BRANCH` への自動付与 → ST 判定 → revert / promote の一括処理
+```
+
+###### 2. 環境変数表追記 — Req 6.1.2
+
+挿入位置: README.md 既存「Phase A 環境変数」表のすぐ下、新規小見出し「Phase B 環境変数」として。
+
+```markdown
+### Phase B 環境変数
+
+| 変数 | デフォルト | 用途 |
+|---|---|---|
+| `PROMOTE_PIPELINE_ENABLED` | `false` | Phase B 全体の opt-in gate。`=true` 明示時のみ起動 |
+| `PROMOTION_TARGET_BRANCH` | `main` | 昇格先ブランチ。`BASE_BRANCH` と等しいなら no-op |
+| `ST_CHECK_RUN_NAME` | `""` | ST check-run 名（単一文字列）。未設定なら ST 連動停止 + WARN |
+| `PROMOTE_MODE` | `on-demand` | `continuous` / `batched` / `on-demand` のいずれか |
+| `PROMOTE_CRON` | `""` | `PROMOTE_MODE=batched` のときの標準 5 フィールド cron 式 |
+| `PROMOTE_FAIL_NOTIFY_ISSUE` | `""` | promote 失敗時の通知先 Issue 番号 |
+```
+
+###### 3. ラベル一覧表に `st-failed` を追加 — Req 6.1.3
+
+挿入位置: README.md 既存ラベル一覧表（`needs-rebase` / `staged-for-release` の直後）。
+
+```markdown
+| `st-failed` | 赤系 (`d73a4a`) | ST failure 検知後に revert 済み（Phase B Promote Pipeline が付与）。Issue に適用 |
+```
+
+加えて既存ラベル一括作成スクリプト例ブロックにも `st-failed` 行を追加:
+
+```bash
+gh label create st-failed --repo owner/repo --color d73a4a --description "ST failure 検知後 revert 済み（Phase B Promote Pipeline が付与）"
+```
+
+###### 4. ラベル状態遷移節への Phase B 補助フロー追記 — Req 6.1.4 / 6.1.5
+
+挿入位置: README.md 既存「ラベル状態遷移まとめ」セクション内、Phase A `needs-rebase` 状態遷移
+の直下に「Phase B 補助フロー」サブセクションとして追加する。
+
+```markdown
+### Phase B: Promote Pipeline 補助フロー（`PROMOTE_PIPELINE_ENABLED=true` 時のみ）
+
+`BASE_BRANCH` への merge 後、以下の状態遷移を Promote Pipeline Processor が自動で進めます。
+**`PROMOTE_PIPELINE_ENABLED=true` を明示していないリポジトリでは本フローは起動しません**
+（既存挙動完全保持）。
+
+| 前ラベル | トリガー | 後ラベル | 副作用 |
+|---|---|---|---|
+| なし | Phase A の `BASE_BRANCH` merge | + `staged-for-release` | 自動付与（人間付与 #100 と同一ラベルを共有） |
+| + `staged-for-release`（既付与） | 自動付与 attempt | 変更なし | 重複付与抑止 |
+| + `staged-for-release` | ST = success（PROMOTE_MODE != on-demand） | − `staged-for-release` | promote 候補集合へ |
+| + `staged-for-release` | ST = success（PROMOTE_MODE = on-demand） | 変更なし | 人間トリガー待ち |
+| + `staged-for-release` | ST = failure | − `staged-for-release` + `st-failed` | revert commit を push、Issue を reopen + コメント |
+| + `staged-for-release` | ST = pending/in_progress | 変更なし | 次サイクルへ持ち越し |
+| + `staged-for-release` | ST_CHECK_RUN_NAME 未設定 / check-run 不在 | 変更なし | WARN ログのみ |
+```
+
+加えて、状態遷移の俯瞰用に Mermaid 図を併記する（design.md 内の状態遷移図と同一の出力を
+README にも転載）:
+
+```markdown
+```mermaid
+stateDiagram-v2
+    [*] --> Approved
+    Approved --> Merged: Phase A が BASE_BRANCH に merge
+    Merged --> Staged: Phase B が staged-for-release を自動付与
+    Staged --> Promoted: ST=success → label 除去 + fast-forward push
+    Staged --> Reverted: ST=failure → revert -m 1 + Issue reopen + st-failed
+    Staged --> [*]: ST=pending → 次サイクル持ち越し
+    Promoted --> [*]
+    Reverted --> [*]
+```
+```
+
+###### 5. 既存 `staged-for-release` 人間付与運用との共存メモ — Req 6.1.5
+
+挿入位置: 上記 4 のラベル状態遷移節の末尾に補足段落として追加。
+
+```markdown
+**既存 `staged-for-release`（#100）との共存**: 運用者が手で付与した `staged-for-release`
+ラベルと、Phase B が自動付与した `staged-for-release` ラベルは**同一ラベル**を共有します。
+Phase B 有効化前から手動で `staged-for-release` を付与していた Issue は、有効化後の最初の
+サイクルから自動的に ST polling 対象に組み込まれます（source の区別は行わない設計）。
+手動運用を維持したい場合は `ST_CHECK_RUN_NAME` を未設定のままにすれば、自動付与
+（Req 2.1）は発生しますが ST 判定は行われず、ラベル除去・revert・promote のいずれも起きません。
+```
+
+###### 6. Migration Note 追記 — Req 6.1.6
+
+挿入位置: README.md 既存「Migration Note（既存ユーザー向け）」セクション末尾に
+「Phase B Promote Pipeline 導入時の注意」サブセクションとして追加。
+
+```markdown
+### Phase B Promote Pipeline 導入時の注意
+
+- **既定挙動の保持**: `PROMOTE_PIPELINE_ENABLED` を設定しない／`=true` 以外の値にしたリポジトリは、
+  既存 env var の意味・既存ラベル契約・既存 lock ファイルパス・既存ログ出力先・既存 exit code を
+  含めて Phase B 導入前と完全に同一の挙動を継続します
+- **2-branch model 限定**: `BASE_BRANCH == PROMOTION_TARGET_BRANCH` の single-branch リポジトリでは
+  no-op として終了します（誤起動防止）
+- **Branch Protection 確認**: revert commit を `BASE_BRANCH` に直接 push するため、Branch Protection
+  ルール（PR 必須等）が設定されている場合は admin bypass / 適切な PAT の用意が必要になる場合があります
+- **既存 `staged-for-release`（#100）との互換性**: 手動付与と自動付与で同一ラベルを共有します。
+  source 区別を必要とする運用は本フェーズの対象外です
+- **Force push の不使用**: revert は `--force-with-lease`、promote は fast-forward のみ。
+  `--force` 単独は一切使用しません
+```
+
+###### 7. QUICK-HOWTO.md / CLAUDE.md 同期 — Req 6.2.1 / 6.2.2
+
+- `QUICK-HOWTO.md` の「作成されるラベル」一覧に `st-failed` 行を追加（README と同一の
+  名前・色・description）
+- 本 repo の `CLAUDE.md` 「idd-claude 特有の設計上の注意」節に「Phase B Promote Pipeline は
+  opt-in gate / 2-branch model 前提 / 既存 `staged-for-release` と同一ラベルを共有」を 1 段落で追記
+- いずれのドキュメントでもラベル名 `st-failed` は lowercase / ハイフン区切りで完全一致表記
+  （grep 全件一致を担保 / Req 6.2.2）
+
+##### Acceptance Criteria → README 追記箇所のトレーサビリティ
+
+| Requirement | README 追記箇所（本ブループリント節） |
+|---|---|
+| 6.1.1 | 「1. 概要セクション」 |
+| 6.1.2 | 「2. 環境変数表追記」 |
+| 6.1.3 | 「3. ラベル一覧表に `st-failed` を追加」 |
+| 6.1.4 | 「4. ラベル状態遷移節への Phase B 補助フロー追記」 |
+| 6.1.5 | 「4」の表 + 「5. 既存 `staged-for-release` 人間付与運用との共存メモ」 |
+| 6.1.6 | 「6. Migration Note 追記」 |
+| 6.2.1 | 「7. QUICK-HOWTO.md / CLAUDE.md 同期」 |
+| 6.2.2 | 「7」末尾の完全一致表記の注 |
 
 ## Data Models
 

--- a/docs/specs/15-phase-b-promote-pipeline-st-base-branch/design.md
+++ b/docs/specs/15-phase-b-promote-pipeline-st-base-branch/design.md
@@ -1,0 +1,932 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本機能（Phase B: Promote Pipeline + ST 連携）は、`BASE_BRANCH` と
+`PROMOTION_TARGET_BRANCH` を分離して運用する idd-claude consumer リポジトリ（例:
+`BASE_BRANCH=develop` / `PROMOTION_TARGET_BRANCH=main`）の release manager に対し、
+**`BASE_BRANCH` に merge された変更を System Test（ST）結果に応じて自動でリリースブランチへ
+昇格、または revert する** という運用を、watcher サイクル内の処理として提供する。
+
+**Users**: idd-claude を multi-branch 運用しているリポジトリの operator / release manager。
+これまで彼／彼女らは Phase A（#14 Merge Queue Processor）で `BASE_BRANCH` に approved PR を
+merge した後、(a) ST 結果を Issue 一覧画面で目視確認、(b) success なら release PR を手動作成、
+(c) failure なら手動で `git revert -m 1` + Issue reopen を実施していた。Phase B はこれらを
+**watcher サイクル内の `process_promote_pipeline()` 単一関数で機械化** する。
+
+**Impact**: 既存の `local-watcher/bin/issue-watcher.sh` は Phase A `process_merge_queue` /
+`process_merge_queue_recheck` を持つ「opt-in / opt-out 切替可能な Processor の集合体」として
+拡張されており、本機能は **同じ構造に従う 3 つ目の Processor（`process_promote_pipeline`）**
+として watcher サイクル冒頭に挿入される。新しい外部サービス呼び出し（GitHub API: check-runs /
+Issues / labels / commits）の起動は **環境変数 `PROMOTE_PIPELINE_ENABLED=true` の明示**
+かつ **`BASE_BRANCH != PROMOTION_TARGET_BRANCH`** の両方を満たすときだけ走り、それ以外の
+リポジトリ（既存の single-branch 運用 / multi-branch 運用で opt-in しない repo）は
+**Phase B 導入前と完全に等価な挙動** を維持する（NFR 1.1）。
+
+### Goals
+
+- approved PR が `BASE_BRANCH` に merge された Issue に `staged-for-release` を**自動付与**する
+- `staged-for-release` 付き Issue の ST check-run 結果を **watcher サイクル内でポーリング** し、
+  success → label 除去 + promote 対象集合に含める、failure → revert + Issue reopen + `st-failed`
+  ラベル付与で **fail-continue** に処理する
+- ST success 済みの変更を `BASE_BRANCH` → `PROMOTION_TARGET_BRANCH` へ **fast-forward push のみ**
+  で昇格する（merge commit / rebase 経由の non-fast-forward 昇格は禁止）
+- `PROMOTE_MODE`（`continuous` / `batched` / `on-demand`、既定 `on-demand`）で昇格タイミングを
+  制御する
+- `PROMOTE_PIPELINE_ENABLED` 未指定または `=false` のリポジトリでは Phase B 導入前と完全に
+  同一の挙動を保つ（既存 env / ラベル / lock / exit code / log 出力先を不変に保つ）
+- `idd-claude-labels.sh`（local-watcher 用 / repo-template 用の両系統）に `st-failed` ラベル定義を
+  追加し、`gh label create` を再実行しても冪等に維持される
+- README / repo-template/CLAUDE.md / 本 repo の CLAUDE.md に Phase B の opt-in 手順・ラベル一覧
+  追記・migration note を反映する
+
+### Non-Goals
+
+- 独立した `STAGING_BRANCH` を介した 3-branch model（`BASE_BRANCH` + `STAGING_BRANCH` +
+  `PROMOTION_TARGET_BRANCH`）の導入。本フェーズは 2-branch model に限定する
+- ST check-run 名を正規表現／複数候補で解決する仕組み（`ST_CHECK_RUN_NAME` は単一文字列のみ）
+- 人間付与の `staged-for-release` と自動付与の `staged-for-release` を区別するラベル名／属性の
+  追加（#100 で定義された同一ラベルを共有する）
+- revert された commit に対する自動的な再修正（再 implement / cherry-pick リトライ等）
+- fork PR を起点とした自動 promote / 自動 revert
+- `.github/workflows/issue-to-pr.yml`（Actions 経路）への Phase B 機能の組み込み
+- semantic conflict の Claude による自動解決（Phase D = #17 の範囲）
+- 並列 promote worker（複数 PROMOTE_MODE を同時に動かす仕組み）
+- `PROMOTE_MODE=batched` における高度なジョブスケジューラ統合（標準 cron 式以外の DSL）
+
+## Architecture
+
+### Existing Architecture Analysis
+
+`local-watcher/bin/issue-watcher.sh` は以下のレイヤ構造で動作している:
+
+| レイヤ | 役割 | 既存実装の場所 |
+|---|---|---|
+| Config | env var 解決 / 既定値 / 正規化 | `~/bin/issue-watcher.sh` 冒頭 `━━━ Config ━━━` ブロック（〜L270 付近） |
+| Quota Resume Processor | `needs-quota-wait` ラベルの自動除去 | `process_quota_resume()`（〜L745 付近） |
+| Phase A Recheck | `needs-rebase` 付き PR の再評価とラベル除去 | `process_merge_queue_recheck()`（〜L1066-1182） |
+| Phase A 本体 | approved PR の mergeability 検知 → 自動 rebase / `needs-rebase` ラベル付与 | `process_merge_queue()`（〜L911-1042） |
+| PR Iteration | `needs-iteration` ラベル付き PR の Claude 自動 iterate | `process_pr_iteration()` 相当 |
+| Design Review Release | 設計 PR merge 後の `awaiting-design-review` 自動除去 | `process_design_review_release()` 相当 |
+| Issue ピックアップ | `auto-dev` ラベル付き Issue を pickup → Triage → implementation | Issue 処理ループ |
+
+Phase B は **Phase A 本体（process_merge_queue）の直後** に 3 つ目の Processor として挿入する。
+これは Phase A が「approved PR を `BASE_BRANCH` に merge する手前」までを担当し、merge 後の
+状態管理が Phase B のスコープであるためで、サイクル内の論理順序として merge 後処理を直後に
+置くのが自然だからである。
+
+**尊重すべきドメイン境界**:
+
+- `BASE_BRANCH` env の意味は #89 で定義された「watcher 経路の base branch の単一の真実源」のまま。
+  Phase B は本変数を **読み取るのみ** で、意味と既定値（`main`）は変更しない（NFR 1.2 / Req 1.1）
+- `staged-for-release` ラベル（#100 で定義）の名前・色・description は変更せず、
+  **付与・除去契約のみを拡張** する（Req 2.1 / 4.2）
+- Phase A の `needs-rebase` ラベル契約は変更しない（Req 4.2）
+- 既存 env var 名（`REPO`, `REPO_DIR`, `LOG_DIR`, `LOCK_FILE`, `BASE_BRANCH`,
+  `MERGE_QUEUE_*`, `BASE_BRANCH`, `MERGE_QUEUE_BASE_BRANCH` 等）の意味とデフォルト挙動を
+  変更しない（NFR 1.2）
+
+**解消・回避する technical debt**:
+
+- 既存の Phase A は `gh pr list` ベースの API call のみで完結していたが、Phase B は
+  ST check-run の状態取得に `gh api repos/{owner}/{repo}/commits/{ref}/check-runs` の使用が
+  必要になる。これは新規 GitHub API endpoint の利用だが、外部サービス追加ではなく **既存 gh CLI
+  経由の同一 GitHub API 内** であるため、CLAUDE.md 「opt-in gate なしで新しい外部サービス呼び出しを
+  有効化」禁止事項には抵触しない（opt-in gate `PROMOTE_PIPELINE_ENABLED=true` で gated）
+
+### Architecture Pattern & Boundary Map
+
+採用パターンは **Processor as Function**（既存 Phase A / PR Iteration / Design Review Release と
+同じ）。すなわち `process_promote_pipeline()` という単一の bash 関数を `set -euo pipefail` 下の
+top-level で 1 回呼び出し、内部は purely 逐次的に Issue 単位の状態判定 → 操作実施 → ログ
+出力を行う（並列処理は導入しない / NFR 3.1 fail-continue を保ちながらも 1 サイクル内の処理は逐次）。
+
+#### 状態遷移図（Mermaid）
+
+```mermaid
+stateDiagram-v2
+    [*] --> Approved: Issue が PR 経由で approved review を獲得
+    Approved --> Merged: Phase A (process_merge_queue) が BASE_BRANCH に merge
+    Merged --> Staged: process_promote_pipeline がリンク Issue に staged-for-release を自動付与 (Req 2.1)
+
+    state Staged {
+        [*] --> PollST: 当該 Issue のリンク commit に対する ST check-run を取得 (Req 2.2)
+        PollST --> Pending: check-run が pending/in_progress (Req 2.2.4)
+        PollST --> Missing: check-run が存在しない (Req 2.2.5)
+        PollST --> Success: ST success (Req 2.3)
+        PollST --> Failure: ST failure (Req 2.4)
+        Pending --> [*]: 次サイクル持ち越し
+        Missing --> [*]: WARN ログのみ
+    }
+
+    Staged --> PromoteCandidate: Success → staged-for-release 除去 + promote 集合へ (Req 2.3, 3.2)
+    Staged --> Reverted: Failure → revert -m 1 + push + Issue reopen + st-failed + staged-for-release 除去 (Req 2.4)
+
+    state PromoteCandidate {
+        [*] --> ModeContinuous: PROMOTE_MODE=continuous (Req 3.2.3)
+        [*] --> ModeBatched: PROMOTE_MODE=batched (Req 3.2.4)
+        [*] --> ModeOnDemand: PROMOTE_MODE=on-demand 既定 (Req 3.2.5)
+        ModeContinuous --> FastForward: 即時 promote
+        ModeBatched --> FastForward: PROMOTE_CRON 一致時のみ
+        ModeOnDemand --> HoldLabel: 人間トリガー待ち (staged-for-release 維持)
+    }
+
+    PromoteCandidate --> Promoted: BASE_BRANCH → PROMOTION_TARGET_BRANCH fast-forward push 成功 (Req 3.1)
+    PromoteCandidate --> PromoteFailed: fast-forward 不可 / push 失敗 (Req 3.1.2, 3.1.3, 3.3)
+
+    Reverted --> [*]: Issue reopened, st-failed 付与済
+    Promoted --> [*]: release 完了
+    PromoteFailed --> [*]: log + (PROMOTE_FAIL_NOTIFY_ISSUE 設定時) Issue コメント (Req 3.3)
+```
+
+**Architecture Integration**:
+
+- 採用パターン: **Processor as Function**（Phase A と同一）。fresh context の Claude を呼ばず、
+  bash + gh CLI + git で完結する状態機械として実装する
+- ドメイン境界: **Promote Pipeline 単一関数** が「ST 判定」「ラベル操作」「revert」「promote」の
+  4 つのサブ責務を持つが、これらは状態機械の一連の遷移であり別関数に分離しても凝集度が下がる
+  ため、内部ヘルパー関数（`pp_resolve_target_branch`、`pp_get_st_state`、`pp_handle_st_success`、
+  `pp_handle_st_failure`、`pp_do_revert`、`pp_do_promote`、`pp_match_cron` 等）でモジュール化する
+- 既存パターンの維持: ログ識別子 prefix（`promote-pipeline:` / `promote-failed`）、timestamp
+  形式（`[YYYY-MM-DD HH:MM:SS]`）、`[$REPO]` プレフィックス、stdout = 機械可読 / stderr = WARN/ERROR
+  の二分契約はすべて Phase A と同一にする
+- 新規コンポーネントの根拠: Phase A は「PR の merge 前」、Phase B は「PR の merge 後」を扱うため、
+  状態機械が直交しており同一関数に統合する利点はない。サイクル順序として Phase A の直後で呼ぶ
+  ことで、`BASE_BRANCH` が clean な状態（Phase A の最終 checkout）から開始できる
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Runtime | bash 4+ | Processor 本体の実装言語 | 既存 issue-watcher.sh と同一 |
+| CLI deps | `gh` / `jq` / `git` / `flock` / `timeout` | API call / JSON 整形 / git 操作 / lock / サブプロセス停止 | 既存依存と同一。新規依存は追加しない |
+| GitHub API | check-runs / commits / issues / pull-requests / labels | ST 状態取得 / 関連 Issue 抽出 / ラベル付与・除去 / コメント / reopen | `gh api repos/.../commits/.../check-runs` / `gh issue edit` / `gh issue reopen` / `gh issue comment` / `gh pr list --search "is:merged base:$BASE_BRANCH"` を組み合わせる |
+| Storage / State | GitHub Issue ラベル | `staged-for-release` / `st-failed` の状態保持 | ローカル状態ファイルは新規導入しない（既存と同様、状態は GitHub 上に保持） |
+| Logging | stdout / stderr（`LOG_DIR` 配下に cron / launchd が redirect） | サマリ・進行状況・ERROR | 新規 `LOG_DIR` を作らず既存パスに集約（Req 5.1, NFR 4.1） |
+
+## File Structure Plan
+
+本機能は新規ファイルを作らず、**既存ファイルへの追記** のみで実現する。watcher 本体・ラベル
+スクリプト・ドキュメントの 3 系統に変更を分散させる。
+
+### Directory Structure
+
+```
+local-watcher/
+└── bin/
+    └── issue-watcher.sh                # 既存。Config ブロックに新 env var 追加 +
+                                        # process_promote_pipeline() 関数群を追加 +
+                                        # サイクル冒頭の呼び出し追加（Phase A の直後）
+
+repo-template/
+├── .github/
+│   └── scripts/
+│       └── idd-claude-labels.sh        # 既存。LABELS 配列に st-failed を追加（冪等性は既存実装に内在）
+└── CLAUDE.md                            # 既存。ラベル一覧 / Feature Flag Protocol 節に
+                                        # Phase B 機能の opt-in 説明（必要に応じて追記）
+
+.github/                                 # 本リポジトリ self-hosting 用
+└── scripts/
+    └── idd-claude-labels.sh             # 既存。同様に st-failed を追加（self-hosting 用と
+                                        # repo-template 用の両系統で同一定義）
+
+README.md                                # 既存。以下を追記:
+                                        #   - 環境変数表に PROMOTE_PIPELINE_ENABLED /
+                                        #     PROMOTION_TARGET_BRANCH / ST_CHECK_RUN_NAME /
+                                        #     PROMOTE_MODE / PROMOTE_CRON /
+                                        #     PROMOTE_FAIL_NOTIFY_ISSUE を追加
+                                        #   - ラベル一覧に st-failed を追加
+                                        #   - ラベル状態遷移節に Phase B 補助フローを追記
+                                        #   - 後方互換性 / migration note を追加
+
+CLAUDE.md                                # 本リポジトリ憲章。「idd-claude 特有の設計上の注意」
+                                        # 節に Phase B 関連の留意点（opt-in gate / 2-branch
+                                        # model 前提 / 既存 staged-for-release 共存）を追記
+
+QUICK-HOWTO.md                          # 既存（要件 6.2.1）。「作成されるラベル」一覧に
+                                        # st-failed を追加（grep で全ドキュメント一致を担保）
+
+docs/specs/
+└── 15-phase-b-promote-pipeline-st-base-branch/
+    ├── requirements.md                  # PM 成果物（既存）
+    ├── design.md                        # 本ファイル
+    └── tasks.md                         # 本ファイルと対のタスク分割
+```
+
+### Modified Files（実装範囲）
+
+| ファイル | 変更内容 | 対応 Component |
+|---|---|---|
+| `local-watcher/bin/issue-watcher.sh` | 1. Config ブロック（既存 `BASE_BRANCH` 直後）に 6 つの env var 追加: `PROMOTE_PIPELINE_ENABLED` / `PROMOTION_TARGET_BRANCH` / `ST_CHECK_RUN_NAME` / `PROMOTE_MODE` / `PROMOTE_CRON` / `PROMOTE_FAIL_NOTIFY_ISSUE`<br>2. `PROMOTE_PIPELINE_ENABLED` を「`=true` を明示した場合のみ有効、それ以外は無効」の opt-in セマンティクス（既存 `MERGE_QUEUE_ENABLED` の opt-out とは逆）として正規化（Req 1.1, NFR 1.1）<br>3. `process_promote_pipeline()` 関数群（ロガー pp_log/pp_warn/pp_error、サブ関数 pp_resolve_target_branch / pp_get_st_state / pp_handle_st_success / pp_handle_st_failure / pp_do_revert / pp_do_promote / pp_match_cron / pp_notify_promote_failure 等）を追加<br>4. Phase A 本体（`process_merge_queue`）の直後に `process_promote_pipeline \|\| pp_warn "..."` を 1 行追加 | Promote Pipeline Processor / 全サブコンポーネント |
+| `repo-template/.github/scripts/idd-claude-labels.sh` | `LABELS=(...)` 配列に `"st-failed\|d73a4a\|【Issue 用】 ST failure 検知後 revert 済み（Phase B Promote Pipeline が付与）"` を 1 行追加。既存ループが新ラベルも同一処理で作成するため、`st-failed` 追加に伴う冪等性は既存実装に内在（Req 4.1） | Labels Setup Script（consumer 用） |
+| `.github/scripts/idd-claude-labels.sh`（self-hosting） | 同上（Req 4.1.3 で「self-hosting と consumer 配布で同一の名前・色・description」を要求しているため、両ファイルに同一行を追加） | Labels Setup Script（self-hosting 用） |
+| `README.md` | (a) 環境変数表に Phase B env 6 種を追加（既存 `MERGE_QUEUE_*` 表と同じ書式）<br>(b) ラベル一覧表に `st-failed` を追加（「適用先」「付与主」「意味」3 列）<br>(c) Phase B Promote Pipeline 概要セクション（目的・対象・タイミング）<br>(d) ラベル状態遷移節に Phase B 補助フロー（`staged-for-release` 自動付与 → ST polling → revert / promote）を追記<br>(e) Migration Note（`PROMOTE_PIPELINE_ENABLED` 未設定時は既存挙動完全保持） | README 全般 |
+| `CLAUDE.md`（本 repo） | 「idd-claude 特有の設計上の注意」節に Phase B 関連の留意点 1 行追加（opt-in gate / 2-branch model 前提 / 人間付与 `staged-for-release` との共存） | Project Guide |
+| `repo-template/CLAUDE.md` | 必要に応じて Phase B 機能の説明を追加（consumer 向けには「opt-in 制」と明記。Feature Flag Protocol 節とは別の文脈） | Consumer Project Guide |
+| `QUICK-HOWTO.md` | 「作成されるラベル」一覧に `st-failed` を追加（Req 6.2.1, 6.2.2） | Quick HOWTO |
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | opt-in gate（PROMOTE_PIPELINE_ENABLED） | Promote Pipeline Processor / Config Normalizer | `process_promote_pipeline()` 冒頭の gate / env 正規化ループ | Config block 読み取り → `=true` 比較 → no-op / 実行 |
+| 1.2 | PROMOTION_TARGET_BRANCH の解釈 | pp_resolve_target_branch | `pp_resolve_target_branch()` | env 未設定なら `main` / remote 存在チェック → 失敗時 ERROR |
+| 2.1 | staged-for-release 自動付与 | pp_collect_merged_issues / pp_label_issue | `gh pr list --search "is:merged base:$BASE_BRANCH"` → `Closes #N` 抽出 → `gh issue edit --add-label` | Phase A merge 後 → merged PR scan → Issue 抽出 → ラベル追加 |
+| 2.2 | ST check-run ポーリング | pp_get_st_state | `gh api repos/.../commits/<sha>/check-runs --jq` | リンク Issue → 対応 commit SHA 解決 → check-run 取得 → 状態判定 |
+| 2.3 | ST success 時の挙動 | pp_handle_st_success | `gh issue edit --remove-label staged-for-release` / promote 候補集合への追加 | success → label 除去 → promote 集合に push |
+| 2.4 | ST failure 時の挙動（revert-and-continue） | pp_handle_st_failure / pp_do_revert | `git revert -m 1 <merge_sha>` / `git push --force-with-lease` / `gh issue reopen` / `gh issue comment` / `gh issue edit --add-label st-failed --remove-label staged-for-release` | failure → revert commit → push → Issue 操作 → 次 Issue へ継続 |
+| 3.1 | 昇格手段（fast-forward） | pp_do_promote | `git push origin <BASE_BRANCH>:<PROMOTION_TARGET_BRANCH>` のみ（fast-forward 強制） | `git merge-base --is-ancestor` で fast-forward 可否確認 → push |
+| 3.2 | PROMOTE_MODE 制御 | pp_resolve_promote_mode / pp_match_cron | env 解析 / cron 式 match | continuous → 即時 / batched → cron 一致時 / on-demand → 待機 |
+| 3.3 | 昇格失敗時の通知 | pp_notify_promote_failure | `gh issue comment $PROMOTE_FAIL_NOTIFY_ISSUE` | promote 失敗時 log + (env 設定時) Issue コメント |
+| 4.1 | st-failed ラベル追加 | Labels Setup Script | `LABELS=(...)` 配列拡張 | `gh label create` 冪等 |
+| 4.2 | 既存ラベル契約の保持 | Labels Setup Script / Promote Pipeline Processor | 既存ラベル定義の不変性 / staged-for-release の付与・除去契約のみ拡張 | 既存 12 ラベルの diff ゼロ |
+| 5.1 | ログ出力契約 | pp_log / pp_warn / pp_error / pp_summary | bash echo with prefix | サイクル開始 / 各 Issue / サマリ |
+| 6.1 | README 記載項目 | Documentation Set | README.md 編集 | 環境変数表 / ラベル一覧 / 状態遷移 / migration note |
+| 6.2 | 関連ドキュメント整合 | Documentation Set | QUICK-HOWTO.md 編集 | st-failed 完全一致表記 |
+| NFR 1.1 | opt-in OFF で既存挙動維持 | Config Normalizer / process_promote_pipeline 冒頭 gate | `[ "$PROMOTE_PIPELINE_ENABLED" != "true" ]` で early return | 既定 false → 何も実行しない |
+| NFR 1.2 | 既存 env var 名の意味維持 | Config block | 既存 env 名は読み取りのみ・代入なし | diff 確認 |
+| NFR 1.3 | 既存ラベル契約の維持 | Promote Pipeline Processor | 既存ラベル名定数を変更しない | grep 確認 |
+| NFR 2.1 | --force-with-lease のみ | pp_do_revert / pp_do_promote | `git push --force-with-lease` 限定 | `--force` 単独使用なし |
+| NFR 2.2 | fast-forward のみ | pp_do_promote | `git merge-base --is-ancestor` ガード | non-ff は中止 |
+| NFR 2.3 | dirty working tree 検知 | process_promote_pipeline 冒頭 | `git status --porcelain` チェック | dirty → ERROR + 中止 |
+| NFR 2.4 | fork PR 除外 | pp_collect_merged_issues | head repo owner == base repo owner フィルタ | 既存 Phase A と同一手法 |
+| NFR 3.1 | fail-continue | process_promote_pipeline ループ | per-Issue try-catch 相当（bash `||` chain） | 1 Issue 失敗 → 次 Issue へ |
+| NFR 3.2 | timeout | 全 gh / git 呼び出し | `timeout "$PROMOTE_GIT_TIMEOUT"` wrap（既存 MERGE_QUEUE_GIT_TIMEOUT を流用または専用 var） | サブプロセスハング防止 |
+| NFR 4.1 | grep 集計可能な識別語 | pp_log | `promote-pipeline:` / `promote-failed` prefix | 既存 merge-queue: と同一構造 |
+| NFR 4.2 | 出力契約（stdout / stderr） | pp_log / pp_warn / pp_error | echo / `>&2` 分離 | 既存 mq_log と同一構造 |
+| NFR 5.1 | 1 サイクル時間（2 分以内） | 全体タイムバジェット | サブプロセス timeout で担保 | 設計上担保 |
+| NFR 5.2 | API call 数（10 回以内 / Issue） | pp_get_st_state / pp_handle_* | API 呼び出し集約 | ST 状態取得 1, label 操作 1-2, comment 1, reopen 1, ＝ 通常 4-5 回 |
+
+## Components and Interfaces
+
+### Promote Pipeline Processor（メイン）
+
+#### process_promote_pipeline
+
+| Field | Detail |
+|-------|--------|
+| Intent | Phase A 直後に呼ばれ、`BASE_BRANCH` に merge 済みの Issue 集合に対して ST 結果連動と昇格を一括処理する |
+| Requirements | 1.1, 1.2, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 5.1, NFR 1.1, NFR 2.3, NFR 3.1 |
+
+**Responsibilities & Constraints**
+
+- 主責務: opt-in gate チェック → dirty tree チェック → 対象 Issue 集合の収集 → 各 Issue の状態判定と
+  アクション実行 → promote 集合の最終昇格 → サマリ出力
+- ドメイン境界: 同一 watcher サイクル内で逐次実行（並列なし）。Phase A `process_merge_queue` が
+  `BASE_BRANCH` checkout で終了することを前提に、本関数も `BASE_BRANCH` 上で開始する
+- データ所有権: 状態は GitHub Issue / GitHub commits / GitHub PR の labels と check-runs に保持。
+  ローカル一時状態は使用しない
+- invariants: 操作終了時に作業ツリーは `BASE_BRANCH` checkout で clean な状態に戻る（NFR 2.3）
+
+**Dependencies**
+
+- Inbound: top-level watcher 制御フロー — Phase A 直後の呼び出し (Critical)
+- Outbound:
+  - `pp_resolve_target_branch` — `PROMOTION_TARGET_BRANCH` 解決と存在検証 (Critical)
+  - `pp_collect_merged_issues` — merge 済み Issue 集合の構築 (Critical)
+  - `pp_get_st_state` — ST 状態取得 (Critical)
+  - `pp_handle_st_success` / `pp_handle_st_failure` — 状態別アクション (Critical)
+  - `pp_do_promote` — fast-forward push (Critical)
+- External: `gh` CLI / `git` / `jq` (Critical)
+
+**Contracts**: Service [x] / API [ ] / Event [ ] / Batch [x] / State [x]
+
+##### Service Interface
+
+```bash
+# process_promote_pipeline: Promote Pipeline Processor のエントリポイント
+#
+# 引数: なし（env var で全制御）
+# 戻り値: 常に 0（fail-continue を維持し、後続 Processor / Issue ループを止めない / NFR 3.1）
+# 標準出力: 機械可読サマリ（`promote-pipeline:` prefix）
+# 標準エラー: 人間向け WARN/ERROR（`promote-pipeline: WARN:` / `promote-pipeline: ERROR:` prefix）
+# 副作用:
+#   - 対象 Issue へのラベル付与・除去（staged-for-release / st-failed）
+#   - 対象 Issue の reopen + コメント投稿（ST failure 時）
+#   - $BASE_BRANCH への revert commit + push（ST failure 時）
+#   - $BASE_BRANCH → $PROMOTION_TARGET_BRANCH への fast-forward push（promote 成功時）
+#   - $PROMOTE_FAIL_NOTIFY_ISSUE への 1 件コメント（promote 失敗時、env 設定時のみ）
+
+process_promote_pipeline() {
+  # 1. opt-in gate (Req 1.1.1, 1.1.2, NFR 1.1)
+  [ "$PROMOTE_PIPELINE_ENABLED" = "true" ] || return 0
+  # 2. 2-branch model gate (Req 1.1.3)
+  [ -n "$BASE_BRANCH" ] && [ "$BASE_BRANCH" != "$PROMOTION_TARGET_BRANCH_RESOLVED" ] || return 0
+  # 3. dirty working tree gate (NFR 2.3)
+  [ -z "$(git status --porcelain 2>/dev/null)" ] || { pp_error "..."; return 0; }
+  # 4. PROMOTION_TARGET_BRANCH のリモート存在検証 (Req 1.2.2)
+  pp_resolve_target_branch || return 0
+  # 5. 対象 Issue 収集と per-Issue 処理
+  pp_collect_merged_issues | while read -r issue_num; do
+    pp_process_one_issue "$issue_num" || pp_warn "..."  # NFR 3.1 fail-continue
+  done
+  # 6. promote 集合の昇格（PROMOTE_MODE 分岐）
+  pp_do_promote_if_eligible
+  # 7. サマリ出力 (Req 5.1.3)
+  pp_summary
+}
+```
+
+- Preconditions: Phase A `process_merge_queue` が直前に呼ばれており、現在 `BASE_BRANCH` を checkout 済
+- Postconditions: `BASE_BRANCH` checkout 状態に復帰、Issue 状態が遷移完了、log 出力済
+- Invariants: 失敗時も exit code は 0、後続処理を止めない
+
+### Config Normalizer
+
+#### Phase B env var 正規化
+
+| Field | Detail |
+|-------|--------|
+| Intent | 6 つの新 env var を Config ブロックで宣言し、`PROMOTE_PIPELINE_ENABLED` のみ既存 `MERGE_QUEUE_ENABLED` 等とは逆の opt-in セマンティクス（`=true` を明示した場合のみ有効）で正規化する |
+| Requirements | 1.1, 1.2, NFR 1.1, NFR 1.2 |
+
+**Responsibilities & Constraints**
+
+- 主責務: env 読み取り + 既定値適用 + 値正規化
+- 既存 env var の意味とデフォルト挙動を変更しない（NFR 1.2）
+- `PROMOTE_PIPELINE_ENABLED` は **新規 opt-in 機能** であり、既存 `MERGE_QUEUE_ENABLED` 等の
+  デフォルト有効化フラグ群とは扱いを分離する（#112 で反転した「デフォルト有効化フラグの値正規化」
+  ループ には含めない）
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [x]
+
+##### Config Block 追記内容（疑似コード）
+
+```bash
+# ─── Phase B: Promote Pipeline Processor 設定 ───
+# 新規 opt-in 機能。既存運用を壊さないため、明示的に `=true` を指定したときだけ
+# Phase B 機能が起動する（NFR 1.1）。`=true` 以外（未設定 / 空 / `false` / `0` / typo 等）は
+# すべて無効として扱う（opt-in 制）。
+PROMOTE_PIPELINE_ENABLED="${PROMOTE_PIPELINE_ENABLED:-false}"
+
+# 昇格先ブランチ。未設定時は既定 `main`（Req 1.2.1）。
+PROMOTION_TARGET_BRANCH="${PROMOTION_TARGET_BRANCH:-main}"
+
+# ST check-run 名。単一文字列のみ（Req 2.2.2）。未設定時は ST 連動全体を停止 + WARN（Req 2.2.3）。
+ST_CHECK_RUN_NAME="${ST_CHECK_RUN_NAME:-}"
+
+# 昇格タイミング: continuous / batched / on-demand のいずれか（既定 on-demand / Req 3.2.2）。
+# 不正値（未列挙の文字列）も既定 on-demand にフォールバック（Req 3.2.2）。
+PROMOTE_MODE="${PROMOTE_MODE:-on-demand}"
+
+# batched モードの cron 式（標準 cron 5 フィールド）。未設定 / 不正なら当該サイクル no-op + WARN
+# （Req 3.2.6）。
+PROMOTE_CRON="${PROMOTE_CRON:-}"
+
+# 昇格失敗時の通知先 Issue 番号（数値）。未設定なら log のみ（Req 3.3.3）。
+PROMOTE_FAIL_NOTIFY_ISSUE="${PROMOTE_FAIL_NOTIFY_ISSUE:-}"
+
+# git / gh サブプロセスの個別 timeout。Phase A の MERGE_QUEUE_GIT_TIMEOUT を流用しても良いが、
+# 専用 env として分離（運用者が Phase B のみタイムアウト変更したい場合に備えて）。
+PROMOTE_GIT_TIMEOUT="${PROMOTE_GIT_TIMEOUT:-${MERGE_QUEUE_GIT_TIMEOUT:-60}}"
+
+# st-failed ラベル名（運用上 override されないが定数として宣言）。
+LABEL_ST_FAILED="st-failed"
+```
+
+**Note**: `PROMOTE_PIPELINE_ENABLED` を既存の「デフォルト有効化フラグの値正規化」ループ（#112 で
+9 種が反転されたあのループ）には含めない。本フラグは **新規追加 = opt-in 制** であり、既定 false
+が要件（Req 1.1.1）。
+
+### ST 連携 / 状態取得
+
+#### pp_resolve_target_branch
+
+| Field | Detail |
+|-------|--------|
+| Intent | `PROMOTION_TARGET_BRANCH` のリモート存在を検証し、`BASE_BRANCH` と異なることを確認する |
+| Requirements | 1.2, 1.1.3 |
+
+```bash
+# 戻り値: 0 = 検証 OK、1 = 中止すべき状態
+pp_resolve_target_branch() {
+  # 1. BASE_BRANCH == PROMOTION_TARGET_BRANCH なら no-op として終了 (Req 1.1.3)
+  if [ "$BASE_BRANCH" = "$PROMOTION_TARGET_BRANCH" ]; then
+    pp_log "BASE_BRANCH と PROMOTION_TARGET_BRANCH が同一、Phase B は no-op"
+    return 1
+  fi
+  # 2. リモートに存在するか検証 (Req 1.2.2)
+  if ! timeout "$PROMOTE_GIT_TIMEOUT" git ls-remote --exit-code --heads origin "$PROMOTION_TARGET_BRANCH" >/dev/null 2>&1; then
+    pp_error "PROMOTION_TARGET_BRANCH '$PROMOTION_TARGET_BRANCH' がリモートに存在しません。promote を中止します。"
+    return 1
+  fi
+  return 0
+}
+```
+
+#### pp_collect_merged_issues
+
+| Field | Detail |
+|-------|--------|
+| Intent | Phase A 直後の状態で「`BASE_BRANCH` に merge 済みかつ `Closes #N` でリンクされている Issue」を抽出し、まだ `staged-for-release` を持たない Issue にはラベル付与、既に持つ Issue は ST 判定対象として返す |
+| Requirements | 2.1, NFR 2.4, NFR 5.2 |
+
+```bash
+# stdout: 処理対象 Issue 番号を 1 行 1 件で出力（staged-for-release を持つもの = 自動付与済 + 既存付与済）
+pp_collect_merged_issues() {
+  # 1. is:merged base:$BASE_BRANCH の最近 PR を取得（最新 50 件、fork PR を除外 / NFR 2.4）
+  local recent_merged_prs_json
+  recent_merged_prs_json=$(timeout "$PROMOTE_GIT_TIMEOUT" gh pr list --repo "$REPO" \
+      --state merged --base "$BASE_BRANCH" --limit 50 \
+      --json number,body,mergeCommit,headRepositoryOwner,closingIssuesReferences)
+  # 2. fork PR を除外（owner 一致のみ通す）
+  # 3. closingIssuesReferences から Issue 番号を抽出
+  # 4. 各 Issue について `staged-for-release` ラベルの有無を確認
+  #    - 未付与 → gh issue edit --add-label staged-for-release で付与（Req 2.1.1）
+  #    - 既付与 → 何もしない（Req 2.1.3, 重複付与抑止）
+  # 5. 全 staged-for-release 付き Issue（自動 + 人間付与の両方を含む）の番号を stdout に出力
+  gh issue list --repo "$REPO" --label "$LABEL_STAGED_FOR_RELEASE" --state open \
+    --json number --limit 100 --jq '.[].number'
+}
+```
+
+**設計判断**: `staged-for-release` 自動付与の source（自動 vs 人間付与）は区別しない（要件 Out
+of Scope に明記）。これにより、人間が #100 由来で手動付与した Issue も自動的にポーリング対象に
+組み込まれ、Phase A 由来の自動付与 Issue も同様に扱われる。
+
+#### pp_get_st_state
+
+| Field | Detail |
+|-------|--------|
+| Intent | 1 つの Issue について、リンクされた最新の `BASE_BRANCH` 上 merge commit に対する ST check-run の状態を取得する |
+| Requirements | 2.2 |
+
+```bash
+# 戻り値（stdout）:
+#   "success"     ST check-run が完了 & conclusion=success
+#   "failure"     ST check-run が完了 & conclusion=failure/cancelled/timed_out
+#   "pending"     ST check-run が in_progress / queued / pending
+#   "missing"     ST check-run が見つからない
+#   "skip-warn"   ST_CHECK_RUN_NAME 未設定（Req 2.2.3）
+# 副作用: なし（純粋関数）
+pp_get_st_state() {
+  local issue_number="$1"
+  if [ -z "$ST_CHECK_RUN_NAME" ]; then
+    echo "skip-warn"; return 0
+  fi
+  # 1. Issue にリンクされた最新の BASE_BRANCH 上 merge commit SHA を解決
+  #    GraphQL: issue.timelineItems で ClosedEvent → closer (PR) → mergeCommit.oid
+  local merge_sha
+  merge_sha=$(pp_resolve_merge_sha "$issue_number") || { echo "missing"; return 0; }
+  # 2. check-runs API でその commit に対する check-run を取得
+  local check_runs_json
+  check_runs_json=$(timeout "$PROMOTE_GIT_TIMEOUT" \
+    gh api "repos/$REPO/commits/$merge_sha/check-runs" --jq '.check_runs')
+  # 3. ST_CHECK_RUN_NAME に一致する check-run を抽出
+  local target
+  target=$(echo "$check_runs_json" | jq --arg n "$ST_CHECK_RUN_NAME" \
+    '[.[] | select(.name == $n)] | sort_by(.completed_at // "") | last')
+  [ "$target" = "null" ] && { echo "missing"; return 0; }
+  # 4. status + conclusion で結果判定
+  local status conclusion
+  status=$(echo "$target" | jq -r '.status')
+  conclusion=$(echo "$target" | jq -r '.conclusion // ""')
+  case "$status" in
+    completed)
+      case "$conclusion" in
+        success) echo "success" ;;
+        failure|cancelled|timed_out|action_required) echo "failure" ;;
+        *) echo "missing" ;;
+      esac
+      ;;
+    queued|in_progress|pending|*) echo "pending" ;;
+  esac
+}
+```
+
+#### pp_handle_st_success
+
+| Field | Detail |
+|-------|--------|
+| Intent | ST success と判定された Issue から `staged-for-release` ラベルを除去し、promote 候補集合に追加する |
+| Requirements | 2.3 |
+
+```bash
+# 入力: $1 = Issue 番号
+# 副作用: ラベル除去 + promote 候補集合への追加（bash 配列 / tmp ファイル）
+# 戻り値: 0 = 成功 / 1 = 失敗（fail-continue で呼び出し側がカウントするのみ）
+pp_handle_st_success() {
+  local issue_number="$1"
+  # PROMOTE_MODE=on-demand のときはラベル除去せず人間トリガー待ち（Req 3.2.5）
+  if [ "$PROMOTE_MODE" = "on-demand" ]; then
+    pp_log "issue=#${issue_number} ST=success mode=on-demand -> hold label, await human trigger"
+    return 0
+  fi
+  # AC 2.3.1: staged-for-release を除去
+  timeout "$PROMOTE_GIT_TIMEOUT" gh issue edit "$issue_number" --repo "$REPO" \
+    --remove-label "$LABEL_STAGED_FOR_RELEASE" || return 1
+  # AC 2.3.2: promote 集合に追加
+  PROMOTE_CANDIDATES+=("$issue_number")
+  pp_log "issue=#${issue_number} ST=success -> label removed, queued for promote"
+}
+```
+
+#### pp_handle_st_failure / pp_do_revert
+
+| Field | Detail |
+|-------|--------|
+| Intent | ST failure と判定された Issue について、対応する merge commit を revert + push、Issue reopen、`st-failed` 付与、ST log URL を含む 1 件のコメント投稿を実施する |
+| Requirements | 2.4 |
+
+```bash
+# 入力: $1 = Issue 番号
+# 副作用: BASE_BRANCH への revert commit push + Issue 操作 4 種
+pp_handle_st_failure() {
+  local issue_number="$1"
+  local merge_sha st_log_url
+  merge_sha=$(pp_resolve_merge_sha "$issue_number") || {
+    pp_warn "issue=#${issue_number} merge SHA 解決失敗 → ST failure 処理を見送り"
+    return 1
+  }
+  st_log_url=$(pp_resolve_st_log_url "$issue_number" "$merge_sha")
+
+  # AC 2.4.2: revert commit を作成して push（fast-forward 不可 → 中止）
+  if ! pp_do_revert "$merge_sha"; then
+    # AC 2.4.6: push 失敗 → st-failed 付与を保留、WARN ログ
+    pp_warn "issue=#${issue_number} revert push 失敗 → st-failed 付与を保留"
+    return 1
+  fi
+  # AC 2.4.1: st-failed 付与
+  gh issue edit "$issue_number" --repo "$REPO" --add-label "$LABEL_ST_FAILED" \
+    --remove-label "$LABEL_STAGED_FOR_RELEASE"  # AC 2.4.4: staged-for-release 除去
+  # AC 2.4.3: Issue reopen + ST log URL を含む 1 件コメント
+  gh issue reopen "$issue_number" --repo "$REPO" || true
+  gh issue comment "$issue_number" --repo "$REPO" --body "$(pp_format_st_failure_comment "$merge_sha" "$st_log_url")"
+  pp_log "issue=#${issue_number} ST=failure -> reverted (${merge_sha:0:7}), reopened, labeled st-failed"
+}
+
+# pp_do_revert: BASE_BRANCH 上で merge commit を revert -m 1 して push（NFR 2.1）
+# 戻り値: 0 = 成功 / 1 = push 失敗（リモート先行等） / 2 = revert 自体が失敗
+pp_do_revert() {
+  local merge_sha="$1"
+  (
+    set +e
+    trap "git revert --abort >/dev/null 2>&1; git checkout '$BASE_BRANCH' >/dev/null 2>&1" EXIT
+    timeout "$PROMOTE_GIT_TIMEOUT" git checkout "$BASE_BRANCH" >/dev/null 2>&1 || exit 2
+    timeout "$PROMOTE_GIT_TIMEOUT" git pull --ff-only origin "$BASE_BRANCH" >/dev/null 2>&1 || exit 2
+    timeout "$PROMOTE_GIT_TIMEOUT" git revert -m 1 --no-edit "$merge_sha" >/dev/null 2>&1 || exit 2
+    # NFR 2.1: 安全な force-with-lease のみ。BASE_BRANCH への直接 push だが、
+    # PR 経由 merge と異なり revert commit のため Branch Protection 設定によっては
+    # admin bypass が必要な場合がある（運用ドキュメントに記載）
+    timeout "$PROMOTE_GIT_TIMEOUT" git push --force-with-lease origin "$BASE_BRANCH" >/dev/null 2>&1 || exit 1
+    exit 0
+  )
+}
+```
+
+### 昇格処理
+
+#### pp_do_promote / pp_match_cron / pp_notify_promote_failure
+
+| Field | Detail |
+|-------|--------|
+| Intent | promote 候補集合に対し、`PROMOTE_MODE` に応じて `BASE_BRANCH` → `PROMOTION_TARGET_BRANCH` の fast-forward push を実行する |
+| Requirements | 3.1, 3.2, 3.3, NFR 2.1, NFR 2.2 |
+
+```bash
+# pp_do_promote_if_eligible: PROMOTE_MODE 分岐の dispatcher
+pp_do_promote_if_eligible() {
+  case "$PROMOTE_MODE" in
+    continuous)
+      [ "${#PROMOTE_CANDIDATES[@]}" -gt 0 ] && pp_do_promote ;;  # Req 3.2.3
+    batched)
+      if pp_match_cron "$PROMOTE_CRON"; then pp_do_promote
+      else pp_log "batched mode: PROMOTE_CRON 不一致 / 未設定 → 本サイクルでは promote をスキップ"
+      fi ;;  # Req 3.2.4, 3.2.6
+    on-demand|*)
+      pp_log "on-demand mode: 人間トリガーを待つ（promote は実行しない）"
+      ;;  # Req 3.2.5
+  esac
+}
+
+# pp_do_promote: BASE_BRANCH HEAD を PROMOTION_TARGET_BRANCH に fast-forward push
+pp_do_promote() {
+  (
+    set +e
+    trap "git checkout '$BASE_BRANCH' >/dev/null 2>&1" EXIT
+    # AC 3.1.1: fast-forward push 直接実行
+    # AC 3.1.2: fast-forward 不可なら中止（gh / git は non-fast-forward push を拒否する）
+    if ! timeout "$PROMOTE_GIT_TIMEOUT" git fetch origin "$PROMOTION_TARGET_BRANCH" >/dev/null 2>&1; then
+      pp_warn "promote-failed: fetch '$PROMOTION_TARGET_BRANCH' 失敗"
+      pp_notify_promote_failure "fetch failed"
+      exit 1
+    fi
+    # AC 3.1.2: PROMOTION_TARGET_BRANCH が BASE_BRANCH の祖先か確認（祖先でなければ fast-forward 不可）
+    if ! git merge-base --is-ancestor "origin/$PROMOTION_TARGET_BRANCH" "origin/$BASE_BRANCH" 2>/dev/null; then
+      pp_warn "promote-failed: '$PROMOTION_TARGET_BRANCH' が '$BASE_BRANCH' の祖先でないため fast-forward 不可"
+      pp_notify_promote_failure "non-fast-forward"
+      exit 1
+    fi
+    # NFR 2.1 / 2.2: fast-forward 限定 push（force 系オプションを付けない = 自然な ff push）
+    if ! timeout "$PROMOTE_GIT_TIMEOUT" \
+        git push origin "refs/remotes/origin/$BASE_BRANCH:refs/heads/$PROMOTION_TARGET_BRANCH" >/dev/null 2>&1; then
+      pp_warn "promote-failed: fast-forward push 失敗"
+      pp_notify_promote_failure "ff-push failed"
+      exit 1
+    fi
+    pp_log "promote-success: '$BASE_BRANCH' -> '$PROMOTION_TARGET_BRANCH' fast-forward OK"
+  )
+}
+
+# pp_match_cron: 標準 cron 5 フィールド式と現在時刻を比較
+# 戻り値: 0 = 一致、1 = 不一致 / 不正
+pp_match_cron() {
+  local cron="$1"
+  [ -n "$cron" ] || return 1
+  # bash 側で標準 cron 式（分 時 日 月 曜日）を date '+%M %H %d %m %u' で取得した値と
+  # cron 各フィールド（`*` / `*/N` / `A,B,C` / `A-B` / 整数）でマッチング。
+  # 実装詳細は impl で確定（Bash 純粋実装 or python -c）。不正な cron 式は 1 を返す（Req 3.2.6）。
+  ...
+}
+
+# pp_notify_promote_failure: promote 失敗を log + (PROMOTE_FAIL_NOTIFY_ISSUE 設定時) Issue コメント
+pp_notify_promote_failure() {
+  local reason="$1"
+  # AC 3.3.1: WARN/ERROR ログは必ず出す（呼び出し元で出している）
+  # AC 3.3.2: Issue 番号が設定されていれば 1 件コメント投稿
+  if [ -n "$PROMOTE_FAIL_NOTIFY_ISSUE" ] && [[ "$PROMOTE_FAIL_NOTIFY_ISSUE" =~ ^[0-9]+$ ]]; then
+    gh issue comment "$PROMOTE_FAIL_NOTIFY_ISSUE" --repo "$REPO" --body \
+      "Phase B Promote Pipeline で promote 失敗を検知しました: reason=$reason base=$BASE_BRANCH target=$PROMOTION_TARGET_BRANCH"
+  fi
+  # AC 3.3.3: 未設定 / 不正なら log のみ（何もしない）
+}
+```
+
+### Labels Setup Script
+
+#### st-failed ラベル追加
+
+| Field | Detail |
+|-------|--------|
+| Intent | self-hosting 用と consumer 配布用テンプレートの両系統で `st-failed` ラベルを同名・同色・同 description で配布する |
+| Requirements | 4.1, 4.2 |
+
+**Responsibilities & Constraints**
+
+- 既存 12 ラベルを変更しない（Req 4.2.1）
+- `st-failed` を「【Issue 用】」prefix で description に含める（既存 `needs-quota-wait` /
+  `staged-for-release` と整合 / Req 4.1.2）
+- 色は GitHub 既定の error 系赤系（例: `d73a4a`、既存 `claude-failed` の `e74c3c` と区別）
+- 既存ループ（`gh label list` キャッシュ → `gh label create --force` の二段）はそのまま流用、
+  追加に伴う特別処理は不要（Req 4.1.4 = 冪等性は既存実装に内在）
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [x] / State [ ]
+
+##### Definition（追記行）
+
+```bash
+# repo-template/.github/scripts/idd-claude-labels.sh と
+# .github/scripts/idd-claude-labels.sh の LABELS=(...) 配列末尾に同一行を追加。
+LABELS=(
+  # ...既存 12 行...
+  "st-failed|d73a4a|【Issue 用】 ST failure 検知後 revert 済み（Phase B Promote Pipeline が付与）"
+)
+```
+
+### Documentation Set
+
+#### README / CLAUDE.md / QUICK-HOWTO 更新
+
+| Field | Detail |
+|-------|--------|
+| Intent | Phase B の opt-in 環境変数・ラベル一覧・状態遷移・後方互換性方針を operator が README から読み取れるようにする |
+| Requirements | 6.1, 6.2 |
+
+**Responsibilities & Constraints**
+
+- 既存 Phase A 記述の書式を踏襲（環境変数表 / ラベル一覧 / 状態遷移 / migration note の 4 セクション構造）
+- `st-failed` を全ドキュメントで lowercase / ハイフン区切りで完全一致表記する（Req 6.2.2）
+- 既存 `staged-for-release`（#100）と Phase B 自動付与の `staged-for-release` が同一ラベルを
+  共有する旨を README に明記する（Req 6.1.5）
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [ ]
+
+## Data Models
+
+### 環境変数定義（Phase B 新規）
+
+| 変数 | デフォルト | 必須? | 用途 | 関連 Req |
+|---|---|---|---|---|
+| `PROMOTE_PIPELINE_ENABLED` | `false` | yes（明示）| Phase B 全体の opt-in gate。`=true` 明示時のみ起動 | 1.1.1, 1.1.2, NFR 1.1 |
+| `PROMOTION_TARGET_BRANCH` | `main` | no | 昇格先ブランチ。`BASE_BRANCH` と等しいなら no-op | 1.1.2, 1.1.3, 1.2.1 |
+| `ST_CHECK_RUN_NAME` | `""` | yes（推奨）| ST check-run 名（単一文字列）。未設定なら ST 連動停止 + WARN | 2.2.2, 2.2.3 |
+| `PROMOTE_MODE` | `on-demand` | no | `continuous` / `batched` / `on-demand` のいずれか | 3.2.1, 3.2.2 |
+| `PROMOTE_CRON` | `""` | no | `PROMOTE_MODE=batched` のときの cron 式（標準 5 フィールド） | 3.2.4, 3.2.6 |
+| `PROMOTE_FAIL_NOTIFY_ISSUE` | `""` | no | promote 失敗時の通知先 Issue 番号 | 3.3.2, 3.3.3 |
+| `PROMOTE_GIT_TIMEOUT` | `${MERGE_QUEUE_GIT_TIMEOUT:-60}` | no | git / gh 各操作の個別タイムアウト | NFR 3.2 |
+
+### ラベル状態遷移表（Phase B 追加）
+
+| Issue 状態 | 前ラベル | トリガー | 後ラベル | 副作用 |
+|---|---|---|---|---|
+| `BASE_BRANCH` merge 直後 | `auto-dev`, `ready-for-review`, ... | Phase A による `BASE_BRANCH` merge | + `staged-for-release` | なし（自動付与） |
+| 既に人間付与済み（#100） | + `staged-for-release` | 自動付与 attempt | 変更なし（重複付与抑止） | 何もしない（Req 2.1.3） |
+| `staged-for-release` 付き | ST = success | promote 成功（非 on-demand） | − `staged-for-release` | promote 集合へ |
+| `staged-for-release` 付き | ST = success（on-demand）| 何もしない | 変更なし | 人間トリガー待ち |
+| `staged-for-release` 付き | ST = failure | revert + reopen + コメント | − `staged-for-release` + `st-failed` | revert commit が push される、Issue が reopen |
+| `staged-for-release` 付き | ST = pending/in_progress | 持ち越し | 変更なし | 次サイクルへ |
+| `staged-for-release` 付き | ST_CHECK_RUN 不在 | WARN ログ | 変更なし | log のみ |
+
+### ST check-run 状態と watcher アクションのマッピング
+
+| GitHub check-run status | conclusion | watcher 内部状態 | アクション |
+|---|---|---|---|
+| `completed` | `success` | `success` | label 除去 + promote 集合へ（PROMOTE_MODE=on-demand 以外）|
+| `completed` | `failure` / `cancelled` / `timed_out` / `action_required` | `failure` | revert + Issue reopen + `st-failed` 付与 |
+| `completed` | `neutral` / `skipped` / `stale` / unknown | `missing` | WARN ログのみ、状態変更なし |
+| `queued` / `in_progress` / `pending` | (任意) | `pending` | 次サイクルへ持ち越し |
+| check-run が見つからない | - | `missing` | WARN ログのみ |
+| `ST_CHECK_RUN_NAME` 未設定 | - | `skip-warn` | WARN ログ + 当該サイクルでの promote を行わない |
+
+## Error Handling
+
+### Error Strategy
+
+Phase A と同じ「**fail-continue with per-step logging**」戦略を採用する。各 Issue / 各操作で
+失敗が発生しても、その 1 件のみをログに記録して次の Issue / 次の操作に進む。サイクル全体としては
+exit code 0 で戻り、後続 Processor / Issue ピックアップを止めない（NFR 3.1）。
+
+### Error Categories and Responses
+
+- **Configuration Errors（gate 経路）**:
+  - `PROMOTE_PIPELINE_ENABLED != "true"` → 静かに `return 0`（NFR 1.1）
+  - `BASE_BRANCH == PROMOTION_TARGET_BRANCH` → INFO ログ + `return 0`（Req 1.1.3）
+  - `PROMOTION_TARGET_BRANCH` がリモートに存在しない → ERROR ログ + サイクル中止（Req 1.2.2）
+  - `ST_CHECK_RUN_NAME` 未設定 → WARN ログ + 当該サイクルの promote を行わない（Req 2.2.3）
+  - `PROMOTE_MODE=batched` かつ `PROMOTE_CRON` 未設定 / 不正 → WARN + 本サイクル no-op（Req 3.2.6）
+  - dirty working tree → ERROR ログ + サイクル中止（NFR 2.3）
+
+- **ST Polling Errors**:
+  - check-run 取得が timeout → WARN ログ、次サイクルに持ち越し（per-Issue で他 Issue 処理継続）
+  - check-run not found → "missing" 状態として WARN ログのみ、状態変更なし（Req 2.2.5）
+  - merge commit SHA 解決失敗 → WARN ログ、当該 Issue をスキップ
+
+- **Revert Errors**:
+  - `git revert -m 1` 自体が失敗（既に revert 済み等）→ WARN ログ、`st-failed` 付与を保留
+    （Req 2.4.6）、次の Issue へ
+  - `git push --force-with-lease` がリモート先行で失敗 → WARN ログ、`st-failed` 付与を保留
+    （Req 2.4.6）、次の Issue へ
+  - revert commit 作成は成功したが Issue 操作（reopen / label / comment）が失敗 → 各 API call ごとに
+    WARN ログ、可能な範囲で他の操作を続行
+
+- **Promote Errors**:
+  - fast-forward 不可（`PROMOTION_TARGET_BRANCH` 側が `BASE_BRANCH` の祖先でない）→ promote 中止、
+    WARN ログ + `promote-failed` 識別語、Issue 側のラベル状態は変更しない（Req 3.1.3）
+  - push 失敗 → 同上 + `pp_notify_promote_failure` で（env 設定時のみ）Issue コメント投稿
+  - `PROMOTE_FAIL_NOTIFY_ISSUE` の値が数値でない / 不正 → 静かに log のみ（Req 3.3.3）
+
+- **Fork PR / 非対象 PR**:
+  - head repo owner != base repo owner（fork PR）→ collect 段階で除外、警告は出さない（NFR 2.4）
+
+### Failure-Mode Diagram
+
+```mermaid
+flowchart TD
+    A[process_promote_pipeline 起動] --> B{opt-in gate}
+    B -->|=false| Z[no-op return 0]
+    B -->|=true| C{2-branch model?}
+    C -->|BASE == TARGET| Z
+    C -->|BASE != TARGET| D{dirty tree?}
+    D -->|dirty| E[ERROR log + return 0]
+    D -->|clean| F[pp_collect_merged_issues]
+    F --> G[Issue loop]
+    G --> H{ST 状態}
+    H -->|success| I[label 除去 + promote 集合へ]
+    H -->|failure| J[pp_do_revert]
+    H -->|pending| K[次サイクル]
+    H -->|missing| L[WARN log]
+    J -->|push 失敗| M[WARN + st-failed 保留]
+    I --> G
+    J --> G
+    K --> G
+    L --> G
+    M --> G
+    G --> N[pp_do_promote_if_eligible]
+    N --> O{PROMOTE_MODE}
+    O -->|continuous / batched 一致| P[fast-forward push]
+    O -->|on-demand / batched 不一致| Q[何もしない]
+    P -->|成功| R[promote-success log]
+    P -->|失敗| S[promote-failed log + 通知]
+    R --> T[pp_summary]
+    Q --> T
+    S --> T
+```
+
+## Testing Strategy
+
+### Unit Tests（bash 関数の dry-run / mock）
+
+- `process_promote_pipeline` opt-in gate: `PROMOTE_PIPELINE_ENABLED=false` で何も実行しないこと
+  （stdout 完全に空、exit 0）
+- `pp_resolve_target_branch` の `BASE_BRANCH == PROMOTION_TARGET_BRANCH` 判定（Req 1.1.3）と
+  リモート存在検証失敗時の ERROR 出力
+- `pp_get_st_state` の jq フィルタ: success / failure / pending / missing / skip-warn の 5 状態を
+  mock JSON で網羅
+- `pp_match_cron` の cron 式 matcher: `*` / `*/15` / `1,15,30` / `0-30` / 不正値の各パターン
+
+### Integration Tests（process_promote_pipeline 関数を harness で起動）
+
+- Phase A 既存 dry-run harness と同等の手法で、`process_promote_pipeline` のみを切り出して
+  clean な git repo 上で実行し、各種 env 組み合わせでの挙動を確認:
+  1. `PROMOTE_PIPELINE_ENABLED=false` → 完全 no-op
+  2. `PROMOTE_PIPELINE_ENABLED=true` + `BASE_BRANCH=main` + `PROMOTION_TARGET_BRANCH=main` →
+     "no-op" INFO ログ + return 0（Req 1.1.3）
+  3. `PROMOTE_PIPELINE_ENABLED=true` + 2 ブランチ環境 + `ST_CHECK_RUN_NAME=""` → WARN ログ
+  4. 全 env 設定済み + 対象 Issue 0 件 → サマリ 0 件、exit 0
+- `idd-claude-labels.sh` 再実行で `st-failed` が冪等に作成されること（Req 4.1.4）
+
+### E2E（dogfooding）
+
+- 本リポジトリ自身に対し、`auto-dev` test Issue を立てて Phase B 機能を `PROMOTE_PIPELINE_ENABLED=true`
+  かつ `BASE_BRANCH=develop` / `PROMOTION_TARGET_BRANCH=main` で 1 サイクル動かし、サマリログが
+  期待値で出ることを確認（Phase A の dogfooding と同手法）
+- cron-like 最小 PATH で claude / gh / jq / flock / git / timeout が解決可能であること:
+  `env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'command -v gh jq git flock timeout'`
+
+### Performance / Load
+
+- 1 サイクル内での Promote Pipeline 処理時間が watcher 最短実行間隔（既定 2 分 = 120 秒）以内に
+  収まること（NFR 5.1）。各 git / gh 操作に `PROMOTE_GIT_TIMEOUT=60` を適用しているため、Issue 数
+  10 件 × 操作 5 件 × 平均 1 秒 = 50 秒程度を見込む
+- 1 Issue あたり GitHub API call 数 ≤ 10 回（NFR 5.2）。標準パスでは: check-run 取得 1, label 操作
+  1-2, reopen 1, comment 1, merge SHA 解決 1 = 通常 5 回、最大ケースでも 8 回
+
+### Static Analysis
+
+- `shellcheck local-watcher/bin/issue-watcher.sh .github/scripts/idd-claude-labels.sh
+  repo-template/.github/scripts/idd-claude-labels.sh` → 警告ゼロを目指す（Phase A 同様）
+- `bash -n` で syntax check
+- 既存 `actionlint` は workflow を変更しないため対象外
+
+## Security Considerations
+
+- **`--force-with-lease` 限定**: revert commit の `BASE_BRANCH` push と、promote の
+  `PROMOTION_TARGET_BRANCH` への fast-forward push の両方で、`--force`（無条件）は使わず、
+  fast-forward push（promote）と `--force-with-lease`（revert）のみを使用する（NFR 2.1）。
+  これにより、watcher サイクル中に他の operator が同じ branch に push しても安全に検知できる
+- **Branch Protection Bypass**: `BASE_BRANCH` への revert commit 直接 push は、Branch Protection
+  ルール（PR 必須等）が設定されている場合は admin bypass / PAT が必要になる可能性がある。
+  本機能の有効化条件として、README に「`BASE_BRANCH` Branch Protection の設定有無を確認のうえ
+  opt-in する」旨を migration note として記載する
+- **fork PR の除外**: head repo owner が base repo owner と異なる PR は除外する（NFR 2.4）。
+  これは Phase A と同一の防衛機構であり、新規導入の必要はない（既存 Phase A の helper を流用）
+- **新しい外部サービスは追加しない**: 利用する API は既存の `gh` CLI 経由の GitHub API のみ。
+  本機能の有効化は `PROMOTE_PIPELINE_ENABLED=true` の明示で opt-in 制（CLAUDE.md 禁止事項に整合）
+
+## Migration Strategy
+
+```mermaid
+flowchart LR
+    A[Phase A merged / main 配布済] --> B[Phase B PR merged]
+    B --> C{operator 判断}
+    C -->|opt-in しない| D[何もしない<br>既存挙動完全保持]
+    C -->|opt-in する| E[cron / launchd に env を追加]
+    E --> F[PROMOTE_PIPELINE_ENABLED=true<br>BASE_BRANCH=develop<br>PROMOTION_TARGET_BRANCH=main<br>ST_CHECK_RUN_NAME=<your-ST-name>]
+    F --> G[次サイクルから自動付与開始]
+    G --> H{過去の Phase A merge 履歴}
+    H -->|手動 staged-for-release あり #100| I[既存ラベルはそのまま尊重<br>同じポーリング対象に組み込まれる]
+    H -->|なし| J[Phase A 由来の自動付与のみ動作]
+```
+
+**既存 `staged-for-release` 手動運用との共存**:
+
+- #100 で運用者が手で `staged-for-release` を付与していた Issue は、Phase B 有効化後の最初の
+  サイクルで自動的に `pp_collect_merged_issues` の出力に含まれる（`gh issue list --label
+  staged-for-release` で抽出されるため）
+- ST_CHECK_RUN_NAME が未設定の状態で opt-in した場合、`pp_get_st_state` が `skip-warn` を返し、
+  ラベル状態は変更されない。手動 `staged-for-release` 運用を維持したい場合は ST_CHECK_RUN_NAME
+  を空のままにすれば、ラベル付与 (Req 2.1) だけが自動化される副作用しか起きない
+- `PROMOTE_MODE=on-demand`（既定）にしておけば、ST success 検知後もラベルが除去されないため、
+  人間が手動で release PR を作る運用との衝突を最小化できる
+
+**opt-in OFF 時の no-op 保証**:
+
+- `process_promote_pipeline` 関数本体の最初の 1 行が `[ "$PROMOTE_PIPELINE_ENABLED" = "true" ] || return 0`
+  であり、env を明示しない限り何も実行しない
+- 関数定義自体は無条件で読み込まれるが、bash の関数は呼び出されない限り副作用ゼロ
+- 既存 Phase A の `process_merge_queue` / `process_merge_queue_recheck` 関数群とは独立した
+  名前空間（`pp_*` prefix）で実装するため、関数名衝突なし
+
+## Optional Sections
+
+### Performance & Scalability
+
+主要なボトルネック候補と対策:
+
+- `gh api repos/.../commits/.../check-runs` は 1 commit あたり 1 回呼び出し（NFR 5.2 範囲内）
+- `pp_collect_merged_issues` の `gh pr list --state merged --base $BASE_BRANCH --limit 50` は
+  サイクル冒頭 1 回のみ（Issue 件数に依らず一定）
+- `pp_resolve_merge_sha` は Issue ごとに 1 回 GraphQL 呼び出し → 10 Issue で 10 回 × 平均 0.5 秒
+  = 5 秒程度
+- 最終的に 1 サイクルの想定処理時間 = 60 秒以内（NFR 5.1）に収まる見積もり
+
+## まとめ
+
+- 新規ファイルなし。既存 7 ファイル（issue-watcher.sh / labels.sh × 2 / README / CLAUDE.md × 2 /
+  QUICK-HOWTO）への追記のみ
+- 関数は `pp_*` 名前空間で完全に独立。既存関数を変更しない（差し戻し容易性 / NFR 1.1）
+- opt-in 制 + 2-branch model gate + dirty tree gate の三重 guard で誤起動を防ぐ
+- すべての破壊的操作（revert push / promote push）は `--force-with-lease` または fast-forward のみで
+  安全 push に限定（NFR 2.1, 2.2）
+- ログ識別子は `promote-pipeline:` / `promote-failed` / `promote-success` で grep 集計を担保
+  （NFR 4.1）

--- a/docs/specs/15-phase-b-promote-pipeline-st-base-branch/requirements.md
+++ b/docs/specs/15-phase-b-promote-pipeline-st-base-branch/requirements.md
@@ -1,0 +1,199 @@
+# Requirements Document
+
+## Introduction
+
+idd-claude を multi-branch（例: `BASE_BRANCH=develop`）運用するリポジトリでは、approved PR が
+Phase A（#14 Merge Queue Processor）によって `BASE_BRANCH` に merge された後、
+リリースブランチ（既定 `main`）に手動で release PR を作って merge するまでの間、System Test（ST）
+の合否確認と revert 判断が運用者の手作業に残っていた。本フェーズ（Phase B）は、`BASE_BRANCH` に
+merge された変更について、watcher サイクル内で ST check-run の結果をポーリングし、success なら
+`BASE_BRANCH` → `PROMOTION_TARGET_BRANCH`（既定 `main`）への fast-forward 昇格、failure なら
+`git revert -m 1` + Issue 再オープン + `st-failed` 通知を自動化する。
+
+本 Issue は既存実装 #89（`BASE_BRANCH` 切替）・#100（`staged-for-release` ラベル定義）・
+#14（Phase A Merge Queue）の上に積み上げる機能であり、それらの再定義は対象外である。
+新規に追加する挙動は (1) ST 結果連動の `staged-for-release` 自動付与／除去、(2) ST 結果ポーリング
+と revert-on-failure、(3) `BASE_BRANCH` → `PROMOTION_TARGET_BRANCH` への fast-forward promote、
+(4) `PROMOTE_MODE`（`continuous` / `batched` / `on-demand`）による昇格タイミング制御の 4 点に
+限定する。Phase B 全体は環境変数 `PROMOTE_PIPELINE_ENABLED=true` を opt-in gate として持ち、
+未設定または `false` のリポジトリでは導入前と完全に同一の挙動を維持する。
+
+なお、single-branch（`BASE_BRANCH` 未設定 = `main` のみ）運用では `BASE_BRANCH` と
+`PROMOTION_TARGET_BRANCH` が同一となるため、本機能は no-op として振る舞う。
+`STAGING_BRANCH` を独立に導入する 3-branch model は本フェーズの対象外とする
+（後続フェーズで検討）。
+
+## Requirements
+
+### 1. Opt-in gate と適用条件
+
+**Objective:** As an existing watcher operator, I want Phase B 機能を環境変数で明示的に有効化したい, so that 既存運用に影響を与えずに段階導入できる。
+
+#### 1.1 環境変数による有効化
+
+1. While `PROMOTE_PIPELINE_ENABLED` が未設定または `false` である, the Issue Watcher shall Phase B 導入前と同一の処理フローのみを実行する
+2. When `PROMOTE_PIPELINE_ENABLED=true` であり、かつ `BASE_BRANCH` と `PROMOTION_TARGET_BRANCH` が異なる値に設定されている, the Issue Watcher shall watcher サイクル内で Promote Pipeline Processor を起動する
+3. While `BASE_BRANCH` が未設定または `PROMOTION_TARGET_BRANCH` と等しい, the Promote Pipeline Processor shall 起動せず no-op として終了する
+4. The Promote Pipeline Processor shall 既存環境変数（`REPO`, `REPO_DIR`, `LOG_DIR`, `LOCK_FILE`, `BASE_BRANCH`, `TRIAGE_MODEL`, `DEV_MODEL` 等）のデフォルト値と意味を変更しない
+
+#### 1.2 `PROMOTION_TARGET_BRANCH` の解釈
+
+1. The Promote Pipeline Processor shall `PROMOTION_TARGET_BRANCH` が未設定の場合に既定値 `main` を採用する
+2. If `PROMOTION_TARGET_BRANCH` がリモートに存在しない, the Promote Pipeline Processor shall 当該サイクルでの promote 操作を中止し、watcher ログに ERROR を記録する
+
+### 2. ST 連携と `staged-for-release` 自動付与
+
+**Objective:** As a release manager, I want `BASE_BRANCH` に merge された変更を ST 結果に応じて自動的に Issue ラベル状態に反映したい, so that release 待ち集合と ST failure 集合を Issue 一覧画面のラベルフィルタだけで把握できる。
+
+#### 2.1 `staged-for-release` 自動付与
+
+1. When approved PR が Phase A の Merge Queue Processor によって `BASE_BRANCH` に merge された, the Promote Pipeline Processor shall 当該 PR に `Closes #N` 等でリンクされた Issue に `staged-for-release` ラベルを自動付与する
+2. The Promote Pipeline Processor shall 既存の人間付与による `staged-for-release` ラベル（#100 で定義された運用）と自動付与による `staged-for-release` ラベルを名前・色・description において区別せず、同一ラベルを使用する
+3. If 対象 Issue にすでに `staged-for-release` ラベルが付いている, the Promote Pipeline Processor shall ラベル付与 API を再送せず、重複付与によるイベント発火を抑止する
+
+#### 2.2 ST check-run 結果のポーリング
+
+1. While Issue に `staged-for-release` ラベルが付与されている, the Promote Pipeline Processor shall 当該 Issue にリンクされた直近の `BASE_BRANCH` commit に対する ST check-run の状態を取得する
+2. The Promote Pipeline Processor shall ポーリング対象の ST check-run 名を環境変数 `ST_CHECK_RUN_NAME` の値（単一文字列）で特定する
+3. If `ST_CHECK_RUN_NAME` が未設定である, the Promote Pipeline Processor shall ST 結果連動を停止し、watcher ログに WARN を記録した上で当該サイクルでの promote を行わない
+4. While ST check-run が `pending` / `in_progress` 相当の未完了状態である, the Promote Pipeline Processor shall 当該 Issue に対するラベル変更・promote を行わず次回サイクルに持ち越す
+5. While Issue が `staged-for-release` でラベル付けされているが対応する ST check-run が存在しない, the Promote Pipeline Processor shall 当該 Issue に対する状態判断を見送り、watcher ログに WARN を記録する
+
+#### 2.3 ST success 時の挙動
+
+1. When ST check-run が success と判定された, the Promote Pipeline Processor shall 当該 Issue から `staged-for-release` ラベルを除去する
+2. When ST success に伴ってラベルを除去した直後, the Promote Pipeline Processor shall 当該変更を `PROMOTION_TARGET_BRANCH` への promote 対象集合に含める
+
+#### 2.4 ST failure 時の挙動（revert-and-continue）
+
+1. When ST check-run が failure と判定された, the Promote Pipeline Processor shall 当該 Issue に `st-failed` ラベルを付与する
+2. When ST failure を検知した, the Promote Pipeline Processor shall `BASE_BRANCH` 上で対応する merge commit に対して `git revert -m 1` 相当の revert commit を作成し、`--force-with-lease` 相当の安全 push でリモートに反映する
+3. When ST failure に伴う revert を行った, the Promote Pipeline Processor shall 対応する Issue を reopen し、ST log の URL を含む 1 件のステータスコメントを Issue に投稿する
+4. When ST failure に伴って revert・Issue 再オープン・コメント投稿を行った, the Promote Pipeline Processor shall 当該 Issue から `staged-for-release` ラベルを除去する
+5. If 1 件の Issue で ST failure を検知した, the Promote Pipeline Processor shall 他の `staged-for-release` 付き Issue の処理を継続する（fail-continue を維持する）
+6. If revert commit の push が失敗した（リモート先行等の理由）, the Promote Pipeline Processor shall 当該 Issue の `st-failed` 付与を保留し、watcher ログに WARN を記録して次の Issue の処理に進む
+
+### 3. `BASE_BRANCH` → `PROMOTION_TARGET_BRANCH` の昇格
+
+**Objective:** As a release manager, I want ST success 済みの変更をリリースブランチへ自動 fast-forward したい, so that 手動 release PR を毎回作成する手間を排除できる。
+
+#### 3.1 昇格手段（fast-forward）
+
+1. When promote 対象が確定した, the Promote Pipeline Processor shall `BASE_BRANCH` の HEAD を `PROMOTION_TARGET_BRANCH` に対して fast-forward push で反映する
+2. The Promote Pipeline Processor shall fast-forward 可能でない状態（`PROMOTION_TARGET_BRANCH` 側が `BASE_BRANCH` の祖先でない）を検知した場合、promote 操作を中止する
+3. If 上記 3.1.2 によって promote 操作を中止した, the Promote Pipeline Processor shall watcher ログに `promote-failed` 相当の識別語を含む WARN を出し、Issue 側のラベル状態を変更しない
+4. The Promote Pipeline Processor shall promote 操作中もローカルワーキングコピーが dirty にならないよう、操作終了時に元の checkout 状態へ復帰する
+
+#### 3.2 `PROMOTE_MODE` による昇格タイミング制御
+
+1. The Promote Pipeline Processor shall 環境変数 `PROMOTE_MODE` から `continuous` / `batched` / `on-demand` のいずれかの値を受け取る
+2. While `PROMOTE_MODE` が未設定または不正値である, the Promote Pipeline Processor shall 既定値 `on-demand` で動作する
+3. Where `PROMOTE_MODE=continuous` が設定されている, the Promote Pipeline Processor shall ST success 検知サイクルと同一サイクルで promote を実行する
+4. Where `PROMOTE_MODE=batched` が設定されている, the Promote Pipeline Processor shall 環境変数 `PROMOTE_CRON` で指定された標準 cron 式に合致する時刻ウィンドウでのみ promote を実行する
+5. Where `PROMOTE_MODE=on-demand` が設定されている, the Promote Pipeline Processor shall ST success 検知後も `staged-for-release` ラベルを除去せず、人間トリガー（明示的な promote コマンド／別 Issue 起票）を待つ
+6. While `PROMOTE_MODE=batched` かつ `PROMOTE_CRON` が未設定または不正な cron 式である, the Promote Pipeline Processor shall 当該サイクルでの promote を行わず、watcher ログに WARN を記録する
+
+#### 3.3 昇格失敗時の通知
+
+1. If promote 操作が失敗した, the Promote Pipeline Processor shall watcher ログに失敗理由を含む WARN/ERROR を必ず記録する
+2. Where 環境変数 `PROMOTE_FAIL_NOTIFY_ISSUE` に有効な Issue 番号が設定されている, the Promote Pipeline Processor shall 当該 Issue に promote 失敗の旨と原因を含む 1 件のコメントを投稿する
+3. While `PROMOTE_FAIL_NOTIFY_ISSUE` が未設定または不正である, the Promote Pipeline Processor shall log 出力のみに留め、Issue へのコメント投稿を行わない
+
+### 4. ラベル定義と既存ラベル契約
+
+**Objective:** As an operator, I want Phase B で増えるラベルが既存の一括ラベル作成スクリプトで配布されるようにしたい, so that 各リポジトリで個別に `gh label create` を打たずに済む。
+
+#### 4.1 `st-failed` ラベルの追加
+
+1. When 運用者が idd-claude の一括ラベル作成スクリプトを実行する, the Labels Setup Script shall `st-failed` ラベルを作成する
+2. The Labels Setup Script shall `st-failed` を「Issue に適用するラベル」として扱い、既存 idd-claude 標準ラベルの description における 適用先 prefix 規約に整合させる
+3. The Labels Setup Script shall idd-claude 自身用（self-hosting）と consumer 配布用テンプレートの両系統で、同一の名前・色・description で `st-failed` を提供する
+4. The Labels Setup Script shall 再実行に対して冪等であり、`st-failed` 追加によって複数回実行時のラベル状態が不整合にならない
+
+#### 4.2 既存ラベル契約の保持
+
+1. The Labels Setup Script shall 既存ラベル（`auto-dev` / `needs-decisions` / `awaiting-design-review` / `claude-claimed` / `claude-picked-up` / `ready-for-review` / `claude-failed` / `skip-triage` / `needs-rebase` / `needs-iteration` / `needs-quota-wait` / `staged-for-release`）の名前・色・description を Phase B 追加に伴って変更しない
+2. The Promote Pipeline Processor shall `staged-for-release` ラベル名・色・description（#100 で定義されたもの）を変更せず、付与・除去契約のみを拡張する
+3. The Promote Pipeline Processor shall 既存ラベルの付与契約（Phase A の `needs-rebase` 付与契約等）の意味と挙動を変更しない
+
+### 5. ロギング・可観測性
+
+**Objective:** As an operator, I want Phase B の判断と操作結果をログから追えるようにしたい, so that ST 失敗時の revert や promote 失敗時の原因を grep だけで特定できる。
+
+#### 5.1 ログ出力契約
+
+1. The Promote Pipeline Processor shall Issue Watcher と同一のタイムスタンプ書式（`[YYYY-MM-DD HH:MM:SS]`）でログを出力する
+2. The Promote Pipeline Processor shall 各 Issue ごとに「Issue 番号」「ST 状態（pending/success/failure/missing）」「実施したアクション（label-add / label-remove / promote / revert / skip）」を 1 行以上のログに出力する
+3. The Promote Pipeline Processor shall サイクル終了時に「ST success → promote 成功数」「ST failure → revert 数」「pending によるスキップ数」「失敗数」のサマリをログに出力する
+4. The Promote Pipeline Processor shall ログ出力先を既存 watcher の `LOG_DIR` 配下に統一し、新規の出力ディレクトリを作らない
+5. The Promote Pipeline Processor shall 各ログ行に対象リポジトリを示す `[$REPO]` プレフィックスと、grep 集計用の識別語（例: `promote-pipeline:` / `promote-failed` 等の機械可読プレフィックス）を含める
+
+### 6. ドキュメント更新（DoD）
+
+**Objective:** As a new operator, I want Phase B の挙動・有効化方法・新ラベルの意味と状態遷移を README から読み取れるようにしたい, so that 既存ユーザが追加機能の opt-in 可否を即判断できる。
+
+#### 6.1 README 記載項目
+
+1. The README.md shall Phase B Promote Pipeline の概要（目的・対象・タイミング）を記述するセクションを含む
+2. The README.md shall Phase B の opt-in 環境変数（`PROMOTE_PIPELINE_ENABLED`, `PROMOTION_TARGET_BRANCH`, `ST_CHECK_RUN_NAME`, `PROMOTE_MODE`, `PROMOTE_CRON`, `PROMOTE_FAIL_NOTIFY_ISSUE`）の名称・デフォルト値・推奨値を明記する
+3. The README.md ラベル一覧 shall `st-failed` の「適用先」「付与主」「意味」を記載する
+4. The README.md ラベル状態遷移節 shall Phase B 導入後の `staged-for-release` 状態遷移（自動付与・ST 結果による除去・revert）を補助フローとして記述する
+5. The README.md shall #100 で定義された人間付与の `staged-for-release` 運用と、Phase B による自動付与の `staged-for-release` 運用が同一ラベルを共有する旨を明記する
+6. The README.md shall Phase B 導入による後方互換性方針（`PROMOTE_PIPELINE_ENABLED` 未設定時に既存挙動が完全保持されること、既存 env / ラベル / lock / exit code が不変であること）を migration note として明記する
+
+#### 6.2 関連ドキュメントとの整合
+
+1. When 運用者が `QUICK-HOWTO.md` の「作成されるラベル」一覧を参照する, the QUICK-HOWTO.md shall `st-failed` を含むラベル一覧を提示する
+2. The Documentation Set shall ラベル名 `st-failed` を全ドキュメントで完全一致（lowercase, ハイフン区切り）で記載する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While `PROMOTE_PIPELINE_ENABLED` が未設定または `false` である, the Issue Watcher shall Phase B 導入前と完全に同一の挙動（既存 env var の意味・既存ラベル契約・既存 lock ファイルパス・既存ログ出力先・既存 exit code）を保持する
+2. The Promote Pipeline Processor shall 既存環境変数名（`REPO`, `REPO_DIR`, `LOG_DIR`, `LOCK_FILE`, `BASE_BRANCH`, `MERGE_QUEUE_ENABLED` 等）の意味とデフォルト挙動を変更しない
+3. The Promote Pipeline Processor shall 既存ラベル契約を破壊しない（Phase A `needs-rebase` 契約・#100 `staged-for-release` 契約を含む）
+
+### NFR 2: 安全性
+
+1. The Promote Pipeline Processor shall リモートに対する破壊的操作として `--force-with-lease` 相当の安全 push のみを使用し、無条件 force push（`--force`）を使わない
+2. The Promote Pipeline Processor shall `PROMOTION_TARGET_BRANCH` への昇格を fast-forward に限定し、merge commit や rebase による non-fast-forward 昇格を行わない
+3. If 想定外のローカル変更（dirty working tree）が検知された, the Promote Pipeline Processor shall 当該サイクルでの promote / revert 操作を中止し、watcher ログに ERROR を記録する
+4. The Promote Pipeline Processor shall fork PR（head repo owner が base repo owner と異なる PR）を起点とした自動 promote・自動 revert 対象から除外する
+
+### NFR 3: 障害分離
+
+1. If 1 件の Issue 処理（ST 判定 / label 操作 / revert / promote のいずれか）が失敗した, the Promote Pipeline Processor shall 他の Issue / PR の処理を中断せず継続する（fail-continue を保持する）
+2. The Promote Pipeline Processor shall 1 件の処理に対してサブプロセス（`gh api` / `git revert` / `git push` 等）のタイムアウトを設け、ハングを防止する
+
+### NFR 4: 観測可能性
+
+1. The Promote Pipeline Processor shall 各操作結果（label-add / label-remove / promote-success / promote-failed / revert / skip）を operator がログ grep するだけで集計できる識別語でマークする
+2. The Promote Pipeline Processor shall watcher 既存の出力契約（標準エラー出力は人間向け WARN/ERROR、標準出力は機械可読集計用）に揃える
+
+### NFR 5: パフォーマンス
+
+1. The Promote Pipeline Processor shall 1 サイクル内での ST ポーリング・promote・revert 操作合計時間が、watcher 最短実行間隔（README 既定 2 分）以内に収まることを目指す
+2. The Promote Pipeline Processor shall 1 Issue あたりの GitHub API 呼び出し回数を、ST 状態取得・ラベル操作・コメント投稿・Issue 状態変更の合計で 10 回以内に抑える
+
+## Out of Scope
+
+- `BASE_BRANCH` 環境変数自体の導入（#89 で完了済み）
+- `staged-for-release` ラベル定義の追加（#100 で完了済み）
+- approved PR を `BASE_BRANCH` へ自動 merge する仕組み（#14 Phase A Merge Queue Processor の範囲）
+- semantic conflict の Claude による自動解決（#17 Phase D の範囲）
+- 並列 promote worker（複数 PROMOTE_MODE を同時に動かす仕組み）
+- 独立した `STAGING_BRANCH` を介した 3-branch model（`BASE_BRANCH` + `STAGING_BRANCH` + `PROMOTION_TARGET_BRANCH`）
+- ST check-run 名を正規表現／複数候補で解決する仕組み（`ST_CHECK_RUN_NAME` は単一文字列のみ）
+- 人間付与の `staged-for-release` と自動付与の `staged-for-release` を区別するラベル名／属性の追加
+- revert された commit に対する自動的な再修正（再 implement / cherry-pick リトライ等）
+- fork からの PR を起点とした自動 promote / 自動 revert
+- GitHub Actions 版ワークフロー（`.github/workflows/issue-to-pr.yml`）への Phase B 機能の組み込み
+- `PROMOTE_MODE=batched` における高度なジョブスケジューラ統合（標準 cron 式以外の DSL 対応）
+
+## 確認事項
+
+- なし（Issue 本文の Open Questions Q1〜Q5 はいずれも Issue コメントで人間が提示した推奨値
+  〈2-branch model 採用 / `PROMOTE_MODE` 既定値 `on-demand` / `ST_CHECK_RUN_NAME` は単一 env /
+  `staged-for-release` source 区別なし / promote 失敗通知は log + `PROMOTE_FAIL_NOTIFY_ISSUE` 指定時の
+  Issue コメント〉に従って本要件に確定済み）

--- a/docs/specs/15-phase-b-promote-pipeline-st-base-branch/tasks.md
+++ b/docs/specs/15-phase-b-promote-pipeline-st-base-branch/tasks.md
@@ -90,15 +90,17 @@
 
 - [ ] 6. ドキュメント更新（DoD）
 - [ ] 6.1 README.md / QUICK-HOWTO.md / CLAUDE.md に Phase B の概要・env var 表・ラベル一覧・状態遷移・migration note を追記する (P)
-  - README に Phase B Promote Pipeline 概要セクション（目的・対象・タイミング）を追加（Req 6.1.1）
-  - README の環境変数表に `PROMOTE_PIPELINE_ENABLED` / `PROMOTION_TARGET_BRANCH` / `ST_CHECK_RUN_NAME` / `PROMOTE_MODE` / `PROMOTE_CRON` / `PROMOTE_FAIL_NOTIFY_ISSUE` を追加（Req 6.1.2）
-  - README のラベル一覧に `st-failed` の「適用先 = Issue」「付与主 = Phase B Promote Pipeline」「意味 = ST failure 検知後に revert 済み」を追加（Req 6.1.3）
-  - README のラベル状態遷移節に Phase B 補助フロー（`staged-for-release` 自動付与 → ST polling → success/failure 分岐）を追加（Req 6.1.4）
-  - #100 で定義された人間付与の `staged-for-release` 運用と Phase B 自動付与が同一ラベルを共有する旨を README に明記（Req 6.1.5）
-  - Migration Note: `PROMOTE_PIPELINE_ENABLED` 未設定で既存挙動完全保持、既存 env / ラベル / lock / exit code 不変、`BASE_BRANCH` Branch Protection 設定確認の推奨を記載（Req 6.1.6）
-  - QUICK-HOWTO.md の「作成されるラベル」一覧に `st-failed` を追加（Req 6.2.1）
-  - 全ドキュメントで `st-failed` を lowercase / ハイフン区切りで完全一致表記（Req 6.2.2）
-  - CLAUDE.md（本 repo）の「idd-claude 特有の設計上の注意」節に Phase B 機能の留意点（opt-in gate / 2-branch model 前提 / 既存 staged-for-release 共存）を 1 段落追記
+  - **具体的な挿入位置・見出し階層・内容スケルトンは `design.md` の「Documentation Set / README 編集ブループリント」節に従う**（Architect が利用方法と状態遷移の README 反映方法を確定済み）
+  - README に Phase B Promote Pipeline **利用方法**セクション（目的・対象・タイミング）を新規 h2 として追加（Req 6.1.1、ブループリント 1）
+  - README の環境変数表に `PROMOTE_PIPELINE_ENABLED` / `PROMOTION_TARGET_BRANCH` / `ST_CHECK_RUN_NAME` / `PROMOTE_MODE` / `PROMOTE_CRON` / `PROMOTE_FAIL_NOTIFY_ISSUE` を追加（Req 6.1.2、ブループリント 2）
+  - README のラベル一覧に `st-failed` の「適用先 = Issue」「付与主 = Phase B Promote Pipeline」「意味 = ST failure 検知後に revert 済み」を追加（Req 6.1.3、ブループリント 3）
+  - README の**ラベル状態遷移節**に Phase B 補助フロー（`staged-for-release` 自動付与 → ST polling → success/failure 分岐）を、**状態遷移表 + Mermaid 図** の両形式で追加（Req 6.1.4、ブループリント 4）
+  - #100 で定義された人間付与の `staged-for-release` 運用と Phase B 自動付与が同一ラベルを共有する旨を README に明記（Req 6.1.5、ブループリント 5）
+  - Migration Note: `PROMOTE_PIPELINE_ENABLED` 未設定で既存挙動完全保持、既存 env / ラベル / lock / exit code 不変、`BASE_BRANCH` Branch Protection 設定確認の推奨を記載（Req 6.1.6、ブループリント 6）
+  - QUICK-HOWTO.md の「作成されるラベル」一覧に `st-failed` を追加（Req 6.2.1、ブループリント 7）
+  - 全ドキュメントで `st-failed` を lowercase / ハイフン区切りで完全一致表記（Req 6.2.2、ブループリント 7）
+  - CLAUDE.md（本 repo）の「idd-claude 特有の設計上の注意」節に Phase B 機能の留意点（opt-in gate / 2-branch model 前提 / 既存 staged-for-release 共存）を 1 段落追記（ブループリント 7）
+  - 完了基準: `design.md` のブループリント「Acceptance Criteria → README 追記箇所のトレーサビリティ」表の Req 6.1.1〜6.2.2 がすべて README / QUICK-HOWTO / CLAUDE.md のいずれかに反映されていること
   - _Requirements: 6.1, 6.2_
   - _Boundary: Documentation Set_
 

--- a/docs/specs/15-phase-b-promote-pipeline-st-base-branch/tasks.md
+++ b/docs/specs/15-phase-b-promote-pipeline-st-base-branch/tasks.md
@@ -1,0 +1,111 @@
+# Implementation Plan
+
+実装は **境界の独立性が高い順** に並べる。タスク 1（labels）→ タスク 2（config + gate）→
+タスク 3〜5（Promote Pipeline 機能本体）→ タスク 6（docs）。タスク 1 と 6 は本体と独立した
+ファイル群を触るため `(P)` で並列実行可能。タスク 3〜5 は `process_promote_pipeline()` の
+内部状態（promote 集合 / Issue ループ）を共有するため直列にする。
+
+- [ ] 1. ラベルセットアップスクリプトに `st-failed` を追加
+- [ ] 1.1 `repo-template/.github/scripts/idd-claude-labels.sh` と `.github/scripts/idd-claude-labels.sh` の `LABELS=(...)` 配列に `st-failed` を追加する (P)
+  - 両ファイルに同一行 `"st-failed|d73a4a|【Issue 用】 ST failure 検知後 revert 済み（Phase B Promote Pipeline が付与）"` を追記
+  - 既存 12 ラベルの定義（名前・色・description）は変更しない（NFR 1.3 / Req 4.2）
+  - `gh label create --force` 再実行で冪等になることを確認（既存ループに変更不要 / Req 4.1.4）
+  - スクリプトを `--force` 付きでローカル実行し `st-failed` が created または created/updated になることを目視確認
+  - _Requirements: 4.1, 4.2, NFR 1.3_
+  - _Boundary: Labels Setup Script_
+
+- [ ] 2. `local-watcher/bin/issue-watcher.sh` Config ブロックに Phase B env var を追加
+- [ ] 2.1 6 つの新 env var を Config ブロックに宣言し、opt-in semantics で正規化する
+  - 追加対象: `PROMOTE_PIPELINE_ENABLED`（既定 `false`）/ `PROMOTION_TARGET_BRANCH`（既定 `main`）/ `ST_CHECK_RUN_NAME`（既定空）/ `PROMOTE_MODE`（既定 `on-demand`）/ `PROMOTE_CRON`（既定空）/ `PROMOTE_FAIL_NOTIFY_ISSUE`（既定空）/ `PROMOTE_GIT_TIMEOUT`（既定は `${MERGE_QUEUE_GIT_TIMEOUT:-60}` を流用）
+  - `LABEL_ST_FAILED="st-failed"` 定数を `LABEL_STAGED_FOR_RELEASE` の直後に宣言
+  - `PROMOTE_PIPELINE_ENABLED` は `=true` を明示した場合のみ有効として正規化する（#112 で反転した既存「デフォルト有効化フラグ」ループには加えない）
+  - 既存の `MERGE_QUEUE_*` / `BASE_BRANCH` / `LOG_DIR` 等の env var 名と既定値は変更しない（NFR 1.2）
+  - 配置位置: 既存 `BASE_BRANCH` 設定ブロックの直後、Phase A `Merge Queue Processor` 設定の直前を推奨
+  - _Requirements: 1.1, 1.2, NFR 1.1, NFR 1.2_
+
+- [ ] 3. Promote Pipeline Processor 本体と staged-for-release 自動付与（B1: gate + 自動付与）
+- [ ] 3.1 `process_promote_pipeline()` のエントリポイント、ロガー、3 重 gate（opt-in / 2-branch model / dirty tree）を実装する
+  - 専用ロガー `pp_log` / `pp_warn` / `pp_error` を Phase A `mq_log` と同一書式（`[YYYY-MM-DD HH:MM:SS] [$REPO] promote-pipeline:` prefix）で定義
+  - `pp_resolve_target_branch()` を実装し、`BASE_BRANCH == PROMOTION_TARGET_BRANCH` の no-op 終了（Req 1.1.3）と `git ls-remote --exit-code --heads origin "$PROMOTION_TARGET_BRANCH"` による存在検証（Req 1.2.2）を行う
+  - `process_promote_pipeline()` の最初に `[ "$PROMOTE_PIPELINE_ENABLED" = "true" ] || return 0`、続けて dirty tree gate（NFR 2.3）を配置
+  - Phase A 本体（`process_merge_queue`）の直後（issue-watcher.sh の `process_merge_queue || ...` の次の行）に `process_promote_pipeline || pp_warn "..."` を 1 行追加
+  - _Requirements: 1.1, 1.2, NFR 1.1, NFR 2.3_
+- [ ] 3.2 `pp_collect_merged_issues()` で `BASE_BRANCH` に merge 済みの PR からリンク Issue を抽出し、未付与の Issue に `staged-for-release` を自動付与する
+  - `gh pr list --state merged --base "$BASE_BRANCH" --limit 50 --json number,body,closingIssuesReferences,headRepositoryOwner` で対象 PR を取得
+  - fork PR を除外（`headRepositoryOwner.login != REPO owner` の PR は除外、NFR 2.4）
+  - 各 PR の `closingIssuesReferences` から Issue 番号を抽出（`Closes #N` 形式を GitHub が解決済みの値を利用）
+  - 既に `staged-for-release` が付いている Issue にはラベル再付与しない（Req 2.1.3、重複付与抑止）
+  - 未付与 Issue には `gh issue edit --add-label "$LABEL_STAGED_FOR_RELEASE"` を実行
+  - 自動付与と人間付与の source 区別はしない（同一ラベルを共有 / Req 2.1.2）
+  - 関数 stdout に「現時点で `staged-for-release` を持つ全 open Issue の番号」を 1 行 1 件で出力（次のステップで ST 判定する対象集合になる）
+  - _Requirements: 2.1, NFR 2.4, NFR 5.2_
+
+- [ ] 4. ST polling と revert-and-continue（B2）
+- [ ] 4.1 `pp_get_st_state()` を実装し、Issue 番号から merge SHA を解決して check-run 状態を取得する
+  - `pp_resolve_merge_sha()` ヘルパで Issue にリンクされた直近の merge commit SHA を取得（GraphQL `issue.timelineItems` 経由 or `gh issue view --json closedByPullRequestsReferences`）
+  - `gh api "repos/$REPO/commits/$merge_sha/check-runs" --jq` で check-run 一覧を取得
+  - `ST_CHECK_RUN_NAME` と完全一致する check-run を抽出し、`completed_at` が最新のものを採用
+  - 出力 5 状態に正規化: `success` / `failure` / `pending` / `missing` / `skip-warn`（`ST_CHECK_RUN_NAME` 未設定時）
+  - `failure` には GitHub の conclusion `failure` / `cancelled` / `timed_out` / `action_required` を含める（neutral / skipped / stale は `missing` 扱い）
+  - `ST_CHECK_RUN_NAME` 未設定なら `skip-warn` を返し、呼び出し元で WARN ログを出させる（Req 2.2.3）
+  - すべての gh / git 操作を `timeout "$PROMOTE_GIT_TIMEOUT"` で wrap（NFR 3.2）
+  - _Requirements: 2.2_
+- [ ] 4.2 `pp_handle_st_failure()` + `pp_do_revert()` を実装し、ST failure 時の revert + Issue 操作 + fail-continue を実現する
+  - `pp_do_revert()`: サブシェル内で `trap` を仕掛けて `BASE_BRANCH` への safe checkout 復帰を保証、`git checkout "$BASE_BRANCH"` → `git pull --ff-only` → `git revert -m 1 --no-edit "$merge_sha"` → `git push --force-with-lease origin "$BASE_BRANCH"` の順で実行（NFR 2.1）
+  - `git push --force-with-lease` 失敗（リモート先行）→ exit 1（呼び出し元で WARN + `st-failed` 付与保留 / Req 2.4.6）
+  - `git revert` 自体の失敗 → exit 2（呼び出し元で WARN + 当該 Issue スキップ）
+  - revert 成功時: `gh issue edit --add-label "$LABEL_ST_FAILED" --remove-label "$LABEL_STAGED_FOR_RELEASE"`（Req 2.4.1, 2.4.4 を 1 call にまとめる）
+  - `gh issue reopen` で Issue を reopen（Req 2.4.3）
+  - `gh issue comment` で ST log URL を含む 1 件のステータスコメント投稿（Req 2.4.3）。コメント body には revert 済みの merge SHA prefix（7 文字）と ST log URL（`gh run view` 経由 or check-run の `details_url`）を含める
+  - 1 件失敗しても他 Issue 処理を継続するため、関数戻り値で集計用カウンタにのみ反映（NFR 3.1, Req 2.4.5）
+  - _Requirements: 2.4, NFR 2.1, NFR 3.1_
+- [ ] 4.3 `pp_handle_st_success()` を実装し、success Issue から `staged-for-release` を除去して promote 集合に追加する
+  - `PROMOTE_MODE=on-demand` のときはラベルを除去せず、`PROMOTE_CANDIDATES` 集合にも入れない（Req 3.2.5、人間トリガー待ち）
+  - それ以外（continuous / batched）は `gh issue edit --remove-label "$LABEL_STAGED_FOR_RELEASE"` 実行 + bash 配列 `PROMOTE_CANDIDATES+=("$issue_number")` に追加（Req 2.3.1, 2.3.2）
+  - `pending` / `missing` / `skip-warn` 状態の Issue は何もせず次サイクルに持ち越す（Req 2.2.4, 2.2.5, 2.2.3）
+  - すべての分岐で「Issue 番号 / ST 状態 / 実施アクション」を 1 行ログに出力（Req 5.1.2）
+  - _Requirements: 2.2, 2.3, 3.2, 5.1_
+
+- [ ] 5. Promote 実行（B3: fast-forward push + PROMOTE_MODE 分岐 + 失敗通知）
+- [ ] 5.1 `pp_do_promote_if_eligible()` と `pp_match_cron()` を実装し、PROMOTE_MODE 3 モードを分岐する
+  - `PROMOTE_MODE=continuous`: promote 集合が 1 件以上なら即時 `pp_do_promote` 呼び出し（Req 3.2.3）
+  - `PROMOTE_MODE=batched`: `pp_match_cron "$PROMOTE_CRON"` が真のときだけ `pp_do_promote`、`PROMOTE_CRON` 未設定 / 不正なら WARN + 当該サイクル no-op（Req 3.2.4, 3.2.6）
+  - `PROMOTE_MODE=on-demand` / 未設定 / 不正値: 何もしない + log 出力（Req 3.2.2, 3.2.5）
+  - `pp_match_cron()`: 標準 5 フィールド cron 式（`分 時 日 月 曜日`）を `date '+%M %H %d %m %u'` の現在時刻と比較。`*` / `*/N` / `A,B,C` / `A-B` / 整数の各サブパターンを bash で実装、不正値は `return 1`
+  - _Requirements: 3.2, 5.1_
+- [ ] 5.2 `pp_do_promote()` で `BASE_BRANCH` → `PROMOTION_TARGET_BRANCH` の fast-forward push を実行する
+  - サブシェル内で `trap` を仕掛けて `BASE_BRANCH` checkout 復帰を保証（NFR 2.3 / Req 3.1.4）
+  - `git fetch origin "$PROMOTION_TARGET_BRANCH"` 実行
+  - `git merge-base --is-ancestor "origin/$PROMOTION_TARGET_BRANCH" "origin/$BASE_BRANCH"` で fast-forward 可否を確認（祖先関係でなければ中止 / Req 3.1.2）
+  - fast-forward 可能なら `git push origin "refs/remotes/origin/$BASE_BRANCH:refs/heads/$PROMOTION_TARGET_BRANCH"` で push（`--force` 系オプションを付けない＝自然な ff push、NFR 2.1, 2.2）
+  - 成功時: `pp_log "promote-success: '$BASE_BRANCH' -> '$PROMOTION_TARGET_BRANCH' fast-forward OK"`
+  - 失敗時: `pp_warn` に `promote-failed` 識別語を含めて出力（NFR 4.1）、ラベル状態は変更しない（Req 3.1.3）
+  - すべての git 操作を `timeout "$PROMOTE_GIT_TIMEOUT"` で wrap（NFR 3.2 / NFR 5.1）
+  - _Requirements: 3.1, NFR 2.1, NFR 2.2, NFR 3.2, NFR 4.1, NFR 5.1_
+- [ ] 5.3 `pp_notify_promote_failure()` と `pp_summary()` を実装し、ログ識別語と Issue コメント通知を仕上げる
+  - `pp_notify_promote_failure`: `PROMOTE_FAIL_NOTIFY_ISSUE` が `^[0-9]+$` にマッチする数値のとき `gh issue comment "$PROMOTE_FAIL_NOTIFY_ISSUE" --repo "$REPO" --body "..."` で 1 件投稿（Req 3.3.2）、それ以外は log のみ（Req 3.3.3）
+  - `pp_summary`: サイクル終了時に `[$REPO] promote-pipeline: サマリ: st-success-promoted=X, st-failure-reverted=Y, pending-skip=Z, promote-failed=W, fail=V` を 1 行で出力（Req 5.1.3）
+  - 各 git / gh 操作の stderr / stdout 分離を NFR 4.2 に合わせて維持（`pp_log` → stdout、`pp_warn` / `pp_error` → `>&2`）
+  - _Requirements: 3.3, 5.1, NFR 4.1, NFR 4.2_
+
+- [ ] 6. ドキュメント更新（DoD）
+- [ ] 6.1 README.md / QUICK-HOWTO.md / CLAUDE.md に Phase B の概要・env var 表・ラベル一覧・状態遷移・migration note を追記する (P)
+  - README に Phase B Promote Pipeline 概要セクション（目的・対象・タイミング）を追加（Req 6.1.1）
+  - README の環境変数表に `PROMOTE_PIPELINE_ENABLED` / `PROMOTION_TARGET_BRANCH` / `ST_CHECK_RUN_NAME` / `PROMOTE_MODE` / `PROMOTE_CRON` / `PROMOTE_FAIL_NOTIFY_ISSUE` を追加（Req 6.1.2）
+  - README のラベル一覧に `st-failed` の「適用先 = Issue」「付与主 = Phase B Promote Pipeline」「意味 = ST failure 検知後に revert 済み」を追加（Req 6.1.3）
+  - README のラベル状態遷移節に Phase B 補助フロー（`staged-for-release` 自動付与 → ST polling → success/failure 分岐）を追加（Req 6.1.4）
+  - #100 で定義された人間付与の `staged-for-release` 運用と Phase B 自動付与が同一ラベルを共有する旨を README に明記（Req 6.1.5）
+  - Migration Note: `PROMOTE_PIPELINE_ENABLED` 未設定で既存挙動完全保持、既存 env / ラベル / lock / exit code 不変、`BASE_BRANCH` Branch Protection 設定確認の推奨を記載（Req 6.1.6）
+  - QUICK-HOWTO.md の「作成されるラベル」一覧に `st-failed` を追加（Req 6.2.1）
+  - 全ドキュメントで `st-failed` を lowercase / ハイフン区切りで完全一致表記（Req 6.2.2）
+  - CLAUDE.md（本 repo）の「idd-claude 特有の設計上の注意」節に Phase B 機能の留意点（opt-in gate / 2-branch model 前提 / 既存 staged-for-release 共存）を 1 段落追記
+  - _Requirements: 6.1, 6.2_
+  - _Boundary: Documentation Set_
+
+- [ ]* 7. テスト追加（optional / deferrable）
+  - `process_promote_pipeline` の opt-in OFF dry-run（exit 0 / 出力空）を harness で再現
+  - `pp_get_st_state` の jq フィルタを mock JSON で 5 状態（success / failure / pending / missing / skip-warn）網羅
+  - `pp_match_cron` の cron 式 matcher を unit test 化（`*` / `*/15` / `1,15` / `0-30` / 不正値の 5 パターン）
+  - `idd-claude-labels.sh` 再実行で `st-failed` が冪等に処理される dry-run（既存ラベル + 新ラベル混在）
+  - cron-like 最小 PATH での依存解決（`env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'command -v gh jq git flock timeout claude'`）
+  - _Requirements: 1.1, 1.2, 2.2, 3.2, 4.1_


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用** です。実装コードは含まれません。
`docs/specs/15-phase-b-promote-pipeline-st-base-branch/` 配下の requirements / design / tasks を merge するためのゲートです。

## 対応 Issue

Refs #15

## 含まれる成果物

- `docs/specs/15-phase-b-promote-pipeline-st-base-branch/requirements.md` — 要件定義（PM 成果物）
- `docs/specs/15-phase-b-promote-pipeline-st-base-branch/design.md` — 設計書（Architect 成果物）
- `docs/specs/15-phase-b-promote-pipeline-st-base-branch/tasks.md` — 実装タスク分割

## 関連 Issue / PR

- Refs #13（親 Issue: idd-claude パイプライン全体設計）
- Refs #89（フェーズ A 既実装: PR iteration watcher）
- Refs #100（フェーズ A 既実装: 追加機能）
- Refs #14（フェーズ A 既実装: 設計 PR）

## 設計判断（確定済み Open Questions）

| # | 問い | 決定 |
|---|---|---|
| Q1 | ブランチモデル | 2-branch model（`BASE_BRANCH` で開発・受け入れ、`PROMOTION_TARGET_BRANCH` で staging/リリース）採用 |
| Q2 | `PROMOTE_MODE` 既定 | `on-demand`（`staged-for-release` ラベル付与時のみ昇格）。`auto` モードは opt-in |
| Q3 | ST チェック名参照 | `ST_CHECK_RUN_NAME` 単一 env 変数で指定。複数チェックが必要な場合は将来拡張 |
| Q4 | `staged-for-release` 付与判別 | source（human / bot）の判別なしで付与を受け入れる |
| Q5 | promote 失敗時 | ログ出力 + `PROMOTE_FAIL_NOTIFY_ISSUE` 指定時に Issue コメントで通知 |

## 確認事項

- `PROMOTION_TARGET_BRANCH` 未設定時に既存挙動（`BASE_BRANCH` のみ運用）が no-op で継続されるか
- `staged-for-release` ラベルを手動付与している既存運用との共存（watcher が誤検知しないか）
- ST チェック名が空の場合のフォールバック動作（promote をスキップするか失敗扱いにするか）
- `PROMOTE_MODE=auto` の発動タイミング（PR merge 直後 vs 定期ポーリング）の確認

## Test plan

設計 PR のため実装コードは含まれません。実装は別 PR（Developer フェーズ）で作成されます。

- [ ] `requirements.md` の EARS 形式 AC に過不足がないか確認
- [ ] `design.md` の File Structure Plan が既存ファイル構成と整合しているか確認
- [ ] `tasks.md` の分割粒度が独立コミット可能か確認
- [ ] 設計判断（Q1〜Q5）が要件と整合しているか確認
- [ ] 後方互換性（`PROMOTION_TARGET_BRANCH` 未設定時の no-op 動作）が設計で担保されているか確認

## 次のステップ

- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
- 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
- やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください

---

この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から `awaiting-design-review` ラベルを外すと実装が自動開始します。

<!-- idd-claude:pr-iteration round=1 last-run=2026-05-20T23:04:30Z no-progress-streak=0 -->