### PR TITLE
spec(#17): Phase D Claude rebase モード + semantic 判定（要件 / 設計 / タスク分割）

### DIFF
--- a/docs/specs/17-phase-d-claude-rebase-semantic/design.md
+++ b/docs/specs/17-phase-d-claude-rebase-semantic/design.md
@@ -1,0 +1,847 @@
+# Design Document
+
+## Overview
+
+**Purpose**: Phase D は、Phase A（#14）と Re-check Processor（#27）が `needs-rebase`
+ラベルで人間判断に回している approved PR を、Claude による rebase で機械的に救済する
+新しい watcher Processor を導入する。Claude rebase の差分が運用者宣言の allowlist
+（`MECHANICAL_PATHS`）に閉じている場合のみ既存 approve を維持して auto-merge へ進め、
+allowlist 外の差分が出た場合は approve を dismissal API で剥がし `ready-for-review` で
+再レビューを誘導する。本機能は `AUTO_REBASE_MODE` 環境変数による明示 opt-in 制で、
+未設定 / `off` / 不正値の場合は本機能導入前と完全に同一の挙動を保つ。
+
+**Users**: idd-claude の watcher 運用者（Phase A 既導入の cron / launchd オペレータ）と、
+当該 repo の PR を approve する人間レビュワー。前者は Phase D を有効化することで
+lockfile 等の機械的 conflict を自動消化でき、後者は semantic 書き換えが自動 merge を
+バイパスしないことの保証を得る。
+
+**Impact**: 現在の watcher は `needs-rebase` を付けた時点で当該 PR を「人間が解消する
+までは何も触らない」状態にしていた。Phase D 導入後は、運用者が opt-in した repo に
+限り、`needs-rebase` 付き approved PR が新たな Processor に流れ込み、Claude rebase
+結果の path filter 判定に基づいて 3 つの結末（`mechanical` / `semantic` / `failed`）
+のいずれかに分類される。Phase A / Re-check の挙動・既存ラベル・既存 env var・既存
+cron 登録文字列はすべて不変（NFR 1.1〜1.5）。
+
+### Goals
+
+- approved + `needs-rebase` 状態で停滞する PR を、運用者が宣言した範囲で自動解消する
+  経路を `AUTO_REBASE_MODE` opt-in で提供する
+- `MECHANICAL_PATHS` allowlist で「人間レビュー不要」と宣言された path に閉じる
+  rebase だけを `mechanical` 扱いとし、approve を維持して auto-merge に到達させる
+- allowlist 外の差分（= semantic 判断含む）が出た場合は approve を確実に dismissal
+  し、`ready-for-review` ラベルと再レビュー誘導コメントで人間 gate に戻す
+- rebase 失敗（conflict / timeout / push / dismissal API エラー）はすべて
+  `claude-failed` ラベルと原因種別コメントで人間エスカレートする
+- `AUTO_REBASE_MODE` 未設定 / `off` / 不正値で挙動不変（後方互換性絶対）
+- watcher の `shellcheck` 警告ゼロを維持し、log prefix `auto-rebase:` で grep 観測可能
+
+### Non-Goals
+
+- 予防的 overlap 検知（Phase E / #18 のスコープ）
+- AST diff による意味的差分判定（言語依存度が高いため対象外。allowlist 方式で start）
+- Claude 自己申告方式の `mechanical` / `semantic` 判定（精度・再現性が allowlist より
+  劣るため本設計では採用しない。Open Questions Q2 で fallback 余地のみ言及）
+- `needs-rebase` ラベルが付かない通常 PR への介入（Phase A の対象外）
+- Phase A 本体（#14）/ Re-check Processor（#27）/ PR Iteration（#26）の挙動変更
+- `MECHANICAL_PATHS` の既定値として特定言語の lockfile 名を内蔵すること（NFR 3.2）
+- 外部 Feature Flag SaaS との連携
+
+## Architecture
+
+### Existing Architecture Analysis
+
+`local-watcher/bin/issue-watcher.sh` は 1 つの bash プロセスが flock で多重起動を防ぎつつ、
+複数の Processor を**直列に**実行する単一スクリプト構成。各 Processor は
+`process_<name>()` 関数として定義され、グローバル env / ラベル / GitHub API を
+共有する。Phase D が尊重すべき既存パターン:
+
+- **Opt-in / opt-out gate**: 各 Processor の冒頭で `[ "$<FLAG>" != "true" ]` または
+  `[ "$<FLAG>" == "false" ]` で早期 return（`MERGE_QUEUE_ENABLED` / `PROMOTE_PIPELINE_ENABLED`
+  等が両パターンの実例）。Phase D は #15 Promote Pipeline と同じ **opt-in 制**（既定 OFF）
+- **Logger 三点セット**: `<prefix>_log` / `<prefix>_warn` / `<prefix>_error`
+  （`mq_*` / `mqr_*` / `pi_*` / `drr_*` / `pp_*` / `qa_*` / `sav_*`）
+- **Log prefix 規約**: `[YYYY-MM-DD HH:MM:SS] [$REPO] <processor>:` の 3 段 prefix
+  （Issue #119）。grep 抽出を機械化するため
+- **GitHub API 呼び出し**: `gh pr list --search` で server-side filter、`jq` で
+  client-side fail-safe filter、`timeout` でサブプロセスごとに個別 timeout
+- **PR ラベル判定**: `mq_pr_has_label` / `drr_already_processed` のように
+  `jq -e ... | map(.name) | index($l)` でラベル配列を走査
+- **競合排除**: `process_merge_queue_recheck` が `needs-rebase` を除去し終えてから
+  `process_merge_queue` が新規付与する**順序依存**で、同一 PR を同サイクルで二重処理
+  しない。Phase D もこの直列順序の延長で挿入する
+- **dirty working tree 取り扱い**: cycle 冒頭で `git status --porcelain` を check し
+  dirty なら `watcher:` prefix で `action=escalate` ログを出し exit 1（Issue #119）
+- **rebase 失敗 rollback**: `mq_try_rebase_pr` が `(subshell + trap)` で
+  `git rebase --abort` + `git checkout $BASE_BRANCH` を保証
+- **強い force push 抑制**: `git push --force-with-lease` のみ使用、`--force` 単独は禁止
+
+解消・回避する technical debt は無し（Phase D は既存実装には触れず、純粋に新規追加）。
+
+### Architecture Pattern & Boundary Map
+
+採用パターン: **Phase A 系列の Processor を 1 段追加する pipeline 拡張**。
+新規 Processor `process_auto_rebase()` を Phase A 本体（`process_merge_queue`）の
+**直後**に挿入する。順序設計は Req 3.1〜3.3 を構造的に保証するため:
+
+```mermaid
+flowchart LR
+    A[process_quota_resume] --> B[process_merge_queue_recheck]
+    B -->|MERGEABLE な PR から<br/>needs-rebase 除去| C[process_merge_queue]
+    C -->|stale base PR を rebase / <br/>conflict PR に needs-rebase 付与| D[process_auto_rebase]
+    D -->|needs-rebase + approved PR の<br/>Claude rebase + path 判定| E[process_promote_pipeline]
+    E --> F[process_pr_iteration]
+    F --> G[process_design_review_release]
+    G --> H[Issue 処理ループ]
+
+    classDef new fill:#fef3c7,stroke:#d97706,stroke-width:2px
+    class D new
+```
+
+**順序根拠（Req 3.1〜3.3）**:
+
+1. **Re-check が最初**: `mergeable=MERGEABLE` に戻った PR の `needs-rebase` を Re-check
+   が除去し終えた後で Phase D が候補抽出するため、Phase D は本来 Re-check が解消できる
+   PR を二重処理しない（Req 3.2）
+2. **Phase A 本体が次**: 新規 `CONFLICTING` PR への `needs-rebase` 付与は Phase D の
+   前段で確定する。これにより Phase D の処理結果（`needs-rebase` 除去 / `claude-failed`
+   付与）が同一サイクル内で Phase A により上書きされない（Req 3.1）
+3. **Phase D が最後の rebase レーン**: 上記 2 段が触らなかった PR のみが Phase D に
+   渡るため、ラベル状態遷移は単一 Processor の責務として閉じる（Req 3.3）
+
+```mermaid
+stateDiagram-v2
+    [*] --> Approved
+    Approved --> NeedsRebase: Phase A が conflict 検知
+    NeedsRebase --> Approved: Re-check が MERGEABLE 検知
+    NeedsRebase --> Mechanical: Phase D rebase + path=allowlist
+    NeedsRebase --> Semantic: Phase D rebase + path 外あり
+    NeedsRebase --> Failed: Phase D rebase / push / dismissal 失敗
+    Mechanical --> [*]: needs-rebase 除去, approve 維持, auto-merge へ
+    Semantic --> ReadyForReview: approve dismiss + needs-rebase 除去 + ready-for-review 付与
+    Failed --> HumanEscalation: claude-failed 付与, needs-rebase 残置
+```
+
+**Architecture Integration**:
+
+- 採用パターン: 既存 Processor pipeline への 1 段追加（独立した bash プロセスや
+  サブシステムは作らない）
+- ドメイン境界: rebase レーン（Phase D）と既存 ラベル付与 / 除去レーン（Phase A 本体 /
+  Re-check）を時系列で分離。同一 PR は同サイクルで高々 1 段にのみ触れる
+- 既存パターンの維持: opt-in gate / logger 三点セット / log prefix 3 段 / `gh pr list
+  --search` + `jq` filter / `timeout` per-subprocess / `(subshell + trap)` rollback /
+  `--force-with-lease` 限定
+- 新規コンポーネントの根拠: Claude 起動 + path filter 判定 + dismissal API 呼び出しは
+  既存のどの Processor とも責務が異なる（Re-check は label 除去のみ、Phase A 本体は
+  非 Claude rebase のみ、PR Iteration は head branch への commit を Claude に任せるが
+  approve dismissal や path filter は持たない）
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Runtime | bash 4+ | Processor 関数 / Claude CLI 起動 | 既存と同一。Node.js / Python 等の依存追加なし（NFR 3.1） |
+| GitHub API client | `gh` CLI（既存依存） | PR 取得 / ラベル付与・除去 / approve dismissal / コメント投稿 | `gh api -X PUT .../pulls/{n}/reviews/{id}/dismissals` を新規利用 |
+| JSON 処理 | `jq` | server filter の保険 / path filter / review id 抽出 | 既存依存 |
+| Git 操作 | `git`（local clone） | `git fetch` / `git rebase` / `git push --force-with-lease` / `git diff` | 既存と同一。Phase A の `mq_try_rebase_pr` パターンを踏襲 |
+| LLM 実行 | `claude` CLI（既存依存） | conflict 解消の 1 round 試行 | `--print` + `--model` + `--max-turns` + `--permission-mode bypassPermissions` で PR Iteration と同形式 |
+| プロセス制御 | `timeout` | Claude 試行 / `gh` / `git` の個別 timeout | `AUTO_REBASE_MAX_TURNS` と `AUTO_REBASE_GIT_TIMEOUT` で制御 |
+| 多重起動防止 | `flock`（既存） | 既存 LOCK_FILE 内で直列実行 | 新規ロックは追加しない |
+
+## File Structure Plan
+
+Phase D は新規ファイル 2 件 + 既存ファイル 4 件への追記で構成する。
+
+### Modified Files（追加・拡張）
+
+```
+local-watcher/
+└── bin/
+    ├── issue-watcher.sh             # +Phase D の env / 関数群 / orchestration 呼出
+    └── auto-rebase-prompt.tmpl      # NEW: Claude rebase 用 prompt template
+
+repo-template/
+└── CLAUDE.md                        # +Phase D 紹介を「オプション機能一覧」相当節へ追加（任意）
+
+.github/scripts/
+└── idd-claude-labels.sh             # +needs-rebase ラベルの description 更新（Phase D で再評価される旨を補足、任意）
+
+README.md                            # +オプション機能一覧に AUTO_REBASE_MODE / MECHANICAL_PATHS を追加
+                                     #   +言語別 MECHANICAL_PATHS 設定例（JS / Python / Go / Rust）
+                                     #   +Branch protection との相互作用注記
+                                     #   +Open Questions Q4 (stale approval dismiss) の対処方針
+
+docs/specs/17-phase-d-claude-rebase-semantic/
+├── requirements.md                  # 既存（PM 成果物、変更しない）
+├── design.md                        # 本ドキュメント
+└── tasks.md                         # tasks.md（本設計と同時に作成）
+```
+
+**`local-watcher/bin/issue-watcher.sh` への追加領域（実装者向け）**:
+
+| 追加領域 | 配置位置（既存コードとの相対位置） | 責務 |
+|---|---|---|
+| Phase D Config block | 既存 Phase A Re-check Config (#27) 直後、`# ─── PR Iteration Processor 設定 (#26) ───` の前 | `AUTO_REBASE_MODE` / `MECHANICAL_PATHS` / `AUTO_REBASE_MODEL` / `AUTO_REBASE_MAX_TURNS` / `AUTO_REBASE_GIT_TIMEOUT` / `AUTO_REBASE_MAX_PRS` の env var 解決と既定値 |
+| Phase D 起動値正規化 | 既存「デフォルト有効化フラグの値正規化」ループ**外**で `AUTO_REBASE_MODE` のみ別途正規化（既定 OFF の opt-in のため、対象 9 種に含めない） | `off` / `claude` / 不正値 → `off` 統合（Req 1.3） |
+| Phase D template 存在チェック | 既存 ITERATION_TEMPLATE check の直後 | `AUTO_REBASE_MODE != off` のときのみ `auto-rebase-prompt.tmpl` の存在を必須化（opt-in gate） |
+| Phase D Processor 関数群 | `process_merge_queue` 関数（L959〜L1090）の直後に挿入 | 詳細は下記「Components and Interfaces」参照 |
+| Phase D orchestration 呼出 | `process_merge_queue || mq_warn ...`（L1233）の**直後**に 1 行追加 | `process_auto_rebase || ar_warn "..."` の 1 行（後続 Processor を阻害しない） |
+| Phase D サイクル開始ログ | `process_auto_rebase` 冒頭で `ar_log "サイクル開始 (mode=..., paths=..., max_prs=..., model=..., max_turns=..., timeout=...s)"` を 1 件出力（Req 1.4） | 運用者が grep `'auto-rebase: サイクル開始'` で確認可 |
+
+**`local-watcher/bin/auto-rebase-prompt.tmpl`（新規 template）**:
+
+- `iteration-prompt.tmpl` と同じプレースホルダ展開方式（`{{KEY}}` を `awk` 置換）。
+  install.sh 既存の `copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.tmpl" "$HOME/bin"`
+  で自動配置される（install.sh 変更不要）
+- プレースホルダ: `{{REPO}}` / `{{PR_NUMBER}}` / `{{PR_TITLE}}` / `{{PR_URL}}` /
+  `{{HEAD_REF}}` / `{{BASE_REF}}` / `{{BASE_BRANCH}}`
+- Claude への指示: 「base ref を head に rebase し、conflict 解消後 working tree
+  clean な状態で終了する。force push / dismissal / label 操作は watcher が行う
+  ので Claude 側では行わない」
+- 禁止事項: `git push` 全般 / `gh pr review` / `gh pr edit --add-label` / `gh pr
+  comment` を厳禁とする。Claude の責務は **rebase 実行 + conflict 解消のみ**
+
+## Requirements Traceability
+
+| Req ID | 要件サマリ | 設計上の対応 |
+|---|---|---|
+| 1.1 | `AUTO_REBASE_MODE` 未設定 / `off` で Phase D 不起動 | `process_auto_rebase` 冒頭の `[ "$AUTO_REBASE_MODE" = "off" ]` 早期 return |
+| 1.2 | 有効化値で各サイクル起動 | `process_auto_rebase` の orchestration 呼出（L1233 直後） |
+| 1.3 | 不正値 → `off` 等価 | Config block の正規化（`off` / `claude` 以外を `off` に固定） |
+| 1.4 | 現在値をサイクル開始時に log | `ar_log "サイクル開始 (mode=${AUTO_REBASE_MODE}, ...)"` + opt-out 時の 1 行 INFO log |
+| 2.1 | `needs-rebase` + approved + open のみ対象 | `gh pr list --search "review:approved label:\"needs-rebase\" -label:\"claude-failed\" -draft:true"` |
+| 2.2 | `claude-failed` 付き PR を除外 | 上記 search の `-label:"$LABEL_FAILED"` |
+| 2.3 | draft 除外 | 上記 search の `-draft:true` + jq client filter |
+| 2.4 | fork PR 除外 | jq filter `select((.headRepositoryOwner.login // "") == $owner)`（Phase A と同パターン） |
+| 2.5 | head branch pattern 整合 | jq filter `select(.headRefName \| test($pattern))` で `MERGE_QUEUE_HEAD_PATTERN` を再利用 |
+| 3.1 | 1 PR を 1 段でしか処理しない | Re-check → Phase A → Phase D の直列順序による構造的排他 |
+| 3.2 | Re-check が解消可能なら Phase D 起動しない | Re-check が Phase D の前に走り `needs-rebase` を除去するため、Phase D 候補に上がらない |
+| 3.3 | Phase D 処理 PR を Re-check が同サイクルで触らない | Re-check は Phase D より前に 1 回だけ走るため、Phase D 後に Re-check は起動しない |
+| 3.4 | サマリログ 1 行出力 | `ar_log "サマリ: mechanical=N, semantic=N, failed=N, skip=N, overflow=N"` |
+| 4.1 | rebase を Claude 経由で 1 回試行 | `ar_run_claude_rebase` で `claude --print ... --max-turns ...` を 1 回起動 |
+| 4.2 | 前後 SHA 記録 | `git rev-parse HEAD` を rebase 前後で取得しログに出力 |
+| 4.3 | 累積 diff（base 比較）取得 | `git diff --name-only "origin/${base_ref}".."${head_ref}"` を判定入力に使用 |
+| 4.4 | Claude conflict 解消失敗 → `claude-failed` + コメント 1 件 | `ar_escalate_to_failed` 関数で原因種別 `conflict-unresolved` を渡す |
+| 4.5 | Claude タイムアウト → `claude-failed` | `timeout "$AUTO_REBASE_MAX_TURNS_SEC"` で wrap し exit 124 を `timeout` として判定 |
+| 4.6 | `--force-with-lease` のみ使用 | `git push --force-with-lease` の 1 系統のみ実装（`--force` 単独は実装しない） |
+| 5.1 | rebase 後 diff の変更ファイル一覧を allowlist 照合 | `ar_classify_diff` 関数が `git diff --name-only` と `MECHANICAL_PATHS` を照合 |
+| 5.2 | 全 path 一致 → `mechanical` | `ar_classify_diff` で全件 match なら `echo mechanical` |
+| 5.3 | 1 件でも一致しない → `semantic` | `ar_classify_diff` で 1 件 unmatch なら `echo semantic`（保守的判定） |
+| 5.4 | `MECHANICAL_PATHS` 未設定 / 空 → 全件 `semantic` | `ar_classify_diff` で `[ -z "$MECHANICAL_PATHS" ]` なら早期に `semantic` 返却 |
+| 5.5 | 判定結果をログに明示 | `ar_log "PR #${pr_number}: classification=mechanical/semantic ..."` |
+| 6.1 | `mechanical` 時 approve 維持 | dismissal API を呼ばない（`ar_apply_mechanical` 関数の責務は label 除去のみ） |
+| 6.2 | `mechanical` 時 `needs-rebase` 除去 | `gh pr edit --remove-label "$LABEL_NEEDS_REBASE"` |
+| 6.3 | `mechanical` 時 追加コメント無し | `ar_apply_mechanical` はコメント投稿 API を呼ばない |
+| 6.4 | Merge Queue 系処理が通常通り扱える状態に戻す | `needs-rebase` 除去後、次サイクルで Re-check / Phase A 本体が当該 PR を再評価可能 |
+| 7.1 | `semantic` 時 approving review すべて dismiss | `ar_dismiss_all_approvals` 関数が `gh api -X PUT /repos/.../reviews/{id}/dismissals` を全件 loop |
+| 7.2 | `semantic` 時 `needs-rebase` 除去 | `ar_apply_semantic` 関数で `gh pr edit --remove-label "$LABEL_NEEDS_REBASE"` |
+| 7.3 | `semantic` 時 `ready-for-review` 付与 | `ar_apply_semantic` 関数で `gh pr edit --add-label "$LABEL_READY"` |
+| 7.4 | `semantic` 時 説明コメント 1 件投稿 | `ar_apply_semantic` 関数で heredoc コメント（rebase 実施・semantic 判定・dismissal・再レビュー要求の理由）を投稿 |
+| 7.5 | dismissal を review dismissal 機構で行う | `gh api -X PUT .../reviews/{review_id}/dismissals` を使用、`gh pr review --request-changes` は使わない |
+| 7.6 | dismissal API 失敗 → `claude-failed` + コメント 1 件 | `ar_dismiss_all_approvals` が non-zero を返したら `ar_escalate_to_failed` を原因種別 `dismissal-failed` で呼ぶ |
+| 8.1 | rebase 失敗時 `needs-rebase` 除去しない | `ar_escalate_to_failed` 関数は `needs-rebase` を触らない |
+| 8.2 | rebase 失敗時 `claude-failed` 付与 | `ar_escalate_to_failed` 関数の最初の API 呼出 |
+| 8.3 | `claude-failed` 付与時 原因種別 + 復旧手順コメント 1 件 | `ar_escalate_to_failed` の heredoc コメント（種別: `conflict-unresolved` / `timeout` / `push-failed` / `dismissal-failed`） |
+| 8.4 | `claude-failed` 付き PR は再試行しない | `gh pr list --search` の `-label:"$LABEL_FAILED"` で server 側除外（既存 Phase A と同じ pattern） |
+| 9.1 | README に `AUTO_REBASE_MODE` 仕様を記載 | README「オプション機能一覧」節 + 「Auto Rebase Processor (Phase D)」新規節 |
+| 9.2 | README に `MECHANICAL_PATHS` 既定空 / 空時挙動を記載 | 同上 |
+| 9.3 | 言語別設定例（JS / Python / Go / Rust） | 新規節に 4 言語の typical lockfile pattern を 1 例ずつ列挙 |
+| 9.4 | dogfood 検証 | idd-claude 自身に `AUTO_REBASE_MODE=claude` / `MECHANICAL_PATHS=package-lock.json` を設定し、watcher ログを観測 |
+| NFR 1.1 | 未設定で挙動不変 | Phase D の env をすべて opt-in（既定 `off` / 空）にし、early return で起動しない |
+| NFR 1.2 | 既存 env var 名・既定値不変 | 既存 9 種 + Phase A 系の env var はいっさい改変しない |
+| NFR 1.3 | 既存ラベル名・意味不変 | `needs-rebase` / `claude-failed` / `ready-for-review` の semantics は維持 |
+| NFR 1.4 | 既存 cron 登録文字列不変 | cron 側で何も追加しなくても起動できる（既定 OFF） |
+| NFR 1.5 | 既存 exit code 不変 | Phase D の異常は `ar_warn` で吸収し、watcher 全体の exit code には反映しない |
+| NFR 2.1 | 1 PR 1 行 ログ（PR 番号 / 判定 / アクション要約） | `ar_log "PR #${pr_number}: classification=... action=..."` |
+| NFR 2.2 | サマリ行 1 件 | `ar_log "サマリ: mechanical=N, semantic=N, failed=N, skip=N, overflow=N"` |
+| NFR 3.1 | 言語ランタイム導入なし | bash / `gh` / `jq` / `git` / `claude` のみ。Node.js / Python は導入しない |
+| NFR 3.2 | `MECHANICAL_PATHS` 既定空 | Config block で `MECHANICAL_PATHS="${MECHANICAL_PATHS:-}"`（空既定） |
+| NFR 4.1 | `shellcheck` 警告ゼロ | 既存 Processor と同パターンの quoting / `command -v` / `>&2` を踏襲 |
+| NFR 5.1 | Claude rebase に observable timeout | `AUTO_REBASE_MAX_TURNS_SEC`（既定 600）を `timeout` で wrap |
+| NFR 5.2 | 失敗時 working tree / base branch 復帰 | `(subshell + trap)` で `git rebase --abort` + `git checkout "$BASE_BRANCH"`（Phase A `mq_try_rebase_pr` パターン踏襲） |
+| NFR 5.3 | force push は `--force-with-lease` のみ | 実装に `--force` 単独は登場させない |
+
+## Components and Interfaces
+
+### Phase D Processor Layer（`local-watcher/bin/issue-watcher.sh` に集約）
+
+#### `process_auto_rebase()`
+
+| Field | Detail |
+|-------|--------|
+| Intent | Phase D のエントリ関数。1 watcher サイクル内で `needs-rebase` + approved + open な PR を抽出し、Claude rebase 試行 + 判定 + ラベル / dismissal 操作を順次実行する |
+| Requirements | 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 2.5, 3.1, 3.4, NFR 2.2 |
+
+**Responsibilities & Constraints**
+
+- opt-in gate（`AUTO_REBASE_MODE != off`）で早期 return
+- dirty working tree check（Phase A `process_merge_queue` と同 pattern、検知時は ERROR + 0 return）
+- 候補 PR 取得（server filter + jq client filter + fork 除外）
+- 候補件数を `AUTO_REBASE_MAX_PRS` で上限制御し overflow を次サイクルへ持ち越し
+- 各 PR について `ar_handle_pr` を呼び、戻り値で `mechanical` / `semantic` / `failed` / `skip` を集計
+- サマリ行を 1 件出力（Req 3.4 / NFR 2.2）
+
+**Dependencies**
+
+- Inbound: orchestration（`process_merge_queue || ...` の直後に呼ばれる）— Critical
+- Outbound: `ar_fetch_candidates` / `ar_handle_pr` / `ar_log` / `ar_warn` — Critical
+- External: `gh pr list` / `jq` — Critical
+
+**Contracts**: Service [x] / API [ ] / Event [ ] / Batch [x] / State [ ]
+
+##### Service Interface
+
+```bash
+process_auto_rebase() {
+  # 入力: グローバル env（AUTO_REBASE_MODE / MECHANICAL_PATHS / AUTO_REBASE_* / REPO / LABEL_* / BASE_BRANCH）
+  # 出力: stdout に ar_log 形式の運用ログ、stderr に ar_warn / ar_error
+  # 戻り値: 常に 0（後続 Processor を阻害しない）。内部失敗は ar_warn で吸収
+}
+```
+
+- Preconditions:
+  - watcher cycle 内で flock 取得済み
+  - `BASE_BRANCH` に checkout 済み、working tree clean
+- Postconditions:
+  - サイクル開始ログ + サマリ行が必ず出力される（mechanical / semantic / failed / skip / overflow の 0 件含む）
+  - 各 PR の処理結果に応じて GitHub 側ラベル / approve 状態が遷移している
+- Invariants:
+  - Phase D で触る PR は `needs-rebase` ラベル + 1 件以上 approving review を持つ open 非 draft PR のみ
+  - サブシェル / trap で `git rebase --abort` + `git checkout "$BASE_BRANCH"` を保証
+
+#### `ar_fetch_candidates()`
+
+| Field | Detail |
+|-------|--------|
+| Intent | Phase D 候補 PR を `gh pr list --search` + jq filter で取得して JSON 配列を stdout に返す |
+| Requirements | 2.1, 2.2, 2.3, 2.4, 2.5, 8.4 |
+
+```bash
+ar_fetch_candidates() {
+  # 出力: jq 配列（headRefName / baseRefName / number / url / labels / isDraft /
+  #       reviewDecision / headRepositoryOwner を含む）
+  # 戻り値: 0=正常（候補ゼロ件含む） / 1=API エラー（呼び出し側で WARN）
+}
+```
+
+Server-side filter（既存 Phase A Re-check の踏襲）:
+
+```text
+review:approved label:"needs-rebase" -label:"claude-failed" -draft:true
+```
+
+Client-side jq filter:
+
+- `isDraft == false` の再確認
+- `reviewDecision == "APPROVED"` の再確認
+- `headRefName | test($MERGE_QUEUE_HEAD_PATTERN)` で人間 PR 除外
+- `headRepositoryOwner.login == $owner` で fork 除外
+
+#### `ar_handle_pr(pr_json)`
+
+| Field | Detail |
+|-------|--------|
+| Intent | 1 PR の Phase D 処理を実行（rebase 試行 → 分類 → mechanical/semantic 後処理 / 失敗時 escalate） |
+| Requirements | 3.4, 4.1〜4.6, 5.1〜5.5, 6.1〜6.4, 7.1〜7.6, 8.1〜8.3, NFR 2.1, NFR 5.2 |
+
+```bash
+ar_handle_pr() {
+  # 入力: $1 = pr_json（gh pr list の 1 要素）
+  # 戻り値:
+  #   0  : mechanical 完了
+  #   1  : semantic 完了
+  #   2  : failed（claude-failed 付与済み）
+  #   10 : skip（push 待ち UNKNOWN 等、次サイクルに委ねる）
+}
+```
+
+処理フロー:
+
+1. PR 情報展開（number / head_ref / base_ref / url）
+2. `ar_run_claude_rebase` を呼ぶ — 成功すれば head は rebased 状態、失敗（conflict /
+   timeout / push）なら `ar_escalate_to_failed` で原因種別を渡し戻り値 2
+3. rebase 成功時、`git diff --name-only "origin/${base_ref}".."${head_ref}"` を取得し
+   `ar_classify_diff` に渡して `mechanical` / `semantic` を判定
+4. `mechanical` なら `ar_apply_mechanical` を呼ぶ — `needs-rebase` 除去のみ
+5. `semantic` なら `ar_apply_semantic` を呼ぶ — approve dismissal + ラベル遷移 +
+   コメント投稿。dismissal API 失敗時は `ar_escalate_to_failed` で `dismissal-failed`
+   原因種別を渡す
+6. 1 行サマリログ `ar_log "PR #${pr_number}: classification=... before_sha=... after_sha=... action=..."` を出力（NFR 2.1）
+
+#### `ar_run_claude_rebase(pr_number, head_ref, base_ref)`
+
+| Field | Detail |
+|-------|--------|
+| Intent | Claude CLI を 1 回起動して conflict 解消 rebase を試行し、成功すれば force-with-lease push する |
+| Requirements | 4.1, 4.2, 4.3, 4.5, 4.6, NFR 5.1, NFR 5.2, NFR 5.3 |
+
+```bash
+ar_run_claude_rebase() {
+  # 入力: $1=pr_number, $2=head_ref, $3=base_ref
+  # 出力（stdout 1 行）: "<before_sha> <after_sha>" 成功時、空文字 失敗時
+  # 戻り値:
+  #   0 : rebase + push 成功
+  #   1 : Claude が conflict を解消できず終了
+  #   2 : timeout
+  #   3 : push 失敗
+  #   4 : その他（fetch / checkout 失敗等）
+}
+```
+
+実装パターン（Phase A `mq_try_rebase_pr` を踏襲しつつ Claude を組み込む）:
+
+```bash
+(
+  set +e
+  trap "git rebase --abort >/dev/null 2>&1; git checkout '$BASE_BRANCH' >/dev/null 2>&1" EXIT
+
+  timeout "$AUTO_REBASE_GIT_TIMEOUT" git fetch origin "$head_ref" "$base_ref" || exit 4
+  timeout "$AUTO_REBASE_GIT_TIMEOUT" git checkout -B "$head_ref" "origin/$head_ref" || exit 4
+  before_sha=$(git rev-parse HEAD)
+
+  # Claude prompt を組み立て、--print + --max-turns で起動。
+  # AUTO_REBASE_MAX_TURNS_SEC で外側 timeout、AUTO_REBASE_MAX_TURNS で turn 数上限。
+  prompt=$(ar_build_prompt "$pr_number" "$head_ref" "$base_ref")
+  log_file="$LOG_DIR/auto-rebase-${pr_number}-$(date +%Y%m%d-%H%M%S).log"
+
+  timeout "$AUTO_REBASE_MAX_TURNS_SEC" \
+    claude --print "$prompt" \
+           --model "$AUTO_REBASE_MODEL" \
+           --permission-mode bypassPermissions \
+           --max-turns "$AUTO_REBASE_MAX_TURNS" \
+           --output-format stream-json \
+           --verbose \
+      >>"$log_file" 2>&1
+  claude_rc=$?
+
+  # exit 124 = timeout（Req 4.5）
+  if [ "$claude_rc" -eq 124 ]; then
+    git rebase --abort >/dev/null 2>&1 || true
+    exit 2
+  fi
+
+  # working tree が dirty なら Claude が conflict 解消半端 → conflict-unresolved
+  if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    git rebase --abort >/dev/null 2>&1 || true
+    exit 1
+  fi
+
+  # before_sha と差分が無い場合は rebase 不要（Re-check が拾うべきケース、skip 扱い）
+  after_sha=$(git rev-parse HEAD)
+  if [ "$before_sha" = "$after_sha" ] && \
+     git merge-base --is-ancestor "origin/$base_ref" "origin/$head_ref"; then
+    printf '%s %s\n' "$before_sha" "$after_sha"
+    exit 5  # skip code（後段で 10 に正規化）
+  fi
+
+  timeout "$AUTO_REBASE_GIT_TIMEOUT" \
+    git push --force-with-lease origin "$head_ref" || exit 3
+
+  printf '%s %s\n' "$before_sha" "$after_sha"
+  exit 0
+)
+```
+
+- Preconditions: head_ref が origin に存在、base_ref も origin に存在
+- Postconditions: 成功時は origin の head_ref が新しい SHA に進んでいる。失敗時は
+  trap で working tree と branch が clean な状態に rollback されている
+- Invariants: `git push --force` 単独は呼ばない。timeout / fetch / push の各
+  サブプロセスに individual timeout を必ず適用（既存 Phase A と同じ pattern）
+
+#### `ar_classify_diff(pr_number, base_ref, head_ref)`
+
+| Field | Detail |
+|-------|--------|
+| Intent | rebase 後 head と base 間の累積 diff の path 集合を `MECHANICAL_PATHS` allowlist と照合し `mechanical` / `semantic` を判定 |
+| Requirements | 5.1, 5.2, 5.3, 5.4, 5.5 |
+
+```bash
+ar_classify_diff() {
+  # 入力: $1=pr_number, $2=base_ref, $3=head_ref
+  # 出力（stdout 1 行）: "mechanical" or "semantic"
+  # 戻り値: 0=正常、1=git diff 失敗（呼び出し側で claude-failed に分岐するかは
+  #         要件範囲外。本設計では 1 を「semantic 同等扱い」とし保守的に倒す）
+}
+```
+
+判定ロジック:
+
+```bash
+# 1. MECHANICAL_PATHS が空なら全件 semantic（Req 5.4 保守的判定）
+if [ -z "$MECHANICAL_PATHS" ]; then
+  echo "semantic"
+  return 0
+fi
+
+# 2. 変更 path 一覧取得
+changed_paths=$(timeout "$AUTO_REBASE_GIT_TIMEOUT" \
+  git diff --name-only "origin/${base_ref}".."${head_ref}" 2>/dev/null) || {
+  echo "semantic"  # 取得失敗時も保守的に semantic
+  return 1
+}
+
+# 3. MECHANICAL_PATHS を `,` 区切りで配列展開
+IFS=',' read -ra patterns <<< "$MECHANICAL_PATHS"
+
+# 4. 各 path について「いずれかの pattern に一致」を確認
+while IFS= read -r path; do
+  [ -z "$path" ] && continue
+  matched=false
+  for pattern in "${patterns[@]}"; do
+    # 前後空白除去
+    pattern="${pattern# }"; pattern="${pattern% }"
+    [ -z "$pattern" ] && continue
+    # POSIX bash の path matching（`==` + glob）
+    # shellcheck disable=SC2053
+    if [[ "$path" == $pattern ]]; then
+      matched=true
+      break
+    fi
+  done
+  if [ "$matched" = "false" ]; then
+    echo "semantic"  # 1 件でも外れたら即 semantic（Req 5.3 保守的判定）
+    return 0
+  fi
+done <<< "$changed_paths"
+
+echo "mechanical"  # 全 path 一致（Req 5.2）
+return 0
+```
+
+**`MECHANICAL_PATHS` 構文（Open Questions Q3 への設計回答）**:
+
+- カンマ区切り（既存の `MERGE_QUEUE_HEAD_PATTERN` がパイプ区切り正規表現なのに対し、
+  本設計では glob を扱うためカンマ区切りとする。改行区切りは cron / launchd の env
+  渡しで扱いにくいため不採用）
+- 各 pattern は bash `[[ str == glob ]]` の glob 構文（`*` / `?` / `[abc]`）に従う。
+  正規表現は使用しない（言語非依存性と既定空（NFR 3.2）の整合を保つため）
+- 例: `package-lock.json` / `**/package-lock.json` / `*.lock` / `Cargo.lock,go.sum`
+
+**ログ出力**: `ar_log "PR #${pr_number}: classification=mechanical paths=N"` または
+`ar_log "PR #${pr_number}: classification=semantic unmatch=<first_unmatched_path>"`（Req 5.5）
+
+#### `ar_apply_mechanical(pr_number)`
+
+| Field | Detail |
+|-------|--------|
+| Intent | mechanical 判定後の副作用（`needs-rebase` 除去のみ）を実行 |
+| Requirements | 6.1, 6.2, 6.3, 6.4 |
+
+```bash
+ar_apply_mechanical() {
+  # 入力: $1=pr_number
+  # 戻り値: 0=成功、1=label 除去 API 失敗（呼び出し側で WARN）
+  timeout "$AUTO_REBASE_GIT_TIMEOUT" gh pr edit "$pr_number" --repo "$REPO" \
+    --remove-label "$LABEL_NEEDS_REBASE"
+}
+```
+
+- approving review への副作用なし（Req 6.1）
+- 追加コメント投稿なし（Req 6.3）— 「lockfile-only 等の機械的 rebase は人間 noise を
+  最小化する」設計意図
+- ラベル除去成功後、次サイクルで Re-check / Phase A 本体が当該 PR を再評価可能（Req 6.4）
+
+#### `ar_apply_semantic(pr_number, pr_url)`
+
+| Field | Detail |
+|-------|--------|
+| Intent | semantic 判定時の副作用（approve dismissal + ラベル遷移 + 説明コメント）を実行 |
+| Requirements | 7.1, 7.2, 7.3, 7.4, 7.5, 7.6 |
+
+```bash
+ar_apply_semantic() {
+  # 入力: $1=pr_number, $2=pr_url（コメント内引用用）
+  # 戻り値: 0=全成功、1=dismissal 失敗（呼び出し側で escalate）、2=label / comment 失敗
+  #
+  # 1. ar_dismiss_all_approvals を呼ぶ
+  # 2. needs-rebase 除去
+  # 3. ready-for-review 付与
+  # 4. 説明コメント投稿
+}
+```
+
+コメント本文（heredoc）には以下を含める（Req 7.4）:
+
+- rebase 実施の事実（`before_sha` → `after_sha`）
+- semantic 判定の理由（変更 path のうち allowlist 外のもの）
+- approve dismissal を行った旨（手動再 approve 推奨）
+- `ready-for-review` 付与の意味と次のアクション
+- hidden marker `<!-- idd-claude:auto-rebase pr=${pr_number} -->`（将来の重複投稿抑止用）
+
+#### `ar_dismiss_all_approvals(pr_number)`
+
+| Field | Detail |
+|-------|--------|
+| Intent | PR の approving review を **review dismissal 機構**（`gh api -X PUT .../reviews/{id}/dismissals`）で全件 dismiss する |
+| Requirements | 7.1, 7.5, 7.6 |
+
+```bash
+ar_dismiss_all_approvals() {
+  # 入力: $1=pr_number
+  # 戻り値: 0=全 approving review の dismissal が成功、1=1 件でも失敗
+  #
+  # 1. gh api "/repos/${REPO}/pulls/${pr_number}/reviews" で全 review を取得
+  # 2. jq で state == "APPROVED" のものだけ id を抽出
+  # 3. 各 id に対して
+  #    gh api -X PUT "/repos/${REPO}/pulls/${pr_number}/reviews/{id}/dismissals" \
+  #           -f message="Phase D semantic rebase: re-review required"
+  #    を呼ぶ（1 件でも失敗したら戻り値 1）
+}
+```
+
+##### API Contract
+
+| Method | Endpoint | Request | Response | Errors |
+|--------|----------|---------|----------|--------|
+| GET | `/repos/{owner}/{repo}/pulls/{pull_number}/reviews` | — | `[{id, state, ...}, ...]` | 401, 403, 404, 5xx |
+| PUT | `/repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/dismissals` | `{message: string}` | 200 / dismissed review | 401, 403, 404, 422, 5xx |
+
+- `request_changes` 形式の別レビューを新規投稿する方式は使わない（Req 7.5）
+- 1 件でも dismissal が失敗した場合は `ar_escalate_to_failed` で `dismissal-failed`
+  原因種別を渡す（Req 7.6）
+
+#### `ar_escalate_to_failed(pr_number, reason)`
+
+| Field | Detail |
+|-------|--------|
+| Intent | `claude-failed` ラベルを付与し、原因種別と手動復旧手順を含むコメントを 1 件投稿する |
+| Requirements | 4.4, 4.5, 7.6, 8.1, 8.2, 8.3, 8.4 |
+
+```bash
+ar_escalate_to_failed() {
+  # 入力: $1=pr_number, $2=reason
+  #   reason ∈ { "conflict-unresolved", "timeout", "push-failed", "dismissal-failed" }
+  # 戻り値: 0=成功、1=失敗（WARN）
+  #
+  # 1. gh pr edit --add-label "$LABEL_FAILED"
+  # 2. gh pr comment --body "<heredoc with reason + recovery steps>"
+}
+```
+
+- `needs-rebase` ラベルには触らない（Req 8.1）— 人間判断が必要なため残置
+- 同 PR への再試行は `gh pr list --search "-label:\"$LABEL_FAILED\""` で server 側
+  自動除外される（Req 8.4）
+- コメント heredoc は原因種別ごとに復旧手順を出し分け:
+  - `conflict-unresolved`: 「Claude が conflict を解消できませんでした。手動で
+    `git rebase origin/${BASE_BRANCH}` を実施してください」
+  - `timeout`: 「Claude rebase が `${AUTO_REBASE_MAX_TURNS_SEC}` 秒を超過しました。
+    PR 規模が大きい場合は手動 rebase を推奨します」
+  - `push-failed`: 「rebase は成功しましたが force-with-lease push に失敗しました。
+    リモートが先行している可能性があります」
+  - `dismissal-failed`: 「rebase 後 semantic 判定で approve dismissal を試みましたが
+    API が失敗しました。手動で approve を取り消してください」
+
+### Configuration Layer（issue-watcher.sh Config block）
+
+#### Env Var Set
+
+| Env Var | 既定値 | 値域 | 用途 |
+|---|---|---|---|
+| `AUTO_REBASE_MODE` | `off` | `off` / `claude` | Phase D の opt-in 制御。それ以外は `off` に正規化 |
+| `MECHANICAL_PATHS` | （空） | カンマ区切り glob | mechanical と看做す path allowlist。空なら全件 semantic |
+| `AUTO_REBASE_MODEL` | `claude-opus-4-7` | Claude モデル ID | rebase 用モデル。`PR_ITERATION_DEV_MODEL` と独立 |
+| `AUTO_REBASE_MAX_TURNS` | `30` | 正整数 | Claude `--max-turns` 値 |
+| `AUTO_REBASE_MAX_TURNS_SEC` | `600` | 正整数（秒） | Claude rebase の外側 timeout（NFR 5.1） |
+| `AUTO_REBASE_GIT_TIMEOUT` | `60` | 正整数（秒） | git / gh の個別 timeout（既存 `MERGE_QUEUE_GIT_TIMEOUT` と同既定） |
+| `AUTO_REBASE_MAX_PRS` | `3` | 正整数 | 1 サイクルで処理する PR 数上限。残りは次サイクル持ち越し |
+| `AUTO_REBASE_TEMPLATE` | `$HOME/bin/auto-rebase-prompt.tmpl` | path | prompt template の配置先（install.sh が自動配置） |
+
+### Logger 三点セット
+
+```bash
+ar_log()   { echo "[$(date '+%F %T')] [$REPO] auto-rebase: $*"; }
+ar_warn()  { echo "[$(date '+%F %T')] [$REPO] auto-rebase: WARN: $*" >&2; }
+ar_error() { echo "[$(date '+%F %T')] [$REPO] auto-rebase: ERROR: $*" >&2; }
+```
+
+既存 `mq_*` / `mqr_*` / `pi_*` の規約に合わせ、grep `'auto-rebase:'` で全件抽出可能（NFR 4.2 同等）。
+
+## Data Models
+
+### Env Var Normalization（`AUTO_REBASE_MODE`）
+
+```
+input     | normalized
+----------|-----------
+off       | off
+(unset)   | off
+""        | off
+on        | off    （Req 1.3: 列挙値 `claude` 以外は off）
+true      | off
+1         | off
+claude    | claude
+CLAUDE    | off    （case-sensitive、typo 安全側）
+```
+
+Config block 末尾で以下のように正規化:
+
+```bash
+case "$AUTO_REBASE_MODE" in
+  claude) : ;;
+  *)      AUTO_REBASE_MODE="off" ;;
+esac
+```
+
+既存「デフォルト有効化フラグの値正規化」ループ（L299〜315）には**加えない**。
+理由: 既存 9 種は「`=false` を明示した時のみ無効」だが Phase D は「明示有効化値の
+時だけ起動」する逆方向の opt-in であり、混在させると保守性が下がる。
+
+### PR 処理状態（Phase D 内）
+
+| 状態 | エントリ条件 | アクション | 終了状態 |
+|---|---|---|---|
+| Pending | `needs-rebase` + `review:approved` + open + 非 draft + 非 fork | candidate 抽出 | Rebase Trial に進む |
+| Rebase Trial | candidate 確定 | Claude CLI 起動 | Success / Conflict / Timeout / PushFailed |
+| Success | rebase + push 成功 | `ar_classify_diff` | Mechanical / Semantic |
+| Mechanical | classification=mechanical | `needs-rebase` 除去 | `[*]`（auto-merge へ） |
+| Semantic | classification=semantic | dismissal + label 遷移 + コメント | DismissalSuccess / DismissalFailed |
+| DismissalFailed | dismissal API non-zero | escalate（`dismissal-failed`） | Failed |
+| Conflict / Timeout / PushFailed | rebase trial 失敗 | escalate（原因種別） | Failed |
+| Failed | `claude-failed` 付与済み | — | `[*]`（次サイクルで `-label:claude-failed` により除外） |
+
+## Error Handling
+
+### Error Strategy
+
+各エラーは `ar_warn` / `ar_error` で stderr に詳細出力し、PR 単位の失敗は `process_auto_rebase`
+全体を停止させずに次の PR / 次の Processor に進める（既存 `mq_*` / `pi_*` 系の踏襲）。
+
+### Error Categories and Responses
+
+- **Configuration Errors**
+  - `AUTO_REBASE_MODE=claude` で template 未配置 → 起動時に `Error: Auto Rebase
+    テンプレートが見つかりません: ...` を stderr に出し exit 1（既存 `ITERATION_TEMPLATE`
+    と同 pattern）
+  - `MECHANICAL_PATHS` が空文字 → 全件 `semantic` 扱い（要件 5.4 通り、エラーではない）
+
+- **Transient API Errors (4xx-non-422 / 5xx / timeout)**
+  - `gh pr list` 失敗 → `ar_warn`、サイクル全体を skip（exit 0）
+  - `gh pr edit --add/remove-label` 失敗 → `ar_warn`、次 PR に進む。mechanical 経路で
+    ラベル除去失敗時は当該 PR を `failed` 扱いしない（次サイクルで再試行可）
+  - `gh pr comment` 失敗 → `ar_warn`、ラベル付与済みの場合はラベル側を残してログのみ
+
+- **Business Logic Errors (422 / 状態遷移エラー)**
+  - dismissal API が 422（review が既に dismissed 等） → 当該 review については skip
+    して次の review へ進む。全件 422 でも警告を出すが `dismissal-failed` 扱いにはしない
+  - `gh pr edit --remove-label` で対象 label が既に無い → 成功扱い
+
+- **Claude / Git Errors**
+  - Claude CLI 非 0 exit + dirty working tree → `conflict-unresolved` escalate
+  - Claude CLI 非 0 exit + clean working tree → `conflict-unresolved` escalate（保守的）
+  - `timeout` 124 exit → `timeout` escalate
+  - `git push --force-with-lease` 失敗 → `push-failed` escalate
+  - `git fetch` / `git checkout` 失敗 → `conflict-unresolved` escalate（rebase に
+    到達できなかった旨をコメントに記載）
+
+- **Idempotency / Reentrancy**
+  - 同一サイクル内で同一 PR を 2 度処理しない（`gh pr list` 結果は unique）
+  - 次サイクル以降の再処理は、`claude-failed` の存在で抑止（Req 8.4）
+  - 1 サイクル内に Phase D が触る PR は最大 `AUTO_REBASE_MAX_PRS` 件、残りは overflow
+
+## Testing Strategy
+
+### Unit Tests（shellcheck + 手動関数単体実行）
+
+1. `ar_classify_diff` が空 `MECHANICAL_PATHS` で常に `semantic` を返す
+2. `ar_classify_diff` が単一 pattern（`package-lock.json`）で完全一致 path のみの場合 `mechanical` を返す
+3. `ar_classify_diff` が複数 pattern（`*.lock,**/go.sum`）で 1 件 unmatch があれば `semantic` を返す
+4. `AUTO_REBASE_MODE` の値正規化（`off` / `claude` / 不正値 → `off`）
+5. `ar_fetch_candidates` の jq filter が fork PR / draft / `claude-failed` を除外
+
+### Integration Tests（dogfood scratch repo）
+
+1. `MECHANICAL_PATHS=package-lock.json` 設定下で lockfile-only conflict の test PR を作り、
+   `mechanical` 判定 + `needs-rebase` 除去 + approve 維持を観測
+2. lockfile + ソースファイルを同時 conflict させた test PR で `semantic` 判定 +
+   approve dismissal + `ready-for-review` 付与 + 説明コメント投稿を観測
+3. `AUTO_REBASE_MODE` 未設定で従来挙動（Phase A 本体のみが動作、Phase D は完全 skip）
+   を確認
+4. `AUTO_REBASE_MODE=claude` + `MECHANICAL_PATHS=` 空で全 conflict が `semantic` 扱いに
+   なることを観測
+
+### E2E / Dogfood Tests（Req 9.4）
+
+1. idd-claude self repo に `AUTO_REBASE_MODE=claude` / `MECHANICAL_PATHS=package-lock.json`
+   を cron / launchd env で追加し、watcher を 24 時間以上稼働
+2. 実際の lockfile-only conflict PR が `mechanical` 判定 + auto-merge に到達することを
+   `grep 'auto-rebase: PR #[0-9]\+: classification=mechanical'` で確認
+3. semantic 判定が 1 件以上発生した場合に approve dismissal が成功し、再レビュー誘導
+   コメントが投稿されていることを確認
+
+### Static Analysis（NFR 4.1）
+
+- `shellcheck local-watcher/bin/issue-watcher.sh` が 警告ゼロ
+- `shellcheck` の `SC2053`（変数を含む glob match）は意図的な glob 一致のため必要箇所に
+  `# shellcheck disable=SC2053` で局所無効化
+
+### Performance（参考）
+
+1. 1 PR あたりの平均処理時間（Claude rebase 試行 + 判定 + ラベル操作）が
+   `AUTO_REBASE_MAX_TURNS_SEC + 30s` 以内
+2. `AUTO_REBASE_MAX_PRS=3` で 1 サイクル合計 30 分以内に収束
+3. cycle 間で overflow が継続的に増えないこと（観測ログのサマリ overflow を grep）
+
+## Security Considerations
+
+### GitHub Token Scopes
+
+- approve dismissal API（`PUT /repos/{owner}/{repo}/pulls/{n}/reviews/{id}/dismissals`）は
+  GitHub 公式 docs によれば、**他者の review を dismiss するには Branch protection の
+  "Allow specified actors to bypass required pull requests" 設定または書き込み権限が
+  必要**。watcher が使用する PAT / `gh auth` token はリポジトリ admin 権限を前提とする
+- README に明記する: **「Phase D を有効化するには、watcher 用 token がリポジトリの
+  Pull Request review dismissal 権限を持つ必要があります（admin / maintain ロール
+  相当）」**
+- `gh api` 呼び出しが 403 を返した場合は `dismissal-failed` で escalate される
+  （Req 7.6 の経路で人間に通知）
+
+### Claude Permission Boundary
+
+- Claude prompt の禁止事項に以下を明示:
+  - `git push` 全般（watcher 側で `--force-with-lease` を行う）
+  - `gh pr review` / `gh pr edit` / `gh pr comment`（ラベル操作・dismissal は watcher の責務）
+  - rebase 以外のファイル編集（unrelated refactor の禁止）
+- `--permission-mode bypassPermissions` を使うため、Claude が任意のシェルコマンドを
+  実行できる。**禁止行為を Claude が実行した場合の検知は post-rebase 時の
+  `git status --porcelain` で dirty 残置 → `conflict-unresolved` escalate に倒れる**
+
+## Migration Strategy
+
+Phase D は **新規 opt-in** のため、既存ユーザに対する破壊的変更はなく migration は不要。
+新規導入者向けの手順を README に追加する:
+
+```mermaid
+flowchart TD
+    A[既存運用<br/>AUTO_REBASE_MODE 未設定] --> B{Phase D 導入?}
+    B -->|No| A
+    B -->|Yes| C[Step 1: token 権限確認<br/>admin / maintain ロール]
+    C --> D[Step 2: MECHANICAL_PATHS 設計<br/>言語別例を README から選択]
+    D --> E[Step 3: cron / launchd env に追加<br/>AUTO_REBASE_MODE=claude<br/>MECHANICAL_PATHS=...]
+    E --> F[Step 4: dogfood watcher log で<br/>auto-rebase: サイクル開始 を grep]
+    F --> G[Step 5: 実 PR で<br/>mechanical / semantic / failed 分布を確認]
+    G --> H{挙動 OK?}
+    H -->|No| I[AUTO_REBASE_MODE=off に戻す]
+    H -->|Yes| J[継続運用]
+```
+
+## Open Questions / 確認事項（PM Open Questions への Architect 回答）
+
+| # | PM Open Question | Architect 回答（design.md で確定） |
+|---|---|---|
+| Q1 | Phase D Processor のループ起動位置（Phase A 本体の前 / 後 / Re-check の前 / 後） | **Re-check → Phase A 本体 → Phase D の順で確定**。理由は Architecture Pattern & Boundary Map 節「順序根拠」を参照。これにより Req 3.1〜3.3 が直列順序により構造的に保証される |
+| Q2 | Claude 自己判定方式（Issue 本文 方式 b）の fallback 余地を残すか | **本設計では完全に Non-Goals**。判定ロジックは `ar_classify_diff` 関数 1 つに閉じており、将来必要なら新規 env `AUTO_REBASE_CLASSIFY_MODE=allowlist/claude-self` を追加して同関数を分岐させる余地はある（コード変更影響は当該関数のみ）。要件への追加は本 PR では行わない |
+| Q3 | `MECHANICAL_PATHS` の構文 | **カンマ区切り + bash glob 構文（`*` / `?` / `[abc]`）で確定**。正規表現は使わない（Components and Interfaces `ar_classify_diff` 節を参照）。改行区切りは cron / launchd の env 渡し制約で採用しない |
+| Q4 | Branch protection の "Dismiss stale pull request approvals when new commits are pushed" が有効な repo での mechanical rebase 後の挙動 | **README に注記として残す**（Phase D 側では検知しない）。理由: GitHub API では当該 protection 設定の有無を polling で確認するコストが高く、watcher 側で「dismiss された後」を観測しようとすると次サイクルの Re-check 経路と重複する。Phase A の既存注記（README L1134〜1141）と同じトーンで「protection 設定有効の repo では mechanical rebase 後も再 approve が必要になる旨」を Phase D 節に追記する。INFO ログでの能動通知は実装しない |
+
+## 自己レビュー結果
+
+### Mechanical Checks
+
+- **Requirements traceability**: requirements.md の Requirement 1.1〜9.4 / NFR 1.1〜5.3 のすべての numeric ID を Requirements Traceability 表で参照済み（48 件）
+- **File Structure Plan の充填**: 具体的なファイルパスのみで構成、"TBD" / プレースホルダ無し
+- **Orphan component なし**: 設計上の Components（`process_auto_rebase` / `ar_fetch_candidates` / `ar_handle_pr` / `ar_run_claude_rebase` / `ar_classify_diff` / `ar_apply_mechanical` / `ar_apply_semantic` / `ar_dismiss_all_approvals` / `ar_escalate_to_failed` / Logger 三点セット）はすべて `local-watcher/bin/issue-watcher.sh` への追加領域として File Structure Plan に対応がある。Template `auto-rebase-prompt.tmpl` も同様に列挙済み
+
+### 判断レビュー
+
+- 要件カバレッジ: Phase D 関連の全 numeric ID をマッピング済み。NFR を含めて未参照ゼロ
+- アーキテクチャ準備: Components 境界 + bash 関数 signature + GitHub API contract を明示
+- 実行可能性: tasks.md（別途生成）で 1 task = 1 commit 単位に分割可能な粒度

--- a/docs/specs/17-phase-d-claude-rebase-semantic/requirements.md
+++ b/docs/specs/17-phase-d-claude-rebase-semantic/requirements.md
@@ -1,0 +1,306 @@
+# Requirements Document
+
+## Overview
+
+Phase D は、Phase A（#14）/ Re-check Processor（#27）が `needs-rebase` ラベルで
+人間判断に回している approved PR を、Claude による rebase で機械的に救済する
+新しい watcher 機能である。Claude による書き換え結果は人間レビューを通って
+いないため、変更ファイルが運用者が宣言した「機械的に安全」な allowlist
+（lockfile 等）に閉じている場合のみ approve を維持して auto-merge を可能にし、
+allowlist 外の差分（= semantic 判断を含む）が出た場合は既存の approve を剥がし
+`ready-for-review` に戻して再レビューを誘導する。本機能は明示的 opt-in 制で、
+未設定時は本機能導入前と完全に同一の挙動を保つ。
+
+## Goals / Non-Goals
+
+### Goals
+
+- approved + `needs-rebase` 状態で停滞する PR を、運用者が許可した範囲で自動解消する
+- Claude による rebase が semantic 判断を含むかどうかを、運用者が宣言した
+  allowlist（パスパターン集合）で判定する
+- semantic と判定された rebase に対しては、人間レビュー gate を保護する
+  （approve 剥がし + `ready-for-review` 復帰 + 説明コメント投稿）
+- rebase そのものが失敗した PR は `claude-failed` ラベルで人間にエスカレートする
+- 未設定 / `off` で挙動不変（後方互換性絶対）
+
+### Non-Goals
+
+- 予防的 overlap 検知（複数 PR が将来 conflict しそうな箇所を事前に検出する仕組み）
+  は Phase E（#18）のスコープであり、本要件には含めない
+- AST diff による意味的差分判定は言語依存度が高いため対象外。allowlist による
+  パス単位判定で start する
+- Claude 自身に「これは mechanical / semantic か」を自己申告させる方式は、
+  本要件では採用しない（精度・再現性が allowlist より劣るため。Open Questions
+  で再評価余地のみ残す）
+- `needs-rebase` ラベルが付かない通常 PR への介入（Phase A の対象外）
+- 外部 Feature Flag SaaS との連携（プロジェクト規約 Feature Flag Protocol とは別物）
+
+## Glossary
+
+- **mechanical rebase**: Claude が rebase した結果の差分が、すべて
+  `MECHANICAL_PATHS` allowlist のパスパターンに一致するもの。人間レビュー不要と
+  運用者が事前に宣言した範囲に閉じている rebase
+- **semantic rebase**: 上記以外の rebase。allowlist 外のパスが 1 つでも変更
+  された rebase はすべて semantic として扱う（保守的判定）
+- **`MECHANICAL_PATHS` allowlist**: 機械的に安全な変更パスを宣言する環境変数。
+  カンマ区切りのパス／glob を想定。具体的な区切り文字・glob 構文は design.md の領分
+- **`AUTO_REBASE_MODE`**: Phase D の opt-in 制御環境変数。`off`（既定） /
+  有効化値（具体値は design.md）。未設定 / `off` で本機能無効
+- **approve dismissal**: 既存 approving review を無効化し PR を未承認状態に戻す操作。
+  GitHub の review dismissal 機構（`gh api` 経由）を使用し、`request_changes` で
+  別レビューを追加投稿する方式は採らない
+- **Phase A / Re-check Processor**: それぞれ `needs-rebase` を付与する loop
+  （#14）と、conflict 解消で自動的に剥がす loop（#27）。本機能はこれらと
+  共存し、同じ PR を同サイクルで二重処理しない
+
+## Requirements
+
+### Requirement 1: opt-in 制御と既定挙動
+
+**Objective:** As a watcher 運用者, I want Phase D を明示宣言時のみ起動する gate, so that 既存
+運用に影響を与えずに段階的に導入できる
+
+#### Acceptance Criteria
+
+1. When `AUTO_REBASE_MODE` が未設定または `off` である, the watcher shall Phase D の
+   rebase 処理を一切起動しない
+2. When `AUTO_REBASE_MODE` が有効化値である, the watcher shall 各サイクルで Phase D の
+   対象 PR を検出する処理を起動する
+3. If `AUTO_REBASE_MODE` の値が `off` でも有効化値でもない不正値である, the watcher shall
+   `off` と同等に扱い Phase D を起動しない
+4. The watcher shall `AUTO_REBASE_MODE` の現在値（有効 / 無効）をサイクル開始時に
+   ログへ出力する
+
+### Requirement 2: 対象 PR の判定
+
+**Objective:** As a watcher 運用者, I want Phase D が処理対象を明確な条件で絞ること, so that
+人間レビュー対象の PR や fork PR を巻き込まない
+
+#### Acceptance Criteria
+
+1. While `AUTO_REBASE_MODE` が有効である, the Phase D Processor shall `needs-rebase`
+   ラベルが付与され、かつ 1 件以上の approving review を持つ open PR のみを対象とする
+2. While `AUTO_REBASE_MODE` が有効である, the Phase D Processor shall `claude-failed`
+   ラベルが付いた PR を対象から除外する
+3. While `AUTO_REBASE_MODE` が有効である, the Phase D Processor shall draft 状態の
+   PR を対象から除外する
+4. While `AUTO_REBASE_MODE` が有効である, the Phase D Processor shall head リポジトリ
+   owner が base リポジトリ owner と異なる fork PR を対象から除外する
+5. While `AUTO_REBASE_MODE` が有効である, the Phase D Processor shall 既存の
+   Phase A 系列が許可する head branch パターンと整合した範囲のみを対象とする
+
+### Requirement 3: 既存ループとの競合排除
+
+**Objective:** As a watcher 運用者, I want Phase D が既存 Phase A / Re-check と同じ PR を
+同サイクルで二重処理しないこと, so that ラベル遷移やレビュー状態が予測可能であること
+
+#### Acceptance Criteria
+
+1. While 同一サイクル中, the watcher shall 1 つの PR を Phase A 本体・Re-check
+   Processor・Phase D のうち高々 1 つにのみ処理させる
+2. When Re-check Processor が当該 PR の `needs-rebase` を除去できる状態
+   （`mergeable=MERGEABLE`）にある, the Phase D Processor shall その PR の rebase を
+   起動しない
+3. When Phase D が当該 PR の rebase を起動した, the Re-check Processor shall 同一
+   サイクル内で当該 PR のラベル除去操作を行わない
+4. The watcher shall Phase D が処理した PR とその判定結果（mechanical / semantic /
+   failed）をサマリログとして 1 行出力する
+
+### Requirement 4: Claude による rebase 実行
+
+**Objective:** As a watcher 運用者, I want conflict 解消を Claude が試行すること, so that 単純
+な textual conflict と lockfile 系 conflict が人手を介さず解消される
+
+#### Acceptance Criteria
+
+1. When Phase D の対象 PR が確定した, the watcher shall 当該 PR の head ref を base ref
+   へ rebase する処理を Claude 経由で 1 回試行する
+2. The watcher shall rebase 試行の前後で当該 PR head ref の commit SHA を記録する
+3. The watcher shall rebase 試行で生成された累積 diff（base ref 比較）を取得し、
+   後段の mechanical / semantic 判定の入力とする
+4. If Claude による rebase が conflict 解消できず終了した, the watcher shall その PR
+   に `claude-failed` ラベルを付与し人間エスカレーション用コメントを 1 件投稿する
+5. If Claude による rebase 試行が watcher 側のタイムアウトを超過した, the watcher shall
+   rebase 操作を中断し当該 PR を `claude-failed` として扱う
+6. The watcher shall rebase 成功時の push 操作で `--force-with-lease` 相当の安全な
+   force push を使用する（`--force` 単独は使用しない）
+
+### Requirement 5: Mechanical / Semantic 判定
+
+**Objective:** As a watcher 運用者, I want Claude rebase 結果の安全性をパス単位で判定すること, so that
+人間レビューを通っていない semantic 変更が自動 merge に流れないこと
+
+#### Acceptance Criteria
+
+1. When Phase D が rebase 後 diff の変更ファイル一覧を取得した, the Phase D Processor
+   shall 各変更パスを `MECHANICAL_PATHS` allowlist と照合する
+2. When すべての変更パスが `MECHANICAL_PATHS` allowlist に一致する, the Phase D
+   Processor shall その rebase を `mechanical` と判定する
+3. If 変更パスのうち 1 つ以上が `MECHANICAL_PATHS` allowlist のいずれにも一致しない,
+   the Phase D Processor shall その rebase を `semantic` と判定する
+4. If `MECHANICAL_PATHS` が未設定または空である, the Phase D Processor shall すべての
+   rebase 結果を `semantic` として扱う（保守的判定）
+5. The Phase D Processor shall 判定結果（`mechanical` / `semantic`）を当該 PR に
+   対応するログ行に明示する
+
+### Requirement 6: Mechanical 判定時の挙動
+
+**Objective:** As a watcher 運用者, I want 安全と判定された rebase は既存 approve を維持して
+auto-merge に到達できること, so that lockfile-only conflict の停滞が解消される
+
+#### Acceptance Criteria
+
+1. When 判定結果が `mechanical` である, the Phase D Processor shall 既存の approving
+   review を剥がさない
+2. When 判定結果が `mechanical` である, the Phase D Processor shall 当該 PR の
+   `needs-rebase` ラベルを除去する
+3. When 判定結果が `mechanical` である, the Phase D Processor shall その PR に追加の
+   再レビュー誘導コメントを投稿しない
+4. While `mechanical` 判定で push が成功している間, the watcher shall 既存の
+   Merge Queue 系処理が当該 PR を通常通り扱える状態に戻す
+
+### Requirement 7: Semantic 判定時の挙動（人間レビュー保護）
+
+**Objective:** As a 人間レビュワー, I want Claude が semantic に書き換えた rebase は再レビュー
+対象として戻されること, so that レビュー gate がバイパスされないこと
+
+#### Acceptance Criteria
+
+1. When 判定結果が `semantic` である, the Phase D Processor shall 当該 PR に付与
+   されているすべての approving review を dismiss する
+2. When 判定結果が `semantic` である, the Phase D Processor shall 当該 PR の
+   `needs-rebase` ラベルを除去する
+3. When 判定結果が `semantic` である, the Phase D Processor shall 当該 PR に
+   `ready-for-review` ラベルを付与する
+4. When 判定結果が `semantic` である, the Phase D Processor shall 当該 PR に
+   人間レビュワー向け説明コメントを 1 件投稿する（rebase 実施・semantic 判定・
+   approve dismissal・再レビュー要求の理由を含む）
+5. The Phase D Processor shall approve dismissal を GitHub の review dismissal
+   機構を通じて行い、`request_changes` 形式の別レビューを新規投稿する方式は使わない
+6. If approve dismissal が API エラーで失敗した, the Phase D Processor shall その PR
+   に `claude-failed` ラベルを付与し人間エスカレーション用コメントを 1 件投稿する
+
+### Requirement 8: Rebase 失敗時のエスカレーション
+
+**Objective:** As a watcher 運用者, I want Claude が rebase 自体に失敗した PR を即座に人間へ
+渡すこと, so that 自動ループが暴走しないこと
+
+#### Acceptance Criteria
+
+1. When Claude rebase が成功しなかった, the watcher shall その PR の `needs-rebase`
+   ラベルを除去しない（人間判断が必要であることを残す）
+2. When Claude rebase が成功しなかった, the watcher shall その PR に `claude-failed`
+   ラベルを付与する
+3. When `claude-failed` を付与した, the watcher shall 失敗原因種別（conflict 解消失敗
+   / タイムアウト / push 失敗 / dismissal 失敗 等）と手動復旧手順を含むコメントを
+   1 件投稿する
+4. While `claude-failed` ラベルが付いている間, the Phase D Processor shall 同一 PR
+   への rebase 再試行を行わない
+
+### Requirement 9: 設定の文書化と dogfood 検証
+
+**Objective:** As a 新規導入者, I want 環境変数の意味と言語別の典型 allowlist 値を README から
+即座に参照できること, so that 設定ミスなく opt-in できること
+
+#### Acceptance Criteria
+
+1. The README shall `AUTO_REBASE_MODE` の既定値・意味・有効化方法・無効化方法を
+   「オプション機能一覧」相当の節に記載する
+2. The README shall `MECHANICAL_PATHS` の既定値（空）・意味・空のときの挙動
+   （すべて semantic 扱い）を記載する
+3. The README shall `MECHANICAL_PATHS` の言語別設定例（JavaScript / Python / Go /
+   Rust）を最低 1 例ずつ示す
+4. When idd-claude 自身を Phase D の dogfood 対象として
+   `MECHANICAL_PATHS=package-lock.json` 相当の設定で運用する, the watcher shall
+   実装後の lockfile-only rebase が `mechanical` 判定で auto-merge へ到達することを
+   観測可能なログとして残す
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. When `AUTO_REBASE_MODE` を含む Phase D 関連の env var が一切設定されていない,
+   the watcher shall 本機能導入前と完全に同一の挙動を保つ
+2. The watcher shall 既存の env var 名（`REPO` / `REPO_DIR` / `LOG_DIR` /
+   `LOCK_FILE` / `TRIAGE_MODEL` / `DEV_MODEL` / `MERGE_QUEUE_*` / `BASE_BRANCH`
+   等）の意味と既定値を変更しない
+3. The watcher shall 既存ラベル名（`auto-dev` / `claude-claimed` / `needs-rebase` /
+   `claude-failed` / `ready-for-review` 等）の名前と意味を変更しない
+4. The watcher shall 既存 cron / launchd 登録文字列（実行コマンド・引数形式）を
+   変更しない
+5. The watcher shall 既存 exit code の意味を変更しない
+
+### NFR 2: 観測可能性
+
+1. The watcher shall Phase D の各 PR 処理について「PR 番号 / 判定結果（`mechanical` /
+   `semantic` / `failed`）/ アクション要約」を 1 行ログとして出力する
+2. The watcher shall Phase D サイクル終了時に「mechanical 件数 / semantic 件数 /
+   failed 件数 / overflow 件数」のサマリ行を 1 件出力する
+
+### NFR 3: 言語非依存性
+
+1. The Phase D Processor shall 特定の言語ランタイム（Node.js / Python / Go / Rust 等）
+   を導入依存に追加しない
+2. The Phase D Processor shall `MECHANICAL_PATHS` の既定値を空とし、特定言語の
+   lockfile 名を既定で内蔵しない
+
+### NFR 4: 静的解析
+
+1. The watcher スクリプト shall 変更後も `shellcheck` 警告ゼロを維持する
+
+### NFR 5: タイムアウトと安全性
+
+1. The Phase D Processor shall 1 PR あたりの Claude rebase 試行に観測可能な timeout
+   を設ける（具体値は design.md）
+2. The Phase D Processor shall 失敗・タイムアウト時に作業ディレクトリと base
+   branch を Phase A 既存実装と同等の rollback パターン（`rebase --abort` 後の
+   base branch 復帰）で原状復帰させる
+3. The Phase D Processor shall force push 時に `--force-with-lease` 相当の安全な
+   形式のみを使用する
+
+## Definition of Done（Issue 本文との対応）
+
+各項目は前述 Requirements / NFR への対応 ID を併記する。
+
+1. lockfile-only conflict の PR が approve を維持して auto-merge に到達する
+   → Req 5.1 / 5.2 / 6.1 / 6.2 / 6.4 / 9.4
+2. コード conflict を Claude が解消した PR が approve を剥がされ `ready-for-review`
+   に戻る → Req 5.3 / 7.1 / 7.2 / 7.3 / 7.4 / 7.5
+3. `AUTO_REBASE_MODE` 環境変数で opt-in/opt-out を制御できる（既定 off）
+   → Req 1.1 / 1.2 / 1.3 / NFR 1.1
+4. rebase 失敗時は `claude-failed` ラベルが付き人間エスカレーションになる
+   → Req 4.4 / 4.5 / 8.1 / 8.2 / 8.3
+5. `MECHANICAL_PATHS` allowlist は既定空（言語非依存）
+   → Req 5.4 / NFR 3.2
+6. README に両 env var の説明と言語別設定例（JS / Python / Go / Rust）がある
+   → Req 9.1 / 9.2 / 9.3
+7. watcher スクリプトの `shellcheck` がクリーン → NFR 4.1
+8. idd-claude 自身での dogfood 検証
+   （`MECHANICAL_PATHS=package-lock.json` 設定下で観測可能） → Req 9.4 / NFR 2.1
+
+## Out of Scope
+
+- 予防的 overlap 検知（Phase E / #18）
+- AST diff による semantic 判定（言語依存）
+- Claude 自己判定方式（精度未検証、Open Questions に再評価余地のみ残す）
+- `needs-rebase` ラベルが付かない PR への自動介入
+- `MECHANICAL_PATHS` の既定値として特定言語の lockfile 名を内蔵すること
+- Phase A 本体（#14）/ Re-check Processor（#27）の挙動変更
+- 外部 Feature Flag SaaS との連携
+
+## Open Questions
+
+1. Phase D Processor のループ起動位置（Phase A 本体の前 / 後 / Re-check の前 / 後）
+   は競合排除条件（Req 3.1〜3.3）を満たす限り design.md で確定すること。
+   要件としては「同一サイクルで二重処理しない」までを規定し、具体的な実行順序は
+   Architect の領分とする
+2. Claude 自己判定方式（Issue 本文の方式 b）を将来 fallback として導入する余地を
+   設計で残すか、または完全に Non-Goals として封じるかは design.md / Issue
+   コメントで Architect が提案すること
+3. `MECHANICAL_PATHS` の構文（カンマ区切り / 改行区切り / glob サポート範囲）は
+   design.md の領分とする。要件としては「allowlist 照合ができること」までを規定
+4. Branch protection で「Dismiss stale pull request approvals when new commits are
+   pushed」が有効な repo では、Phase D の `mechanical` rebase 後の force push でも
+   既存 approve が dismiss される。この場合の挙動（再 approve を待つ / 人間に
+   通知する）は Issue 本文に明示されていない。README に注記として残すか、
+   Phase D 側で検知して INFO ログのみとするかは Architect が判断する

--- a/docs/specs/17-phase-d-claude-rebase-semantic/tasks.md
+++ b/docs/specs/17-phase-d-claude-rebase-semantic/tasks.md
@@ -1,0 +1,167 @@
+# Implementation Plan
+
+> 設計参照: [`design.md`](./design.md)
+> 要件参照: [`requirements.md`](./requirements.md)
+>
+> 実装順序の原則: Config / logger / 候補抽出（1.x）→ rebase 試行（2.x）→ 分類 + 後処理（3.x）
+> → orchestration 配線（4.x）→ template 配置（5.x）→ ドキュメント（6.x）→ dogfood（7.x）
+> 各タスクは 1 commit 単位を目安。`(P)` を付けたタスクは `_Boundary:_` の異なる別ファイル
+> 領域に閉じるため並列実装可能。同一関数本体や同一ファイルの隣接編集は直列とする。
+
+## 1. Phase D 基盤（Config / Logger / 候補抽出）
+
+- [ ] 1.1 `AUTO_REBASE_*` env var 群と起動時 template 存在チェックを Config block に追加
+  - `local-watcher/bin/issue-watcher.sh` の Phase A Re-check Config 直後に Phase D Config を新設
+  - 追加 env var: `AUTO_REBASE_MODE` (既定 `off`) / `MECHANICAL_PATHS` (既定 空) / `AUTO_REBASE_MODEL` (既定 `claude-opus-4-7`) / `AUTO_REBASE_MAX_TURNS` (既定 `30`) / `AUTO_REBASE_MAX_TURNS_SEC` (既定 `600`) / `AUTO_REBASE_GIT_TIMEOUT` (既定 `60`) / `AUTO_REBASE_MAX_PRS` (既定 `3`) / `AUTO_REBASE_TEMPLATE` (既定 `$HOME/bin/auto-rebase-prompt.tmpl`)
+  - `AUTO_REBASE_MODE` を `case` で正規化（`claude` のみ通し、他はすべて `off` に固定）
+  - 既存「デフォルト有効化フラグの値正規化」ループには加えない（opt-in 制のため別扱い）
+  - `AUTO_REBASE_MODE != off` のとき `auto-rebase-prompt.tmpl` の存在を必須化（既存 ITERATION_TEMPLATE と同 pattern）
+  - サイクル開始時に有効値をログに出力する設定値（`base-branch=` ログ近傍）
+  - 既存 env var（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `TRIAGE_MODEL` / `DEV_MODEL` / `MERGE_QUEUE_*` / `BASE_BRANCH` 等）の意味・既定値・正規化方式は変更しない（NFR 1.2）
+  - _Requirements: 1.1, 1.3, NFR 1.1, NFR 1.2, NFR 3.2_
+
+- [ ] 1.2 `auto-rebase:` prefix の logger 三点セットと `process_auto_rebase` スケルトンを追加
+  - `process_merge_queue` 関数（既存 L1090 直後）の直後に Phase D セクションを新設
+  - `ar_log` / `ar_warn` / `ar_error` を既存 `mq_*` と同じ書式（`[YYYY-MM-DD HH:MM:SS] [$REPO] auto-rebase:` の 3 段 prefix）で定義
+  - `process_auto_rebase()` のエントリ関数を作成: opt-in gate / dirty working tree check / サイクル開始ログ / 空サマリ行出力までを実装（候補抽出と PR 処理は次タスク）
+  - _Requirements: 1.1, 1.2, 1.4, 3.4, NFR 1.1, NFR 2.2, NFR 4.1_
+
+- [ ] 1.3 `ar_fetch_candidates` で `needs-rebase` + approved + 非 draft + 非 fork PR を抽出
+  - `gh pr list --search "review:approved label:\"needs-rebase\" -label:\"claude-failed\" -draft:true"` を server filter として使用
+  - jq client filter: `isDraft == false` / `reviewDecision == "APPROVED"` / `headRefName | test($MERGE_QUEUE_HEAD_PATTERN)` / `headRepositoryOwner.login == $owner`
+  - `process_auto_rebase` 内から呼び出し、overflow（`AUTO_REBASE_MAX_PRS` 超過分）の集計とログ出力までを実装
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 8.4_
+
+## 2. Claude rebase 試行と rollback
+
+- [ ] 2.1 `ar_build_prompt` で auto-rebase-prompt.tmpl のプレースホルダ展開を実装
+  - `auto-rebase-prompt.tmpl` のプレースホルダ（`{{REPO}}` / `{{PR_NUMBER}}` / `{{PR_TITLE}}` / `{{PR_URL}}` / `{{HEAD_REF}}` / `{{BASE_REF}}` / `{{BASE_BRANCH}}`）を awk 置換で展開する関数を実装（既存 `pi_build_iteration_prompt` を参考）
+  - _Requirements: 4.1_
+
+- [ ] 2.2 `ar_run_claude_rebase` で Claude CLI 起動 + rollback + `--force-with-lease` push を実装
+  - `(subshell + trap)` で `git rebase --abort` + `git checkout "$BASE_BRANCH"` を保証（Phase A `mq_try_rebase_pr` 踏襲）
+  - `git fetch origin "$head_ref" "$base_ref"` → `git checkout -B "$head_ref" "origin/$head_ref"` → before_sha 取得 → `timeout "$AUTO_REBASE_MAX_TURNS_SEC" claude --print "$prompt" --model "$AUTO_REBASE_MODEL" --permission-mode bypassPermissions --max-turns "$AUTO_REBASE_MAX_TURNS" --output-format stream-json --verbose` → claude 終了後 dirty check → after_sha 取得 → `git push --force-with-lease`
+  - 戻り値仕様: `0`=成功、`1`=conflict 未解消（dirty 残置）、`2`=timeout（exit 124）、`3`=push 失敗、`4`=fetch/checkout 失敗、`5`=rebase 不要（skip）
+  - 各 git/gh サブプロセスに `timeout "$AUTO_REBASE_GIT_TIMEOUT"` を必ず適用
+  - ログファイルは `$LOG_DIR/auto-rebase-<pr_number>-<timestamp>.log`
+  - _Requirements: 4.1, 4.2, 4.3, 4.5, 4.6, NFR 5.1, NFR 5.2, NFR 5.3_
+
+## 3. 分類と後処理（mechanical / semantic / failed）
+
+- [ ] 3.1 `ar_classify_diff` で `MECHANICAL_PATHS` allowlist と path 集合の照合を実装 (P)
+  - `git diff --name-only "origin/${base_ref}".."${head_ref}"` で変更 path 一覧を取得
+  - `MECHANICAL_PATHS` 空 → 全件 `semantic`（保守的判定）
+  - カンマ区切り pattern 配列を bash `[[ $path == $pattern ]]` glob 照合で走査（`# shellcheck disable=SC2053` を必要箇所に付与）
+  - 全 path 一致 → `mechanical`、1 件でも unmatch → `semantic`（最初の unmatched path をログに含める）
+  - 戻り値仕様: stdout に `mechanical` / `semantic` の 1 語、戻り値 `0`=正常、`1`=`git diff` 失敗（呼び出し側は保守的に `semantic` 扱い）
+  - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+  - _Boundary: ar_classify_diff_
+
+- [ ] 3.2 `ar_apply_mechanical` で `needs-rebase` 除去のみを実装 (P)
+  - `gh pr edit "$pr_number" --repo "$REPO" --remove-label "$LABEL_NEEDS_REBASE"` の単一 API 呼び出し（個別 timeout 付与）
+  - approve 維持 / 追加コメント無し（Req 6.1 / 6.3 を構造的に保証）
+  - 戻り値: `0`=成功、`1`=API 失敗（呼び出し側で WARN）
+  - _Requirements: 6.1, 6.2, 6.3, 6.4_
+  - _Boundary: ar_apply_mechanical_
+
+- [ ] 3.3 `ar_dismiss_all_approvals` で review dismissal API を実装 (P)
+  - `gh api "/repos/${REPO}/pulls/${pr_number}/reviews"` で全 review を取得
+  - jq で `state == "APPROVED"` の id のみ抽出
+  - 各 id について `gh api -X PUT "/repos/${REPO}/pulls/${pr_number}/reviews/{id}/dismissals" -f message="Phase D semantic rebase: re-review required"` を順次実行
+  - 422（既に dismissed 等）は当該 review skip、それ以外の non-zero は全体失敗扱い（戻り値 `1`）
+  - `gh pr review --request-changes` は使用しない（Req 7.5）
+  - _Requirements: 7.1, 7.5, 7.6_
+  - _Boundary: ar_dismiss_all_approvals_
+
+- [ ] 3.4 `ar_apply_semantic` で dismissal + label 遷移 + 説明コメント投稿を実装
+  - 順序: `ar_dismiss_all_approvals` → `needs-rebase` 除去 → `ready-for-review` 付与 → 説明コメント投稿
+  - heredoc コメント本文に before_sha / after_sha、最初の unmatched path、dismissal 実施の旨、再レビュー要求の理由、hidden marker `<!-- idd-claude:auto-rebase pr=${pr_number} -->` を含める
+  - dismissal 失敗時は呼び出し側（`ar_handle_pr`）に戻り値で通知し escalate 経路に流す
+  - _Requirements: 7.1, 7.2, 7.3, 7.4_
+  - _Depends: 3.3_
+
+- [ ] 3.5 `ar_escalate_to_failed` で `claude-failed` 付与と原因種別コメントを実装 (P)
+  - 入力 `reason` ∈ `{conflict-unresolved, timeout, push-failed, dismissal-failed}` で heredoc を分岐
+  - `needs-rebase` には触らない（Req 8.1）
+  - `gh pr edit --add-label "$LABEL_FAILED"` + `gh pr comment` の順で実行（label 付与失敗時もコメントは試みる）
+  - _Requirements: 4.4, 4.5, 7.6, 8.1, 8.2, 8.3_
+  - _Boundary: ar_escalate_to_failed_
+
+- [ ] 3.6 `ar_handle_pr` で 1 PR 分の処理フロー（rebase → 分類 → 後処理 / escalate）を統合
+  - `ar_run_claude_rebase` の戻り値に応じて `ar_escalate_to_failed`（種別: conflict-unresolved / timeout / push-failed）に振り分け
+  - 成功時は `ar_classify_diff` の結果で `ar_apply_mechanical` / `ar_apply_semantic` に分岐
+  - `ar_apply_semantic` 内の dismissal 失敗時は `ar_escalate_to_failed dismissal-failed` を呼ぶ
+  - 1 PR 1 行サマリログ（`PR #N: classification=... before_sha=... after_sha=... action=...`）を出力（NFR 2.1）
+  - 戻り値: `0`=mechanical / `1`=semantic / `2`=failed / `10`=skip
+  - _Requirements: 3.4, 4.4, 4.5, 5.5, 7.6, NFR 2.1_
+  - _Depends: 2.2, 3.1, 3.2, 3.4, 3.5_
+
+- [ ] 3.7 `process_auto_rebase` の本処理ループとサマリ集計を完成させる
+  - 1.3 で取得した候補配列を順次 `ar_handle_pr` に渡す
+  - 戻り値別カウンタ（mechanical / semantic / failed / skip / overflow）を集計
+  - `ar_log "サマリ: mechanical=N, semantic=N, failed=N, skip=N, overflow=N"` を 1 件出力（Req 3.4 / NFR 2.2）
+  - サイクル末尾で保険として `git checkout "$BASE_BRANCH"` に戻す
+  - _Requirements: 3.4, NFR 2.2_
+  - _Depends: 3.6_
+
+## 4. Orchestration 配線（既存 Phase A 系列との競合排除）
+
+- [ ] 4.1 `process_merge_queue` 呼び出し（L1233）の直後に `process_auto_rebase` を直列配置
+  - 既存呼び出し行 `process_merge_queue || mq_warn "..."` の**直後**に 1 行追加: `process_auto_rebase || ar_warn "process_auto_rebase が想定外のエラーで終了しました（後続 Issue 処理は継続）"`
+  - これにより Re-check（先行）→ Phase A 本体 → Phase D の順序が確定し、Req 3.1〜3.3 が直列順序により構造的に保証される
+  - 既存ラベル名（`needs-rebase` / `claude-failed` / `ready-for-review` 等）の名前と意味は変更せず、Phase D は既存定数（`$LABEL_NEEDS_REBASE` / `$LABEL_FAILED` / `$LABEL_READY`）を再利用する（NFR 1.3）
+  - _Requirements: 3.1, 3.2, 3.3, NFR 1.3_
+  - _Depends: 3.7_
+
+## 5. Prompt template 配置
+
+- [ ] 5.1 `auto-rebase-prompt.tmpl` を新規作成し install.sh の自動配置経路で配布 (P)
+  - 配置: `local-watcher/bin/auto-rebase-prompt.tmpl`
+  - プレースホルダ: `{{REPO}}` / `{{PR_NUMBER}}` / `{{PR_TITLE}}` / `{{PR_URL}}` / `{{HEAD_REF}}` / `{{BASE_REF}}` / `{{BASE_BRANCH}}`
+  - Claude への指示: 「base ref を head に rebase し conflict 解消後 working tree clean な状態で終了する。force push / dismissal / label 操作は watcher が行うため Claude 側では行わない」
+  - 禁止事項節: `git push` 全般 / `gh pr review` / `gh pr edit --add-label` / `gh pr comment` / rebase 範囲外の不要 refactor を厳禁
+  - install.sh は既存 `copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.tmpl" "$HOME/bin"` で自動配置されるため install.sh 自体の変更は不要
+  - _Requirements: 4.1_
+  - _Boundary: auto-rebase-prompt.tmpl_
+
+## 6. ドキュメント更新
+
+- [ ] 6.1 README に Phase D 節を追加し言語別 `MECHANICAL_PATHS` 設定例を記載 (P)
+  - 「オプション機能一覧」節の「opt-in（既定 OFF）」表に Phase D 行を追加（`AUTO_REBASE_MODE` / 既定 `off`）
+  - 新規節「Auto Rebase Processor (Phase D)」を Phase B / Phase C と同階層で作成し、以下を含める:
+    - 対象 PR の判定条件
+    - 動作フロー（mechanical / semantic / failed の挙動表）
+    - 環境変数仕様（`AUTO_REBASE_MODE` / `MECHANICAL_PATHS` / `AUTO_REBASE_MODEL` / `AUTO_REBASE_MAX_TURNS` / `AUTO_REBASE_MAX_TURNS_SEC` / `AUTO_REBASE_GIT_TIMEOUT` / `AUTO_REBASE_MAX_PRS`）
+    - 言語別 `MECHANICAL_PATHS` 設定例: JavaScript (`package-lock.json,yarn.lock,pnpm-lock.yaml`) / Python (`poetry.lock,Pipfile.lock,uv.lock`) / Go (`go.sum`) / Rust (`Cargo.lock`)
+    - Branch protection "Dismiss stale pull request approvals when new commits are pushed" との相互作用に関する注記（Phase A 既存注記と同トーン）
+    - watcher token に必要な権限（admin / maintain 相当）
+    - ログ観測コマンド例（`grep 'auto-rebase:' $HOME/.issue-watcher/logs/...`）
+  - _Requirements: 9.1, 9.2, 9.3_
+  - _Boundary: README.md_
+
+- [ ] 6.2 `repo-template/CLAUDE.md` の禁止事項 / agent 連携節に Phase D の存在を補足（任意、影響軽微） (P)
+  - 「idd-claude 特有の設計上の注意」節に Phase D Processor の opt-in 制と既存 cron 互換性を 1〜2 行で追記
+  - PR Iteration の `claude-failed` 説明と同形式で、Phase D 起点の `claude-failed` 復旧手順への参照を追加
+  - _Requirements: 9.1_
+  - _Boundary: repo-template/CLAUDE.md_
+
+## 7. 検証 / Dogfood
+
+- [ ] 7.1 `shellcheck` を `issue-watcher.sh` に対して通し警告ゼロを確認
+  - `shellcheck local-watcher/bin/issue-watcher.sh` を実行
+  - 必要な `# shellcheck disable=SC2053` を `ar_classify_diff` の glob 一致行にのみ局所付与
+  - PR 本文の Test plan に shellcheck 出力を記載
+  - _Requirements: NFR 4.1_
+
+- [ ] 7.2 cron-like 最小 PATH での起動確認と従来挙動の不変性スモークテスト
+  - `env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'command -v claude gh jq flock git timeout'`
+  - `AUTO_REBASE_MODE` 未設定で `REPO=owner/test REPO_DIR=/tmp/test-repo $HOME/bin/issue-watcher.sh` を流し、Phase D 関連の起動ログが一切出ないこと、既存 Phase A / Re-check / PR Iteration のサマリ行が従来通り出力されることを確認
+  - PR 本文の Test plan に観測ログ抜粋を記載
+  - _Requirements: 1.1, NFR 1.1, NFR 1.4, NFR 1.5_
+
+- [ ]* 7.3 idd-claude self repo での dogfood（`MECHANICAL_PATHS=package-lock.json` 設定下）
+  - 自分の cron / launchd に `AUTO_REBASE_MODE=claude` / `MECHANICAL_PATHS=package-lock.json` を追加（既存 env はそのまま）
+  - lockfile-only conflict の test PR で `mechanical` 判定 → `needs-rebase` 除去 → auto-merge 到達のフルパスをログから確認
+  - lockfile + source 混在 conflict の test PR で `semantic` 判定 → approve dismissal → `ready-for-review` 付与 → 説明コメント投稿の各 API 呼び出しが成功することを確認
+  - 観測コマンド: `grep 'auto-rebase: PR #' $HOME/.issue-watcher/logs/<repo-slug>/*.log`
+  - _Requirements: 9.4, NFR 2.1, NFR 2.2_


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用** です。実装コードは含まれません。
`docs/specs/17-phase-d-claude-rebase-semantic/` 配下の requirements / design / tasks を merge するためのゲートです。

## 対応 Issue

Refs #17

## 含まれる成果物

- `docs/specs/17-phase-d-claude-rebase-semantic/requirements.md` — 要件定義（PM 成果物）
- `docs/specs/17-phase-d-claude-rebase-semantic/design.md` — 設計書（Architect 成果物）
- `docs/specs/17-phase-d-claude-rebase-semantic/tasks.md` — 実装タスク分割

## トレーサビリティ概要

- Requirement 数: 9 エリア（Req 1〜9）+ NFR 5 エリア（NFR 1〜5）= 合計 numeric ID 48 件
- Acceptance Criteria 数: 各 Requirement に EARS 形式 AC 複数件（合計 45 AC）
- Task 数: 18 タスク（7 フェーズ）、うち (P)（並列可）5 件
- Requirements Traceability: design.md が全 48 numeric ID を参照済み（自己レビュー確認済み）

## 関連 Issue / PR

なし

## レビュー観点

- requirements.md の FR / NFR / AC に過不足はないか
- design.md のモジュール構成・公開 IF が FR をカバーしているか
- 既存コードの再利用が検討されているか、重複実装が混じっていないか（Phase A `mq_try_rebase_pr` / `process_merge_queue_recheck` との整合）
- tasks.md の分割粒度が独立コミット可能か

## 確認事項

### 設計判断の根拠

1. **Processor 挿入順序（Req 3.1〜3.3）**: Re-check → Phase A 本体 → Phase D の直列順序で構造的に競合排除。Phase D は「Re-check・Phase A 本体が触らなかった PR のみを扱う」
2. **`MECHANICAL_PATHS` 構文（Open Questions Q3）**: カンマ区切り + bash glob（`[[ str == glob ]]`）を採用。正規表現は言語非依存性・既定空（NFR 3.2）との整合から不採用。改行区切りは cron/launchd の env 渡し制約で不採用
3. **Claude 自己判定方式（Open Questions Q2）**: 本設計では完全に Non-Goals。将来の fallback 余地は `ar_classify_diff` 単一関数への新規 env 分岐で対応可能（コード変更影響を当該関数に閉じる設計）
4. **Branch protection との相互作用（Open Questions Q4）**: README に注記として残す。Phase D 側では検知しない（Phase A 既存注記と同トーン）

### 人間に確認してほしい点

- approve dismissal API（`PUT /reviews/{id}/dismissals`）を使用するため、watcher token に admin/maintain 相当の権限が必要。この制約の README への明記方針（Security Considerations 節に記載済み）に異論がないか
- `AUTO_REBASE_MAX_PRS` 既定値 `3`、`AUTO_REBASE_MAX_TURNS` 既定値 `30`、`AUTO_REBASE_MAX_TURNS_SEC` 既定値 `600`（秒）の適切性。現行 PR Iteration の同等値と比較して問題ないか
- mechanical / semantic 判定で `git diff` 失敗時を「保守的に semantic 扱い」とする設計（`ar_classify_diff` 戻り値 1 の扱い）が許容範囲か

## Test plan

- [ ] markdown lint: 3 ファイルともコードフェンスに言語タグあり、h1 先頭 1 つ
- [ ] リンク到達確認: `docs/specs/17-phase-d-claude-rebase-semantic/` 配下 3 ファイルが存在
- [ ] numeric ID トレース: requirements.md の全 req ID（1.1〜9.4 / NFR 1.1〜5.3）が design.md の Requirements Traceability 表に出現することを目視確認
- [ ] Mermaid 構文: GitHub PR ビューで flowchart / stateDiagram-v2 が正しくレンダリングされること
- [ ] tasks.md の `(P)` タスクに `_Boundary:_` アノテーションがあることを確認（5 件）
- [ ] auto-close キーワード（Closes / Fixes / Resolves 等）が PR 本文に含まれないことを確認

## Base branch verification

`gh pr view 130 --json baseRefName --jq '.baseRefName'` の結果: `main` — 一致確認済み

## 次のステップ

- この PR を **merge** したら、Issue #17 から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
- 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
- やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue #17 から `awaiting-design-review` ラベルを外すと実装が自動開始します。
