### PR TITLE
fix(template): feature.yml の空 title 行を削除して issue forms picker に表示されるよう修正

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,5 @@
 name: 機能要望・改善（idd-claude 自動開発）
 description: Claude Code に自動開発を依頼する Issue テンプレート。PM エージェントが誤解なくキャッチできる順序で質問を並べています
-title: ""
 labels: ["auto-dev"]
 body:
   - type: markdown


### PR DESCRIPTION
## Summary

- GitHub web UI の Issue picker に `feature.yml` が表示されず、`?template=feature.yml` 直リンクも blank になる事象を修正
- 原因は `title: ""`（空文字列）— GitHub Issue Forms のパーサが空 title を silently 拒否し、テンプレート全体が picker から落ちる挙動が観測された
- `bug-report.yml` は `title: "[Bug] "` で動作しており、有意な差分は title フィールドのみ

## 変更点

- `.github/ISSUE_TEMPLATE/feature.yml` から `title: ""` 行を削除
- Issue タイトルは Triage で PM が自動整形する現行運用と合致するため、テンプレート側でのデフォルト指定は不要

## Test plan

- [ ] PR 作成後、`https://github.com/hitoshiichikawa/idd-claude/issues/new?template=feature.yml` がフォーム表示される（main マージ前は branch URL `https://github.com/hitoshiichikawa/idd-claude/issues/new?template=feature.yml&ref=fix/issue-template-feature-empty-title` を試す手もあるが、GitHub web UI の template 直リンクは default branch を見る仕様のため、最終確認は merge 後）
- [ ] `https://github.com/hitoshiichikawa/idd-claude/issues/new/choose` の picker に `機能要望・改善（idd-claude 自動開発）` が `バグレポート` と並んで表示される
- [ ] `gh issue create --repo hitoshiichikawa/idd-claude --template feature.yml` が動作（参考）

## 確認事項

- merge 後も picker に出ない場合、原因は title 以外（placeholder 長や YAML 構造）の可能性があるため、再度調査が必要
- `title: ""` を空のまま使っていたのは 544db95（feat(template): PM が誤解なく…）以降。それ以前の値 `title: "[feat] "` に戻す選択もあったが、Triage で PM が title 整形する現行運用ではプレフィックス固定は冗長と判断し、削除を選択した

🤖 Generated with [Claude Code](https://claude.com/claude-code)