### PR TITLE
feat(#133): tasks.md の checkbox 形式を必須化し Developer 進捗表現を統一

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -206,6 +206,9 @@ interface <ComponentName>Service {
   - _Requirements: 2.1_
   - _Boundary: CheckoutService_
   - _Depends: 1.2_
+
+- [ ]* 2.2 <deferrable な追加テストタスク>
+  - _Requirements: 2.3_
 ```
 
 ## 重要なアノテーション
@@ -214,6 +217,15 @@ interface <ComponentName>Service {
 - `_Boundary:_` — `(P)` タスクでは必須。design.md の Components 名を列挙
 - `_Depends:_` — 非自明な cross-boundary 依存がある場合のみ
 - `(P)` — 並列実行可能を明示（`_Boundary:_` とセット）
+
+## Checkbox 形式の必須化
+
+**すべてのタスク行は `- [ ]`（未完了）または `- [ ]*`（deferrable 印）の checkbox 形式で
+開始すること**。これは Developer の resume 機能（`IMPL_RESUME_PROGRESS_TRACKING=true`、
+Issue #67 / #112 以降の既定）が `- [ ]` → `- [x]` の markdown checkbox 編集を進捗の **正本**
+として読む前提を確実に成立させるためです。markdown header のみ（例: `## T-01: タスク名` /
+`### Task 1` / `#### 1.1 子タスク`）でタスクを表現することは禁止されます。詳細は
+[`tasks-generation.md`](../rules/tasks-generation.md) の「Checkbox 形式の必須化」節を参照。
 
 # 行動指針
 
@@ -242,6 +254,12 @@ interface <ComponentName>Service {
 - [ ] `(P)` タスクには `_Boundary:_` が明示されている
 - [ ] **Budget overflow check**: tasks.md の最上位 numeric ID タスク件数が 10 件以下
       （後述「Budget overflow が検出された場合の対応」節を参照）
+- [ ] **tasks.md checkbox enforcement**: tasks.md の全タスク行が checkbox 形式
+      （`- [ ]` または `- [ ]*`）で開始し、markdown header のみのタスク表現が無いこと
+      （Developer の resume 機能が `- [ ]` → `- [x]` の markdown checkbox を進捗の正本として
+      読むため、checkbox 形式が必須。詳細は
+      [`design-review-gate.md`](../rules/design-review-gate.md) の「tasks.md checkbox
+      enforcement check」節を参照）
 
 問題が見つかれば draft を修正し、最大 2 パスで再レビューします。それでも曖昧性が残る場合は
 要件フェーズへ差し戻します（design.md 側で要件を発明しない）。

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -107,12 +107,24 @@ main に載っている）前提です。矛盾や実装上の問題に気づい
 - **書き換え禁止領域**: タスク本文 / `_Requirements:_` / `_Boundary:_` / `_Depends:_` /
   タスク順序 / 親タスクのインデント / deferrable 印 `- [ ]*`（アスタリスク付き、
   tasks-generation.md の deferrable 規約）
+- **タスク完了は checkbox 編集で表現する**: タスク完了時は `tasks.md` 上で該当タスク行の
+  `- [ ]` を `- [x]` に書き換えることでタスク完了を表現する。これが進捗の **正本** であり、
+  内部 TaskCreate / TaskUpdate ツール（エージェント内部の TODO トラッキング機能）や hidden
+  marker（コメントベースの隠し進捗マーカー）等を **進捗の正本としては用いない**（内部 TODO
+  ツールを思考補助として併用することは可だが、それを基に PR レビュワーが進捗を判断する
+  ことは想定しない）
 - **進捗 commit は別 commit**: マーカー更新は実装 commit と分けて
   `docs(tasks): mark <task-id> as done` で commit する。当該 commit には `tasks.md` 以外を
-  含めない
+  含めない（batch commit は不可。1 タスク完了 = 1 marker commit）
 - **親タスクの完了判定**: 子タスクが全て `- [x]` になったタイミングで親タスクも `- [x]`
   に更新する。deferrable 子タスク `- [ ]*` は未完了でも親完了に含めて良い
 - **hidden marker は使わない**（設計論点 2: `- [x]` の markdown checkbox のみで進捗を表現）
+- **tasks.md は checkbox 形式である前提**: Architect の自己レビューゲート
+  ([`design-review-gate.md`](../rules/design-review-gate.md) の「tasks.md checkbox
+  enforcement check」) により、全タスク行が `- [ ]` または `- [ ]*` で開始することが保証
+  されている。万が一 checkbox を持たないタスク行（markdown header のみで表現された行など）
+  を発見した場合は、`tasks.md` を勝手に書き換えず PR 本文「確認事項」に記載し、Architect への
+  差し戻しを Issue コメントで提案する
 
 本機能 OFF（`IMPL_RESUME_PRESERVE_COMMITS=false` を明示）の場合、本節は適用されない。
 watcher は注入セクション自体を出力しないため、Developer は通常通り tasks.md の番号順で

--- a/.claude/rules/design-review-gate.md
+++ b/.claude/rules/design-review-gate.md
@@ -43,6 +43,9 @@ Architect が `design.md` を書き終える前に、このゲートに従って
   File Structure Plan に対応ファイルが無いものを検出
 - **Budget overflow check**: tasks.md の最上位 numeric ID タスク件数を機械的にカウントし、
   閾値に応じて分岐する（後述「Budget overflow check（tasks.md 件数）」節を参照）
+- **tasks.md checkbox enforcement check**: tasks.md のすべてのタスク行が checkbox 形式
+  （`- [ ]` または `- [ ]*`）で開始することを機械的に確認する（後述「tasks.md checkbox
+  enforcement check」節を参照）
 
 ### Budget overflow check（tasks.md 件数）
 
@@ -95,6 +98,62 @@ Architect は `design.md` の **末尾**（既存セクション群の後）に 
 - `docs/specs/131-feat-architect-tasks-md-budget-overflow/test-fixtures/tasks-13.md`（consolidate → split）
 - `docs/specs/131-feat-architect-tasks-md-budget-overflow/test-fixtures/tasks-14.md`（forced split）
 - `docs/specs/131-feat-architect-tasks-md-budget-overflow/test-count.sh` — count 抽出 regex の整合性検証
+
+### tasks.md checkbox enforcement check
+
+`tasks.md` の **すべてのタスク行** が checkbox 形式（`- [ ]` 未完了 / `- [ ]*` deferrable）で
+開始することを機械的に確認します。本チェックは Developer の resume 機能
+（`IMPL_RESUME_PROGRESS_TRACKING=true`、Issue #67 / #112 以降の既定）が markdown 上の
+checkbox を進捗の **正本** として読む前提を、Architect 段階で確実に成立させるためのものです。
+
+#### 判定パターン（参照実装）
+
+タスク行と認識する POSIX 互換 ERE:
+
+```
+^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? 
+```
+
+意味: 行頭が `- [ ]` / `- [ ]*` / `- [x]` / `- [x]*` のいずれかで、続けて numeric 階層 ID
+（`1` / `1.1` / `2.1.3` 等）+ 半角スペースで始まる行をタスク行と認識する（最上位タスクは
+ID 末尾の `.` あり [`- [ ] 1. <名前>`]、子タスクは末尾の `.` なし [`- [ ] 1.1 <名前>`] が
+既存表記。regex 末尾の `\.?` がこの差を吸収）。checkbox を持たないタスク表現
+（例: `## T-01: タスク名` / `### Task 1` / `#### 1.1 子タスク` 等の markdown header だけで
+タスクを表す行）は本パターンにマッチせず、**違反として報告**されます。
+
+#### 検証手順
+
+1. Architect は `tasks.md` ドラフトの確定直前に、上記判定パターンで全タスク行を抽出する
+2. タスク本体を表す行が **markdown header のみ**（`^#{1,6} ` で始まり、リスト項目になって
+   いない行）でタスクを表現している箇所が無いかを目視確認する（例: `## T-01: タスク名` /
+   `### 子タスク`）
+3. checkbox 不在のタスク行を 1 件でも検出した場合、該当行を `- [ ] <numeric ID>. <タスク名>`
+   形式（または `- [ ]* <numeric ID> <タスク名>`）に修正してから確定する
+4. [`tasks-generation.md`](./tasks-generation.md) の「Checkbox 形式の必須化」節と整合する
+   ことを確認する（同節と本チェックは同一 checkbox 規約に依拠する）
+
+#### Budget overflow check との関係
+
+本 checkbox enforcement check と既存の **Budget overflow check** は、**同一の checkbox 規約**
+（`- [ ]` / `- [ ]*` で始まるタスク行の認識）に依拠しています:
+
+- Budget overflow check の count 抽出 regex `^- \[ \]\*? [0-9]+\. ` は **最上位 numeric ID
+  タスク**のみを数える狭い判定（ID 末尾の `.` を必須化）
+- checkbox enforcement check の判定パターン `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` は
+  **親タスク・子タスク・完了済みタスク** を含む広い判定（ID 末尾の `.` をオプショナル化）
+- 両者は同じ「タスク行 = リスト項目 + checkbox + numeric ID」という規約を共有しており、
+  本機能導入により Budget overflow check の判定境界（10 / 11 / 13 / 14 件）は **変化しません**
+  （`docs/specs/131-feat-architect-tasks-md-budget-overflow/test-fixtures/` の 4 fixture が
+  全て `- [ ]` checkbox を持つことで引き続き動作します）
+
+#### 適用範囲（後方互換性）
+
+- 本チェックの対象は **Architect が新規に生成・編集する `tasks.md`** に限定する
+- 既に main に merge 済みの spec の `tasks.md` に対する **遡及的なルール違反検出は要求しない**
+  （retrofit は本 rule のスコープ外）
+- 既存 deferrable テストタスク表記 `- [ ]*` は有効な checkbox 形式として扱う（違反として
+  報告しない）
+- ≤ 10 件の正常ケースを含む Budget overflow check の挙動は変化しない
 
 ### `/goal` による自動ループ運用（Claude Code v2.1.139+）
 

--- a/.claude/rules/tasks-generation.md
+++ b/.claude/rules/tasks-generation.md
@@ -28,6 +28,29 @@ Architect が出力する `tasks.md` は、Developer が迷わず実装を進め
   - _Depends: 2.1_
 ```
 
+## Checkbox 形式の必須化
+
+`tasks.md` の **すべての実装タスク行**は、行頭が `- [ ]`（未完了）または `- [ ]*`（deferrable
+印、後述）の checkbox 形式で開始することを **必須** とします。これは Developer の resume
+機能（`IMPL_RESUME_PROGRESS_TRACKING=true`、Issue #67 / #112 以降の既定）が `- [ ]` → `- [x]`
+の markdown checkbox 編集を進捗の **正本** として読む前提を確実に成立させるためです。
+
+- **親タスク行・子タスク行のいずれにも checkbox を付与すること**
+  （例: `- [ ] 1. ...` / `- [ ] 1.1 ...` のように親も子もリスト項目 + checkbox で書く）
+- **markdown header のみ**（例: `## T-01: タスク名` / `### Task 1` / `#### 1.1 子タスク`）で
+  タスクを表現することは **禁止**。タスク行は必ずリスト項目 (`- [ ]`) で書くこと
+- 詳細項目（`_Requirements:_` 等のアノテーション行や説明箇条書き）は checkbox を持たない
+  通常のリスト項目で構わない（タスクそのものを表現する行のみが checkbox 必須）
+- 判定パターン（POSIX 互換 ERE）: `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` — 行頭が `- [ ]`
+  / `- [ ]*` / `- [x]` / `- [x]*` のいずれかで、続けて numeric 階層 ID（`1` / `1.1` /
+  `2.1.3` 等）+ 半角スペースで始まる行をタスク行と認識する（最上位タスクは ID 末尾の
+  `.` あり [`- [ ] 1. <名前>`]、子タスクは末尾の `.` なし [`- [ ] 1.1 <名前>`] が既存表記）
+
+> **Mechanical Check との対応**: 上記必須化は Architect の自己レビュー時に
+> [`design-review-gate.md`](./design-review-gate.md) の **tasks.md checkbox enforcement check**
+> Mechanical Check が機械的に検証します（checkbox 不在のタスク行を 1 件でも検出した場合は
+> 違反として報告し、Architect が `- [ ] <numeric ID>. <タスク名>` 形式に修正してから確定する）。
+
 ## アノテーション
 
 | キー | 必須? | 用途 |
@@ -50,7 +73,8 @@ Architect が出力する `tasks.md` は、Developer が迷わず実装を進め
 ## Optional なテストタスク
 
 deferrable なテスト追加タスクは checkbox を `- [ ]*`（アスタリスク付き）と記述し、詳細項目で
-対応する AC を説明します:
+対応する AC を説明します。**`- [ ]*` も checkbox 形式の一種**として扱われ、上記
+「Checkbox 形式の必須化」節および Mechanical Check の判定で違反として報告されません:
 
 ```markdown
 - [ ]* 1.3 統合テスト追加

--- a/docs/specs/133-feat-architect-developer-tasks-md-checkb/impl-notes.md
+++ b/docs/specs/133-feat-architect-developer-tasks-md-checkb/impl-notes.md
@@ -1,0 +1,169 @@
+# Implementation Notes — Issue #133
+
+## 概要
+
+`tasks.md` の checkbox 形式（`- [ ]` / `- [ ]*`）必須化に伴い、4 ファイルを更新:
+
+1. `.claude/rules/tasks-generation.md` — Checkbox 形式の必須化節を追加
+2. `.claude/rules/design-review-gate.md` — Mechanical Checks に `tasks.md checkbox enforcement check` を追加 + サブセクション展開
+3. `.claude/agents/architect.md` — tasks.md テンプレに `- [ ]*` 例を追加、Checkbox 形式必須化節、品質チェックリストに項目追加
+4. `.claude/agents/developer.md` — checkbox 編集で進捗を表現する規約 / TaskCreate / TaskUpdate を進捗の正本としない旨を明示
+
+## 実装上の判断ポイント
+
+### 1. 判定 regex の現実調整
+
+要件 NFR 2.2 では例として `^- \[[ x]\]\*? [0-9]+\.` が提示されていたが、既存
+`tasks-generation.md` の親子テンプレートを精査したところ:
+
+- 最上位タスク: `- [ ] 1. <タスク>` （ID 末尾に `.` あり）
+- 子タスク: `- [ ] 1.1 <子タスク>` （ID 末尾に `.` なし）
+
+の表記差があるため、checkbox enforcement check の判定パターンは末尾の `.` をオプショナル化
+した `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` を採用した。これにより最上位タスク・子タスク・
+完了済みタスク (`- [x]`) の全てが検出される。
+
+既存の Budget overflow check の regex `^- \[ \]\*? [0-9]+\. ` は変更せず（AC 5.3「正常ケース
+挙動を変化させない」要件のため）、両 regex は同じ「タスク行 = リスト項目 + checkbox + numeric
+ID」規約に依拠する。
+
+### 2. `/goal` 完了条件テンプレへの組み込み見送り
+
+`design-review-gate.md` の `/goal` 自動ループ運用節は、既存の `上記 3 つの Mechanical Checks`
+表現で固定（Budget overflow check も追加されているが既存節は更新されていない）。本 Issue の
+スコープは Mechanical Checks セクションへの項目追加までで、`/goal` テンプレ自体への
+組み込みは要件 AC に明示されていない。スコープ拡大を避けるため見送り。
+
+### 3. tasks-generation.md の deferrable 節への補足追加
+
+「Checkbox 形式の必須化」節と deferrable 節が独立に存在すると、`- [ ]*` が必須要件で
+報告されないかの誤読リスクがあるため、deferrable 節に「`- [ ]*` も checkbox 形式の一種として
+扱われ、Mechanical Check の判定で違反として報告されません」と 1 行追記して整合性を明示した
+（AC 1.4 / 5.2 のサポート）。
+
+### 4. Developer 規約は既存「impl-resume / tasks.md 進捗追跡規約」節へ統合
+
+Developer エージェントの規約は既存節 `## impl-resume / tasks.md 進捗追跡規約` に集約されて
+おり、checkbox を進捗の正本とする規約は同節に統合した（独立節は作らない）。AC 4.1〜4.4 は
+同節内の箇条書き 3 項目（「タスク完了は checkbox 編集で表現する」「進捗 commit は別
+commit」「tasks.md は checkbox 形式である前提」）でカバー。
+
+## 受入基準のテスト・検証マッピング
+
+本 Issue は markdown ルール定義の変更が主体であるため、unit test ではなく **grep ベースの
+キーワード存在確認** および **既存 fixture によるリグレッション検証** で AC を担保する。
+
+| AC | 確認手段 | 担保箇所 |
+|---|---|---|
+| 1.1 | grep | `.claude/rules/tasks-generation.md` L33 「すべての実装タスク行...必須」 |
+| 1.2 | grep | 同 L40 「markdown header のみ...禁止」 |
+| 1.3 | grep | 同 L38 「親タスク行・子タスク行のいずれにも checkbox を付与」 |
+| 1.4 | grep | 同 L75-77 deferrable 節の checkbox 形式扱い明示 |
+| 1.5 | grep | 同 L70-71 既存「ID 規則」節維持 |
+| 2.1 | grep | `.claude/rules/design-review-gate.md` L46-48 Mechanical Checks 箇条書きに項目追加 |
+| 2.2 | 目視 | 同 L120-122 「checkbox を持たないタスク表現...違反として報告」 |
+| 2.3 | 目視 | 同 L130-131 「該当行を `- [ ] <numeric ID>. <タスク名>` 形式に修正」 |
+| 2.4 | grep | 同 L113-114 判定パターン (POSIX 互換 ERE) を記載 |
+| 2.5 | grep | 同 L135-148 「Budget overflow check との関係」節で同一 checkbox 規約に依拠を明示 |
+| 3.1 | 目視 | `.claude/agents/architect.md` L193-212 テンプレに `- [ ]*` 例追加、全タスク行が checkbox |
+| 3.2 | grep | 同 L257-262 品質チェックリストに「tasks.md checkbox enforcement」項目追加 |
+| 3.3 | grep | 同 L221-228 「Checkbox 形式の必須化」節（resume 機能との関連を 1 行以上で説明）|
+| 4.1 | grep | `.claude/agents/developer.md` L110-111 「タスク完了は checkbox 編集で表現する」 |
+| 4.2 | 目視 | 同 L116-118 既存 `docs(tasks): mark <task-id> as done` 規約維持 |
+| 4.3 | grep | 同 L112-115 「TaskCreate / TaskUpdate ... を進捗の正本としては用いない」 |
+| 4.4 | 目視 | 同 L105-106 既存「行内 4 文字差分」規約維持 |
+| 5.1 | grep | `.claude/rules/design-review-gate.md` L151 「Architect が新規に生成・編集する `tasks.md` に限定」 |
+| 5.2 | grep | 同 L154-155 「既存 deferrable テストタスク表記 `- [ ]*` は有効な checkbox 形式」 |
+| 5.3 | fixture test | `bash docs/specs/131-feat-architect-tasks-md-budget-overflow/test-count.sh` で 4 件全 pass |
+| 5.4 | grep | 同 L152-153 「retrofit は本 rule のスコープ外」 |
+| NFR 1.1 | 目視 | 既存ルール（EARS / requirements-review-gate / design-principles / feature-flag）と矛盾なし |
+| NFR 1.2 | 目視 | 言語非依存（markdown checkbox / numeric ID のみで構成、特定言語に依存しない） |
+| NFR 1.3 | 目視 | `.claude/rules/design-review-gate.md` L38-48 Mechanical Checks 箇条書きで既存 4 項目と並列列挙 |
+| NFR 2.1 | 目視 | 判定パターンが POSIX 互換 ERE で明示され、第三者が 1 分以内に確認可能 |
+| NFR 2.2 | fixture test | 判定パターンが既存 fixture 4 件で 100% タスク行を検出（grep -cE 検証） |
+
+## 検証結果
+
+### 1. 必須キーワードの grep 確認
+
+```
+=== tasks-generation.md ===
+31:## Checkbox 形式の必須化
+33:`tasks.md` の **すべての実装タスク行**は、行頭が `- [ ]`（未完了）または `- [ ]*`（deferrable
+38:- **親タスク行・子タスク行のいずれにも checkbox を付与すること**
+40:- **markdown header のみ**（例: `## T-01: タスク名` / `### Task 1` / `#### 1.1 子タスク`）で
+
+=== design-review-gate.md ===
+46:- **tasks.md checkbox enforcement check**: tasks.md のすべてのタスク行が checkbox 形式
+102:### tasks.md checkbox enforcement check
+135:#### Budget overflow check との関係
+
+=== architect.md ===
+210:- [ ]* 2.2 <deferrable な追加テストタスク>
+221:## Checkbox 形式の必須化
+257:- [ ] **tasks.md checkbox enforcement**: tasks.md の全タスク行が checkbox 形式
+
+=== developer.md ===
+110-115:タスク完了は checkbox 編集で表現する / TaskCreate / TaskUpdate ツール ... 進捗の正本としては用いない
+122-127:tasks.md は checkbox 形式である前提
+```
+
+### 2. 既存 fixture によるリグレッション検証（AC 5.3）
+
+```
+$ bash docs/specs/131-feat-architect-tasks-md-budget-overflow/test-count.sh
+[OK]   tasks-10.md: count=10, class=pass
+[OK]   tasks-11.md: count=11, class=consolidate
+[OK]   tasks-13.md: count=13, class=consolidate
+[OK]   tasks-14.md: count=14, class=forced_split
+
+All 4 boundary fixtures match expected count and classification.
+```
+
+Budget overflow check の判定境界 (10/11/13/14) は本変更により **変化なし**。
+
+### 3. checkbox enforcement の判定パターン検証（NFR 2.2）
+
+新規追加した判定パターン `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` を既存 fixture に適用:
+
+```
+$ for f in docs/specs/131-feat-architect-tasks-md-budget-overflow/test-fixtures/*.md; do
+    total=$(grep -cE '^- \[' "$f")
+    detected=$(grep -cE '^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ' "$f")
+    echo "$f: checkbox-lines=$total, detected-task-lines=$detected"
+  done
+
+tasks-10.md: checkbox-lines=12, detected-task-lines=12
+tasks-11.md: checkbox-lines=13, detected-task-lines=13
+tasks-13.md: checkbox-lines=15, detected-task-lines=15
+tasks-14.md: checkbox-lines=16, detected-task-lines=16
+```
+
+既存 fixture の全 checkbox 行（最上位 + 子 + deferrable）が判定パターンで 100% 検出される。
+
+## 確認事項（人間レビュワーへの問い）
+
+1. **design-review-gate.md `/goal` 完了条件テンプレへの組み込み**: 本 PR では `/goal` 自動
+   ループ運用節の完了条件テンプレに checkbox enforcement check を追加していない（要件 AC
+   未明示のため）。Architect 自己レビューで `/goal` を使うフローで checkbox enforcement check
+   も自動収束対象にする場合、別 Issue で追加する余地あり
+
+2. **既存節 `/goal` テンプレの「上記 3 つの Mechanical Checks」表現**: 既存テンプレは
+   Budget overflow check 追加後も `上記 3 つ` の表現で固定されている。本 PR でも更新して
+   いないが、将来的に整合性確保（`上記 5 つ` への更新等）の小修正 Issue を切る価値あり
+
+3. **既存 spec の retrofit を要望する声が出た場合**: AC 5.4 に従い本 Issue では対象外と
+   しているが、将来的に必要になった場合は別 Issue として「過去 merged tasks.md の checkbox
+   後付け」を起票することを想定（impl-notes として記録）
+
+## 派生タスク候補（次の Issue に切り出すべき）
+
+- 上記「確認事項 1, 2」を `/goal` テンプレ更新 Issue として切り出し
+- watcher Stage A prompt（`local-watcher/bin/issue-watcher.sh`）の `tasks.md` 進捗追跡セクション
+  でも checkbox 必須化前提を明示すると、resume 時の Developer 振る舞いがより明確になる
+  （ただし本 Issue Out of Scope: watcher prompt 改修は対象外）
+
+## Feature Flag Protocol
+
+本リポジトリ `CLAUDE.md` には `## Feature Flag Protocol` 節がないため、**opt-out として
+解釈**（Req 1.3, 3.4, NFR 1.1）。通常フローで実装し、flag 関連の追加実装は行わない。

--- a/docs/specs/133-feat-architect-developer-tasks-md-checkb/requirements.md
+++ b/docs/specs/133-feat-architect-developer-tasks-md-checkb/requirements.md
@@ -1,0 +1,119 @@
+# Requirements Document
+
+## Introduction
+
+`local-watcher/bin/issue-watcher.sh` の Stage A prompt は、`IMPL_RESUME_PROGRESS_TRACKING=true`
+（#67 / #112 以降の既定）の下で Developer エージェントに「`tasks.md` の `- [ ]` checkbox を
+`- [x]` に書き換えることで進捗を表現する」という規約を要請している。一方、`.claude/rules/tasks-generation.md`
+は checkbox を含む基本フォーマットを提示しているものの、Architect の自己レビューゲート
+（`.claude/rules/design-review-gate.md`）には checkbox 有無の機械的検証が無く、Architect が
+markdown header のみ（例: `## T-01: タスク名`）の `tasks.md` を出力するケースを排除できない。
+
+実際に hitoshiichikawa/KeyNest#91 では `tasks.md` が checkbox 無しで生成されたため、Developer の
+resume 機能が機能せず、Developer は内部の TaskCreate / TaskUpdate ツールで進捗を二重管理し
+（全 tool call の 29%）、turn budget を浪費した。本要件では、`tasks.md` の checkbox 形式を
+Architect 側で必須化し、Mechanical Check で enforce することで、Developer が markdown 上の
+checkbox のみで進捗を表現できる前提を確実に成立させる。
+
+## Requirements
+
+### Requirement 1: tasks.md の checkbox 形式必須化（ルール側）
+
+**Objective:** As an Architect agent, I want tasks.md の各タスク行が必ず checkbox を持つ規約として明文化された rule を参照できる, so that markdown header のみのタスク表現を生成せず、Developer の resume 機能が機能する前提を満たす
+
+#### Acceptance Criteria
+
+1. The `tasks-generation.md` shall すべての実装タスク行が `- [ ]` または `- [ ]*`（deferrable 印）の checkbox 形式で開始することを必須要件として明示する
+2. The `tasks-generation.md` shall markdown header のみ（例: `## T-01:` / `### Task 1`）でタスクを表現することを禁止する旨を明文化する
+3. The `tasks-generation.md` shall 親タスク行・子タスク行のいずれにも checkbox を付与することを規定する
+4. Where deferrable テストタスクである場合, the `tasks-generation.md` shall checkbox を `- [ ]*`（アスタリスク付き）で記述する既存規約を維持する
+5. The `tasks-generation.md` shall タスク ID は numeric 階層 ID（`1`, `1.1`, `2.1` 等）のみを使用し、`T-01` / `FR-01` 等の英字 ID は使用しない旨の既存規定を維持する
+
+### Requirement 2: Architect 自己レビューでの checkbox enforcement（Mechanical Check）
+
+**Objective:** As an Architect agent, I want tasks.md の checkbox 形式違反を Mechanical Check で機械的に検出できる, so that ドラフト確定前に違反を是正でき、Developer に checkbox 不在の tasks.md が渡らない
+
+#### Acceptance Criteria
+
+1. The `design-review-gate.md` shall Mechanical Checks セクションに「`tasks.md` のすべてのタスク行が checkbox 形式で開始すること」を確認する項目を追加する
+2. When Architect が `tasks.md` ドラフトを自己レビューするとき, the Mechanical Check shall checkbox を持たないタスク行（markdown header のみで表現された行など）を 1 件でも検出した場合に違反として報告する
+3. If Mechanical Check で checkbox 不在のタスク行が検出された場合, the Architect shall 該当行を `- [ ] <numeric ID>. <タスク名>` 形式に修正してから確定する
+4. The `design-review-gate.md` shall checkbox 検出に使用する判定パターン（行頭が `- [ ]` または `- [ ]*` で始まる行をタスク行と認識する規約）を参照可能な形で記載する
+5. The `design-review-gate.md` shall 本 Mechanical Check と既存の Budget overflow check（最上位タスク件数判定）が同一の checkbox 規約に依拠していることを明示する
+
+### Requirement 3: Architect エージェント定義の整合更新
+
+**Objective:** As an Architect agent, I want エージェント定義ファイル内のテンプレートと品質チェック項目が checkbox 必須規約と整合している, so that テンプレートからの逸脱で checkbox 不在の tasks.md を生成しない
+
+#### Acceptance Criteria
+
+1. The `architect.md` shall `tasks.md` テンプレート例の全タスク行が `- [ ]` または `- [ ]*` の checkbox 形式で始まることを保ち、markdown header のみのタスク例を含まない
+2. The `architect.md` shall 自己レビューの品質チェックリストに「全タスク行が checkbox 形式である」項目を含める
+3. The `architect.md` shall Developer が `- [ ]` → `- [x]` で進捗を表現する前提を維持するために checkbox 形式が必須である理由を 1 行以上で説明する
+
+### Requirement 4: Developer エージェント定義の整合更新
+
+**Objective:** As a Developer agent, I want エージェント定義が tasks.md の checkbox を編集することで進捗を表現する規約を明示している, so that 内部 TaskCreate / TaskUpdate での二重管理ではなく markdown checkbox 編集で進捗を表現できる
+
+#### Acceptance Criteria
+
+1. The `developer.md` shall タスク完了時に該当タスク行の `- [ ]` を `- [x]` に書き換えることでタスク完了を表現する規約を明示する
+2. The `developer.md` shall タスク完了マーカーの更新は実装 commit とは別の独立した commit（既存規約: `docs(tasks): mark <task-id> as done`）で行う既存規約を維持する
+3. While `IMPL_RESUME_PROGRESS_TRACKING=true` の状態, the `developer.md` shall 進捗表現の手段として markdown checkbox 編集を採用し、hidden marker や内部 TaskCreate / TaskUpdate を進捗の正本としては用いない旨を明示する
+4. The `developer.md` shall checkbox 書き換えで許容される差分が「`- [ ]` ↔ `- [x]` の行内 4 文字差分のみ」である既存規約を維持する
+
+### Requirement 5: 後方互換性と既存 spec 資産の扱い
+
+**Objective:** As a repository maintainer, I want 既に merge 済みの spec（過去の tasks.md）に対して破壊的影響を与えない, so that 本ルール強化が既存 PR / ブランチ / Issue を遡及的に壊さない
+
+#### Acceptance Criteria
+
+1. The Mechanical Check shall 本機能の対象を「Architect が新規に生成・編集する `tasks.md`」に限定し、既存 merged spec の `tasks.md` に対する遡及的なルール違反検出は要求しない
+2. The Mechanical Check shall 既存の deferrable テストタスク表記（`- [ ]*`）を有効な checkbox 形式として扱い、違反として報告しない
+3. While 本機能のルール強化が main に取り込まれた後, the Mechanical Check shall ≤ 10 件の正常ケースを含む既存挙動を変化させない（Budget overflow check の判定境界には影響しない）
+4. The repository maintainer shall 既存 merged spec の retrofit（過去の tasks.md への checkbox 後付け）を本要件のスコープに含めない
+
+## Non-Functional Requirements
+
+### NFR 1: 言語・基盤非依存性とドキュメント整合性
+
+1. The `tasks-generation.md` / `design-review-gate.md` / `architect.md` / `developer.md` shall 既存の他ルール（EARS / requirements-review-gate / design-principles / feature-flag）と矛盾する記述を含まない
+2. The 更新後のルール群 shall 言語非依存（特定の実装言語に依存しない記述）であることを保つ
+3. The `design-review-gate.md` shall checkbox enforcement の Mechanical Check 項目を、既存 3 項目（Requirements traceability / File Structure Plan / orphan component）と Budget overflow check と並列に列挙可能な粒度で記述する
+
+### NFR 2: 検証可能性
+
+1. The Mechanical Check 規約 shall 第三者（人間レビュワーや別エージェント）が `tasks.md` を読んで checkbox 有無を 1 分以内に機械的に判定できる程度の明確さを持つ
+2. The 判定パターン shall POSIX 互換 ERE で表現可能な regex（例: `^- \[[ x]\]\*? [0-9]+\.`）で機械検証できることを保つ
+
+## Out of Scope
+
+- Developer の内部 TaskCreate / TaskUpdate ツール呼び出しの **ハード制限**（#132 サブ #B として別 Issue で扱う）
+- parallel tool call 規律の見直し（#132 サブ #C として別 Issue で扱う）
+- batch commit（複数タスク完了マーカーを 1 commit にまとめる）の許容（本要件では既存規約「マーカー更新は実装 commit と分けて 1 タスク = 1 commit」を維持）
+- 既存 merged spec の `tasks.md` への checkbox 後付け（retrofit）作業
+- `IMPL_RESUME_PROGRESS_TRACKING` の値変更や env 名の改名
+- watcher Stage A prompt 自体の改修（本要件は rule / agent 定義側の整合確保が主目的で、prompt 改修は不要）
+- 外部 task tracker（GitHub Projects / Linear / Jira 等）との連携や自動 sync
+- checkbox 以外の進捗表現手段の導入（hidden marker / 別ファイル進捗ログ等）
+
+## Open Questions
+
+Issue #133 本文の「確認事項」3 項目は、現時点で人間からの追加コメントが付いていない。PM
+判断として暫定 stance を以下に示す（後段の Architect / Developer の判断材料）:
+
+1. **checkbox 番号体系の統一**（numeric 階層 ID vs `T-01` 混在）
+   - **暫定 stance**: 既存 `tasks-generation.md` の「numeric 階層 ID のみ使用、`T-01` / `FR-01` は不可」既定を維持し、混在を許容しない。Mechanical Check では「行頭 `- [ ]` の直後に numeric ID（`[0-9]+(\.[0-9]+)*\.`）が来ること」を必須化する方向で、Architect が design / tasks 整合性を確保しやすい統一表記を採る
+   - **判断委任先**: Architect（具体的な regex / 検出パターンは design.md で確定）
+
+2. **既存 merged spec の retro fit 要否**
+   - **暫定 stance**: retrofit は **本要件のスコープ外**（Out of Scope に明記）。既存 merged spec の tasks.md は当時の合意済み成果物であり、遡及的な書き換えは git 履歴の追跡性を損ねる。新規生成・編集される tasks.md のみを Mechanical Check の対象とする
+   - **判断委任先**: 人間運用者（必要なら別 Issue として retrofit を起票）
+
+3. **per-task commit の負荷（batch commit 許容否）**
+   - **暫定 stance**: 既存 `developer.md` の「マーカー更新は実装 commit と分けて `docs(tasks): mark <task-id> as done` で commit」を維持し、batch commit は許容しない。理由: (a) #67 / #112 で確立した resume 機能の挙動と整合させる必要がある、(b) 1 task = 1 marker commit の方が PR 上での進捗可視性が高い、(c) 本 Issue のスコープは checkbox 必須化であり、commit 粒度の変更は範囲外
+   - **判断委任先**: Architect（commit メッセージテンプレートの細部は design.md で確定可能）
+
+なお、これらの暫定 stance は requirements.md 自身の AC として束縛しない方針とし、AC 5.4 で
+「retrofit はスコープ外」のみを明示している。Architect は上記 stance を踏まえつつ、必要に
+応じて Issue コメントで人間判断を仰いで構わない。

--- a/docs/specs/133-feat-architect-developer-tasks-md-checkb/review-notes.md
+++ b/docs/specs/133-feat-architect-developer-tasks-md-checkb/review-notes.md
@@ -1,0 +1,49 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-22T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-133-impl-feat-architect-developer-tasks-md-checkb
+- HEAD commit: e6e3bac7125592ca54ba49e70b06f4e95de0909a
+- Compared to: main..HEAD
+- Feature Flag Protocol: CLAUDE.md に該当節なし → opt-out 解釈（flag 観点の細目チェックは適用しない）
+
+## Verified Requirements
+
+- 1.1 — `.claude/rules/tasks-generation.md` L31-36「すべての実装タスク行は…checkbox 形式で開始することを必須」を明示
+- 1.2 — `.claude/rules/tasks-generation.md` L40-41「markdown header のみ（例: `## T-01: タスク名` / `### Task 1` …）でタスクを表現することは禁止」を明示
+- 1.3 — `.claude/rules/tasks-generation.md` L38-39「親タスク行・子タスク行のいずれにも checkbox を付与すること」を明示
+- 1.4 — `.claude/rules/tasks-generation.md` L75-77 deferrable 節維持 + 「`- [ ]*` も checkbox 形式の一種として扱われ…違反として報告されません」追記
+- 1.5 — `.claude/rules/tasks-generation.md` L68-71「ID 規則」節（numeric 階層 ID 必須、`T-01` / `FR-01` 不可）は diff で変更されていない（既存規定維持）
+- 2.1 — `.claude/rules/design-review-gate.md` L46-48 Mechanical Checks 箇条書きに「tasks.md checkbox enforcement check」項目追加
+- 2.2 — `.claude/rules/design-review-gate.md` 新設「tasks.md checkbox enforcement check」節「判定パターン」「検証手順」項で「checkbox 不在のタスク行を 1 件でも検出した場合に違反として報告」を明示
+- 2.3 — 同節「検証手順」3「該当行を `- [ ] <numeric ID>. <タスク名>` 形式に修正してから確定する」を明示
+- 2.4 — 同節「判定パターン（参照実装）」項に POSIX 互換 ERE `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` を記載（参照可能な形式）
+- 2.5 — 同節「Budget overflow check との関係」項で「両者は同じ『タスク行 = リスト項目 + checkbox + numeric ID』という規約を共有」を明示
+- 3.1 — `.claude/agents/architect.md` L192-212 テンプレに `- [ ]*` deferrable 例追加、全タスク行が `- [ ]` / `- [ ]*` の checkbox 形式（markdown header のみのタスク例なし）
+- 3.2 — `.claude/agents/architect.md` L257-262 自己レビュー品質チェックリストに「tasks.md checkbox enforcement」項目追加
+- 3.3 — `.claude/agents/architect.md` L221-228 新設「Checkbox 形式の必須化」節で「Developer の resume 機能…前提を確実に成立させるため」と理由を 1 行以上で説明
+- 4.1 — `.claude/agents/developer.md` L110-115「タスク完了は checkbox 編集で表現する: タスク完了時は `tasks.md` 上で該当タスク行の `- [ ]` を `- [x]` に書き換えることでタスク完了を表現する」を明示
+- 4.2 — `.claude/agents/developer.md` L116-118 既存規約「マーカー更新は実装 commit と分けて `docs(tasks): mark <task-id> as done` で commit する」を維持（diff で「batch commit は不可」追記のみ）
+- 4.3 — `.claude/agents/developer.md` L86-94「impl-resume / tasks.md 進捗追跡規約」節（`IMPL_RESUME_PROGRESS_TRACKING=true|false` の状態下）配下に L110-115「これが進捗の **正本** であり、内部 TaskCreate / TaskUpdate ツール…hidden marker 等を **進捗の正本としては用いない**」を明示
+- 4.4 — `.claude/agents/developer.md` L105-106 既存「行内 4 文字差分」規約を維持（diff で削除なし）
+- 5.1 — `.claude/rules/design-review-gate.md`「適用範囲（後方互換性）」節「本チェックの対象は **Architect が新規に生成・編集する `tasks.md`** に限定する」を明示
+- 5.2 — 同節「既存 deferrable テストタスク表記 `- [ ]*` は有効な checkbox 形式として扱う（違反として報告しない）」を明示
+- 5.3 — 同節「≤ 10 件の正常ケースを含む Budget overflow check の挙動は変化しない」を明示。Reviewer 側で `docs/specs/131-feat-architect-tasks-md-budget-overflow/test-count.sh` を再実行し、4 fixture (10/11/13/14 件) が期待 class と一致することを確認
+- 5.4 — 同節「既に main に merge 済みの spec の `tasks.md` に対する **遡及的なルール違反検出は要求しない**（retrofit は本 rule のスコープ外）」を明示
+- NFR 1.1 — 既存ルール（EARS / requirements-review-gate / design-principles / feature-flag）との矛盾は diff レビュー範囲で検出せず（既存節への追記・新規節追加のみ）
+- NFR 1.2 — 追加された規約は markdown / checkbox / numeric ID のみで構成、特定実装言語に依存しない記述
+- NFR 1.3 — `.claude/rules/design-review-gate.md` Mechanical Checks 箇条書き（L38-48）で既存 4 項目（Requirements traceability / File Structure Plan / orphan component / Budget overflow check）と並列粒度で列挙
+- NFR 2.1 — 判定パターンが POSIX 互換 ERE で明示され、第三者が 1 分以内に機械的判定可能
+- NFR 2.2 — Reviewer 側で `grep -cE '^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? '` を 4 fixture に適用し、全 checkbox 行（最上位 + 子 + deferrable）が 100% 検出されることを再確認 (tasks-10/11/13/14 で checkbox-lines == detected-task-lines)
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #133 が要求する 4 ファイル（`.claude/rules/tasks-generation.md` / `.claude/rules/design-review-gate.md` / `.claude/agents/architect.md` / `.claude/agents/developer.md`）の変更が、Req 1.1〜5.4 および NFR 1.1〜2.2 のすべての numeric ID に対してドキュメント記述または既存規約維持として観測可能。Budget overflow check の判定境界不変（AC 5.3）および判定 regex の fixture 検出率 100% (NFR 2.2) は Reviewer 側で再実行して担保を確認した。Out of Scope（watcher prompt 改修・retrofit・env 名改名）に手を出しておらず、boundary 逸脱は検出されない。本 repo は unit test フレームワークを持たない markdown ルール変更が主体のため、CLAUDE.md「テスト・検証」節に従って grep + 既存 fixture リグレッション検証で AC を担保しており missing test も該当しない。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

`tasks.md` の checkbox 形式（`- [ ]` / `- [ ]*`）を Architect 側で必須化し、Mechanical Check で enforce する変更です。従来は Architect が markdown header のみ（例: `## T-01: タスク名`）の `tasks.md` を生成しても検出できず、Developer の resume 機能（`IMPL_RESUME_PROGRESS_TRACKING=true` による `- [ ]` → `- [x]` 進捗追跡）が機能しないケースがありました。本 PR により、Architect 自己レビュー時に checkbox 不在のタスク行を機械的に検出・修正できるようになります。また Developer エージェント定義に、checkbox 編集が進捗の正本であり内部 TaskCreate / TaskUpdate を正本としない旨を明示します。

変更対象:
- `.claude/rules/tasks-generation.md` — Checkbox 形式の必須化節を追加
- `.claude/rules/design-review-gate.md` — Mechanical Checks に `tasks.md checkbox enforcement check` を追加
- `.claude/agents/architect.md` — テンプレ・品質チェックリスト・Checkbox 必須化節を追加
- `.claude/agents/developer.md` — checkbox 編集を進捗の正本とする規約を明示

## 対応 Issue

Closes #133

## 関連 PR

なし（設計 PR は走っていない）

## 実装内容

- (Req 1) `tasks-generation.md` に Checkbox 形式の必須化節を追加。親タスク・子タスクとも `- [ ]` / `- [ ]*` 形式を必須化し、markdown header のみのタスク表現を禁止
- (Req 2) `design-review-gate.md` の Mechanical Checks セクションに `tasks.md checkbox enforcement check` を追加。判定パターン（POSIX 互換 ERE `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? `）と Budget overflow check との関係を明示
- (Req 3) `architect.md` のテンプレ例・品質チェックリスト・Checkbox 必須化節を整合更新
- (Req 4) `developer.md` の impl-resume / tasks.md 進捗追跡規約節に checkbox 編集規約を明示（TaskCreate / TaskUpdate は進捗の正本としない）
- (Req 5) 後方互換性確保：Mechanical Check の対象を新規生成 tasks.md に限定、deferrable `- [ ]*` は有効扱い、Budget overflow check 判定境界は不変

## 受入基準チェック

- [x] Req 1.1: The `tasks-generation.md` shall すべての実装タスク行が `- [ ]` または `- [ ]*` の checkbox 形式で開始することを必須要件として明示する ← `tasks-generation.md` L31-36
- [x] Req 1.2: The `tasks-generation.md` shall markdown header のみでタスクを表現することを禁止する旨を明文化する ← 同 L40-41
- [x] Req 1.3: The `tasks-generation.md` shall 親タスク行・子タスク行のいずれにも checkbox を付与することを規定する ← 同 L38-39
- [x] Req 1.4: Where deferrable テストタスクである場合, the `tasks-generation.md` shall checkbox を `- [ ]*` で記述する既存規約を維持する ← 同 L75-77
- [x] Req 1.5: The `tasks-generation.md` shall タスク ID は numeric 階層 ID のみを使用する既存規定を維持する ← 同「ID 規則」節
- [x] Req 2.1: The `design-review-gate.md` shall Mechanical Checks セクションに checkbox enforcement 項目を追加する ← `design-review-gate.md` L46-48
- [x] Req 2.2: When Architect が tasks.md ドラフトを自己レビューするとき, the Mechanical Check shall checkbox 不在のタスク行を 1 件でも検出した場合に違反として報告する ← 同「tasks.md checkbox enforcement check」節
- [x] Req 2.3: If Mechanical Check で checkbox 不在のタスク行が検出された場合, the Architect shall 該当行を `- [ ] <numeric ID>. <タスク名>` 形式に修正してから確定する ← 同「検証手順」3
- [x] Req 2.4: The `design-review-gate.md` shall 判定パターンを参照可能な形で記載する ← 同「判定パターン（参照実装）」
- [x] Req 2.5: The `design-review-gate.md` shall 本 Mechanical Check と Budget overflow check が同一の checkbox 規約に依拠していることを明示する ← 同「Budget overflow check との関係」節
- [x] Req 3.1: The `architect.md` shall tasks.md テンプレ例の全タスク行が checkbox 形式で始まることを保つ ← `architect.md` L192-212
- [x] Req 3.2: The `architect.md` shall 自己レビューの品質チェックリストに「全タスク行が checkbox 形式である」項目を含める ← 同 L257-262
- [x] Req 3.3: The `architect.md` shall Developer の resume 機能との関連を 1 行以上で説明する ← 同 L221-228
- [x] Req 4.1: The `developer.md` shall タスク完了時に `- [ ]` を `- [x]` に書き換えることでタスク完了を表現する規約を明示する ← `developer.md` L110-115
- [x] Req 4.2: The `developer.md` shall `docs(tasks): mark <task-id> as done` の既存規約を維持する ← 同 L116-118
- [x] Req 4.3: While `IMPL_RESUME_PROGRESS_TRACKING=true` の状態, the `developer.md` shall markdown checkbox 編集を進捗の正本とし、TaskCreate / TaskUpdate を正本としない旨を明示する ← 同 L112-115
- [x] Req 4.4: The `developer.md` shall checkbox 書き換えで許容される差分が「行内 4 文字差分のみ」である既存規約を維持する ← 同 L105-106
- [x] Req 5.1: The Mechanical Check shall 対象を「Architect が新規に生成・編集する tasks.md」に限定する ← `design-review-gate.md`「適用範囲（後方互換性）」節
- [x] Req 5.2: The Mechanical Check shall `- [ ]*` を有効な checkbox 形式として扱い違反として報告しない ← 同節
- [x] Req 5.3: Budget overflow check の判定境界が変化しないこと ← fixture 4 件全 pass（test-count.sh 再実行済み）
- [x] Req 5.4: retrofit はスコープ外 ← 同節「retrofit は本 rule のスコープ外」を明示

## テスト結果

```
$ bash docs/specs/131-feat-architect-tasks-md-budget-overflow/test-count.sh
[OK]   tasks-10.md: count=10, class=pass
[OK]   tasks-11.md: count=11, class=consolidate
[OK]   tasks-13.md: count=13, class=consolidate
[OK]   tasks-14.md: count=14, class=forced_split

All 4 boundary fixtures match expected count and classification.
```

Budget overflow check の判定境界 (10/11/13/14) は本変更により変化なし。

新規追加した判定パターン `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` を既存 fixture に適用した結果、全 fixture で `checkbox-lines == detected-task-lines`（100% 検出）を確認。

本リポジトリは unit test フレームワークを持たない markdown ルール変更が主体のため、CLAUDE.md「テスト・検証」節に従って grep + 既存 fixture リグレッション検証で AC を担保。

## 実装上の判断

詳細は `docs/specs/133-feat-architect-developer-tasks-md-checkb/impl-notes.md` を参照。主な判断:

1. **判定 regex の現実調整**: 要件例示の regex を `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` に調整（親タスクの ID 末尾 `.` と子タスクの ID 末尾なしの差を `.?` で吸収）
2. **`/goal` 完了条件テンプレへの組み込み見送り**: AC 未明示のためスコープ外とした（確認事項 1 参照）
3. **Developer 規約の既存節への統合**: 独立節を作らず既存 `impl-resume / tasks.md 進捗追跡規約` 節に集約

## 確認事項 / レビュワーへの依頼

1. **`design-review-gate.md` `/goal` 完了条件テンプレへの checkbox enforcement check 組み込み**: 本 PR では未対応（要件 AC 未明示のため）。必要なら別 Issue で追加可（impl-notes.md の「確認事項 1」を参照）
2. **既存節「上記 3 つの Mechanical Checks」表現の更新**: Budget overflow check 追加後も `上記 3 つ` の表現で固定されており、本 PR でも更新していない（「確認事項 2」参照）
3. **Reviewer の判定**: `RESULT: approve`（`docs/specs/133-feat-architect-developer-tasks-md-checkb/review-notes.md` 参照）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #133 のコメントを参照してください。
