### PR TITLE
feat(#132): Developer エージェント turn budget overhead 削減 (umbrella close-out)

### DIFF
--- a/docs/specs/132-feat-developer-developer-turn-budget-ove/impl-notes.md
+++ b/docs/specs/132-feat-developer-developer-turn-budget-ove/impl-notes.md
@@ -1,0 +1,200 @@
+# Implementation Notes — Issue #132 (Umbrella Close-Out)
+
+## Umbrella の趣旨要約
+
+Issue #132 は Developer エージェントの **turn budget overflow**（典型 60 turn 上限の到達）
+および **内部 TODO トラッキング由来の overhead**（TaskCreate / TaskUpdate が全 tool call の
+29% を占めていた事象）を改善するための **umbrella 親 Issue** です。改善目標は (1) TaskCreate /
+TaskUpdate 比率を 29% → 10% 以下に削減し、(2) tool call/turn 比率を 1.7 → 2.5+ に押し上げ
+ることで、tool call 予算を実装本体（テスト追加 / commit / AC 達成）に振り向け、turn budget
+overrun による Developer 自動失敗を抑制することです。本体実装は 3 件のサブ Issue に分割
+され、いずれも CLOSED かつ main に merge 済みとなっています。本 umbrella では新規 feature
+実装は行わず、サブ Issue の完了状態確認とドキュメント集約のみを行います（Requirement 5 の
+スコープ境界）。
+
+## サブ Issue 一覧（rollout Option A 順）
+
+人間運用者は Issue #132 のコメント上で rollout 順 **Option A**（`#A → #B → #C` すなわち
+**#133 → #134 → #135**）を承認しており、本承認のもとで以下の順序で main に merge され
+ました。各 spec ディレクトリへの相対パスは本ファイルから見たものです。
+
+1. **#133** — feat(architect/developer): tasks.md の checkbox 形式を必須化し、Developer
+   は checkbox 編集で進捗を表現する
+   ([`../133-feat-architect-developer-tasks-md-checkb/`](../133-feat-architect-developer-tasks-md-checkb/))
+2. **#134** — feat(developer): TaskCreate / TaskUpdate の使用を `tasks.md` にない緊急対応
+   のみに制限
+   ([`../134-feat-developer-taskcreate-taskupdate-tas/`](../134-feat-developer-taskcreate-taskupdate-tas/))
+3. **#135** — feat(developer): independent な tool 操作を 1 turn にまとめて parallel call
+   で実行する規律を強化
+   ([`../135-feat-developer-independent-tool-1-turn-p/`](../135-feat-developer-independent-tool-1-turn-p/))
+
+## 確認時のリポジトリ状態（NFR 1.2）
+
+- 確認時 git SHA: `75ae4afb8575f7e873306b6d15126bc8dba367a3`（main HEAD）
+- 確認日: 2026-05-22
+- ブランチ: `claude/issue-132-impl-feat-developer-developer-turn-budget-ove`（本 close-out 作業ブランチ）
+
+## Requirement 1 の確認結果（サブ Issue 完了の検証）
+
+| AC | 確認対象 | 確認結果 |
+|---|---|---|
+| 1.1 | `docs/specs/133-feat-architect-developer-tasks-md-checkb/` 配下の `requirements.md` と `impl-notes.md` | **存在確認 OK**（`ls -la` で 2 ファイル + `review-notes.md` を確認） |
+| 1.2 | `docs/specs/134-feat-developer-taskcreate-taskupdate-tas/` 配下の `requirements.md` と `impl-notes.md` | **存在確認 OK**（同上） |
+| 1.3 | `docs/specs/135-feat-developer-independent-tool-1-turn-p/` 配下の `requirements.md` と `impl-notes.md` | **存在確認 OK**（同上） |
+| 1.4 | 上記いずれかに欠落があった場合の保留条件 | 該当なし（全ファイル揃っている） |
+| 1.5 | サブ Issue 3 件の closed 状態 | **3 件すべて CLOSED 確認**（`gh issue view 133/134/135 --json state` で `"state":"CLOSED"`） |
+
+## Requirement 2 の確認結果（規約・エージェント定義への反映確認）
+
+すべて Grep ベースで反映を確認しました。確認対象ファイルは self-hosting 側（`.claude/`
+配下）です。
+
+| AC | 確認対象ファイル | 確認した節 / 行 | 確認結果 |
+|---|---|---|---|
+| 2.1 | `.claude/rules/tasks-generation.md` | L31 `## Checkbox 形式の必須化`, L33-77 規約本文 | **OK**（#133 由来。「すべての実装タスク行が `- [ ]` または `- [ ]*` の checkbox 形式で開始する」明示） |
+| 2.2 | `.claude/rules/design-review-gate.md` | L46 Mechanical Checks 箇条書き + L102 `### tasks.md checkbox enforcement check` | **OK**（#133 由来。Mechanical Checks セクションへの項目追加 + サブセクション展開を確認） |
+| 2.3 | `.claude/agents/architect.md` | L221 `## Checkbox 形式の必須化`, L257-262 品質チェックリスト項目 | **OK**（#133 由来。テンプレ・規約・チェックリスト 3 箇所に反映） |
+| 2.4 | `.claude/agents/developer.md` | L200 `## TaskCreate / TaskUpdate の使用制限（Issue #134 以降適用）` | **OK**（#134 由来。許容ケースの限定列挙、reminder への defensive 応答禁止、進捗の正本は checkbox 規約を含む） |
+| 2.5 | `.claude/agents/developer.md` | L55 `# Tool 呼び出しの並列化規律（Issue #135 以降適用）` | **OK**（#135 由来。規律ステートメント / 並列化すべき具体例 / 直列にすべきケース / 数値ガイド / 過度な並列化への注意を含む） |
+| 2.6 | 上記いずれかに欠落がある場合の保留条件 | — | 該当なし（5 項目すべて反映確認済み） |
+
+### 補足: `repo-template/` 配下の同期状況
+
+#134 / #135 由来の Developer 規約は `repo-template/.claude/agents/developer.md` にも反映済み
+を Grep で確認しました（`Tool 呼び出しの並列化規律` / `TaskCreate / TaskUpdate の使用制限`
+ともに同ファイルにヒット）。一方で #133 由来の checkbox 規約については以下を発見しました:
+
+- `repo-template/.claude/agents/architect.md` には `Checkbox 形式の必須化` 節が **未反映**
+- `repo-template/.claude/rules/tasks-generation.md` / `repo-template/.claude/rules/design-review-gate.md`
+  ともに #133 由来の checkbox 規約 / Mechanical Check 追加が **未反映**
+
+これは #133 の責務範囲（consumer repo にも同じ規約を配布する `repo-template/` 配下への
+同期）であり、本 umbrella #132 の close-out スコープ（Requirement 5: 3 サブ Issue で
+merge 済みの内容を変更しない）からは外れる事項です。**対応方針**: 本 close-out では補完
+せず、別 Issue として独立に起票することを推奨します（Requirement 5.3 に則り、追加対応が
+必要な事項は別 Issue 化）。具体的なタイトル案: `chore(template): #133 の checkbox 規約を
+repo-template/ 配下に同期`。
+
+なお self-hosting 側（idd-claude 自身が次回 cron 実行で参照する `.claude/` 配下）には #133
+の全規約が反映済みであるため、umbrella #132 が直接目標とする「Developer / Architect の
+挙動改善」は self-hosting 範囲では達成済みです。consumer repo（idd-claude を install した
+他リポジトリ）への配布は次回 `install.sh` 再実行時に repo-template を base として上書き
+されるため、上記同期が未完了のままだと consumer 側に #133 の checkbox 規約が伝播しません。
+
+## Requirement 3 の確認結果（umbrella spec ディレクトリの整備）
+
+- AC 3.1: `docs/specs/132-feat-developer-developer-turn-budget-ove/` ディレクトリに
+  `requirements.md`（PM 作成済み）と本 `impl-notes.md`（本ファイル）を配置 → **OK**
+- AC 3.2: umbrella の趣旨を本ファイル冒頭「Umbrella の趣旨要約」節で 1 段落以上で要約 → **OK**
+- AC 3.3: 3 サブ Issue spec ディレクトリへの相対パスリンクを「サブ Issue 一覧」節に各 1 件
+  記載 → **OK**
+- AC 3.4: rollout Option A（#133 → #134 → #135）が人間運用者承認のもとで適用された旨を
+  「サブ Issue 一覧」節で明記 → **OK**
+- AC 3.5: Requirement 2 で発見した repo-template 同期不足について、本ノート「Requirement 2
+  の補足」節に対応方針（別 Issue 起票推奨）を記載 → **OK**
+
+## Requirement 4 の確認結果（README / CLAUDE.md への umbrella レベル更新要否判定）
+
+### 判定: README.md / CLAUDE.md / repo-template/CLAUDE.md ともに **追加更新不要**
+
+判定根拠:
+
+1. **CLAUDE.md（root）と `repo-template/CLAUDE.md`**: Grep で `#132` / `#133` / `#134` /
+   `#135` / `umbrella` / `turn budget` / `TaskCreate` のいずれにもヒットなしを確認。
+   両 CLAUDE.md は **エージェント運用憲章**（言語方針 / コード規約 / 禁止事項 / エージェント
+   連携ルール）を扱うレイヤであり、個別 Issue 由来の Developer / Architect の作業手順詳細
+   （checkbox 必須化 / TaskCreate 制限 / 並列化規律）は **エージェント定義ファイル
+   `.claude/agents/*.md` および規約 `.claude/rules/*.md`** が一次的な情報源です。各サブ
+   Issue がそれぞれの担当ファイル（`developer.md` / `architect.md` / `tasks-generation.md`
+   / `design-review-gate.md`）を更新済みであり、CLAUDE.md レベルで重複参照を追加する必要
+   は無いと判断しました。
+2. **README.md**: `umbrella` / `turn budget` / `TaskCreate` の関連語を Grep した結果、既に
+   `turn budget` についての説明（5 件のヒット）が記述されており、`partial_overrun` / Developer
+   の halt 判断などの運用観点での扱いが説明されています。これらは #148（partial halt 機構）
+   などの別 Issue で整備された記述であり、本 umbrella #132 のサブ Issue で追加変更すべき
+   箇所はありません。具体的には:
+   - README L3236 付近: turn budget 超過の事前抑止に関する記述
+   - README L3676 付近: Reviewer 起動と turn budget の関係
+   - README L3689 付近: `partial_overrun` ステータスの表
+   - README L3759 付近: `partial_overrun` 判定の数値基準
+   - README L3993 付近: Developer の turn budget 概念紹介
+
+   これらの記述は umbrella #132 のサブ Issue（#133 / #134 / #135）が変更すべき範囲では
+   なく、本 close-out で追加更新する必要はありません。
+3. **README / CLAUDE.md と各サブ Issue で更新済みの規約 / エージェント定義の矛盾チェック**:
+   目視で確認した範囲では、CLAUDE.md の「エージェント連携ルール」節で Developer が
+   `design.md` / `tasks.md` を書き換えないこと、PR 品質チェック項目に shellcheck / actionlint
+   が含まれること、後方互換性の維持が必須であること等が記述されており、これらは #133 / #134 /
+   #135 のサブ Issue 規約と **整合**（矛盾なし）であることを確認しました。
+
+### AC 4 の達成状況
+
+| AC | 内容 | 結果 |
+|---|---|---|
+| 4.1 | README.md / CLAUDE.md について umbrella として追加更新が必要かを明示的に判定 | **OK**（上記「判定: 追加更新不要」） |
+| 4.2 | サブ Issue が必要箇所を更新済みと判定したときに追加更新を行わず、根拠を impl-notes に記録 | **OK**（上記「判定根拠」1〜3） |
+| 4.3 | umbrella レベルで補完すべき不整合を発見した場合の方針判断 | 該当する不整合は **発見せず**（repo-template 同期不足は Requirement 2 補足に別 Issue 化推奨として記録済み。README / CLAUDE.md 本文には不整合なし） |
+| 4.4 | README / CLAUDE.md と各サブ Issue で更新済みの規約 / エージェント定義の間に矛盾が無いことを目視確認 | **OK**（上記「判定根拠」3） |
+
+## Requirement 5 の確認結果（スコープ境界の維持）
+
+本 close-out で実施した変更は **本 `impl-notes.md` の追加のみ** です。
+
+| AC | 内容 | 遵守状況 |
+|---|---|---|
+| 5.1 | 3 サブ Issue で merge 済みの規約 / エージェント定義 / テンプレートの挙動を変更しない | **OK**（本 close-out では `.claude/rules/*.md` / `.claude/agents/*.md` / `repo-template/**` を一切変更していない） |
+| 5.2 | 新規の規律 / 数値目標 / 計測機構 / ハード制限を追加導入しない | **OK**（追加導入なし） |
+| 5.3 | 追加対応が必要な事項が発見された場合は別 Issue として起票する方針を採る | **適用**（repo-template 同期不足を別 Issue 起票推奨として Requirement 2 補足に記録） |
+| 5.4 | 既存の env var 名 / ラベル名 / cron 登録文字列 / exit code 意味の後方互換性を変更しない | **OK**（本 close-out では bash スクリプト / workflow / install スクリプト群を一切変更していない） |
+
+## 非機能要件の充足
+
+- **NFR 1.1 / 1.2**: 本 impl-notes の確認結果は確認対象ファイルの相対パス、対象節の見出し名、
+  確認時の git SHA（`75ae4afb...`）を含む粒度で記録しており、第三者がリポジトリ checkout
+  状態で 10 分以内に再確認可能。
+- **NFR 2.1**: 本ファイルは既存ルール群（`ears-format.md` / `requirements-review-gate.md` /
+  `design-principles.md` / `tasks-generation.md` / `design-review-gate.md` / `feature-flag.md`）
+  と矛盾する記述を含まない（規約への参照のみで、規約自体の解釈変更や上書きをしていない）。
+- **NFR 2.2**: サブ Issue の参照は canonical 記法に整合（`Parent:` 配下の sub Issue として
+  Issue 番号 `#133` / `#134` / `#135` を使用、`Depends on:` の cross-Issue 依存は本 close-out
+  では使用しない）。
+- **NFR 3.1**: 本文は日本語ベース、EARS トリガーキーワード / ファイルパス / コマンド名 /
+  Issue 番号は英語固定で記述。
+
+## 不足や懸念
+
+- **発見した不足**: `repo-template/.claude/agents/architect.md` および
+  `repo-template/.claude/rules/tasks-generation.md` / `repo-template/.claude/rules/design-review-gate.md`
+  に #133 由来の checkbox 必須化規約が未反映。詳細は Requirement 2 の「補足」節を参照。
+- **対応方針**: 本 close-out では補完せず、別 Issue として独立に起票する（Requirement 5.3
+  の方針に従う）。
+- **その他の懸念**: なし
+
+## 確認事項
+
+なし。本 umbrella close-out に必要な人間判断（rollout 順 Option A の承認）は Issue #132
+コメントで完了済みであり、本 close-out 作業は Issue #132 本文と requirements.md の AC
+（Requirement 1〜5 / NFR 1〜3）に従って機械的に完了可能でした。
+
+repo-template 同期不足の別 Issue 起票についても、本ファイル「Requirement 2 の補足」節で
+具体案（タイトル案 `chore(template): #133 の checkbox 規約を repo-template/ 配下に同期`）
+を提示済みであり、人間運用者の判断ポイントは「(a) 別 Issue として起票するか / (b) 既知の
+制約として受容するか」の二択のみです。
+
+## 受入基準のテスト・検証マッピング
+
+本 Issue は docs / spec 集約作業であり、コード変更を伴わないため unit test は追加しません。
+各 AC は **本 impl-notes.md 内の該当節への記述**で担保します。
+
+| Requirement | AC | 担保箇所 |
+|---|---|---|
+| 1 | 1.1〜1.5 | 本ファイル「Requirement 1 の確認結果」節 |
+| 2 | 2.1〜2.6 | 本ファイル「Requirement 2 の確認結果」節 + 「補足」節 |
+| 3 | 3.1〜3.5 | 本ファイル全体（特に冒頭〜「サブ Issue 一覧」節、および「Requirement 3 の確認結果」節） |
+| 4 | 4.1〜4.4 | 本ファイル「Requirement 4 の確認結果」節 |
+| 5 | 5.1〜5.4 | 本ファイル「Requirement 5 の確認結果」節 |
+| NFR 1 | 1.1〜1.2 | 本ファイル「非機能要件の充足」節 |
+| NFR 2 | 2.1〜2.2 | 本ファイル「非機能要件の充足」節 |
+| NFR 3 | 3.1 | 本ファイル全体（言語方針への準拠） |
+
+STATUS: complete

--- a/docs/specs/132-feat-developer-developer-turn-budget-ove/requirements.md
+++ b/docs/specs/132-feat-developer-developer-turn-budget-ove/requirements.md
@@ -1,0 +1,112 @@
+# Requirements Document
+
+## Introduction
+
+Issue #132 は Developer エージェントの turn budget overflow（60 turn 上限の到達）と
+内部 TODO トラッキング由来の overhead（TaskCreate / TaskUpdate が全 tool call の 29% を
+占めていた）を改善するための **umbrella 親 Issue** です。本体の実装は 3 つのサブ Issue
+（#133 / #134 / #135）に分割され、いずれも CLOSED かつ main に merge 済みです。
+人間運用者は Issue #132 のコメントで rollout 順 Option A（#A→#B→#C すなわち #133→#134→#135）
+を承認済みであり、3 件すべての merge が完了した現時点では、umbrella としての close-out
+（締めくくり）作業のみが残っています。
+
+本要件は「umbrella を閉じてよいと判断するための受入基準」を定義します。具体的には、
+3 サブ Issue の成果物がリポジトリ内に揃っていることの確認、関連する規約 / エージェント
+定義ファイルへの変更が実際に反映されていることの確認、umbrella spec ディレクトリへの
+集約ドキュメント整備、README / CLAUDE.md レベルでの umbrella 視点の追加更新要否判定、
+の 4 観点をカバーします。本要件は新規 feature 実装ではなく、umbrella クローズ作業の
+完了基準を AC として束縛することを目的とします。
+
+## Requirements
+
+### Requirement 1: サブ Issue 完了の検証可能性
+
+**Objective:** As a repository maintainer, I want umbrella #132 配下の 3 サブ Issue（#133 / #134 / #135）が closed かつ merge 済みであり、各 spec ディレクトリに成果物が存在することをリポジトリ内で確認できる, so that umbrella を閉じる前に各サブ Issue の完了状態を独立に検証できる
+
+#### Acceptance Criteria
+
+1. The Close-Out Process shall サブ Issue #133 の spec ディレクトリ（`docs/specs/133-feat-architect-developer-tasks-md-checkb/`）に `requirements.md` と `impl-notes.md` が存在することを umbrella close-out 前に確認する
+2. The Close-Out Process shall サブ Issue #134 の spec ディレクトリ（`docs/specs/134-feat-developer-taskcreate-taskupdate-tas/`）に `requirements.md` と `impl-notes.md` が存在することを umbrella close-out 前に確認する
+3. The Close-Out Process shall サブ Issue #135 の spec ディレクトリ（`docs/specs/135-feat-developer-independent-tool-1-turn-p/`）に `requirements.md` と `impl-notes.md` が存在することを umbrella close-out 前に確認する
+4. If 上記 3 spec ディレクトリのいずれかに `requirements.md` または `impl-notes.md` が欠落している場合, the Close-Out Process shall umbrella close-out を保留し、欠落事実と原因を `docs/specs/132-feat-developer-developer-turn-budget-ove/impl-notes.md` に記録する
+5. The Close-Out Process shall 3 サブ Issue のいずれかが closed 状態でない場合 umbrella close-out を保留する
+
+### Requirement 2: 規約・エージェント定義ファイルへの反映確認
+
+**Objective:** As a repository maintainer, I want 3 サブ Issue が変更すべきだった規約 / エージェント定義ファイルに、当該サブ Issue の趣旨に対応する変更が実際に取り込まれていることを umbrella レベルで再確認できる, so that 個別サブ Issue の merge 漏れや revert 事故に umbrella close-out 時点で気付ける
+
+#### Acceptance Criteria
+
+1. The Close-Out Process shall `.claude/rules/tasks-generation.md` に「すべての実装タスク行が `- [ ]` または `- [ ]*` の checkbox 形式で開始する」規約（#133 由来）が含まれていることを確認する
+2. The Close-Out Process shall `.claude/rules/design-review-gate.md` に「tasks.md checkbox enforcement check」（#133 由来）が Mechanical Checks セクションに含まれていることを確認する
+3. The Close-Out Process shall `.claude/agents/architect.md` に「tasks.md の checkbox 形式必須化」と整合したテンプレート・品質チェックリスト項目（#133 由来）が含まれていることを確認する
+4. The Close-Out Process shall `.claude/agents/developer.md` に「TaskCreate / TaskUpdate の使用制限」節（#134 由来）が含まれていることを確認する
+5. The Close-Out Process shall `.claude/agents/developer.md` に「Tool 呼び出しの並列化規律」または同等趣旨の規律ステートメント（#135 由来）が含まれていることを確認する
+6. If 上記 5 項目のいずれかが該当ファイルに含まれていない場合, the Close-Out Process shall umbrella close-out を保留し、不足事実と該当サブ Issue 番号を `docs/specs/132-feat-developer-developer-turn-budget-ove/impl-notes.md` に記録する
+
+### Requirement 3: umbrella spec ディレクトリの整備
+
+**Objective:** As a repository maintainer, I want umbrella Issue #132 の趣旨と close-out 状態を集約した spec ディレクトリと `impl-notes.md` を残す, so that 後続の運用者が umbrella の全体像と 3 サブ Issue への入口を 1 箇所から辿れる
+
+#### Acceptance Criteria
+
+1. The Close-Out Process shall `docs/specs/132-feat-developer-developer-turn-budget-ove/` ディレクトリに `requirements.md`（本ファイル）と `impl-notes.md` を残す
+2. The `impl-notes.md` shall umbrella #132 の趣旨（Developer turn budget overflow / TaskCreate overhead 29% の問題と 10% 以下 / 2.5+ tool call per turn への改善目標）を 1 段落以上で要約する
+3. The `impl-notes.md` shall 3 サブ Issue（#133 / #134 / #135）の spec ディレクトリへの相対パスリンクをそれぞれ 1 件以上記載する
+4. The `impl-notes.md` shall rollout 順 Option A（#133 → #134 → #135）が人間運用者承認のもとで適用された旨を記録する
+5. Where Requirement 1 / Requirement 2 の確認結果に不足や懸念が発生した場合, the `impl-notes.md` shall 当該事実と対応方針（別 Issue 起票 / 暫定回避 / 既知の制約として受容 等）を 1 項目以上記録する
+
+### Requirement 4: README / CLAUDE.md への umbrella レベル更新要否判定
+
+**Objective:** As a repository maintainer, I want umbrella レベルで README または CLAUDE.md に追加更新が必要かを明示的に判定し、不要と結論した場合もその根拠を残す, so that umbrella close-out 時点で「漏れによる README 不整合」と「意図的な non-update」を区別できる
+
+#### Acceptance Criteria
+
+1. The Close-Out Process shall README.md と CLAUDE.md について umbrella #132 として追加更新が必要かを明示的に判定する
+2. When 各サブ Issue（#133 / #134 / #135）が README または CLAUDE.md の必要箇所を既に更新していると判定したとき, the Close-Out Process shall 追加更新を行わず、その判定根拠を `docs/specs/132-feat-developer-developer-turn-budget-ove/impl-notes.md` に記録する
+3. If umbrella レベルで補完すべき README または CLAUDE.md の不整合をクローズ前に発見した場合, the Close-Out Process shall 同一 PR 内で補完するか、別 Issue として起票するかを判断し、いずれの方針を採ったかを `impl-notes.md` に記録する
+4. The Close-Out Process shall README / CLAUDE.md の挙動説明と各サブ Issue で更新済みの規約 / エージェント定義の間に矛盾が無いことを目視確認する
+
+### Requirement 5: スコープ境界の維持
+
+**Objective:** As a repository maintainer, I want umbrella close-out 作業のスコープが 3 サブ Issue の完了確認とドキュメント集約に限定され、新規 feature や挙動変更を含まないことを束縛する, so that close-out PR が unintended な挙動変更を引き連れず、レビュー範囲を予測可能に保てる
+
+#### Acceptance Criteria
+
+1. The Close-Out Process shall 3 サブ Issue で merge 済みの規約 / エージェント定義 / テンプレートの挙動を変更しない
+2. The Close-Out Process shall 新規の規律 / 数値目標 / 計測機構 / ハード制限を本 umbrella close-out に追加導入しない
+3. If umbrella close-out 中に追加対応が必要な事項が発見された場合, the Close-Out Process shall 当該事項を別 Issue として起票する方針を採り、本 close-out PR にコード変更として含めない
+4. The Close-Out Process shall 既存の env var 名 / ラベル名 / cron 登録文字列 / exit code 意味の後方互換性を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: 検証可能性
+
+1. The Close-Out Process shall Requirement 1 / Requirement 2 で要求する各確認項目を、第三者（人間レビュワーや別エージェント）がリポジトリ checkout 状態で 10 分以内に独立に再確認できる粒度で `impl-notes.md` に記録する
+2. The `impl-notes.md` 内の確認結果記録 shall 確認対象ファイルへの相対パス、対象節の見出し名または行範囲、確認時のコミット SHA または日時のいずれか 1 つ以上を含む
+
+### NFR 2: 既存ドキュメント整合性
+
+1. The umbrella `requirements.md` および `impl-notes.md` shall 既存ルール群（`.claude/rules/ears-format.md` / `requirements-review-gate.md` / `design-principles.md` / `tasks-generation.md` / `design-review-gate.md` / `feature-flag.md`）と矛盾する記述を含まない
+2. The umbrella close-out 成果物 shall `.claude/rules/issue-dependency.md` の canonical 記法（`Parent:` / `Depends on:` 等）と整合した形でサブ Issue を参照する
+
+### NFR 3: 言語方針との整合
+
+1. The umbrella `requirements.md` および `impl-notes.md` shall CLAUDE.md「言語方針」節に従い、本文は日本語ベースで記述し、EARS トリガーキーワード（`When` / `If` / `While` / `Where` / `shall`）と識別子 / ファイルパス / コマンド名は英語固定で記述する
+
+## Out of Scope
+
+- 各サブ Issue（#133 / #134 / #135）の規約 / エージェント定義そのものの追加変更や挙動修正（merge 済みの内容に対する変更は別 Issue で扱う）
+- Developer 実行ログからの TaskCreate / TaskUpdate 比率や tool call/turn 比率の **本 close-out PR 内での新規計測**（計測手順は #134 / #135 で定義済み、本 umbrella では計測手順自体の変更や新規実行は要求しない）
+- harness（`local-watcher/bin/issue-watcher.sh`）への自動計測機構や自動ダッシュボードの追加
+- 他エージェント（PM / Architect / Reviewer / Project Manager / Debugger）への並列化規律 / TaskCreate 制限の横展開
+- TaskCreate / TaskUpdate のハード制限（tool 自体の無効化）導入
+- Claude Code SDK 側への subagent-specific reminder 抑制機能追加の実装
+- 既に merge 済みの過去 Developer 実行（ログ / PR）への遡及的な計測・是正・retrofit
+- 新規サブ Issue の追加切り出し（必要が判明した場合は別 Issue として独立起票し、本 umbrella の close-out には含めない）
+
+## Open Questions
+
+なし。Issue #132 本文の論点（rollout 順）は人間運用者により Option A（#133 → #134 → #135）で承認済み、かつ 3 サブ Issue は既に CLOSED かつ main に merge 済みであるため、umbrella close-out に必要な人間判断は完了している。
+
+なお、Issue #132 当初の効果目標（TaskCreate / TaskUpdate 比率 29% → 10% 以下、tool call/turn 比率 1.7 → 2.5+）の **実測による達成判定** は #134 / #135 の各 requirements で計測手段 / 達成目標が既に束縛されており、本 umbrella requirements としては再記述しない。close-out 後の実測トラッキングが必要な場合は別 Issue として独立に起票する想定である。

--- a/docs/specs/132-feat-developer-developer-turn-budget-ove/review-notes.md
+++ b/docs/specs/132-feat-developer-developer-turn-budget-ove/review-notes.md
@@ -1,0 +1,86 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-22T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-132-impl-feat-developer-developer-turn-budget-ove
+- HEAD commit: eda8248c6d3aa8155d0c9f4cda125b223608cadd
+- Compared to: main..HEAD
+- Diff stat: 2 ファイル追加（umbrella spec の `requirements.md` + `impl-notes.md` のみ、計 +312 行）
+- Commits:
+  - `eda8248 docs(specs): add umbrella requirements.md for #132`
+  - `88d0005 docs(specs): add umbrella close-out notes for #132`
+- 補足: 本 umbrella spec に `tasks.md` は存在しないが、requirements.md は umbrella close-out
+  作業のみを要求しており、`_Boundary:_` の境界は「コード／規約に挙動変更を加えない」
+  (Requirement 5) として表現される。本 close-out PR の diff は `docs/specs/132-…/` 配下
+  への 2 ファイル追加のみであり、Req 5 と整合している。
+
+## Verified Requirements
+
+- 1.1 — `docs/specs/133-feat-architect-developer-tasks-md-checkb/` 配下に `requirements.md` と
+  `impl-notes.md` が存在（`ls -la` で確認）。impl-notes.md「Requirement 1 の確認結果」表で記録
+- 1.2 — `docs/specs/134-feat-developer-taskcreate-taskupdate-tas/` 配下に `requirements.md` と
+  `impl-notes.md` が存在（同上）
+- 1.3 — `docs/specs/135-feat-developer-independent-tool-1-turn-p/` 配下に `requirements.md` と
+  `impl-notes.md` が存在（同上）
+- 1.4 — 欠落なし。保留条件不発動（impl-notes.md に「該当なし」と記録）
+- 1.5 — `gh issue view 133/134/135 --json state` でいずれも `CLOSED` を確認
+  （Reviewer 側でも `gh` 再実行して `CLOSED` `CLOSED` `CLOSED` を確認済み）
+- 2.1 — `.claude/rules/tasks-generation.md` L31 `## Checkbox 形式の必須化` 節を Grep 確認
+- 2.2 — `.claude/rules/design-review-gate.md` L46 Mechanical Checks 内の bullet +
+  L102 `### tasks.md checkbox enforcement check` サブセクションを Grep 確認
+- 2.3 — `.claude/agents/architect.md` L221 `## Checkbox 形式の必須化` 節を Grep 確認
+- 2.4 — `.claude/agents/developer.md` L200 `## TaskCreate / TaskUpdate の使用制限（Issue #134 以降適用）`
+  節を Grep 確認
+- 2.5 — `.claude/agents/developer.md` L55 `# Tool 呼び出しの並列化規律（Issue #135 以降適用）`
+  節を Grep 確認
+- 2.6 — 欠落なし。保留条件不発動（impl-notes.md に「該当なし」と記録）
+- 3.1 — `docs/specs/132-…/` ディレクトリに `requirements.md`（PM 作成）と `impl-notes.md`
+  （本 close-out で追加）の両方を配置（git ls-tree で 2 ファイル確認）
+- 3.2 — impl-notes.md 冒頭「Umbrella の趣旨要約」節で turn budget overflow / TaskCreate
+  overhead 29% / 改善目標（10% 以下 / 2.5+ tool call per turn）を 1 段落以上で要約
+- 3.3 — impl-notes.md「サブ Issue 一覧」節で 3 サブ Issue の spec ディレクトリへの相対パス
+  リンクを各 1 件記載（`../133-…/` / `../134-…/` / `../135-…/`）
+- 3.4 — 同節で「rollout Option A（#133 → #134 → #135）が人間運用者承認のもとで適用」を明記
+- 3.5 — `repo-template/` 配下への #133 規約同期不足の発見と、対応方針（別 Issue 起票推奨、
+  Requirement 5.3 に従う）を「Requirement 2 の補足」節と「不足や懸念」節に記録
+- 4.1 — impl-notes.md「Requirement 4 の確認結果」節で README.md / CLAUDE.md について
+  「追加更新不要」と明示判定
+- 4.2 — 判定根拠 3 項（CLAUDE.md / README.md / 整合性確認）を「判定根拠」リストとして
+  impl-notes.md に記録
+- 4.3 — umbrella レベルで補完すべき README / CLAUDE.md 不整合は発見せず（repo-template 同期
+  不足は別 Issue 起票推奨として記録済み）。impl-notes.md AC 4.3 行で明記
+- 4.4 — README / CLAUDE.md の挙動説明と各サブ Issue 規約 / エージェント定義の間に矛盾無し
+  を目視確認した旨を impl-notes.md「判定根拠」3 項目に記録
+- 5.1 — 本 close-out diff（2 ファイル）は `docs/specs/132-…/` 配下のみで、`.claude/rules/*.md`
+  / `.claude/agents/*.md` / `repo-template/**` を一切変更していないことを Reviewer 側でも
+  `git diff --stat main..HEAD` で再確認
+- 5.2 — 新規規律 / 数値目標 / 計測機構 / ハード制限の追加なし（impl-notes.md は規約への参照
+  のみ）
+- 5.3 — 追加対応事項（repo-template 同期不足）を別 Issue 起票推奨として記録、本 PR には含めず
+- 5.4 — bash スクリプト / workflow / install スクリプトの変更なし（diff stat で確認）
+- NFR 1.1 / 1.2 — impl-notes.md は確認対象ファイルの相対パス、対象節の見出し名、git SHA
+  （`75ae4afb...`）を含む粒度で記録されており、第三者が 10 分以内に再確認可能
+- NFR 2.1 — 既存ルール群との矛盾無し（impl-notes.md は参照のみで規約の解釈変更や上書きを
+  していない）
+- NFR 2.2 — サブ Issue 参照は `#133` / `#134` / `#135` のキャノニカル `Parent:` 配下の sub
+  Issue 表現と整合（cross-Issue `Depends on:` は使用していない）
+- NFR 3.1 — 本文は日本語ベース、EARS トリガーキーワード（`When` / `If` / `Where` / `shall`）
+  / ファイルパス / コマンド名 / Issue 番号は英語固定で記述されている
+
+## Findings
+
+なし
+
+## Summary
+
+umbrella close-out として要求された全 AC（Requirement 1〜5 / NFR 1〜3）が impl-notes.md の
+該当節で網羅的に担保されている。Reviewer 側でも (a) サブ Issue spec ディレクトリの存在、
+(b) 3 サブ Issue の CLOSED 状態、(c) `.claude/rules/*.md` / `.claude/agents/*.md` への 5 項目
+反映（Grep で行番号一致）、(d) diff が `docs/specs/132-…/` 配下のみで Req 5 スコープ境界
+内に収まること、を独立に再確認した。`repo-template/` 配下への #133 規約同期不足は本 umbrella
+スコープ外（Req 5.3 に従い別 Issue 起票推奨として記録済み）であり、本 close-out の reject
+理由にはならない。AC 未カバー / missing test / boundary 逸脱 のいずれも検出せず。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

Issue #132 は Developer エージェントの turn budget overflow（60 turn 上限の到達）と、TaskCreate / TaskUpdate の内部 TODO トラッキング由来の overhead（全 tool call の 29% を占めていた問題）を改善するための umbrella 親 Issue です。本体実装は 3 つのサブ Issue に分割されており、いずれも CLOSED かつ main に merge 済みです。本 PR は umbrella の close-out 作業であり、3 サブ Issue の完了状態確認・規約反映確認・ドキュメント集約の成果物（requirements.md / impl-notes.md / review-notes.md）を main に追加します。コード変更・規約変更は一切含まず、`docs/specs/132-feat-developer-developer-turn-budget-ove/` 配下への 3 ファイル追加のみです。

## 対応 Issue

Closes #132

## 関連 PR

- 設計 PR: なし（本 Issue は umbrella close-out であり、Architect フェーズは走っていないため）
- サブ Issue #133 の実装 PR: 既に main に merge 済み
- サブ Issue #134 の実装 PR: 既に main に merge 済み
- サブ Issue #135 の実装 PR: 既に main に merge 済み

## 実装内容

- (Req 1 / 全 AC) サブ Issue #133 / #134 / #135 の spec ディレクトリに requirements.md と impl-notes.md が存在し、3 件すべての GitHub Issue が CLOSED 状態であることを確認
- (Req 2 / 全 AC) `.claude/rules/tasks-generation.md` / `.claude/rules/design-review-gate.md` / `.claude/agents/architect.md` / `.claude/agents/developer.md` への 5 項目の規約反映を Grep 検証で確認
- (Req 3 / 全 AC) umbrella spec ディレクトリ（`docs/specs/132-feat-developer-developer-turn-budget-ove/`）に requirements.md・impl-notes.md を整備し、趣旨要約・サブ Issue 相対パスリンク・rollout Option A 承認記録を収録
- (Req 4 / 全 AC) README.md / CLAUDE.md への umbrella レベル追加更新が不要であることを明示判定し、根拠を impl-notes.md に記録
- (Req 5 / 全 AC) close-out スコープが docs 追加のみ（コード変更ゼロ）に収まることを diff stat で確認
- (NFR 1〜3) 確認時 git SHA・確認対象ファイルパス・節見出し名を impl-notes.md に記録し、第三者が 10 分以内に再確認可能な粒度を維持

## 受入基準チェック

- [x] Req 1.1〜1.3: サブ Issue 3 件の spec ディレクトリ存在確認 ← impl-notes.md「Requirement 1 の確認結果」節
- [x] Req 1.4〜1.5: 欠落なし / 全件 CLOSED ← 同上（該当なし 記録）
- [x] Req 2.1〜2.6: 規約・エージェント定義 5 項目の反映確認 ← impl-notes.md「Requirement 2 の確認結果」節
- [x] Req 3.1〜3.5: umbrella spec ディレクトリ整備 ← impl-notes.md「Requirement 3 の確認結果」節
- [x] Req 4.1〜4.4: README / CLAUDE.md 更新要否判定（不要・根拠記録） ← impl-notes.md「Requirement 4 の確認結果」節
- [x] Req 5.1〜5.4: スコープ境界の維持（コード変更ゼロ） ← impl-notes.md「Requirement 5 の確認結果」節
- [x] NFR 1.1〜1.2: 第三者再確認可能な粒度での記録（git SHA 含む） ← impl-notes.md「非機能要件の充足」節
- [x] NFR 2.1〜2.2: 既存ルール群との矛盾なし・canonical 記法整合 ← 同上
- [x] NFR 3.1: 言語方針（日本語本文 / EARS キーワード英語固定）との整合 ← 同上

## テスト結果

```
本 PR は docs/ 配下の 3 ファイル追加のみ（コード変更なし）のため、unit test の追加は
要求されていません（requirements.md 参照: 「本 Issue は docs / spec 集約作業であり、コード
変更を伴わないため unit test は追加しません」）。

Reviewer（独立 review-notes.md）による確認結果:
- 全 AC（Requirement 1〜5 / NFR 1〜3）の達成を独立に再確認
- RESULT: approve
- Findings: なし（AC 未カバー / missing test / boundary 逸脱 のいずれも検出せず）

詳細は docs/specs/132-feat-developer-developer-turn-budget-ove/review-notes.md を参照。
```

## 実装上の判断

- **umbrella close-out のスコープ確定**: 本 PR は Requirement 5 のスコープ境界に従い、コード変更を一切含まない。3 サブ Issue（#133 / #134 / #135）の merge 済み成果物に対する変更も行っていない
- **repo-template 同期不足の発見**: `repo-template/.claude/agents/architect.md` 他 2 ファイルに #133 由来の checkbox 規約が未反映であることを発見。本 close-out では補完せず Requirement 5.3 の方針に従い別 Issue 起票を推奨。提案タイトル: `chore(template): #133 の checkbox 規約を repo-template/ 配下に同期`（impl-notes.md「Requirement 2 の補足」節に詳細記載）
- **README / CLAUDE.md 更新**: 各サブ Issue がそれぞれの担当ファイル（`.claude/agents/*.md` / `.claude/rules/*.md`）を更新済みであり、CLAUDE.md / README.md レベルで重複参照を追加する必要はないと判定

## 確認事項 / レビュワーへの依頼

- Reviewer の approve 判定の詳細は `docs/specs/132-feat-developer-developer-turn-budget-ove/review-notes.md` を参照
- repo-template/ 配下の #133 規約同期不足について、別 Issue 起票の要否を確認してください（impl-notes.md「Requirement 2 の補足」節参照）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #132 のコメントを参照してください。