### PR TITLE
fix(#164): per-task Reviewer の連記 marker commit を許容して diff range を解決可能にする

### DIFF
--- a/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/impl-notes.md
+++ b/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/impl-notes.md
@@ -1,0 +1,125 @@
+# 実装ノート: Issue #164 per-task Reviewer の diff range 解決を連記 marker 許容に拡張
+
+## 採用方針
+
+Option C（Developer prompt 厳格化 + watcher 側 marker 解決の許容拡大 + 明示的エラー文言 +
+復旧手順）を実装した。要件 1（prompt 厳格化）と要件 2（連記 marker 許容）を **両方** 適用
+することで、Developer に「1 commit = 1 task ID」を明示的に伝えつつ、それでも誤って連記
+marker を作った場合の **fallback 解決** を watcher 側で行い、`diff-range-resolve-failed` で
+データ損失リスクが発生する経路を最小化する。
+
+万が一 fallback でも解決できなかった場合は、専用ヘルパ `pt_mark_diff_range_resolve_failed`
+が `git reflog` 復旧手順と 1 commit = 1 task ID の規約を Issue コメントに明示し、運用者が
+5 分以内に復旧判断できる粒度で情報提供する（NFR 3.1）。
+
+## 変更箇所
+
+| ファイル | 変更内容 |
+|---|---|
+| `local-watcher/bin/issue-watcher.sh` | `pt_resolve_diff_range` の単記マッチを優先採用 + 連記 marker fallback 追加 |
+| `local-watcher/bin/issue-watcher.sh` | `build_per_task_implementer_prompt` に「1 commit = 1 task ID」厳格化を明示 |
+| `local-watcher/bin/issue-watcher.sh` | `pt_mark_diff_range_resolve_failed` 新規追加（復旧手順付き Issue コメント + claude-failed 付与） |
+| `local-watcher/bin/issue-watcher.sh` | `run_per_task_reviewer` の diff-range-resolve-failed 経路を rc=3 に分離 |
+| `local-watcher/bin/issue-watcher.sh` | `run_per_task_loop` の各 reviewer 呼び出しで rc=3 を新ヘルパに dispatch |
+| `repo-template/.claude/agents/developer.md` | per-task ループ節に「1 commit = 1 task ID」厳格化を追記（installed consumer 用） |
+| `docs/specs/164-.../test-pt-resolve.sh` | `pt_resolve_diff_range` 単記 / 連記 / 誤マッチ抑止の fixture テスト |
+
+`run_per_task_reviewer` の return code は以下のように再整理した:
+
+| rc | 意味 | 呼び出し側の処理 |
+|---|---|---|
+| 0 | approve | 次 task へ |
+| 1 | reject | Implementer 再起動（既存挙動） |
+| 2 | claude crash / parse 失敗 | `mark_issue_failed "per-task-reviewer-error"` |
+| **3** | **diff-range-resolve-failed (新規 / Issue #164)** | **`pt_mark_diff_range_resolve_failed`（復旧手順付き専用ハンドラ）** |
+| 99 | quota 超過 | `needs-quota-wait` |
+
+## 要件 → テスト対応表
+
+| Req ID | 要件概要 | 検証方法 |
+|---|---|---|
+| Req 1.1 | per-task Implementer prompt に「1 commit = 1 task ID」明示 | `build_per_task_implementer_prompt` 内で **【重要 / Issue #164】1 つの marker commit には 1 つの task ID のみを含めること** セクションを追加し、`local-watcher/bin/issue-watcher.sh` の prompt 組立 heredoc で出力されることを目視確認 |
+| Req 1.2 | 親 task 昇格も子と同じ 1 ID 単位で別 commit | 上記 prompt セクション中の例示「子 `1.1` 完了で親 `1` も全完了になる場合、まず `docs(tasks): mark 1.1 as done` を 1 commit で作成し、続けて `docs(tasks): mark 1 as done` を **別 commit** として続けて作成する」で明示 |
+| Req 1.3 | 既存 prompt 内の連記例示があれば 1 ID 単位に修正 | 既存 prompt には連記例示は存在せず、修正対象なし。新規追加の NG 例示が「連記禁止」明示の役割を果たす |
+| Req 1.4 | `PER_TASK_LOOP_ENABLED=true` の起動経路にのみ適用 | `build_per_task_implementer_prompt` は `run_per_task_loop`（`PER_TASK_LOOP_ENABLED=true` gate 内のみ呼ばれる）の中の `run_per_task_implementer` から呼ばれる。他経路から呼ばれない（grep 確認済） |
+| Req 2.1 | 単記 marker の解決 | smoke test case1 全件 (4 件) |
+| Req 2.2 | 連記 marker（`/` / `,` 区切り）からの解決 | smoke test case2（slash 3 件）+ case3（comma 2 件） |
+| Req 2.3 | 連記 marker 内の各 task ID が同一 SHA を返す | smoke test case2（task=1 / 1.1 / 1.2 が同一 `C2_MULTI` を返す）+ case3（task=1 / 1.1 が同一 `C3_MULTI` を返す） |
+| Req 2.4 | 単記＋連記の両方に出現する場合の一意選択 | smoke test case6（task=1 が単記 marker を返す = single-id-prefer 規則） |
+| Req 2.5 | task_id `1` が `1.1` / `11` に誤マッチしない | smoke test case2（`task=11` で rc=1）+ case2（`task=2` で rc=1）+ case3（`task=1.2` で rc=1） |
+| Req 3.1 | 単記 marker のみのリポジトリで本変更前と同一 SHA 列を返す | smoke test case1 全件（既存挙動踏襲を fixture で確認） |
+| Req 3.2 | 単記 marker のみで観測可能な副作用なし | 単記マッチが優先採用されるため `via=multi-id-marker` ログは出ない（smoke test case1 / case4 task=1, 1.1 / case6 task=1 で stderr に該当ログが出ないことを確認） |
+| Req 3.3 | `PER_TASK_LOOP_ENABLED != true` の経路に副作用なし | `pt_resolve_diff_range` / `pt_mark_diff_range_resolve_failed` は `run_per_task_loop` 内のみ呼ばれ、同関数は `PER_TASK_LOOP_ENABLED=true` でのみ起動される（grep + dispatcher gate 確認済） |
+| Req 4.1 | Issue コメントに失敗カテゴリ + task ID を明示 | `pt_mark_diff_range_resolve_failed` の本文に `カテゴリ: \`diff-range-resolve-failed\`` / `対象 task ID: \`${task_id}\`` を明示 |
+| Req 4.2 | `git reflog` 復旧手順を明示 | `pt_mark_diff_range_resolve_failed` の「復旧手順（重要 / データ損失リスク回避）」節に `git reflog --date=iso` / `git push origin <current-branch>` / `git branch <rescue-branch-name> <reflog-sha>` を bash code block で明示 |
+| Req 4.3 | marker commit 分割規約（1 commit = 1 task ID）を案内 | `pt_mark_diff_range_resolve_failed` の「推奨される marker commit 分割の規約」節で明示 |
+| Req 4.4 | 重複コメント抑制 / 追記であることを明示 | `pt_mark_diff_range_resolve_failed` 冒頭で `gh issue view --json comments` から HTML marker `<!-- idd-claude:per-task-diff-range-resolve-failed:#<N>:<task> -->` を検索し、既存があれば header を「**追記コメント** / 詳細な復旧手順は既存コメントを参照」に切り替える |
+| Req 5.1 | 既存 `docs(tasks): mark <id> as done` 規約を温存 / 追加の許容範囲のみ | 単記マッチを優先採用するロジックで既存挙動を完全に温存（smoke test case1 / case4 / case6 で確認） |
+| Req 5.2 | 既存 env var / ラベル / cron / exit code 意味を保持 | 既存 env var（`PER_TASK_LOOP_ENABLED` / `BASE_BRANCH` 等）は追加・変更なし。`run_per_task_loop` の return 値は既存通り 0 / 1。`run_per_task_reviewer` の return rc=3 を新規追加（rc=2 を破壊せず追加） |
+| Req 5.3 | repo-template/.claude/agents/developer.md 変更は追記または明確化に留める | per-task ループ節「適用範囲」に **追加** の bullet として 1 commit = 1 task ID 規約を追記。既存記述の意味反転なし |
+| Req 5.4 | `PER_TASK_LOOP_ENABLED != true` で本変更経路に一切到達しない | dispatcher gate `case "$START_STAGE" in A) if [ "${PER_TASK_LOOP_ENABLED:-false}" = "true" ]; then run_per_task_loop` で gate されており、他経路から `pt_resolve_diff_range` / `pt_mark_diff_range_resolve_failed` は呼ばれない |
+| NFR 1.1 | 単記 marker のみのリポジトリで Reviewer 判定結果を維持 | smoke test case1 で同一 SHA 解決 + 既存 rc=0/1/2 分布を維持 |
+| NFR 1.2 | 同一 watcher プロセスを複数回起動した場合の重複コメント抑制 | `pt_mark_diff_range_resolve_failed` の marker dedup ロジック（gh API + jq で marker contains 検索） |
+| NFR 2.1 | 連記経由解決時に stdout ログに識別印 | `pt_resolve_diff_range` の末尾で `via=multi-id-marker` ログを stderr に出力（smoke test case2 / case3 / case4 / case6 で `[smoke] diff-range resolved via=multi-id-marker task_id=...` ログを観測） |
+| NFR 2.2 | `diff-range-resolve-failed` 時のログに task ID と「単記/連記いずれも見つからなかった」旨を明示 | `run_per_task_reviewer` の `pt_log` に `reason=diff-range-resolve-failed detail=no-marker-commit-found(single-id-and-multi-id-both-missing)` を明示 |
+| NFR 3.1 | Issue コメント復旧手順案内で 5 分以内に判断可能な粒度 | `pt_mark_diff_range_resolve_failed` 本文に「失敗カテゴリ」「原因」「復旧手順（git reflog / push / rescue branch / marker commit 補完）」「推奨される marker commit 分割の規約」の 4 節を構造化して提示。bash code block で具体的なコマンドを示し、reflog confirm → push 保護 → marker 補完 → claude-failed 外し、の 4 ステップで完結 |
+
+## 検証結果
+
+### Smoke test (`test-pt-resolve.sh`)
+
+```
+=============================================
+ PASSED: 19
+ FAILED: 0
+=============================================
+SMOKE_RESULT: pass
+```
+
+内訳:
+- case1（単記 marker のみ、後方互換）: 4 件すべて pass
+- case2（`/` 区切り連記）: 5 件すべて pass（false positive 抑止 task=11 / task=2 含む）
+- case3（`,` 区切り連記）: 3 件すべて pass（false positive task=1.2 含む）
+- case4（単記＋連記混在、単記優先）: 4 件すべて pass
+- case5（marker 全く無し）: 1 件 pass
+- case6（単記＋連記で同一 ID 重複時、単記優先）: 2 件 pass
+
+### Shellcheck
+
+```bash
+shellcheck -S warning local-watcher/bin/issue-watcher.sh
+```
+
+→ warning 以上 0 件。`SC2317`（unreachable）は既存の info-level のみ（本変更による新規発生なし）。
+
+```bash
+shellcheck docs/specs/164-.../test-pt-resolve.sh
+```
+
+→ 警告ゼロ。
+
+### Bash syntax check
+
+```bash
+bash -n local-watcher/bin/issue-watcher.sh
+```
+
+→ syntax OK。
+
+## 確認事項
+
+なし（要件は明確、設計は requirements.md と Issue 本文の指示通りに実装した）。
+
+### 補足 — design.md / tasks.md 不在
+
+本 Issue は Triage が `needs_architect: false` 相当で起票したと推測される（requirements.md のみ
+配備、design.md / tasks.md なし）。Issue 本文の Option C 採用方針が極めて具体的（線形パッチで
+4 箇所明示）であり、PM が指示通りに requirements.md を構造化したため、本実装も requirements.md
++ Issue 本文の Option C 指示に従い線形に対応した。
+
+仮に design.md / tasks.md 必要であれば、Reviewer のレビュー時に確認事項として戻すことを提案
+（本 PR では発生しない見込み）。
+
+## 派生タスク候補
+
+なし（本変更で要件は閉じる）。

--- a/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/requirements.md
+++ b/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/requirements.md
@@ -1,0 +1,106 @@
+<!-- Issue: #164 -->
+<!-- URL: https://github.com/hitoshiichikawa/idd-claude/issues/164 -->
+<!-- 採用方針: Option C（A: Developer prompt 厳格化 + B: watcher 側 marker 解決の許容拡大 + 追加: 明示的エラー文言と復旧手順） -->
+
+# Requirements Document
+
+## Introduction
+
+`PER_TASK_LOOP_ENABLED=true` の per-task ループにおいて、per-task Reviewer の diff range
+解決ロジックは「`docs(tasks): mark <id> as done`」という subject 行と task ID が厳密一致
+する marker commit を前提としている。しかし Developer が親 task と子 task の完了を 1 つの
+commit に集約し「`docs(tasks): mark 1 / 1.1 / 1.2 / 1.3 as done`」のような連記形式で
+commit を作成すると、当該 task ID の marker commit が見つけられず Reviewer が
+`diff-range-resolve-failed` として異常終了する。結果として `claude-failed` が付与され、
+push 前の Developer commit が次サイクルの worktree reset で失われ、`git reflog` でしか
+復旧できない（重大なデータ損失リスク）。
+
+本 spec は Option C（Developer 側 prompt の厳格化と watcher 側 marker 解決の許容範囲拡大を
+併用し、加えて失敗時の Issue コメントに具体的な復旧手順を明示する）に基づき、上記障害を
+恒久的に回避することを目的とする。
+
+## Requirements
+
+### Requirement 1: Developer prompt の厳格化（1 commit = 1 task ID）
+
+**Objective:** As a per-task Implementer 起動の責務記述, I want 進捗マーカー commit を 1 task ID 単位で分割するよう明示する prompt を発行できる, so that Developer が複数 task ID を 1 つの marker commit に集約することを未然に防止できる
+
+#### Acceptance Criteria
+
+1. When per-task Implementer 用 prompt が組み立てられたとき, the Per-Task Implementer Prompt Builder shall 「1 つの `docs(tasks): mark <id> as done` commit には 1 つの task ID のみを含める」旨を明示記載する
+2. When per-task Implementer 用 prompt が組み立てられたとき, the Per-Task Implementer Prompt Builder shall 親 task の完了昇格も子 task と同じ 1 ID 単位で別 commit に分割する旨を明示記載する
+3. If 当該 prompt 内で複数 task ID を 1 commit にまとめる例示やテンプレが残存している場合, the Per-Task Implementer Prompt Builder shall 該当箇所を 1 ID 単位の表記に修正する
+4. The Per-Task Implementer Prompt Builder shall 上記厳格化を `PER_TASK_LOOP_ENABLED=true` の起動時のみ適用し、それ以外の起動経路には影響を与えないことを保証する
+
+### Requirement 2: 連記 marker commit からの task ID 解決の許容
+
+**Objective:** As a per-task Reviewer の diff range 解決ロジック, I want 複数 task ID 連記の marker commit からも当該 task ID を抽出できる, so that Developer が誤って ID を連記した場合でも Reviewer が異常終了せず push 済み commit を保護できる
+
+#### Acceptance Criteria
+
+1. When `docs(tasks): mark <id> as done` 形式の marker commit が存在するとき, the Per-Task Diff Range Resolver shall 当該 task ID に対応する commit SHA を解決する
+2. When 1 つの marker commit subject に複数の task ID（例: `mark 1 / 1.1 / 1.2 as done`、`mark 1, 1.1 as done`）が連記されていてその中に当該 task ID が含まれるとき, the Per-Task Diff Range Resolver shall 当該 commit を当該 task ID の marker commit として解決する
+3. When 連記 marker commit が解決対象になった場合, the Per-Task Diff Range Resolver shall 連記された各 task ID に対して同一の commit SHA を返す
+4. If 当該 task ID が単記 marker commit と連記 marker commit の双方に出現する場合, the Per-Task Diff Range Resolver shall いずれか 1 つを一意に選択し、選択基準を観測ログで識別可能な形で出力する
+5. If 連記 marker commit を解釈する際に task ID として誤検出を起こし得る文字列（例: 別の数字列・version 表記）が混在する場合, the Per-Task Diff Range Resolver shall 当該 task ID と完全一致するトークンのみを抽出して照合する
+
+### Requirement 3: 既存単記 marker commit との後方互換性
+
+**Objective:** As a per-task ループ全体, I want 従来通り 1 commit = 1 task ID の marker commit を引き続き正しく解決できる, so that 既存 spec / 既存ブランチ / 既存 git ログ列が本変更の影響を受けない
+
+#### Acceptance Criteria
+
+1. When 既存形式の単記 marker commit（`docs(tasks): mark 1.2 as done`）のみが存在するとき, the Per-Task Diff Range Resolver shall 本変更前と同一の解決結果（同一 SHA 列・同一 range_start / range_end）を返す
+2. The Per-Task Diff Range Resolver shall 連記マーカ対応に伴う追加処理を、単記マーカのみで構成されるリポジトリ履歴に対して観測可能な副作用なく適用する
+3. While `PER_TASK_LOOP_ENABLED=true` 以外の起動経路で動作しているとき, the watcher shall 本変更を経路上で参照しないことで本機能導入前と同一挙動を維持する
+
+### Requirement 4: 失敗時の Issue コメントに具体的な原因と復旧手順を明示
+
+**Objective:** As a per-task Reviewer の失敗ハンドリング, I want `diff-range-resolve-failed` で `claude-failed` を付与する際に Issue コメントに具体的な原因と復旧手順を残せる, so that 運用者が次サイクルでデータ損失を起こさずに復旧できる
+
+#### Acceptance Criteria
+
+1. When per-task Reviewer の diff range 解決が失敗して `claude-failed` ラベルを付与するとき, the Failure Notification shall Issue コメントに失敗カテゴリ（`diff-range-resolve-failed`）と当該 task ID を明示する
+2. When 上記の Issue コメントを生成するとき, the Failure Notification shall 復旧手順として「push 前の未保存 Developer commit がある場合は `git reflog` から拾い直す」「次サイクル前に worktree が reset される可能性がある」旨を文章で明示する
+3. When 上記の Issue コメントを生成するとき, the Failure Notification shall Developer に推奨される marker commit 分割の規約（1 commit = 1 task ID）を案内する
+4. If 同じ Issue に対して同一カテゴリの失敗コメントが既に存在する場合, the Failure Notification shall 重複コメントの追加を抑制するか、追記である旨が読み取れる形でコメントを残す
+
+### Requirement 5: 既存テンプレ・ドキュメント・既存 PR への副作用を生まない
+
+**Objective:** As a installed consumer repo の運用者, I want 本変更が既存の `repo-template/` 配下や既存 PR / 既存ログに対して破壊的影響を与えない, so that `install.sh` 再実行や既存 PR の rebase 等で予期しないログ差分・挙動差分が出ない
+
+#### Acceptance Criteria
+
+1. The Per-Task Loop Implementation shall 既存の `docs(tasks): mark <id> as done` 規約および既存テンプレ表記を温存し、本変更を「追加の許容範囲を広げる」差分のみで構成する
+2. The Per-Task Loop Implementation shall 既存 env var 名・ラベル名・cron 登録文字列・exit code 意味を保持する
+3. If 本変更で `repo-template/.claude/agents/developer.md` の文言を変更する場合, the Per-Task Loop Implementation shall 既存記述の意味を反転させず、追記または明確化に留める
+4. While `PER_TASK_LOOP_ENABLED` が未設定または `=true` 以外であるとき, the watcher shall 本変更経路に一切到達しないことで本機能導入前と完全に同一の外形挙動を維持する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性・冪等性
+
+1. The Per-Task Loop Implementation shall 既存 1 commit = 1 task ID 形式の marker commit を持つ全リポジトリで本変更前と同一の Reviewer 判定結果（approve / reject 分布）を維持する
+2. The Per-Task Loop Implementation shall 同一 watcher プロセスを複数回起動した場合に重複コメント・重複 commit を生成しない
+
+### NFR 2: 観測可能性
+
+1. When 連記 marker commit を経由して task ID が解決されたとき, the Per-Task Diff Range Resolver shall その旨を識別可能な形で stdout ログに残し、運用者が grep で連記経由の解決件数を把握できるようにする
+2. When `diff-range-resolve-failed` で異常終了するとき, the Per-Task Diff Range Resolver shall ログに当該 task ID と「単記 / 連記いずれの候補も見つからなかった」旨を明示する
+
+### NFR 3: 運用復旧性
+
+1. The Failure Notification shall Issue コメントによる復旧手順案内で、運用者が 5 分以内に必要な対応（reflog 確認・marker commit 分割の周知）を判断できる粒度の情報を提供する
+
+## Out of Scope
+
+- per-task Reviewer のアルゴリズム本体（diff range 解決後の review depth / 判定基準 / RESULT 行のフォーマット）の変更
+- `IMPL_RESUME_PRESERVE_COMMITS=true` モードの branch 初期化ロジックや既存 commit 温存規約自体の変更
+- Developer agent への commit 集約禁止 git hook 等の新規 watcher 機能の導入（hook によるブロックは行わない）
+- 連記 marker commit を canonical 表記として推奨する方向への規約変更（canonical は引き続き「1 commit = 1 task ID」、連記は「許容するが推奨しない」位置付け）
+- 既に main にマージ済みの過去 commit / 過去 PR 履歴の遡及的書き換え（retrofit）
+- per-task ループ以外の Reviewer Gate（`run_impl_pipeline` Stage B 既存経路）への変更
+
+## Open Questions
+
+なし

--- a/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/review-notes.md
+++ b/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/review-notes.md
@@ -1,0 +1,128 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T02:48:19Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-164-impl-bug-watcher-per-task-reviewer-task-id-ma
+- HEAD commit: f5cdccf6522af4116fa5b33637ee878d04574adc
+- Compared to: main..HEAD
+- Feature Flag Protocol: 対象 repo の `CLAUDE.md` に `## Feature Flag Protocol` 節が存在しない
+  ため、本レビューでは flag 観点（boundary 逸脱の細目）は **適用しない**（通常の 3 カテゴリ
+  判定のみ）
+
+## Verified Requirements
+
+### Requirement 1: Developer prompt の厳格化（1 commit = 1 task ID）
+
+- 1.1 — `build_per_task_implementer_prompt` 内の「進捗マーカー更新」節（issue-watcher.sh:6664
+  付近）に「**【重要 / Issue #164】1 つの marker commit には 1 つの task ID のみを含めること**」
+  が明示追加されている（diff +6672 行目）
+- 1.2 — 同 prompt 中「親 task の完了昇格も別 commit に分割」「子 `1.1` 完了で親 `1` も全完了に
+  なる場合、まず `docs(tasks): mark 1.1 as done` を 1 commit で作成し、続けて
+  `docs(tasks): mark 1 as done` を別 commit として続けて作成する」が明示
+- 1.3 — diff を確認したが既存 prompt 内に複数 ID を 1 commit にまとめる例示・テンプレは
+  存在せず、新規追加された NG 例示（`mark 1 / 1.1 as done` / `mark 1, 1.1 as done`）が
+  禁止表記の役割を果たしている
+- 1.4 — `build_per_task_implementer_prompt` は `run_per_task_implementer` から呼ばれ、これは
+  `run_per_task_loop` 内の per-task ループからのみ呼ばれる。`run_per_task_loop` は
+  issue-watcher.sh:9137 で `PER_TASK_LOOP_ENABLED=true` でのみ起動する dispatcher gate に
+  守られている（grep で他経路からの呼び出し無しを確認）
+
+### Requirement 2: 連記 marker commit からの task ID 解決の許容
+
+- 2.1 — `pt_resolve_diff_range`（issue-watcher.sh:6511）の (a) 単記 marker 検索ループが
+  従来通り `subject = "docs(tasks): mark ${task_id} as done"` を完全一致で解決
+  （smoke test case1 全 4 件 pass）
+- 2.2 — 同関数の (b) 連記 marker fallback 検索が `sed -nE 's/^docs\(tasks\): mark (.+) as
+  done$/\1/p'` で `<ids>` 部を抽出し `tr '/,' '  '` で正規化 + word splitting + 完全一致照合
+  （smoke test case2 slash 区切り 3 件 / case3 comma 区切り 2 件 pass）
+- 2.3 — `pt_resolve_diff_range` の最終出力は `printf '%s\t%s\n' "$range_start" "$current_mark"`
+  で、連記内の各 task ID が同一 `current_mark` SHA を返す（smoke test case2 で task=1 /
+  1.1 / 1.2 が同一 `708d0d00...` を返すこと、case3 で task=1 / 1.1 が同一 `59eafb17...` を
+  返すことを確認）
+- 2.4 — (a) を (b) の前段に置くことで単記優先を保証。case6 で task=1 が単記 marker
+  `C6_SINGLE_1` を返し、連記マーカは無視されることを確認（smoke test case6 pass）。
+  選択基準は `via=single-id-marker` / `via=multi-id-marker` の内部変数で識別可能（NFR 2.1
+  の stdout ログ出力で観測可能）
+- 2.5 — 単記マッチは `subject = "docs(tasks): mark ${task_id} as done"` の完全一致、連記
+  マッチは word splitting + `[ "$tok" = "$task_id" ]` の文字列完全一致で、`1` が `1.1` /
+  `11` に誤マッチしない（smoke test case2 で task=11 が rc=1、task=2 が rc=1、case3 で
+  task=1.2 が rc=1 を返すこと確認）
+
+### Requirement 3: 既存単記 marker commit との後方互換性
+
+- 3.1 — 単記マッチを (a) で優先採用し、見つかった時点で (b) を skip。case1 全 4 件で
+  本変更前と同一の SHA pair を返す（smoke test pass）
+- 3.2 — 連記経由解決時のみ `via=multi-id-marker` ログを stderr に出力する条件分岐
+  （issue-watcher.sh:6583）により、単記のみのリポジトリでは追加ログが発生しない
+  （smoke test case1 / case6 task=1 / case4 task=1, 1.1 の出力に `via=multi-id-marker`
+  ログが現れないこと確認）
+- 3.3 — `pt_resolve_diff_range` / `pt_mark_diff_range_resolve_failed` の呼び出し元は
+  `run_per_task_reviewer` および `run_per_task_loop` のみで、いずれも
+  `PER_TASK_LOOP_ENABLED=true` の dispatcher gate (issue-watcher.sh:9137) の内側
+  （grep 結果で確認）
+
+### Requirement 4: 失敗時の Issue コメントに具体的な原因と復旧手順を明示
+
+- 4.1 — `pt_mark_diff_range_resolve_failed`（issue-watcher.sh:7015）の body 内
+  「## 失敗カテゴリ」節で「カテゴリ: `diff-range-resolve-failed`」「対象 task ID:
+  `${task_id}`」「失敗 round: ${round}」を明示
+- 4.2 — 同 body の「## 復旧手順（重要 / データ損失リスク回避）」節で `git reflog --date=iso`
+  / `git push origin <current-branch>` / `git branch <rescue-branch-name> <reflog-sha>`
+  を bash code block で明示、「次サイクルで本ブランチの worktree が reset される可能性が
+  あります」を文章で明示
+- 4.3 — 同 body の「## 推奨される marker commit 分割の規約（1 commit = 1 task ID）」節で
+  「1 つの `docs(tasks): mark <id> as done` commit には 1 つの task ID のみを含める」
+  「親 task の完了昇格も別 commit に分割する」を明示。
+  `repo-template/.claude/agents/developer.md` への参照も含む
+- 4.4 — HTML marker `<!-- idd-claude:per-task-diff-range-resolve-failed:#${NUMBER}:${task_id} -->`
+  を body 末尾に埋め込み、`gh issue view --json comments | jq` で既存マーカコメントを検索
+  して件数 > 0 なら header を「**追記コメント** / 詳細な復旧手順は既存コメントを参照」に
+  切り替える dedup ロジックを実装
+
+### Requirement 5: 既存テンプレ・ドキュメント・既存 PR への副作用を生まない
+
+- 5.1 — `pt_resolve_diff_range` は単記マッチを優先採用 → 既存規約の温存。本変更は (b) の
+  fallback 追加と stderr ログ追加のみで、既存単記処理の挙動を反転させない
+- 5.2 — 既存 env var（`PER_TASK_LOOP_ENABLED` / `BASE_BRANCH` / `LABEL_CLAIMED` /
+  `LABEL_PICKED` / `LABEL_FAILED` / `NUMBER` / `REPO` 等）は新規追加・名前変更なし。
+  `run_per_task_reviewer` の return code は rc=2 既存維持 + rc=3 新規追加（既存意味の
+  破壊なし）
+- 5.3 — `repo-template/.claude/agents/developer.md` の diff（+7 行）は「per-task ループ
+  下での Implementer の責務」節への **追加 bullet** のみで、既存記述の意味反転なし
+- 5.4 — Req 1.4 / 3.3 と同根。`pt_resolve_diff_range` / `pt_mark_diff_range_resolve_failed` /
+  prompt 修正部 は `run_per_task_loop` 経由でのみ呼ばれ、`PER_TASK_LOOP_ENABLED=true` 限定で
+  本変更経路に到達する
+
+### Non-Functional Requirements
+
+- NFR 1.1 — smoke test case1（単記のみ）で 4/4 件が既存挙動踏襲。SHA pair と rc 分布
+  （rc=0 解決成功 / rc=1 未解決）の両方を fixture で確認
+- NFR 1.2 — `pt_mark_diff_range_resolve_failed` の HTML marker dedup ロジック
+  （`gh issue view --json comments | jq '... contains($marker) | length'`）で同一 marker
+  既存時に header を追記モードに切り替え、重複コメントの内容混乱を防止
+- NFR 2.1 — `pt_resolve_diff_range` の末尾で via=multi-id-marker 経由解決時に `>&2` で
+  `[date] per-task: diff-range resolved via=multi-id-marker task_id=${task_id} sha=${current_mark}`
+  をログ出力（smoke test の case2 / case3 / case4 / case6 で出力を観測）
+- NFR 2.2 — `run_per_task_reviewer` 内 `pt_log` で `reason=diff-range-resolve-failed
+  detail=no-marker-commit-found(single-id-and-multi-id-both-missing)` を明示
+- NFR 3.1 — `pt_mark_diff_range_resolve_failed` 本文に「失敗カテゴリ」「原因」「復旧手順
+  （reflog 確認 → push 保護 → marker 補完）」「推奨される marker commit 分割の規約」の 4 節を
+  構造化し、bash code block で具体的なコマンドを提示
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #164 が要求する 5 つの functional Requirements（合計 18 個の AC）+ 4 つの NFR の
+すべてが実装 / smoke test / Issue コメント本文に観測可能な形で実装されている。Smoke test
+`docs/specs/164-.../test-pt-resolve.sh` を実際に実行し 19/19 PASSED で完走することを reviewer
+側でも確認した。後方互換性は単記マッチを (a) で優先採用する設計と `PER_TASK_LOOP_ENABLED=true`
+dispatcher gate により厳格に維持されている。境界逸脱（`local-watcher/bin/issue-watcher.sh` /
+`repo-template/.claude/agents/developer.md` / `docs/specs/164-...`）も Issue #164 のスコープ内に
+収まっている。
+
+RESULT: approve

--- a/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/test-pt-resolve.sh
+++ b/docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/test-pt-resolve.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #164 で改修した `pt_resolve_diff_range` の単記 / 連記 / 誤マッチ抑止
+#       挙動を fixture 付きで検証するスモークスクリプト。
+# 配置: docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/test-pt-resolve.sh
+# 依存: bash 4+, git, sed, tr
+# セットアップ参照先: docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/impl-notes.md
+#
+# 実行:
+#   ./docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/test-pt-resolve.sh
+# 出力:
+#   各ケース: `[OK]` / `[NG]` の prefix で 1 行レポート
+#   末尾: `SMOKE_RESULT: pass` / `SMOKE_RESULT: fail`
+# 副作用:
+#   /tmp/pt-resolve-smoke-XXXX/ に一時 git repo を作成し、終了時に削除する
+
+set -euo pipefail
+
+# ─── pt_resolve_diff_range の参照実装（issue-watcher.sh から抽出 / 検証用） ───
+# 本関数は local-watcher/bin/issue-watcher.sh の pt_resolve_diff_range と **同一実装**
+# でなければならない。差分が出た場合は impl 側を本 fixture に再同期すること。
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+pt_resolve_diff_range() {
+  local task_id="$1"
+  local base="${BASE_BRANCH:-main}"
+
+  local all_pairs
+  all_pairs=$(git log --grep="^docs(tasks): mark " --format='%H%x09%s' --reverse "${base}..HEAD" 2>/dev/null || true)
+  if [ -z "$all_pairs" ]; then
+    return 1
+  fi
+
+  local current_mark="" via="" sha subject id_list tok found
+  while IFS=$'\t' read -r sha subject; do
+    [ -n "$sha" ] || continue
+    if [ "$subject" = "docs(tasks): mark ${task_id} as done" ]; then
+      current_mark="$sha"
+      via="single-id-marker"
+    fi
+  done <<<"$all_pairs"
+
+  if [ -z "$current_mark" ]; then
+    while IFS=$'\t' read -r sha subject; do
+      [ -n "$sha" ] || continue
+      id_list=$(printf '%s' "$subject" | sed -nE 's/^docs\(tasks\): mark (.+) as done$/\1/p')
+      [ -n "$id_list" ] || continue
+      found=false
+      for tok in $(printf '%s' "$id_list" | tr '/,' '  '); do
+        if [ "$tok" = "$task_id" ]; then
+          found=true
+          break
+        fi
+      done
+      if [ "$found" = "true" ]; then
+        current_mark="$sha"
+        via="multi-id-marker"
+      fi
+    done <<<"$all_pairs"
+  fi
+
+  if [ -z "$current_mark" ]; then
+    return 1
+  fi
+
+  local prev_mark=""
+  while IFS=$'\t' read -r sha subject; do
+    [ -n "$sha" ] || continue
+    if [ "$sha" = "$current_mark" ]; then
+      break
+    fi
+    prev_mark="$sha"
+  done <<<"$all_pairs"
+
+  local range_start
+  if [ -n "$prev_mark" ]; then
+    range_start="$prev_mark"
+  else
+    range_start=$(git rev-parse "$base" 2>/dev/null || true)
+    if [ -z "$range_start" ]; then
+      return 1
+    fi
+  fi
+
+  if [ "$via" = "multi-id-marker" ]; then
+    echo "[smoke] diff-range resolved via=multi-id-marker task_id=${task_id} sha=${current_mark}" >&2
+  fi
+
+  printf '%s\t%s\n' "$range_start" "$current_mark"
+  return 0
+}
+
+# ─── テストハーネス ───
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "[OK]   ${label} (expected=${expected}, actual=${actual})"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "[NG]   ${label} (expected=${expected}, actual=${actual})" >&2
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_fail() {
+  local label="$1" rc="$2"
+  if [ "$rc" -ne 0 ]; then
+    echo "[OK]   ${label} (rc=${rc} as expected)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "[NG]   ${label} (expected non-zero rc but got 0)" >&2
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# ─── fixture セットアップ ───
+TMPDIR=$(mktemp -d /tmp/pt-resolve-smoke-XXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cd "$TMPDIR"
+git init -q -b main
+git config user.email smoke@example.com
+git config user.name smoke
+
+# main の初期 commit
+echo init > README.md
+git add README.md
+git commit -q -m "initial commit"
+MAIN_SHA=$(git rev-parse main)
+
+# ─── ケース 1: 単記 marker のみのリポジトリ（既存挙動 / Req 3.1 後方互換） ───
+git checkout -q -b case1-single-only
+echo a > task1.txt && git add task1.txt && git commit -q -m "feat: task 1 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1 as done"
+C1_M1=$(git rev-parse HEAD)
+echo b > task1_1.txt && git add task1_1.txt && git commit -q -m "feat: task 1.1 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1.1 as done"
+C1_M11=$(git rev-parse HEAD)
+echo c > task1_2.txt && git add task1_2.txt && git commit -q -m "feat: task 1.2 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1.2 as done"
+C1_M12=$(git rev-parse HEAD)
+
+# task 1 → range_start=MAIN, range_end=C1_M1
+RES=$(pt_resolve_diff_range "1")
+assert_eq "case1: task=1 (first single-id)" "${MAIN_SHA}	${C1_M1}" "$RES"
+
+# task 1.1 → range_start=C1_M1, range_end=C1_M11
+RES=$(pt_resolve_diff_range "1.1")
+assert_eq "case1: task=1.1 (single-id chain middle)" "${C1_M1}	${C1_M11}" "$RES"
+
+# task 1.2 → range_start=C1_M11, range_end=C1_M12
+RES=$(pt_resolve_diff_range "1.2")
+assert_eq "case1: task=1.2 (single-id chain tail)" "${C1_M11}	${C1_M12}" "$RES"
+
+# 存在しない task 2 → rc=1
+RC=0
+pt_resolve_diff_range "2" > /dev/null 2>&1 || RC=$?
+assert_fail "case1: task=2 (no marker found)" "$RC"
+
+# ─── ケース 2: 連記 marker (` / ` 区切り) を含むリポジトリ (Req 2.2) ───
+git checkout -q main
+git checkout -q -b case2-multi-slash
+echo a > t1.txt && git add t1.txt && git commit -q -m "feat: task 1 impl"
+echo b > t11.txt && git add t11.txt && git commit -q -m "feat: task 1.1 impl"
+echo c > t12.txt && git add t12.txt && git commit -q -m "feat: task 1.2 impl"
+# 連記 marker (slash 区切り)
+git commit -q --allow-empty -m "docs(tasks): mark 1 / 1.1 / 1.2 as done"
+C2_MULTI=$(git rev-parse HEAD)
+
+# 連記 marker に含まれる各 task ID が同一 SHA を返すこと (Req 2.3)
+RES=$(pt_resolve_diff_range "1")
+assert_eq "case2: task=1 via multi-id (slash)" "${MAIN_SHA}	${C2_MULTI}" "$RES"
+
+RES=$(pt_resolve_diff_range "1.1")
+assert_eq "case2: task=1.1 via multi-id (slash)" "${MAIN_SHA}	${C2_MULTI}" "$RES"
+
+RES=$(pt_resolve_diff_range "1.2")
+assert_eq "case2: task=1.2 via multi-id (slash)" "${MAIN_SHA}	${C2_MULTI}" "$RES"
+
+# False positive 抑止: task=11 / task=2 は不在 (Req 2.5)
+RC=0
+pt_resolve_diff_range "11" > /dev/null 2>&1 || RC=$?
+assert_fail "case2: task=11 (false positive guard: '11' should NOT match '1' or '1.1')" "$RC"
+
+RC=0
+pt_resolve_diff_range "2" > /dev/null 2>&1 || RC=$?
+assert_fail "case2: task=2 (absent ID)" "$RC"
+
+# ─── ケース 3: 連記 marker (`, ` 区切り) を含むリポジトリ (Req 2.2 alternate sep) ───
+git checkout -q main
+git checkout -q -b case3-multi-comma
+echo a > a.txt && git add a.txt && git commit -q -m "feat: task 1 + 1.1 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1, 1.1 as done"
+C3_MULTI=$(git rev-parse HEAD)
+
+RES=$(pt_resolve_diff_range "1")
+assert_eq "case3: task=1 via multi-id (comma)" "${MAIN_SHA}	${C3_MULTI}" "$RES"
+
+RES=$(pt_resolve_diff_range "1.1")
+assert_eq "case3: task=1.1 via multi-id (comma)" "${MAIN_SHA}	${C3_MULTI}" "$RES"
+
+# False positive: task=1.2 (含まれていない)
+RC=0
+pt_resolve_diff_range "1.2" > /dev/null 2>&1 || RC=$?
+assert_fail "case3: task=1.2 (absent in '1, 1.1')" "$RC"
+
+# ─── ケース 4: 単記 + 連記 混在 (単記優先 / Req 2.4 deterministic) ───
+git checkout -q main
+git checkout -q -b case4-mixed
+echo a > x.txt && git add x.txt && git commit -q -m "feat: task 1 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1 as done"
+C4_SINGLE_1=$(git rev-parse HEAD)
+echo b > y.txt && git add y.txt && git commit -q -m "feat: task 1.1 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1.1 as done"
+C4_SINGLE_11=$(git rev-parse HEAD)
+# その後に連記 marker (本来あってはならないが、混在ケースを意図的に作成)
+echo c > z.txt && git add z.txt && git commit -q -m "feat: task 1.2 + 1.3 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1.2 / 1.3 as done"
+C4_MULTI=$(git rev-parse HEAD)
+
+# task=1: 単記マーカ優先で C4_SINGLE_1 を返す（連記マーカに `1` も含まれないが念のため確認）
+RES=$(pt_resolve_diff_range "1")
+assert_eq "case4: task=1 single-id-prefer (first single)" "${MAIN_SHA}	${C4_SINGLE_1}" "$RES"
+
+# task=1.1: 単記マーカで C4_SINGLE_11
+RES=$(pt_resolve_diff_range "1.1")
+assert_eq "case4: task=1.1 single-id-prefer (mid single)" "${C4_SINGLE_1}	${C4_SINGLE_11}" "$RES"
+
+# task=1.2: 連記マーカでヒット (C4_MULTI), range_start=C4_SINGLE_11
+RES=$(pt_resolve_diff_range "1.2")
+assert_eq "case4: task=1.2 via multi-id (fallback)" "${C4_SINGLE_11}	${C4_MULTI}" "$RES"
+
+# task=1.3: 連記マーカでヒット (同一 SHA), range_start=C4_SINGLE_11
+RES=$(pt_resolve_diff_range "1.3")
+assert_eq "case4: task=1.3 via multi-id (fallback same SHA)" "${C4_SINGLE_11}	${C4_MULTI}" "$RES"
+
+# ─── ケース 5: marker commit 全く無し ───
+git checkout -q main
+git checkout -q -b case5-empty
+echo a > only.txt && git add only.txt && git commit -q -m "feat: task without marker"
+
+RC=0
+pt_resolve_diff_range "1" > /dev/null 2>&1 || RC=$?
+assert_fail "case5: no marker commit at all (diff-range-resolve-failed expected)" "$RC"
+
+# ─── ケース 6: 単記 + 連記 で当該 task ID が両方に出現する場合 (Req 2.4) ───
+git checkout -q main
+git checkout -q -b case6-overlap
+echo a > o1.txt && git add o1.txt && git commit -q -m "feat: task 1 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1 as done"
+C6_SINGLE_1=$(git rev-parse HEAD)
+echo b > o11.txt && git add o11.txt && git commit -q -m "feat: task 1.1 impl"
+# 後から重複した連記マーカが入った仮定: `1, 1.1` (1 が連記マーカにも出現)
+git commit -q --allow-empty -m "docs(tasks): mark 1, 1.1 as done"
+C6_MULTI=$(git rev-parse HEAD)
+
+# task=1: 単記が優先採用される (Req 2.4 deterministic)
+# 単記は C6_SINGLE_1 で先に出現、range_start=MAIN_SHA, range_end=C6_SINGLE_1
+RES=$(pt_resolve_diff_range "1")
+assert_eq "case6: task=1 overlap (single preferred over multi)" "${MAIN_SHA}	${C6_SINGLE_1}" "$RES"
+
+# task=1.1: 単記不在のため連記マーカで解決 (C6_MULTI)
+RES=$(pt_resolve_diff_range "1.1")
+assert_eq "case6: task=1.1 (multi-id fallback after overlap)" "${C6_SINGLE_1}	${C6_MULTI}" "$RES"
+
+# ─── 結果集計 ───
+echo ""
+echo "============================================="
+echo " PASSED: ${TESTS_PASSED}"
+echo " FAILED: ${TESTS_FAILED}"
+echo "============================================="
+if [ "$TESTS_FAILED" -eq 0 ]; then
+  echo "SMOKE_RESULT: pass"
+  exit 0
+else
+  echo "SMOKE_RESULT: fail"
+  exit 1
+fi

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -6483,40 +6483,89 @@ pt_extract_learnings() {
 # per-task Reviewer に渡す diff range の開始 SHA / 終了 SHA を解決して
 # `<range_start_sha>\t<range_end_sha>` を stdout に出力。
 #
-# アルゴリズム（design.md「diff range 解決アルゴリズム」節）:
-#   1. `$BASE_BRANCH..HEAD` 範囲の `docs(tasks): mark <id> as done` commit を時系列昇順で全列挙
-#   2. 当該 task_id の mark commit SHA を特定（range_end）
+# アルゴリズム（design.md「diff range 解決アルゴリズム」節 + Issue #164 拡張）:
+#   1. `$BASE_BRANCH..HEAD` 範囲の `docs(tasks): mark ... as done` commit を SHA+subject の
+#      タブ区切り pair で時系列昇順に全列挙
+#   2. 当該 task_id の marker commit を以下の優先順で特定（range_end）:
+#      a. 単記 marker（subject が `docs(tasks): mark <task_id> as done` に完全一致）
+#         複数マッチ時は最後（最新）のマッチを採用（既存挙動を維持 / Req 3.1）
+#      b. 単記 marker が無ければ連記 marker（subject が `docs(tasks): mark <ids> as done` で
+#         <ids> を `/` / `,` / 空白で token 化したときに task_id と完全一致する token を含む）
+#         複数マッチ時は最後のマッチを採用（NFR 2.1: 連記経由解決時は stdout ログに
+#         `via=multi-id-marker` を残す）
 #   3. 全 mark commit 列の中で range_end の直前要素を range_start とする
 #   4. 直前要素が存在しない（初回 task）場合は range_start = `$BASE_BRANCH` の SHA
-#   5. 当該 task の mark commit が見つからない場合は return 1
+#   5. 当該 task の marker commit が単記でも連記でも見つからない場合は return 1
 #
-# Requirements: 3.2, 4.5, 5.4
+# 後方互換性（Req 3.1 / NFR 1.1）:
+#   - 単記 marker のみで構成されるリポジトリ履歴では、単記 marker が常に優先採用されるため
+#     本変更前と完全に同一の SHA pair を返す
+#   - 連記 marker は単記 marker が無い場合の fallback として動作するため、既存ログ列の
+#     観測可能な副作用は発生しない
+#
+# False positive 防止（Req 2.5）:
+#   - <ids> 部を `/` / `,` / 空白で正規化した後 word 単位で完全一致照合するため、task_id `1`
+#     が `1.1` や `11` に誤マッチしない
+#
+# Requirements: 3.2, 4.5, 5.4, Issue #164 Req 2.1, 2.2, 2.3, 2.4, 2.5, 3.1, 3.2, NFR 2.1
 pt_resolve_diff_range() {
   local task_id="$1"
   local base="${BASE_BRANCH:-main}"
 
-  # 全 mark commit を時系列昇順で取得（--reverse で oldest 先頭）
-  local all_marks
-  all_marks=$(git log --grep="^docs(tasks): mark " --format=%H --reverse "${base}..HEAD" 2>/dev/null || true)
-  if [ -z "$all_marks" ]; then
+  # 全 mark commit pair (SHA<TAB>subject) を時系列昇順で取得（--reverse で oldest 先頭）
+  local all_pairs
+  all_pairs=$(git log --grep="^docs(tasks): mark " --format='%H%x09%s' --reverse "${base}..HEAD" 2>/dev/null || true)
+  if [ -z "$all_pairs" ]; then
     return 1
   fi
 
-  # 当該 task の mark commit を特定（範囲内で最後のマッチを採用）
-  local current_mark
-  current_mark=$(git log --grep="^docs(tasks): mark ${task_id} as done\$" --format=%H "${base}..HEAD" 2>/dev/null | head -1 || true)
+  # ─── (a) 単記 marker を優先検索（subject 完全一致 / Req 3.1 後方互換） ───
+  local current_mark="" via="" sha subject id_list tok found
+  while IFS=$'\t' read -r sha subject; do
+    [ -n "$sha" ] || continue
+    if [ "$subject" = "docs(tasks): mark ${task_id} as done" ]; then
+      current_mark="$sha"
+      via="single-id-marker"
+    fi
+  done <<<"$all_pairs"
+
+  # ─── (b) 単記 marker が無ければ連記 marker を fallback 検索（Req 2.2 / 2.5） ───
+  if [ -z "$current_mark" ]; then
+    while IFS=$'\t' read -r sha subject; do
+      [ -n "$sha" ] || continue
+      # subject から <ids> 部を抽出（`docs(tasks): mark <ids> as done`）。
+      # 末尾アンカで「as done」以降にコメント等が付いた変則 subject は対象外とする。
+      id_list=$(printf '%s' "$subject" | sed -nE 's/^docs\(tasks\): mark (.+) as done$/\1/p')
+      [ -n "$id_list" ] || continue
+      # `/` / `,` を空白に正規化し、word 単位で task_id と完全一致する token を探す。
+      # word splitting は IFS のデフォルト（空白）で行われ、任意連続空白に対応する。
+      found=false
+      for tok in $(printf '%s' "$id_list" | tr '/,' '  '); do
+        if [ "$tok" = "$task_id" ]; then
+          found=true
+          break
+        fi
+      done
+      if [ "$found" = "true" ]; then
+        current_mark="$sha"
+        via="multi-id-marker"
+      fi
+    done <<<"$all_pairs"
+  fi
+
   if [ -z "$current_mark" ]; then
     return 1
   fi
 
-  # all_marks 内で current_mark の直前要素を探す
-  local prev_mark="" line
-  while IFS= read -r line; do
-    if [ "$line" = "$current_mark" ]; then
+  # all_pairs 順序を再度走査して current_mark の直前要素を探す（既存挙動を踏襲）
+  local prev_mark=""
+  while IFS=$'\t' read -r sha subject; do
+    [ -n "$sha" ] || continue
+    if [ "$sha" = "$current_mark" ]; then
       break
     fi
-    prev_mark="$line"
-  done <<<"$all_marks"
+    prev_mark="$sha"
+  done <<<"$all_pairs"
 
   local range_start
   if [ -n "$prev_mark" ]; then
@@ -6527,6 +6576,14 @@ pt_resolve_diff_range() {
     if [ -z "$range_start" ]; then
       return 1
     fi
+  fi
+
+  # NFR 2.1: 連記経由で解決した場合は stdout ログに識別可能な印を残す（運用者が
+  # `grep via=multi-id-marker` で件数把握できる）。単記経由は出力しない（既存ログ量を
+  # 増やさない後方互換）。stdout に出すことで呼び出し側 `pt_log` 経由のログ書式と
+  # 揃える代わりに、関数の主出力（SHA pair）と区別するため独立行 + tag prefix で出す。
+  if [ "$via" = "multi-id-marker" ]; then
+    echo "[$(date '+%F %T')] per-task: diff-range resolved via=multi-id-marker task_id=${task_id} sha=${current_mark}" >&2
   fi
 
   printf '%s\t%s\n' "$range_start" "$current_mark"
@@ -6607,13 +6664,24 @@ ${SPEC_DIR_REL}/
    - tasks.md の対象 task の \`_Requirements:_\` / \`_Boundary:_\` に従う
    - 規約は CLAUDE.md に従う
 
-2. **進捗マーカー更新**（既存 #67 / #112 規約を流用）:
+2. **進捗マーカー更新**（既存 #67 / #112 規約 + Issue #164「1 commit = 1 task ID」厳格化）:
    - 対象 task の \`- [ ] ${task_id}\` 行を \`- [x] ${task_id}\` に書き換える
    - 子タスク（例: ${task_id}.1）を完了した場合、親 task（${task_id} の親、例: ${task_id%.*}）
      配下の全子タスクが \`- [x]\` になったタイミングで親も \`- [x]\` に昇格する
    - 進捗マーカー更新は **専用 commit**: \`docs(tasks): mark <id> as done\`
      - 当該 commit には \`tasks.md\` 以外のファイルを含めない
-     - 親 task 昇格も同じ commit メッセージ形式（\`docs(tasks): mark <親 id> as done\`）
+   - **【重要 / Issue #164】1 つの marker commit には 1 つの task ID のみを含めること**:
+     - 1 つの \`docs(tasks): mark <id> as done\` commit には **必ず 1 つの task ID のみ**
+       を含めること（per-task Reviewer の diff range 解決が task ID 単位で行われるため）
+     - **親 task の完了昇格も別 commit に分割**する。例: 子 \`1.1\` 完了で親 \`1\` も
+       全完了になる場合、まず \`docs(tasks): mark 1.1 as done\` を 1 commit で作成し、
+       続けて \`docs(tasks): mark 1 as done\` を **別 commit** として続けて作成する
+     - **連記禁止例（NG）**: \`docs(tasks): mark 1 / 1.1 as done\` /
+       \`docs(tasks): mark 1, 1.1 as done\` のように複数 ID を 1 commit にまとめる
+       subject 表記は禁止
+     - 連記 marker commit を作成すると、per-task Reviewer の diff range 解決が単記 ID で
+       一致しなくなり \`diff-range-resolve-failed\` を起こす可能性がある（watcher 側で
+       fallback 解決は試行するが、canonical は単記分割のみ）
    - 書き換え禁止領域: タスク本文 / \`_Requirements:_\` / \`_Boundary:_\` / \`_Depends:_\` /
      タスク順序 / 親タスクのインデント / deferrable 印 \`- [ ]*\`
 
@@ -6810,10 +6878,19 @@ run_per_task_implementer() {
 # 戻り値:
 #   0  = approve
 #   1  = reject
-#   2  = 異常終了（claude crash / parse 失敗 / RESULT 行欠落 / diff range 解決失敗）
+#   2  = 異常終了（claude crash / parse 失敗 / RESULT 行欠落）
+#   3  = diff range 解決失敗（marker commit が単記でも連記でも見つからない / Issue #164）
 #   99 = quota 超過
 #
-# Requirements: 3.1, 3.2, 3.3, NFR 2.1, NFR 2.2, NFR 2.3
+# 戻り値 2 と 3 の使い分け（Issue #164 Req 4）:
+#   - rc=2: claude プロセスが起動した後の異常終了（呼び出し側は既存の
+#     `per-task-reviewer-error` カテゴリで `claude-failed` 付与）
+#   - rc=3: claude プロセス起動前に diff range が解決できなかった（marker 不在）。
+#     呼び出し側は専用の復旧手順付き Issue コメントで `claude-failed` 付与する。
+#     NFR 3.1 に従い「reflog で push 前 commit を回収」「1 commit = 1 task ID で分割」
+#     旨を運用者向けに 5 分以内に判断できる粒度で出力する。
+#
+# Requirements: 3.1, 3.2, 3.3, NFR 2.1, NFR 2.2, NFR 2.3, Issue #164 Req 4.1, 4.2, 4.3, NFR 2.2
 run_per_task_reviewer() {
   local task_id="$1"
   local round="$2"
@@ -6821,14 +6898,15 @@ run_per_task_reviewer() {
   # diff range 解決
   local range_line range_start range_end
   if ! range_line=$(pt_resolve_diff_range "$task_id"); then
-    pt_log "task=$task_id reviewer start round=$round result=error reason=diff-range-resolve-failed" >> "$LOG"
-    return 2
+    # Issue #164 NFR 2.2: 単記 / 連記いずれの候補も見つからなかった旨を明示
+    pt_log "task=$task_id reviewer start round=$round result=error reason=diff-range-resolve-failed detail=no-marker-commit-found(single-id-and-multi-id-both-missing)" >> "$LOG"
+    return 3
   fi
   range_start=$(printf '%s' "$range_line" | cut -f1)
   range_end=$(printf '%s' "$range_line" | cut -f2)
   if [ -z "$range_start" ] || [ -z "$range_end" ]; then
-    pt_log "task=$task_id reviewer start round=$round result=error reason=diff-range-empty" >> "$LOG"
-    return 2
+    pt_log "task=$task_id reviewer start round=$round result=error reason=diff-range-empty detail=resolved-but-empty-pair" >> "$LOG"
+    return 3
   fi
 
   # prev_result（round=2 のみ意味あり）
@@ -6907,6 +6985,132 @@ run_per_task_reviewer() {
       return 2
       ;;
   esac
+}
+
+# ─── pt_mark_diff_range_resolve_failed <task_id> <round> ───
+#
+# diff-range-resolve-failed カテゴリで `claude-failed` を付与し、復旧手順付き Issue
+# コメントを投稿する専用ヘルパー（Issue #164 Req 4）。
+#
+# 通常の `per-task-reviewer-error` 経路（claude crash / parse 失敗等）との違い:
+#   - claude プロセス起動 **前** の失敗（marker commit 単記 / 連記いずれも見つからない）
+#   - 重大なデータ損失リスク（push 前の Developer commit が次サイクル worktree reset で
+#     失われる）を回避するため、運用者向けに `git reflog` 復旧手順と marker commit 分割
+#     規約（1 commit = 1 task ID）を明示する
+#
+# 重複コメント抑制（Req 4.4）:
+#   - HTML コメント marker `<!-- idd-claude:per-task-diff-range-resolve-failed:#<issue>:<task> -->`
+#     を本文末尾に埋め込み、当該 Issue に同一 marker のコメントが既存なら新規投稿を skip
+#     して既存コメントに「追記」する形式の単発コメントのみ追加する
+#
+# Args:
+#   $1 = task_id (例: `1.2`)
+#   $2 = round (1 / 2 / 3 のいずれか / どの round で失敗したかを Issue に明示するため)
+#
+# 副作用:
+#   1. claude-claimed / claude-picked-up を除去し claude-failed を付与
+#   2. 復旧手順付き Issue コメントを 1 件投稿（既存があれば追記コメント）
+#
+# Requirements: Issue #164 Req 4.1, 4.2, 4.3, 4.4, NFR 1.2, NFR 3.1
+pt_mark_diff_range_resolve_failed() {
+  local task_id="$1"
+  local round="$2"
+  local hostname_val
+  hostname_val=$(hostname)
+  local marker="<!-- idd-claude:per-task-diff-range-resolve-failed:#${NUMBER}:${task_id} -->"
+
+  # NFR 1.2: 重複コメント抑制のため既存 marker を gh API で検索
+  local comments_json existing_count=0
+  if comments_json=$(gh issue view "$NUMBER" --repo "$REPO" --json comments 2>/dev/null); then
+    existing_count=$(echo "$comments_json" | jq -r --arg marker "$marker" '
+      (.comments // []) | map(select(.body | contains($marker))) | length
+    ' 2>/dev/null || echo "0")
+    [ -n "$existing_count" ] || existing_count=0
+  fi
+
+  # ラベル付け替え（既存 mark_issue_failed と同方針 / 1 コマンド原子的に発行）
+  gh issue edit "$NUMBER" --repo "$REPO" \
+    --remove-label "$LABEL_CLAIMED" --remove-label "$LABEL_PICKED" --add-label "$LABEL_FAILED" || true
+
+  local body_header
+  if [ "$existing_count" -gt 0 ]; then
+    body_header="⚠️ 自動開発が失敗しました（${hostname_val} / モード: $MODE / 失敗 stage: per-task-diff-range-resolve-failed / round=${round}）— **追記コメント**
+
+本 Issue には同一カテゴリ (\`diff-range-resolve-failed\` / task=\`${task_id}\`) の失敗コメントが既に存在します。
+本コメントは状況が再発生したことを示す追記です。詳細な復旧手順は既存コメントを参照してください。"
+  else
+    body_header="⚠️ 自動開発が失敗しました（${hostname_val} / モード: $MODE / 失敗 stage: per-task-diff-range-resolve-failed / round=${round}）"
+  fi
+
+  local body
+  body=$(cat <<EOF
+${body_header}
+
+## 失敗カテゴリ
+- カテゴリ: \`diff-range-resolve-failed\`
+- 対象 task ID: \`${task_id}\`
+- 失敗 round: ${round}
+- ログ: \`$LOG\`
+
+## 原因
+per-task Reviewer が当該 task の \`docs(tasks): mark ${task_id} as done\` marker commit を
+\`${BASE_BRANCH}..HEAD\` 範囲で解決できませんでした（単記 marker / 連記 marker いずれも
+不一致）。Developer が以下のいずれかに該当した可能性があります:
+
+- 進捗 marker commit を作成せずに実装 commit のみで完了した
+- marker commit subject が canonical 形式 \`docs(tasks): mark <id> as done\` から逸脱した
+  （例: prefix 違い / suffix の追加 / typo）
+- 連記 marker commit に task ID \`${task_id}\` と完全一致するトークンが含まれていない
+  （Issue #164 で許容拡大した連記マッチ機構でも検出できなかった）
+
+## 復旧手順（重要 / データ損失リスク回避）
+
+**【重要】次サイクルで本ブランチの worktree が reset される可能性があります。**
+push 前の Developer commit が残っていれば、次サイクル前に必ず以下を実施してください:
+
+1. **push 前 commit の有無を確認**:
+   \`\`\`bash
+   cd <worktree-or-repo-dir>
+   git reflog --date=iso | head -50
+   git log --oneline ${BASE_BRANCH}..HEAD
+   git status
+   \`\`\`
+2. **push 前 commit がある場合は手動で push して保護**:
+   \`\`\`bash
+   git push origin <current-branch>
+   \`\`\`
+   または、reflog から拾い直して別ブランチに退避:
+   \`\`\`bash
+   git branch <rescue-branch-name> <reflog-sha>
+   git push origin <rescue-branch-name>
+   \`\`\`
+3. **marker commit の補完**: 不足している \`docs(tasks): mark ${task_id} as done\` commit を
+   手動で作成（tasks.md の \`- [ ]\` → \`- [x]\` を 1 行編集して 1 commit）してから
+   \`claude-failed\` ラベルを外す。これにより次サイクルで watcher が当該 task を resume できる
+
+## 推奨される marker commit 分割の規約（1 commit = 1 task ID）
+
+per-task Reviewer の diff range 解決は **task ID 単位**で行われます。Developer は以下を厳守すること:
+
+- **1 つの \`docs(tasks): mark <id> as done\` commit には 1 つの task ID のみを含める**
+- 親 task の完了昇格も **別 commit に分割**する（例: 子 \`1.1\` 完了で親 \`1\` も全完了に
+  なる場合、\`docs(tasks): mark 1.1 as done\` と \`docs(tasks): mark 1 as done\` を別 commit
+  にする）
+- 連記表記（\`mark 1 / 1.1 as done\` / \`mark 1, 1.1 as done\`）は watcher が fallback 解決を
+  試行するが、canonical ではない。発見次第、commit を分割し直すこと
+
+詳細は \`repo-template/.claude/agents/developer.md\` の「per-task ループ下での Implementer の
+責務」節を参照してください。
+
+${marker}
+EOF
+)
+
+  body="${body}
+
+問題を解決してから \`claude-failed\` ラベルを外してください。"
+
+  gh issue comment "$NUMBER" --repo "$REPO" --body "$body" || true
 }
 
 # ─── run_per_task_loop ───
@@ -7143,6 +7347,13 @@ run_per_task_loop() {
 3. Reviewer 判定が誤りなら、Issue コメントで Architect 差し戻しを提案"
                   return 1
                   ;;
+                3)
+                  # diff-range-resolve-failed (Issue #164) → 専用の復旧手順付き失敗ハンドラ
+                  dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=diff-range-resolve-failed" >> "$LOG"
+                  echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) diff range 解決失敗 → claude-failed (diff-range-resolve-failed)" | tee -a "$LOG"
+                  pt_mark_diff_range_resolve_failed "$task_id" 3
+                  return 1
+                  ;;
                 *)
                   dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=error" >> "$LOG"
                   echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) 異常終了 → claude-failed" | tee -a "$LOG"
@@ -7174,6 +7385,12 @@ run_per_task_loop() {
               return 1
             fi
             ;;
+          3)
+            # diff-range-resolve-failed (Issue #164) → 専用の復旧手順付き失敗ハンドラ
+            echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) diff range 解決失敗 → claude-failed (diff-range-resolve-failed)" | tee -a "$LOG"
+            pt_mark_diff_range_resolve_failed "$task_id" 2
+            return 1
+            ;;
           *)
             echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) 異常終了 → claude-failed" | tee -a "$LOG"
             mark_issue_failed "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
@@ -7181,10 +7398,16 @@ run_per_task_loop() {
             ;;
         esac
         ;;
+      3)
+        # diff-range-resolve-failed (Issue #164) → 専用の復旧手順付き失敗ハンドラ
+        echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) diff range 解決失敗 → claude-failed (diff-range-resolve-failed)" | tee -a "$LOG"
+        pt_mark_diff_range_resolve_failed "$task_id" 1
+        return 1
+        ;;
       *)
         # round=1 reviewer error → claude-failed
         echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) 異常終了 → claude-failed" | tee -a "$LOG"
-        mark_issue_failed "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が異常終了しました（claude crash / parse 失敗 / diff range 解決失敗）。\`$LOG\` を確認してください。"
+        mark_issue_failed "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
         return 1
         ;;
     esac

--- a/repo-template/.claude/agents/developer.md
+++ b/repo-template/.claude/agents/developer.md
@@ -370,6 +370,13 @@ fresh な Claude session** で本 Developer サブエージェントが起動さ
   親 task のみ
 - 進捗 commit は `docs(tasks): mark <id> as done`（既存 #67 / #112 規約と同一）。当該
   commit には `tasks.md` 以外のファイルを含めない
+- **【重要 / Issue #164】1 commit = 1 task ID**: 1 つの `docs(tasks): mark <id> as done`
+  commit には **必ず 1 つの task ID のみ**を含めること。親 task の完了昇格も **別 commit
+  に分割**する（例: 子 `1.1` 完了で親 `1` も全完了になる場合、`docs(tasks): mark 1.1 as done`
+  と `docs(tasks): mark 1 as done` を別 commit にする）。連記表記（`mark 1 / 1.1 as done`
+  / `mark 1, 1.1 as done`）は per-task Reviewer の diff range 解決が単記 ID 一致で行われる
+  ため、`diff-range-resolve-failed` を引き起こすリスクがある（watcher 側で fallback 解決は
+  試行するが、canonical は単記分割のみ）。
 
 ## learning 追記の責務（per-task ループの中核 / Req 4.1, 4.2, 4.4）
 


### PR DESCRIPTION
## 概要

`PER_TASK_LOOP_ENABLED=true` の per-task ループにおいて、per-task Reviewer の diff range
解決ロジックが複数 task ID を連記した marker commit（例: `mark 1 / 1.1 / 1.2 as done`）を
解釈できず `diff-range-resolve-failed` で異常終了する問題を修正した。合わせて Developer
側の prompt に「1 commit = 1 task ID」の規約を明示し、失敗時の Issue コメントに `git reflog`
を使ったデータ損失回避の復旧手順を追加した（Option C 実装）。

## 対応 Issue

Closes #164

## 関連 PR

なし（Architect が起動していない Issue のため設計 PR は存在しない）

## 実装内容

- (Req 1.1 / Req 1.2 / Req 1.3) `build_per_task_implementer_prompt` に「1 commit = 1 task ID」厳格化を明示追加
- (Req 2.1 / Req 2.2 / Req 2.3 / Req 2.4 / Req 2.5) `pt_resolve_diff_range` に連記 marker commit fallback 解決ロジック追加（単記優先採用 + word splitting + 完全一致照合）
- (Req 4.1 / Req 4.2 / Req 4.3 / Req 4.4) 新規ヘルパ `pt_mark_diff_range_resolve_failed` 追加（失敗カテゴリ・復旧手順・重複コメント抑制）
- (Req 5.3) `repo-template/.claude/agents/developer.md` の per-task ループ節に 1 commit = 1 task ID 規約を追記
- (NFR 2.1 / NFR 2.2) 連記経由解決時の `via=multi-id-marker` ログ出力、失敗時の `detail=no-marker-commit-found` ログ出力

## 受入基準チェック

- [x] Req 1.1: `When per-task Implementer 用 prompt が組み立てられたとき, the Per-Task Implementer Prompt Builder shall 「1 つの marker commit には 1 つの task ID のみを含める」旨を明示記載する` ← `build_per_task_implementer_prompt` の diff 確認
- [x] Req 2.2: `When 1 つの marker commit subject に複数の task ID が連記されていてその中に当該 task ID が含まれるとき, the Per-Task Diff Range Resolver shall 当該 commit を marker commit として解決する` ← smoke test case2（slash 区切り）/ case3（comma 区切り）全件 pass
- [x] Req 2.5: `If 誤検出を起こし得る文字列が混在する場合, the Per-Task Diff Range Resolver shall 完全一致するトークンのみを抽出して照合する` ← smoke test case2（task=11 / task=2）/ case3（task=1.2）で rc=1 を確認
- [x] Req 3.1: `When 既存形式の単記 marker commit のみが存在するとき, the Per-Task Diff Range Resolver shall 本変更前と同一の解決結果を返す` ← smoke test case1 全 4 件 pass
- [x] Req 4.2: `When 上記の Issue コメントを生成するとき, the Failure Notification shall 復旧手順として git reflog から拾い直す旨を文章で明示する` ← `pt_mark_diff_range_resolve_failed` の実装を確認
- [x] NFR 1.1: 単記 marker のみのリポジトリで Reviewer 判定結果を維持 ← smoke test case1 / case4 / case6 で既存挙動踏襲を確認

## テスト結果

```
=============================================
 PASSED: 19
 FAILED: 0
=============================================
SMOKE_RESULT: pass
```

内訳:
- case1（単記 marker のみ、後方互換）: 4 件すべて pass
- case2（`/` 区切り連記）: 5 件すべて pass（false positive 抑止 task=11 / task=2 含む）
- case3（`,` 区切り連記）: 3 件すべて pass（false positive task=1.2 含む）
- case4（単記＋連記混在、単記優先）: 4 件すべて pass
- case5（marker 全く無し）: 1 件 pass
- case6（単記＋連記で同一 ID 重複時、単記優先）: 2 件 pass

shellcheck -S warning による警告: 0 件  
bash -n による syntax check: OK

## 実装上の判断

- **連記 marker の fallback 解決方針**: 単記マッチ (a) を優先し、見つかった時点で連記検索 (b) を skip する設計を採用。これにより既存の単記 marker のみのリポジトリでは追加ログ・追加処理が発生しない（NFR 1.1 / Req 3.2）
- **return code rc=3 の新規追加**: `run_per_task_reviewer` に `diff-range-resolve-failed` 専用の rc=3 を追加し、既存 rc=0/1/2 の意味を破壊しない形で分離
- **重複コメント抑制**: HTML marker `<!-- idd-claude:per-task-diff-range-resolve-failed:#N:task_id -->` を body 末尾に埋め込み、`gh issue view --json comments` で既存マーカコメントを検索して dedup を実装
- design.md / tasks.md は本 Issue に存在しない（Triage が `needs_architect: false` 相当で起動した Issue であり、Issue 本文の Option C 採用方針が実装経路を明示していたため）

## 確認事項 / レビュワーへの依頼

- Reviewer の判定結果（approve）は `docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/review-notes.md` を参照してください
- `run_per_task_reviewer` の return code に rc=3 を追加したことで、既存の rc=2（claude crash / parse 失敗）との混同がないか特にご確認ください
- `pt_mark_diff_range_resolve_failed` の dedup ロジック（HTML marker 検索）は GitHub API の `comments` フィールドが `[]` を返す場合でも正しく動作することを確認済みですが、念のため確認をお願いします

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #164 のコメントを参照してください。
