### PR TITLE
fix(#166): PER_TASK_LOOP_ENABLED 下で tasks.md 不在時に Stage A へフォールバック

### DIFF
--- a/README.md
+++ b/README.md
@@ -3429,6 +3429,13 @@ cron / launchd の `REPO=... REPO_DIR=...` に `PER_TASK_LOOP_ENABLED=true` を 
 
 opt-in した状態で `impl` / `impl-resume` モードが Stage A に入ると、以下のフローに変わります:
 
+> **tasks.md 不在時のフォールバック (#166)**: `PER_TASK_LOOP_ENABLED=true` でも対象 Issue の
+> `docs/specs/<番号>-<slug>/tasks.md` が存在しない場合（Architect 不要 triage を通過した
+> Issue 等）、watcher は Issue を `claude-failed` 扱いせず、**従来の単一 Developer Stage A
+> 経路（single-shot Implementer + Reviewer round=1 + PR 作成）へフォールバック**します。
+> フォールバック発生時は slot ログに `per-task: tasks.md 不在 → Stage A fallback` 行が出力
+> されます（Req 1.1 / AC5）。
+
 1. **未完了 task 抽出**: `tasks.md` から `- [ ]` で始まる numeric ID task 行を抽出し、
    `sort -V` で numeric 階層昇順に並べる（`1.10` > `1.2` を保証 / deferrable `- [ ]*` は除外）
 2. **task ごとのループ**: 各 task について以下を順次実行:

--- a/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/impl-notes.md
+++ b/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/impl-notes.md
@@ -1,0 +1,113 @@
+# 実装ノート（Issue #166）
+
+## 概要
+
+`PER_TASK_LOOP_ENABLED=true` 下で `tasks.md` を持たない Issue（Architect 不要 triage を通過した
+Issue 等）が、ログ上は「Stage A にフォールバックする」と表示しながら実際は `claude-failed` を
+付与して即停止していた不整合を修正した。`tasks.md` 不在時は Issue を失敗扱いせず従来 Stage A
+（single-shot Implementer + Reviewer round=1 + PR 作成）へ正しくフォールバックする。
+
+## 採用した設計（Option C: 上位層の事前分岐）
+
+requirements.md の Open Questions で提示された Option A / B / C のうち、Issue 指示の推奨かつ
+NFR 2.1（per-task ループ dispatcher 本体アルゴリズムを変えず fallback 判定のみ追加）を最も
+素直に満たす **Option C（上位層 `run_impl_pipeline()` の Stage A 分岐で事前判定）** を採用した。
+
+### 採用理由
+
+- **NFR 2.1 の責務境界保全**: `run_per_task_loop()` 本体（タスク逐次消化・round 制御・Debugger
+  Gate）には一切手を入れず、起動判定（gate）のみを上位の `case "$START_STAGE" in A)` 分岐に
+  追加した。dispatcher 本体アルゴリズムは無変更。
+- **コード重複の回避**: 従来 Stage A は独立関数ではなく `else` ブランチ（`build_dev_prompt_a` +
+  `qa_run_claude_stage "StageA"` + `verify_pushed_or_retry` + `handle_partial_status` の
+  インライン展開）である。Option C は per-task ループ起動条件を `if` に畳むことで、`_pt_loop_enabled`
+  が false のとき自然に既存 `else` ブランチへフォールスルーする。Stage A ブロックを複製せずに
+  到達させられるため、Option B（`run_per_task_loop` 内から Stage A を直接呼ぶ）で必要になる
+  関数抽出やコード複製を回避できた。
+
+### Option A / B を採らなかった理由
+
+- **Option A（fallback signal code を返し呼び出し側が Stage A 起動）**: `run_per_task_loop` が
+  新たな signal（例 return 2）を返し呼び出し側で分岐する形。判定ロジックが関数内外に分散し、
+  「tasks.md の有無」という単一判定を 2 箇所に持つことになる。Option C の方が判定が 1 箇所に
+  集約され明快。
+- **Option B（`run_per_task_loop` 内で従来 Stage A を直接呼ぶ）**: 従来 Stage A が独立関数で
+  ないため、関数抽出（`run_stage_a`）を新設するか Stage A コードを複製する必要があり、NFR 2.1
+  の「dispatcher 本体を変えない」制約と相性が悪い。
+
+## 変更箇所
+
+### 1. `local-watcher/bin/issue-watcher.sh`
+
+#### `run_impl_pipeline()` の Stage A 分岐（`case "$START_STAGE" in A)`、9140 行付近）
+
+- per-task ループ起動判定を `if [ "${PER_TASK_LOOP_ENABLED:-false}" = "true" ] && [ -f tasks.md ]`
+  相当に変更（`_pt_loop_enabled` フラグ変数 + フォールスルー）。
+- `PER_TASK_LOOP_ENABLED=true` かつ `tasks.md` 不在のときは、AC5 の判別可能なログ行
+  `--- per-task: tasks.md 不在 → Stage A fallback（<path>）---` を `tee -a "$LOG"` で出力してから
+  従来 Stage A の `else` ブランチへフォールスルーする（`claude-failed` は付けない）。
+- 既存 Stage A `else` ブロック（`build_dev_prompt_a` 以降）は無変更。
+
+#### `run_per_task_loop()` の tasks.md 不在ブランチ（7132 行付近）
+
+- 上位で事前分岐するため通常経路からは到達しなくなるが、防御ガードとして残置。
+- ただし旧実装の `mark_issue_failed "per-task-tasks-missing"` + `return 1`（新挙動と矛盾する
+  失敗扱い）を撤去し、`pt_warn` + `return 0`（no-op）に変更。万一直接呼び出し等で到達しても
+  Issue を失敗扱いせず、メッセージ（「フォールバック相当」）と実装（実際は failed 化）の乖離を
+  解消した（Issue の主訴）。
+- 関数 docstring の戻り値説明も `return 0` の防御ガードケースを追記して同期。
+
+### 2. `README.md`（per-task ループ節「新挙動（opt-in 時）」）
+
+- 「tasks.md 不在時のフォールバック (#166)」の引用ブロックを追記。`tasks.md` 不在時は
+  `claude-failed` 扱いせず従来 Stage A 経路へフォールバックし、slot ログに
+  `per-task: tasks.md 不在 → Stage A fallback` が出る旨を明記（README との二重管理規約）。
+
+### 3. スモークスクリプト（新規）
+
+- `docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/test-pt-fallback.sh` を追加。
+  起動判定ロジックを参照実装として抽出し、`tasks.md` あり/なし × `PER_TASK_LOOP_ENABLED`
+  true/false/typo の組合せで分岐（per-task-loop / stage-a-fallback / stage-a-traditional）と
+  AC5 フォールバックログの有無を機械検証する。
+
+## テスト・検証結果
+
+| 検証 | コマンド | 結果 |
+|---|---|---|
+| bash 構文 | `bash -n local-watcher/bin/issue-watcher.sh` | OK（`SYNTAX_OK`） |
+| shellcheck（本体） | `shellcheck local-watcher/bin/issue-watcher.sh` | 新規警告ゼロ。残存は既存 SC2317（info, 関数 indirection 由来。編集行 9140-9230 / 7132 周辺に新規 finding なし） |
+| shellcheck（スモーク） | `shellcheck docs/specs/166-.../test-pt-fallback.sh` | クリーン（`SMOKE_SHELLCHECK_CLEAN`） |
+| スモークテスト | `./docs/specs/166-.../test-pt-fallback.sh` | 12 ケース全 `[OK]` / `SMOKE_RESULT: pass` |
+| cron-like 最小 PATH | `env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'command -v claude gh jq flock git'` | gh / jq / flock / git は解決。`claude` は script の PATH-prepend（line 37 `export PATH="$HOME/.local/bin:..."`）経由で解決（`command -v claude` → `$HOME/.local/bin/claude`）。本修正は PATH 処理に無関係 |
+| dry-run（対象なし正常終了） | — | 未実施。理由: 本検証は `REPO` / `gh` 認証 / 実 Issue 状態に依存し worktree 環境で安全に再現困難。判定分岐はスモークスクリプトで機械検証済み |
+
+## AC トレーサビリティ
+
+| AC / NFR | 内容 | 担保 |
+|---|---|---|
+| AC 1.1 | flag=true + tasks.md 不在 → `claude-failed` を付けず従来 Stage A へフォールバック | impl: 9148-9155 行の事前分岐（`_pt_loop_enabled=false` のまま `else` フォールスルー）。smoke: `AC1: flag=true + tasks.md 不在 → stage-a-fallback` |
+| AC 1.2 | フォールバック開始時に `claude-failed` 起因の失敗通知コメントを投稿しない | impl: 事前分岐は `mark_issue_failed` / `gh issue comment` を呼ばずログ行のみ出力。`run_per_task_loop` の不在ブランチからも `mark_issue_failed` を撤去 |
+| AC 1.3 | フォールバック実行中、Implementer → Reviewer round=1 → PR 作成の順で従来同等の成果物を生成 | impl: 従来 Stage A `else` ブランチ（`build_dev_prompt_a` + `qa_run_claude_stage` + 後続 Stage B/C）に無変更で合流するため従来 Stage A と同一フロー |
+| AC 1.4 | フォールバック中に Implementer/Reviewer が失敗したら従来同一の `claude-failed` ハンドリング | impl: 従来 Stage A `else` ブランチの失敗ハンドリング（`mark_issue_failed "stageA"`）を無変更で流用 |
+| AC 2.1 | flag=true + tasks.md あり + pending≥1 → 従来 per-task ループで逐次処理 | impl: `_pt_loop_enabled=true` で `run_per_task_loop` 呼び出し（本体無変更）。smoke: `AC3: flag=true + tasks.md あり → per-task loop` |
+| AC 2.2 | flag=true + tasks.md あり + pending 0 → Stage A 完了相当で正常終了 | impl: `run_per_task_loop` 内 `pending=0 → return 0`（無変更）。本ケースは tasks.md 存在のため上位判定で per-task ループへ入る |
+| AC 2.3 | flag 未指定/true 以外 → per-task 分岐に入らず従来 Stage A | impl: `PER_TASK_LOOP_ENABLED:-false` の厳密一致判定（無変更）。smoke: NFR1.1 各ケース（空/false/True/1） |
+| AC 3.1 | フォールバック発生をログで判別可能 | impl: 9153 行 `--- per-task: tasks.md 不在 → Stage A fallback（<path>）---`。smoke: `AC5: フォールバック発生時に判別可能ログ行` |
+| NFR 1.1 | flag 未指定/true 以外で Stage A 外形挙動（ログ/ラベル遷移/exit code）が導入前と同一 | impl: flag off 時は `_pt_loop_enabled=false` でフォールバックログも出さず（`if PER_TASK_LOOP_ENABLED=true` の内側でのみ判定）従来 `else` へ直行。smoke: NFR1.1 各ケースで `stage-a-traditional` かつ fallback ログなし |
+| NFR 1.2 | flag=true + tasks.md あり時の per-task 結果が導入前と同一 | impl: `run_per_task_loop` 本体無変更。tasks.md 存在時の起動条件も従来と等価 |
+| NFR 2.1 | dispatcher 本体（逐次消化/round/Debugger Gate）を変えず fallback 判定のみ追加 | impl: `run_per_task_loop` 本体ループ（7160 行以降）に変更なし。追加したのは上位 gate と不在ブランチの失敗→no-op 化のみ |
+
+## 確認事項（Reviewer / 人間判断ポイント）
+
+- **`run_per_task_loop()` 不在ブランチの残置 vs 撤去**: 上位事前分岐により通常経路からは到達
+  しないため撤去も可能だが、防御ガードとして残置し失敗扱い（`mark_issue_failed` + `return 1`）
+  を no-op（`return 0`）に変更する方針を採った。これは「メッセージと実装の乖離を解消」という
+  Issue 主訴と、万一の直接呼び出し時にも Issue を失敗扱いしないという AC1.1 の精神に沿わせる
+  ためである。完全撤去を望む場合は要レビュー判断。
+- **dry-run スモーク未実施**: 上記テスト表のとおり実 Issue / gh 認証依存のため未実施。分岐判定は
+  `test-pt-fallback.sh` で機械検証済み。E2E は dogfooding（本 repo に test issue を立てる）で
+  別途確認するのが望ましいが、本 PR スコープ外とした。
+- **要件・設計の曖昧点**: なし。Open Questions の Option 選択は Developer 領分（Architect 不要
+  triage）として Option C を確定した。requirements.md の AC 解釈に追加の発明・変更は加えていない。
+
+STATUS: complete

--- a/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/requirements.md
+++ b/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/requirements.md
@@ -1,0 +1,64 @@
+# Requirements Document
+
+## Introduction
+
+`PER_TASK_LOOP_ENABLED=true` を有効化した運用下では、impl 系モードの Issue は Stage A の実体が
+per-task ループ dispatcher に置き換わる。しかし Architect 不要 triage を通過した Issue（設計フェーズ
+を経ず `docs/specs/<番号>-<slug>/tasks.md` が生成されない Issue）が per-task ループ起動に到達すると、
+`tasks.md` 不在を理由に無条件で `claude-failed` が付与され、Implementer が一度も起動しないまま停止する。
+ログ上は「従来 Stage A にフォールバックする」と表示されるが、実際にはフォールバックが実装されておらず
+Issue が失敗扱いになる挙動の不整合がある。本要件は、`tasks.md` 不在時に Issue を失敗扱いせず従来の
+Stage A（single-shot Implementer + Reviewer round=1 + PR 作成）相当のフローへ正しくフォールバックさせ、
+かつ `tasks.md` が存在する既存ケースの後方互換を完全に維持することを定義する。
+
+## Requirements
+
+### Requirement 1: tasks.md 不在時の Stage A フォールバック
+
+**Objective:** As a idd-claude 運用者, I want `PER_TASK_LOOP_ENABLED=true` 下でも tasks.md を持たない Issue が失敗扱いされず実装に進むこと, so that Architect 不要 triage を通過した Issue が per-task ループ有効化だけを理由に停止しない
+
+#### Acceptance Criteria
+
+1. While `PER_TASK_LOOP_ENABLED=true` であり Stage A 相当の処理に到達している状態, when 対象 Issue の `tasks.md` が存在しないことを検出したとき, the watcher は `claude-failed` ラベルを付与せず従来 Stage A フロー（single-shot Implementer + Reviewer round=1）へフォールバックする shall
+2. When tasks.md 不在による Stage A フォールバックを開始したとき, the watcher は対象 Issue へ `claude-failed` 起因の失敗通知コメントを投稿しない shall
+3. While tasks.md 不在による Stage A フォールバックを実行中, the watcher は Implementer 起動 → Reviewer round=1 → PR 作成の順で従来 Stage A と同等の成果物を生成する shall
+4. If tasks.md 不在による Stage A フォールバック中に Implementer または Reviewer が失敗したとき, the watcher は従来 Stage A と同一の失敗ハンドリング（`claude-failed` 付与）に従う shall
+
+### Requirement 2: tasks.md 存在時の後方互換
+
+**Objective:** As a idd-claude 運用者, I want tasks.md が存在する既存 Issue の per-task ループ挙動が変わらないこと, so that 本修正導入前に成立していた Architect 経由フローの結果が完全に再現される
+
+#### Acceptance Criteria
+
+1. While `PER_TASK_LOOP_ENABLED=true`, when 対象 Issue の `tasks.md` が存在し pending タスクが 1 件以上あるとき, the watcher は従来通り per-task ループで各タスクを逐次処理する shall
+2. While `PER_TASK_LOOP_ENABLED=true`, when 対象 Issue の `tasks.md` が存在し pending タスクが 0 件のとき, the watcher は Stage A 完了相当として正常終了する shall
+3. While `PER_TASK_LOOP_ENABLED` が未指定または `true` 以外, the watcher は per-task ループ分岐へ入らず従来の Stage A 経路をそのまま実行する shall
+
+### Requirement 3: フォールバック経路の可観測性
+
+**Objective:** As a idd-claude 運用者, I want tasks.md 不在による Stage A フォールバックが発生したことをログで判別できること, so that per-task ループ有効時に Issue がどの経路で処理されたか事後追跡できる
+
+#### Acceptance Criteria
+
+1. When tasks.md 不在による Stage A フォールバックを開始したとき, the watcher は slot ログへフォールバック発生を判別可能な行（例: `per-task: tasks.md 不在 → Stage A fallback`）を出力する shall
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While `PER_TASK_LOOP_ENABLED` が未指定または `true` 以外, the watcher は本修正導入前と同一の Stage A 外形挙動（ログ出力・ラベル遷移・exit code の意味）を維持する shall
+2. While `PER_TASK_LOOP_ENABLED=true` かつ `tasks.md` が存在する状態, the watcher は本修正導入前と同一の per-task ループ結果（pending 件数に応じた処理またはno-op 正常終了）を維持する shall
+
+### NFR 2: 責務境界の保全
+
+1. The watcher は per-task ループ dispatcher の本体アルゴリズム（タスク逐次消化・round 制御・Debugger Gate）に変更を加えず、tasks.md 不在時のフォールバック判定のみを追加する shall
+
+## Out of Scope
+
+- per-task ループ本体のアルゴリズム変更（タスク逐次消化ロジック・round 制御・Debugger Gate の挙動変更）
+- Architect 不要 triage の判定ロジック変更
+- tasks.md を Implementer agent が自前生成する case の追加
+
+## Open Questions
+
+- フォールバックを per-task ループ内部で行うか、呼び出し階層の上位（Stage A 分岐）で「tasks.md 不在なら Stage A 直行」と判定するかは設計判断（design.md / Architect の領分）に委ねる。Issue 本文では Option A（fallback signal code を返し呼び出し側が Stage A 起動）/ Option B（`run_per_task_loop` 内で従来 Stage A を直接呼ぶ）/ Option C（上位層で事前分岐）の 3 案が提示されている。requirements としては「NFR 2.1 の責務境界を壊さないこと」のみを制約とし、いずれの実装でも AC が満たされれば許容する。

--- a/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/review-notes.md
+++ b/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/review-notes.md
@@ -1,0 +1,72 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T11:03:48Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-166-impl-bug-watcher-per-task-loop-enabled-impl-m
+- HEAD commit: a9b065d3dbf7105fbabd6f20c8dd66c5acb54311
+- Compared to: main..HEAD
+
+変更ファイル: `local-watcher/bin/issue-watcher.sh`（+27/-4）, `README.md`（+7）,
+spec 配下の `requirements.md` / `impl-notes.md` / `test-pt-fallback.sh`（新規）。
+
+Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節は存在しない →
+opt-out として解釈。flag 観点（boundary 細目）は適用せず通常の 3 カテゴリ判定のみ実施。
+tasks.md / design.md は spec 配下に不在（本 Issue は Architect 不要 triage を通過した
+ケースであり、これ自体が修正対象の文脈と整合）。境界判定は requirements.md の NFR 2.1
+（per-task ループ dispatcher 本体を変更しない）を基準に確認した。
+
+## Verified Requirements
+
+- 1.1 — `issue-watcher.sh:9146-9156` の事前分岐。`PER_TASK_LOOP_ENABLED=true` かつ
+  `tasks.md` 不在のとき `_pt_loop_enabled=false` のまま従来 Stage A の `else`（9179行〜）へ
+  フォールスルー。`claude-failed` を付けない。smoke: `AC1: flag=true + tasks.md 不在 →
+  stage-a-fallback`（[OK]）
+- 1.2 — 事前分岐は `echo ... | tee -a "$LOG"` のログ行のみで `mark_issue_failed` /
+  `gh issue comment` を呼ばない（9151-9154行）。失敗通知コメントが投稿されないことを確認
+- 1.3 — フォールバック先は無変更の従来 Stage A `else` ブランチ（`build_dev_prompt_a` →
+  `qa_run_claude_stage "StageA"` → `verify_pushed_or_retry` → 後続 Stage B/C）。main との
+  diff で `else` ブロック本体が byte 等価であることを確認（Implementer → Reviewer → PR の
+  従来順序を維持）
+- 1.4 — フォールバック後は従来 Stage A `else` の失敗ハンドリング（9226行〜の `mark_issue_failed
+  "stageA"` 系）を無変更で流用。失敗時の `claude-failed` 付与挙動は導入前と同一
+- 2.1 — `_pt_loop_enabled=true`（tasks.md あり + flag=true）で `run_per_task_loop` を呼び出し。
+  loop 本体（7160行以降）は main と byte 等価（diff は関数頭の +3 行コメントによる行ずれのみ）。
+  smoke: `AC3: flag=true + tasks.md あり → per-task-loop`（[OK]）
+- 2.2 — `run_per_task_loop` 内の pending=0 → `return 0`（無変更）。tasks.md 存在ケースは
+  上位判定で per-task ループへ入るため到達可能
+- 2.3 — `[ "${PER_TASK_LOOP_ENABLED:-false}" = "true" ]` の厳密一致判定は main と同一。
+  flag 未指定 / false / typo（True / 1）はいずれも `_pt_loop_enabled=false` で従来 Stage A
+  直行。smoke: NFR1.1 各ケース（空 / false / True / 1）が `stage-a-traditional`（[OK]）
+- 3.1 — `issue-watcher.sh:9153` の判別可能ログ行 `--- per-task: tasks.md 不在 → Stage A
+  fallback（<path>）---` を slot ログ（`tee -a "$LOG"`）へ出力。smoke:
+  `AC5: フォールバック発生時に判別可能ログ行`（[OK]）
+- NFR 1.1 — flag off 時は `if PER_TASK_LOOP_ENABLED=true` の内側でのみ fallback 判定するため
+  ログ行も出さず従来 `else` へ直行。smoke: NFR1.1 各ケースで fallback ログなしを確認（[OK]）
+- NFR 1.2 — `run_per_task_loop` 本体無変更により tasks.md 存在時の per-task 結果は導入前と同一
+- NFR 2.1 — dispatcher 本体ループ（7160行〜）は main と byte 等価。追加は上位 gate と
+  不在ブランチの失敗→no-op 化のみ。main との region diff で本体に意味的差分なしを確認
+
+## 追加で確認した点
+
+- `run_per_task_loop` の唯一の呼び出し元は 9158行のみ。修正後この呼び出しは
+  `_pt_loop_enabled=true`（= tasks.md 存在）のときだけ到達するため、関数内 tasks.md 不在
+  ブランチの `return 0`（旧 `mark_issue_failed`+`return 1` を撤去）は通常経路から到達せず、
+  防御ガードとして無害。旧 `return 1` に依存していた他呼び出し元は存在しない
+- `bash -n local-watcher/bin/issue-watcher.sh` → SYNTAX_OK
+- `./docs/specs/166-.../test-pt-fallback.sh` → 12 ケース全 [OK] / `SMOKE_RESULT: pass`（再実行で確認）
+- smoke の `resolve_stage_a_route` 参照実装は impl の gate ロジック（9146-9156行）と同一
+- README の per-task 節にフォールバック挙動の migration note が追記され二重管理規約を満たす
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric ID（1.1〜3.1）と NFR 1.1 / 1.2 / 2.1 について実装とスモークテストで担保を確認した。
+従来 Stage A `else` ブロックと per-task ループ dispatcher 本体は main と byte 等価で後方互換を
+維持。boundary 逸脱・missing test・AC 未カバーいずれも検出されず。
+
+RESULT: approve

--- a/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/test-pt-fallback.sh
+++ b/docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/test-pt-fallback.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #166 で追加した「per-task ループ起動判定（tasks.md 不在時の Stage A
+#       フォールバック）」の分岐挙動を fixture 付きで検証するスモークスクリプト。
+# 配置: docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/test-pt-fallback.sh
+# 依存: bash 4+
+# セットアップ参照先: docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/impl-notes.md
+#
+# 実行:
+#   ./docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/test-pt-fallback.sh
+# 出力:
+#   各ケース: `[OK]` / `[NG]` の prefix で 1 行レポート
+#   末尾: `SMOKE_RESULT: pass` / `SMOKE_RESULT: fail`
+# 副作用:
+#   /tmp/pt-fallback-smoke-XXXX/ に一時ディレクトリ（tasks.md fixture）を作成し、
+#   終了時に削除する
+
+set -euo pipefail
+
+# ─── 判定ロジックの参照実装（issue-watcher.sh の run_impl_pipeline() Stage A 分岐から抽出） ───
+# 本関数は local-watcher/bin/issue-watcher.sh の `case "$START_STAGE" in A)` 分岐の
+# per-task ループ起動判定と **同一ロジック**でなければならない。差分が出た場合は impl 側を
+# 本 fixture に再同期すること。
+#
+# 引数:
+#   $1 = PER_TASK_LOOP_ENABLED の値（"true" / "false" / "" / 任意文字列）
+#   $2 = tasks.md の絶対パス
+# stdout:
+#   "per-task-loop"       — per-task ループへ入る（tasks.md あり + flag=true）
+#   "stage-a-fallback"    — flag=true だが tasks.md 不在 → 従来 Stage A へフォールバック
+#   "stage-a-traditional" — flag 未指定 / true 以外 → 従来 Stage A 経路（fallback ログなし）
+# 副作用:
+#   fallback 経路では stderr に AC5 のフォールバックログ行を出力する
+resolve_stage_a_route() {
+  local per_task_loop_enabled="$1"
+  local tasks_md="$2"
+
+  local _pt_loop_enabled=false
+  if [ "${per_task_loop_enabled:-false}" = "true" ]; then
+    if [ -f "$tasks_md" ]; then
+      _pt_loop_enabled=true
+    else
+      # AC5: フォールバック発生を判別可能なログ行を出力（claude-failed は付けない）
+      echo "--- per-task: tasks.md 不在 → Stage A fallback（$tasks_md）---" >&2
+      echo "stage-a-fallback"
+      return 0
+    fi
+  fi
+
+  if [ "$_pt_loop_enabled" = "true" ]; then
+    echo "per-task-loop"
+  else
+    echo "stage-a-traditional"
+  fi
+}
+
+# ─── テストハーネス ───
+WORKDIR="$(mktemp -d /tmp/pt-fallback-smoke-XXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+TASKS_PRESENT="$WORKDIR/with-tasks/tasks.md"
+TASKS_ABSENT="$WORKDIR/no-tasks/tasks.md"
+mkdir -p "$WORKDIR/with-tasks" "$WORKDIR/no-tasks"
+cat > "$TASKS_PRESENT" <<'EOF'
+- [ ] 1. サンプルタスク
+  - _Requirements: 1.1_
+EOF
+
+FAIL=0
+assert_route() {
+  local desc="$1" enabled="$2" tasks_md="$3" expected="$4"
+  local got
+  got=$(resolve_stage_a_route "$enabled" "$tasks_md" 2>/dev/null)
+  if [ "$got" = "$expected" ]; then
+    echo "[OK] $desc (route=$got)"
+  else
+    echo "[NG] $desc (expected=$expected got=$got)"
+    FAIL=1
+  fi
+}
+
+assert_fallback_log() {
+  local desc="$1" enabled="$2" tasks_md="$3"
+  local stderr
+  stderr=$(resolve_stage_a_route "$enabled" "$tasks_md" 2>&1 >/dev/null)
+  if printf '%s' "$stderr" | grep -q 'per-task: tasks.md 不在 → Stage A fallback'; then
+    echo "[OK] $desc (fallback ログ行を検出)"
+  else
+    echo "[NG] $desc (fallback ログ行が出力されていない: '$stderr')"
+    FAIL=1
+  fi
+}
+
+assert_no_fallback_log() {
+  local desc="$1" enabled="$2" tasks_md="$3"
+  local stderr
+  stderr=$(resolve_stage_a_route "$enabled" "$tasks_md" 2>&1 >/dev/null)
+  if printf '%s' "$stderr" | grep -q 'Stage A fallback'; then
+    echo "[NG] $desc (不要な fallback ログが出力された: '$stderr')"
+    FAIL=1
+  else
+    echo "[OK] $desc (fallback ログなし)"
+  fi
+}
+
+echo "=== Issue #166 per-task ループ Stage A フォールバック判定スモーク ==="
+
+# AC1: flag=true + tasks.md 不在 → Stage A フォールバック（claude-failed なし）
+assert_route "AC1: flag=true + tasks.md 不在 → Stage A fallback" "true" "$TASKS_ABSENT" "stage-a-fallback"
+# AC5/Req3.1: フォールバック発生時は判別可能なログ行を出力
+assert_fallback_log "AC5: フォールバック発生時に判別可能ログ行" "true" "$TASKS_ABSENT"
+
+# AC3 / NFR1.2: flag=true + tasks.md あり → per-task ループ（挙動不変）
+assert_route "AC3: flag=true + tasks.md あり → per-task loop" "true" "$TASKS_PRESENT" "per-task-loop"
+# per-task ループ起動時はフォールバックログを出さない
+assert_no_fallback_log "AC3: per-task loop 起動時は fallback ログなし" "true" "$TASKS_PRESENT"
+
+# NFR1.1: flag 未指定（空） → 従来 Stage A 経路（tasks.md の有無に関わらず）
+assert_route "NFR1.1: flag 空 + tasks.md あり → 従来 Stage A" "" "$TASKS_PRESENT" "stage-a-traditional"
+assert_route "NFR1.1: flag 空 + tasks.md 不在 → 従来 Stage A" "" "$TASKS_ABSENT" "stage-a-traditional"
+assert_no_fallback_log "NFR1.1: flag 空時は fallback ログなし" "" "$TASKS_ABSENT"
+
+# NFR1.1: flag=false → 従来 Stage A 経路
+assert_route "NFR1.1: flag=false + tasks.md あり → 従来 Stage A" "false" "$TASKS_PRESENT" "stage-a-traditional"
+assert_route "NFR1.1: flag=false + tasks.md 不在 → 従来 Stage A" "false" "$TASKS_ABSENT" "stage-a-traditional"
+
+# NFR1.1: flag=厳密一致以外（typo / True / 1） → 従来 Stage A 経路
+assert_route "NFR1.1: flag=True（大文字）→ 従来 Stage A" "True" "$TASKS_PRESENT" "stage-a-traditional"
+assert_route "NFR1.1: flag=1 → 従来 Stage A" "1" "$TASKS_PRESENT" "stage-a-traditional"
+assert_no_fallback_log "NFR1.1: flag=True 時は fallback ログなし" "True" "$TASKS_ABSENT"
+
+echo "---"
+if [ "$FAIL" -eq 0 ]; then
+  echo "SMOKE_RESULT: pass"
+  exit 0
+else
+  echo "SMOKE_RESULT: fail"
+  exit 1
+fi

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -7119,7 +7119,8 @@ EOF
 # 消化する dispatcher。
 #
 # 戻り値:
-#   0  = 全 task 消化成功（Stage A 完了相当）または pending 0 件で no-op
+#   0  = 全 task 消化成功（Stage A 完了相当）/ pending 0 件で no-op /
+#        tasks.md 不在の防御ガード（呼び出し側で Stage A fallback 済みの想定 / #166）
 #   1  = Implementer / Reviewer 失敗で claude-failed 付与済み（呼び出し側は伝搬 return 1）
 #
 # 副作用:
@@ -7131,10 +7132,13 @@ EOF
 # Requirements: 2.1, 2.6, 2.7, 3.4, 3.5, 3.6, 3.7, 5.1, 5.2
 run_per_task_loop() {
   local tasks_md="$REPO_DIR/$SPEC_DIR_REL/tasks.md"
+  # tasks.md 不在の事前分岐は呼び出し側 run_impl_pipeline() の Stage A 分岐で実施済み
+  # （#166: tasks.md 不在なら per-task ループへ入らず従来 Stage A へフォールバックする）。
+  # 本ブロックは万一直接呼び出し等で到達した場合の防御ガード。Issue を失敗扱いせず
+  # （claude-failed を付けず）no-op return 0 で抜け、メッセージと実装の乖離を作らない。
   if [ ! -f "$tasks_md" ]; then
-    pt_warn "tasks.md が存在しません: $tasks_md → 通常 Stage A にフォールバック相当として return 1"
-    mark_issue_failed "per-task-tasks-missing" "per-task ループ起動に必要な \`tasks.md\` が見つかりません: \`$tasks_md\`。"
-    return 1
+    pt_warn "tasks.md が存在しません: $tasks_md → per-task ループを起動せず no-op return 0（呼び出し側で Stage A fallback 済みの想定）"
+    return 0
   fi
 
   # pending タスク一覧
@@ -9134,7 +9138,22 @@ run_impl_pipeline() {
   # Stage B / Stage C は分岐の外で従来通り実行される（NFR 1.4）。
   case "$START_STAGE" in
     A)
+      # per-task loop は `tasks.md` が存在する場合にのみ起動する。`PER_TASK_LOOP_ENABLED=true`
+      # でも tasks.md 不在（Architect 不要 triage を通過した Issue 等）の場合は、Issue を
+      # 失敗扱いせず従来の単一 Developer 経路（else ブランチ）へフォールバックする（#166 /
+      # Req 1.1, 1.2, 3.1）。判定を if 条件に畳むことで、従来 Stage A ブロックを重複させずに
+      # 到達させる（NFR 2.1: per-task ループ dispatcher 本体は変更しない）。
+      local _pt_tasks_md="$REPO_DIR/$SPEC_DIR_REL/tasks.md"
+      local _pt_loop_enabled=false
       if [ "${PER_TASK_LOOP_ENABLED:-false}" = "true" ]; then
+        if [ -f "$_pt_tasks_md" ]; then
+          _pt_loop_enabled=true
+        else
+          # AC5: フォールバック発生を判別可能なログ行を slot ログに出力（claude-failed は付けない）
+          echo "--- per-task: tasks.md 不在 → Stage A fallback（$_pt_tasks_md）---" | tee -a "$LOG"
+        fi
+      fi
+      if [ "$_pt_loop_enabled" = "true" ]; then
         echo "--- Stage A 実行（$MODE / per-task loop / PER_TASK_LOOP_ENABLED=true）---" >> "$LOG"
         if ! run_per_task_loop; then
           # run_per_task_loop 内で claude-failed 付与済 / 既に Issue コメント済。


### PR DESCRIPTION
## 概要

`PER_TASK_LOOP_ENABLED=true` を有効化した環境で、Architect 不要 triage を通過した Issue（`tasks.md` が生成されない Issue）が per-task ループ起動に到達すると、`tasks.md` 不在を理由に `claude-failed` が付与されて Implementer が一度も起動しないまま停止していた。ログ上は「Stage A にフォールバックする」と表示しながら実際にはフォールバックが実装されておらず、メッセージと挙動の乖離があった。

本 PR はその不整合を修正する。`run_impl_pipeline()` の Stage A 分岐において `tasks.md` 不在を上位層で事前判定し（Option C）、`claude-failed` を付与せず従来 Stage A（single-shot Implementer + Reviewer round=1 + PR 作成）へ正しくフォールバックさせる。`tasks.md` が存在する既存 Issue の per-task ループ挙動は byte 等価で後方互換を維持する。

## 対応 Issue

Closes #166

## 関連 PR

- 設計 PR: なし（本 Issue は Architect 不要 triage を通過したケース）

## 実装内容

- (Req 1.1 / 1.2 / 1.3 / 1.4) `run_impl_pipeline()` Stage A 分岐に事前判定ガードを追加。`PER_TASK_LOOP_ENABLED=true` かつ `tasks.md` 不在のとき `_pt_loop_enabled=false` のまま従来 Stage A `else` ブランチへフォールスルー。`mark_issue_failed` / `gh issue comment` を呼ばずログ行のみ出力してから従来 Stage A と同一フローに合流する
- (Req 3.1) フォールバック発生時に判別可能なログ行 `--- per-task: tasks.md 不在 → Stage A fallback（<path>）---` を `tee -a "$LOG"` で出力
- (NFR 2.1) `run_per_task_loop()` 本体（タスク逐次消化・round 制御・Debugger Gate）は無変更。不在ブランチの旧実装 `mark_issue_failed "per-task-tasks-missing"` + `return 1`（新挙動と矛盾する失敗扱い）を撤去し `pt_warn` + `return 0`（防御ガード as no-op）に変更
- (README 二重管理規約) per-task ループ節「新挙動（opt-in 時）」に `tasks.md` 不在時フォールバック挙動の migration note を追記
- (スモークスクリプト) `docs/specs/166-.../test-pt-fallback.sh` を新規追加。`tasks.md` あり/なし × `PER_TASK_LOOP_ENABLED` true/false/typo の組合せ 12 ケース全 `[OK]`

## 受入基準チェック

- [x] Req 1.1: While `PER_TASK_LOOP_ENABLED=true`、tasks.md 不在 → `claude-failed` 付与せず Stage A フォールバック ← `issue-watcher.sh:9146-9156` 事前分岐 + smoke AC1
- [x] Req 1.2: フォールバック開始時に `claude-failed` 起因の失敗通知コメントを投稿しない ← 事前分岐は `mark_issue_failed` / `gh issue comment` を呼ばない
- [x] Req 1.3: フォールバック実行中、Implementer → Reviewer round=1 → PR 作成の順で従来同等の成果物を生成 ← 従来 Stage A `else` ブランチ（byte 等価）へ合流
- [x] Req 1.4: フォールバック中の Implementer/Reviewer 失敗時は従来同一の `claude-failed` ハンドリング ← 従来 Stage A 失敗ハンドリング（9226行〜）を無変更流用
- [x] Req 2.1: tasks.md あり + pending≥1 → 従来通り per-task ループで逐次処理 ← smoke AC3
- [x] Req 2.2: tasks.md あり + pending 0 → Stage A 完了相当で正常終了 ← `run_per_task_loop` 内 pending=0 → return 0（無変更）
- [x] Req 2.3: flag 未指定/true 以外 → per-task 分岐に入らず従来 Stage A ← smoke NFR1.1（空/false/True/1）
- [x] Req 3.1: フォールバック発生をログで判別可能 ← `issue-watcher.sh:9153` ログ行 + smoke AC5
- [x] NFR 1.1: flag off 時の Stage A 外形挙動（ログ/ラベル遷移/exit code）は導入前と同一 ← smoke NFR1.1 各ケースで fallback ログなし確認
- [x] NFR 2.1: dispatcher 本体（逐次消化/round/Debugger Gate）を変えず fallback 判定のみ追加 ← 本体ループ（7160行以降）は main と byte 等価

## テスト結果

```
スモークテスト（test-pt-fallback.sh）: 12 ケース全 [OK] / SMOKE_RESULT: pass
bash -n local-watcher/bin/issue-watcher.sh: SYNTAX_OK
shellcheck local-watcher/bin/issue-watcher.sh: 新規警告ゼロ（残存は既存 SC2317 info、編集行付近に新規 finding なし）
shellcheck docs/specs/166-.../test-pt-fallback.sh: SMOKE_SHELLCHECK_CLEAN
```

## 実装上の判断

requirements.md の Open Questions で提示された Option A / B / C のうち、Option C（上位層 `run_impl_pipeline()` の Stage A 分岐で事前判定）を採用した。主な理由:
- NFR 2.1（dispatcher 本体を変えない）: `run_per_task_loop()` 本体には一切手を入れず、起動条件の gate のみ上位に追加
- Option B（Stage A コード複製 or 関数抽出）が必要なコード増分を、`if` 判定のフォールスルー 1 箇所に集約できた

## 確認事項 / レビュワーへの依頼

- **base ブランチ検証**: `gh pr view 171 --json baseRefName` → `main` (一致、確認済み)
- **Reviewer 独立レビュー**: `docs/specs/166-bug-watcher-per-task-loop-enabled-impl-m/review-notes.md` 参照（round=1、RESULT: approve）
- **`run_per_task_loop()` 不在ブランチの残置方針**: 防御ガード（`return 0`）として残置し、完全撤去は不採用。詳細は impl-notes.md の「確認事項」節を参照
- **dry-run スモーク未実施**: 実 Issue / gh 認証依存のため未実施。分岐判定はスモークスクリプトで機械検証済み

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #166 のコメントを参照してください。
