### PR TITLE
fix(watcher): 非同期 tee の flush レース解消と Dispatcher シグナル trap 追加 (#170)

### DIFF
--- a/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/impl-notes.md
+++ b/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/impl-notes.md
@@ -1,0 +1,171 @@
+# 実装ノート（Issue #170）
+
+`local-watcher/bin/issue-watcher.sh` のシェル堅牢化 3 件（SLOT_INIT_HOOK stderr 同期捕捉 /
+slot ログ堅牢化 / Dispatcher シグナル trap）の実装記録。
+
+## 変更サマリ
+
+| Requirement | 対応 | 変更内容 |
+|---|---|---|
+| Req 1（最優先） | 実装 | `_hook_invoke` の stderr 捕捉を非同期 `tee` プロセス置換から同期リダイレクト `2>"$stderr_tmp"` に変更し、フック終了後に `cat "$stderr_tmp" >&2` で stderr を運用者へ転記 |
+| Req 2（低優先・表示品質） | 現状維持＋判断記録 | 確実な低リスク同期手法が無いため現状維持。後述の判断理由を参照 |
+| Req 3（低優先・最小実装） | 実装 | Dispatcher トップレベルに SIGINT/SIGTERM trap を追加（子プロセス kill + worktree prune 1 回、再入ガード付き） |
+
+## Requirement 1: SLOT_INIT_HOOK stderr 捕捉の同期化
+
+### 変更内容
+- 旧: `"$SLOT_INIT_HOOK" 2> >(tee -a "$stderr_tmp" >&2) || rc=$?`
+  - 非同期プロセス置換のため、フック終了直後の `tail -c 2000` 読み出しと tee の flush の間に
+    レースが生じ、失敗ログ末尾が欠落しうる
+- 新: `"$SLOT_INIT_HOOK" 2>"$stderr_tmp" || rc=$?`
+  - 同期リダイレクト。フック終了時点で一時ファイルが確定する
+  - フック終了後に `if [ -s "$stderr_tmp" ]; then cat "$stderr_tmp" >&2 || true; fi` で
+    stderr を従来どおり運用者へ流す（Req 1.4: stderr 観測性維持）
+  - `set -euo pipefail` 下で `cat` 失敗が `_hook_invoke` を誤って致命化しないよう `|| true` でガード
+- 既存の `tail -c 2000` 転記（rc != 0 時）/ `rm -f`（正常時の一時ファイル削除）/ exit code 取得
+  （`|| rc=$?`）の意味は変更していない
+
+### AC 対応
+- **AC 1.1**（非ゼロ exit 時に stderr 末尾 2000 バイトをログ転記）: 既存の `tail -c 2000 "$stderr_tmp"`
+  ロジックを温存。同期化により一時ファイルが完全に確定した状態で読むため末尾欠落しない
+- **AC 1.2**（フック終了を待ってから一時ファイル読み出し / flush レースを生じさせない）:
+  同期リダイレクト `2>"$stderr_tmp"` でフック終了 = ファイル確定。非同期 tee を排除
+- **AC 1.3**（正常終了時は一時ファイル削除・追加エラー出力なし）: 既存の `rm -f "$stderr_tmp"` を温存。
+  `rc == 0` のとき ERROR ログを出さない既存挙動を変更していない
+- **AC 1.4**（stderr を従来どおり運用者から観測可能に保持）: 同期捕捉後に `cat "$stderr_tmp" >&2`
+  で stderr へ転記。旧実装の `tee >&2` と同じく運用者から観測可能
+- **AC 1.5**（exit code を 0=成功/非ゼロ=失敗で呼び出し元へ返す）: `|| rc=$?` と末尾の
+  `return 1 / return 0` を変更せず温存
+
+### スモーク検証（Req 1）
+即異常終了し 200 行（>2000 バイト）の stderr を吐くフックを `2>"$tmp"` で捕捉 →
+`tail -c 2000` で末尾を読む再現テストを実施:
+- 末尾行 `ERRLINE-200` が捕捉 tail に含まれる（**TAIL_OK**: 末尾欠落なし）
+- exit code 7 が保持される（**RC_OK**）
+- 検証用スクリプトはリポジトリにコミットせず削除済み
+
+## Requirement 2: slot ログ出力の堅牢化（現状維持＋判断記録）
+
+### 判断: 現状維持
+`exec > >(tee -a "$SLOT_LOG") 2>&1`（11086 行付近）は **変更しない**。理由:
+
+1. **dual-write には tee が構造上必要**: stdout（cron mailer 経路）と slot ログファイルの
+   双方へ同時に書き出す要件（AC 2.1）は、1 ストリームを 2 宛先へ複製する `tee` でのみ実現できる。
+   同期リダイレクト単独では dual-write を代替できない
+2. **確実な低リスク同期手法が無い**: tee 子プロセスの flush 同期は、
+   `exec > >(tee ...)` 直後の `$!` で tee PID を捕捉し subshell 終了時に `wait` する方法が
+   考えられるが、(a) `$!` の挙動が bash バージョン依存で脆い、(b) `_slot_run_issue` subshell に
+   新規 EXIT trap を追加すると、ネストした helper 関数内の既存サブシェル trap（rebase/revert/checkout
+   復帰）との相互作用が非自明になり、Req 3.4「既存サブシェル trap の挙動を変更しない」制約への
+   リスクが生じる。タスク指示の「過剰修正リスク警戒」に従い、確実な低リスク手法が無いと判断
+3. **機能影響が無い**: Req 2 は表示順序の乱れ（display quality）であり機能影響なし。
+   親 Dispatcher は終端で全 subshell を `wait`（11738 行付近）するため、ファイル内容は
+   subshell とその tee 子プロセスが終了した後に最終的に完全な状態になる
+
+### AC 対応（現状維持で充足）
+- **AC 2.1**（stdout と slot ログファイル両方へ書き出す）: 既存 `tee -a "$SLOT_LOG"` で充足。変更不要
+- **AC 2.2**（完了時にログ行を欠落なく確定）: 親の終端 `wait` で subshell + tee の終了を待ち合わせ、
+  ファイル内容は最終的に確定する。表示順序の乱れは機能影響なし
+- **AC 2.3**（パス命名規約 `slot-<slot番号>-<Issue番号>-<タイムスタンプ>.log` を従来と同一に保つ）:
+  `SLOT_LOG="$LOG_DIR/slot-${IDD_SLOT_NUMBER}-${NUMBER}-${TS}.log"` を変更していない
+
+## Requirement 3: Dispatcher のシグナル捕捉（最小実装）
+
+### 変更内容
+Dispatcher トップレベル（`_DISPATCHER_SLOT_PIDS` 宣言の直後）に以下を追加:
+- `_DISPATCHER_SIGNAL_HANDLED` ガードフラグ（初期値 0）
+- `_dispatcher_on_signal()` ハンドラ関数
+  - 再入ガード: 既に処理済みなら即 `return 0`（NFR 2.2）
+  - fork 済み slot worker（`_DISPATCHER_SLOT_PIDS` の各 PID）へ `kill -TERM`（Req 3.1）
+  - `wait` で子プロセス回収（孤立防止）
+  - `git -C "$REPO_DIR" worktree prune` を 1 回実行（Req 3.2、既存コードと同じ idiom）
+  - exit code は bash 慣例の 128+signal（SIGINT=130 / SIGTERM=143）
+- `trap '_dispatcher_on_signal INT' INT` / `trap '_dispatcher_on_signal TERM' TERM`
+
+### 設計判断
+- **trap はトップレベルに配置**: メインスクリプト本体に置く。サブシェル `( _slot_run_issue ... ) &`
+  には trap は伝播しない（bash はサブシェルで trap をリセットする）ため、既存のサブシェル内
+  ローカル EXIT trap（1174/1515/3128/3461/4748 行付近の rebase/revert/checkout 復帰）の挙動は
+  一切変更されない（Req 3.4）
+- **flock fd 200 の解放契約を維持**: fd 200 の flock はメインプロセスが保持し、プロセス終了時に
+  OS が自動解放する。ハンドラは最後に `exit` するため、多重起動防止ロックの解放契約は従来どおり
+  （Req 3.3）。per-slot lock（fd 210+N）方式も触れていない
+- **kill -TERM を使用**: 子へ SIGTERM を送る。子 subshell 側は SIGTERM で素直に終了する
+  （子に独自 trap を仕込む graceful shutdown は本 Issue のスコープ外 / Out of Scope）
+
+### AC 対応
+- **AC 3.1**（SIGINT/SIGTERM 受信時に fork 済み slot worker 子プロセスへ終了シグナルを送る）:
+  `_DISPATCHER_SLOT_PIDS` の各 PID へ `kill -TERM`
+- **AC 3.2**（中断終了時に worktree prune を 1 回実行）: `git -C "$REPO_DIR" worktree prune`
+- **AC 3.3**（flock fd 200 の解放契約を従来どおり維持）: fd 200 は触れず、ハンドラ末尾 `exit` で
+  OS が解放
+- **AC 3.4**（既存サブシェル内ローカル trap の挙動を変更しない）: trap はトップレベルのみ。
+  既存 trap 行（1174/1515/3128/3461/4748）は未変更
+- **AC 3.5**（通常完了時の挙動・exit code を導入前と同一に保つ）: シグナル未受信時は trap が
+  発火せず、既存の `_dispatcher_run` → `exit 0`（11743 行付近）/ `exit $DISPATCHER_RC` の経路を
+  そのまま通る
+- **NFR 2.2**（同一シグナル再送で prune 二重実行しない）: `_DISPATCHER_SIGNAL_HANDLED` ガードで
+  1 回に制限。スモークで再送 3 回でも prune 1 回のみを確認（**GUARD_OK**）
+
+### スモーク検証（Req 3）
+- 再入ガードのユニットスモーク: ハンドラを 3 回（TERM/TERM/INT）呼んでも prune 相当処理が
+  1 回のみ実行されることを確認（**GUARD_OK**）
+
+## テスト・検証結果
+
+1. **shellcheck**（NFR 3.1）: `shellcheck local-watcher/bin/issue-watcher.sh`
+   - 変更前後で findings コード件数の diff を取得 → **NO_CODE_DIFF（新規 findings ゼロ）**
+   - 既存 findings は SC2317（info 級、trap ハンドラ false positive）41 件のみ。本 repo は従来
+     これらを許容（disable directive 不使用）
+   - 新規追加した `_dispatcher_on_signal` も trap 経由 = SC2317 info を誘発するため、新規関数に
+     `# shellcheck disable=SC2317` を 1 行付与して件数増を回避（warning/error/style 級の findings は
+     変更前後とも 0 件）
+2. **cron-like 最小 PATH 依存解決**: `env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'command -v claude gh jq flock git'`
+   - `gh` / `jq` / `flock` / `git` は解決（exit 0）。`claude` は本検証環境の最小 PATH に不在
+     （スクリプト冒頭 37 行の `export PATH="$HOME/.local/bin:..."` prepend で実 cron 環境では解決される。
+     本変更は PATH prepend ロジックを触っていない）
+3. **構文チェック**: `bash -n local-watcher/bin/issue-watcher.sh` → **SYNTAX_OK**
+   - dry run（`$HOME/bin/issue-watcher.sh` の実行）は実環境を汚すため指示どおり実行せず
+4. **Req 1 レース解消スモーク**: 即異常終了フックの stderr 末尾が同期捕捉で欠落しないこと
+   （**TAIL_OK** / **RC_OK**）。検証スクリプトは削除済み（コミットせず）
+
+## 受入基準カバレッジ一覧
+
+| AC | 担保方法 |
+|---|---|
+| 1.1 | 既存 `tail -c 2000` 温存 + 同期化で末尾欠落解消（Req 1 スモーク TAIL_OK） |
+| 1.2 | 同期リダイレクト `2>"$stderr_tmp"`（非同期 tee 排除） |
+| 1.3 | 既存 `rm -f` / 正常時 ERROR 非出力を温存 |
+| 1.4 | フック終了後 `cat "$stderr_tmp" >&2`（stderr 観測性維持） |
+| 1.5 | `|| rc=$?` / `return 1\|0` 温存（exit code 意味不変） |
+| 2.1 | 既存 `tee -a "$SLOT_LOG"` dual-write 温存 |
+| 2.2 | 親終端 `wait` で確定（表示順序乱れは機能影響なし / 現状維持判断） |
+| 2.3 | `SLOT_LOG` パス命名規約 未変更 |
+| 3.1 | `_DISPATCHER_SLOT_PIDS` 各 PID へ `kill -TERM` |
+| 3.2 | `git -C "$REPO_DIR" worktree prune` 1 回 |
+| 3.3 | fd 200 flock 未変更（ハンドラ末尾 exit で OS 解放） |
+| 3.4 | trap はトップレベルのみ（既存サブシェル trap 未変更） |
+| 3.5 | シグナル未受信時は trap 不発（既存 exit 経路温存） |
+| NFR 1.1/1.2/1.3 | env var 名 / exit code 意味 / ログ命名規約 すべて未変更 |
+| NFR 2.1 | 冪等性: 追加処理は trap 発火時のみ。通常 cron 再実行で副作用なし |
+| NFR 2.2 | `_DISPATCHER_SIGNAL_HANDLED` ガードで prune 二重実行防止（スモーク GUARD_OK） |
+| NFR 3.1 | shellcheck 新規 findings ゼロ（NO_CODE_DIFF） |
+
+## 確認事項（レビュワー判断ポイント）
+
+1. **Req 2 を現状維持とした判断**: 上記「Requirement 2」の判断理由のとおり、確実な低リスク同期
+   手法が無く機能影響も無いため現状維持とした。tee flush の同期化を将来別 Issue で扱うべきか、
+   本判断で AC 2.1〜2.3 を充足とみなせるかはレビュワー / 人間の判断に委ねる
+2. **shellcheck disable=SC2317 の新規導入**: 本 repo は従来 SC2317（trap ハンドラ false positive）を
+   disable directive 無しで許容していたが、新規 trap ハンドラの件数増を「新規警告ゼロ」要件
+   （NFR 3.1）に照らして避けるため、新規関数 1 か所のみに disable directive を付与した。既存
+   コードのスタイル（directive 不使用）からの逸脱だが影響は新規関数に限定される
+3. **Req 3 の exit code（130/143）**: 中断由来の終了は bash 慣例の 128+signal とした。NFR 1.2 の
+   既存 exit code（0/1）は「シグナルを受けない通常完了時」の話であり、シグナル中断時の exit code は
+   従来定義が無かった（trap 不在で bash デフォルト動作）。130/143 は bash デフォルトと整合する
+
+## 設計成果物の有無
+- design.md / tasks.md は本 Issue には存在しない（requirements.md のみ）。番号順タスク消化ではなく
+  requirements.md の Requirement 1→3 を優先度順に実装した
+
+STATUS: complete

--- a/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/requirements.md
+++ b/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/requirements.md
@@ -1,0 +1,70 @@
+# Requirements Document
+
+## Introduction
+
+`local-watcher/bin/issue-watcher.sh` には、非同期プロセス置換 `tee` と Dispatcher のシグナル trap 欠如に起因する 3 件のシェル堅牢化課題がある。第一に、SLOT_INIT_HOOK の stderr 捕捉が `2> >(tee -a "$stderr_tmp" >&2)` という非同期プロセス置換で行われており、フック終了直後の `tail -c 2000` 読み出しと flush の間にレースが生じ、失敗時のログ末尾が欠落しうる。第二に、slot ログの `exec > >(tee -a "$SLOT_LOG") 2>&1` も同じ非同期性を持ち、表示順序が乱れうる（機能影響はない）。第三に、Dispatcher 本体に SIGINT/SIGTERM の trap が無く、cron/launchd からの中断や手動 Ctrl-C 時に fork 済み slot worker が孤立し、`.broken-*` worktree の蓄積要因になる。idd-claude は self-hosting（dogfooding）で稼働し、このスクリプト自身が次回 cron で自分を動かすため、後方互換性（exit code・ログ出力先・既存 env var 名）と冪等性を最優先に、優先度を明確に切り分けて改善する。
+
+## Requirements
+
+### Requirement 1: SLOT_INIT_HOOK stderr 捕捉の同期化（最優先）
+
+**Objective:** As a 運用者, I want SLOT_INIT_HOOK 失敗時の stderr 末尾が確実にログへ転記されること, so that フック失敗の原因をログだけで追える
+
+#### Acceptance Criteria
+
+1. If SLOT_INIT_HOOK が非ゼロ exit code で終了したとき, the Hook Invoker shall フック実行中に発生した stderr の末尾 2000 バイトを slot ログへ転記する
+2. While SLOT_INIT_HOOK の stderr を一時ファイルへ捕捉する間, the Hook Invoker shall フック終了を待ってから一時ファイルを読み出す（非同期プロセス置換による flush レースを生じさせない）
+3. When SLOT_INIT_HOOK が正常終了したとき, the Hook Invoker shall 一時ファイルを削除し、追加のエラー出力を行わない
+4. The Hook Invoker shall SLOT_INIT_HOOK の stderr を従来どおり運用者から観測可能な形で保持する（捕捉化により stderr を握り潰さない）
+5. The Hook Invoker shall SLOT_INIT_HOOK の exit code を従来と同一の意味（0=成功 / 非ゼロ=失敗）で呼び出し元へ返す
+
+### Requirement 2: slot ログ出力の堅牢化（低優先・表示品質）
+
+**Objective:** As a 運用者, I want slot ログの行が cron mailer 出力とログファイルの双方に欠落なく現れること, so that 並行 slot 実行時もログの可読性が保たれる
+
+#### Acceptance Criteria
+
+1. The Slot Runner shall slot 運用ログを標準出力（cron mailer 経路）と slot ログファイルの両方へ書き出す
+2. When slot worker が処理を完了したとき, the Slot Runner shall その時点までに書き出した slot ログ行をログファイルへ欠落なく確定させる
+3. The Slot Runner shall slot ログファイルの出力先パス命名規約（`slot-<slot番号>-<Issue番号>-<タイムスタンプ>.log`）を従来と同一に保つ
+
+### Requirement 3: Dispatcher のシグナル捕捉（低優先・最小実装）
+
+**Objective:** As a 運用者, I want Dispatcher が中断シグナルを受けたとき fork 済み slot worker を孤立させずに終了すること, so that 中断のたびに `.broken-*` worktree が蓄積しない
+
+#### Acceptance Criteria
+
+1. When Dispatcher が SIGINT または SIGTERM を受信したとき, the Dispatcher shall fork 済みの slot worker 子プロセスへ終了シグナルを送る
+2. When Dispatcher が中断シグナルにより終了処理を行うとき, the Dispatcher shall worktree の prune（孤立 worktree の整理）を 1 回実行する
+3. While Dispatcher が中断シグナルを処理する間, the Dispatcher shall 多重起動防止ロック（fd 200 の flock）の解放契約を従来どおり維持する
+4. While Dispatcher が中断シグナルを処理する間, the Dispatcher shall 既存のサブシェル内ローカル trap（rebase/revert/checkout の base branch 復帰）の挙動を変更しない
+5. The Dispatcher shall 中断シグナルを受けない通常完了時の挙動・exit code を本変更導入前と同一に保つ
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The watcher script shall 既存 env var 名（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `SLOT_INIT_HOOK` / `PARALLEL_SLOTS` 等）の名前と意味を変更しない
+2. The watcher script shall 正常完了 exit 0 / 致命的失敗 exit 1 / 他インスタンス実行中スキップ exit 0 という既存 exit code の意味を変更しない
+3. The watcher script shall ログ出力先（`LOG_DIR` 配下の Issue ログおよび slot ログのパス命名規約）を変更しない
+
+### NFR 2: 冪等性と self-hosting 安全性
+
+1. The watcher script shall 本変更後も再 cron 実行で破壊的副作用を生じさせない（複数回連続実行で状態が悪化しない）
+2. Where Dispatcher のシグナル捕捉が追加される場合, the Dispatcher shall 同一シグナルが処理中に再送されても worktree prune を二重実行して状態を破壊しない
+
+### NFR 3: 静的解析
+
+1. The watcher script shall 変更箇所が `shellcheck local-watcher/bin/issue-watcher.sh` で新規警告を発生させない
+
+## Out of Scope
+
+- `_hook_invoke` の stderr 一時ファイルリーク（補足報告書 1.3）は既に対処済みのため本 Issue の対象外とする
+- Requirement 3 のシグナル捕捉は最小実装（子プロセス kill + worktree prune）に限定し、graceful shutdown の段階的待機・タイムアウト・進行中 Issue のラベル巻き戻し等の高度な終了処理は扱わない（スコープが膨らむ場合は別 Issue へ分割する）
+- 並列 slot 数の上限変更・slot ロック方式（fd 210+N）の見直しは扱わない
+- GitHub Actions 版ワークフロー（`.github/workflows/issue-to-pr.yml`）の同等修正は扱わない
+- README / CLAUDE.md の挙動説明更新は、本変更で運用者可視の挙動が変わる範囲に限って行い、ドキュメント全面改訂は扱わない
+
+## Open Questions
+
+- なし（Issue 本文・コメントは watcher の自動開始メッセージのみで、人間による追加決定事項は確認されなかった。Requirement 3 のスコープ膨張時に別 Issue 分割を提案する判断は、Architect / 人間レビューに委ねる）

--- a/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/review-notes.md
+++ b/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/review-notes.md
@@ -1,0 +1,40 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T11:24:37Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-170-impl-bug-watcher-tee-stderr-flush-dispatcher
+- HEAD commit: 0d6066d2842fbf959d5bc9e14077bfbe380f7981
+- Compared to: HEAD~1..HEAD（実装差分は `local-watcher/bin/issue-watcher.sh` のみ。spec 2 ファイルは docs）
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節なし → opt-out 扱い。flag 観点の確認は行わない（通常 3 カテゴリ判定）
+
+## Verified Requirements
+
+- 1.1 — 非ゼロ exit 時の `tail -c 2000 "$stderr_tmp"` 転記（issue-watcher.sh:10231）を温存。同期リダイレクト化でファイル確定後に読むため末尾欠落なし
+- 1.2 — `2>"$stderr_tmp"`（10212）で非同期プロセス置換 `2> >(tee ...)` を排除。フック終了 = ファイル確定で flush レースを解消
+- 1.3 — 正常時の `rm -f "$stderr_tmp"`（10241）温存。ERROR ログは `rc -ne 0` 時のみ出力（10228）で追加エラー出力なし
+- 1.4 — フック終了後 `if [ -s "$stderr_tmp" ]; then cat "$stderr_tmp" >&2 || true; fi`（10216-10218）で stderr を運用者へ転記。観測性維持
+- 1.5 — `... 2>"$stderr_tmp" || rc=$?`（10212）と末尾 `return 1 / return 0`（10245-10247）を変更せず exit code 意味を保持
+- 2.1 — 既存 `exec > >(tee -a "$SLOT_LOG") 2>&1` の dual-write を温存（現状維持判断、informational）
+- 2.2 — 親 Dispatcher 終端 `wait`（11786）で subshell + tee 終了を待ち合わせ、ファイル内容を最終確定。表示順序乱れは機能影響なし
+- 2.3 — `SLOT_LOG` のパス命名規約 `slot-<slot>-<NUMBER>-<TS>.log` を未変更
+- 3.1 — `_dispatcher_on_signal` が `_DISPATCHER_SLOT_PIDS` 各 PID へ `kill -TERM`（11592-11599）。`kill -0` で生存確認後に送信
+- 3.2 — `git -C "$REPO_DIR" worktree prune`（11604）を 1 回実行（既存 idiom と同一）
+- 3.3 — fd 200 flock（489-490）は未変更。ハンドラ末尾 `exit` でメインプロセス終了時に OS が解放（解放契約維持）
+- 3.4 — trap はトップレベル（11614-11615）にのみ配置。既存サブシェル内ローカル trap（1174/1515/3128/3461/4748 行付近）の差分は diff hunk（@@ 10197 / @@ 11566 のみ）に含まれず未変更
+- 3.5 — シグナル未受信時は trap 不発。既存 `_dispatcher_run` → `exit 0`（11803）/ `exit $DISPATCHER_RC`（11800）経路を温存
+- NFR 1.1/1.2/1.3 — env var 名 / exit code 意味（0/1） / ログ命名規約 すべて未変更
+- NFR 2.1 — 追加処理は trap 発火時のみ。通常 cron 再実行で副作用なし（冪等）
+- NFR 2.2 — `_DISPATCHER_SIGNAL_HANDLED` ガード（11586-11589）で再入時 prune 二重実行を防止
+- NFR 3.1 — shellcheck 非 SC2317 findings 件数 1→1 で不変（既存 SC2012 のみ、変更箇所外の 4448 行）。SC2317 件数 40→40 で不変（新規ハンドラへ `# shellcheck disable=SC2317` を 1 行付与）。`bash -n` SYNTAX_OK
+
+## Findings
+
+なし
+
+## Summary
+
+Req 1（stderr 同期捕捉）/ Req 3（Dispatcher シグナル trap）は全 AC を実装で充足し、exit code 取得（`|| rc=$?`）・stderr 観測性（cat 転記）・flock fd 200 解放契約・既存サブシェル trap・通常完了経路のいずれも非破壊で温存されている。重点確認項目 (A)(B)(C) はすべて問題なし: 同期リダイレクト化で exit code 取得と stderr 観測性は保たれ、trap はトップレベル限定で既存サブシェル trap と fd 200 に未介入、`_DISPATCHER_SIGNAL_HANDLED` で prune 二重実行を防止。Req 2 は「dual-write に tee が構造上必須・親終端 wait で内容確定・機能影響なし」を理由とする現状維持判断で AC 2.1〜2.3 を充足とみなせる（残る表示順序の同期化は別 Issue 候補として記録済み、本判定の reject 対象外）。shellcheck 新規 findings ゼロ・bash -n クリーンで NFR 3.1 も満たす。
+
+RESULT: approve

--- a/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/review-notes.md
+++ b/docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/review-notes.md
@@ -1,33 +1,36 @@
 # Review Notes
 
-<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T11:24:37Z -->
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T11:40:00Z -->
 
 ## Reviewed Scope
 
 - Branch: claude/issue-170-impl-bug-watcher-tee-stderr-flush-dispatcher
-- HEAD commit: 0d6066d2842fbf959d5bc9e14077bfbe380f7981
-- Compared to: HEAD~1..HEAD（実装差分は `local-watcher/bin/issue-watcher.sh` のみ。spec 2 ファイルは docs）
+- HEAD commit: dddf78a7fba421fd527749f6128be2127ccc4a96
+- Compared to: main..HEAD（実装差分は `local-watcher/bin/issue-watcher.sh` のみ。spec 3 ファイルは docs）
 - Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節なし → opt-out 扱い。flag 観点の確認は行わない（通常 3 カテゴリ判定）
+- tasks.md: 本 Issue には存在しない（requirements.md のみ）。`_Boundary:_` 制約は無く、変更ファイルは watcher script に限定されることを diff で確認
 
 ## Verified Requirements
 
-- 1.1 — 非ゼロ exit 時の `tail -c 2000 "$stderr_tmp"` 転記（issue-watcher.sh:10231）を温存。同期リダイレクト化でファイル確定後に読むため末尾欠落なし
-- 1.2 — `2>"$stderr_tmp"`（10212）で非同期プロセス置換 `2> >(tee ...)` を排除。フック終了 = ファイル確定で flush レースを解消
-- 1.3 — 正常時の `rm -f "$stderr_tmp"`（10241）温存。ERROR ログは `rc -ne 0` 時のみ出力（10228）で追加エラー出力なし
-- 1.4 — フック終了後 `if [ -s "$stderr_tmp" ]; then cat "$stderr_tmp" >&2 || true; fi`（10216-10218）で stderr を運用者へ転記。観測性維持
-- 1.5 — `... 2>"$stderr_tmp" || rc=$?`（10212）と末尾 `return 1 / return 0`（10245-10247）を変更せず exit code 意味を保持
-- 2.1 — 既存 `exec > >(tee -a "$SLOT_LOG") 2>&1` の dual-write を温存（現状維持判断、informational）
-- 2.2 — 親 Dispatcher 終端 `wait`（11786）で subshell + tee 終了を待ち合わせ、ファイル内容を最終確定。表示順序乱れは機能影響なし
-- 2.3 — `SLOT_LOG` のパス命名規約 `slot-<slot>-<NUMBER>-<TS>.log` を未変更
-- 3.1 — `_dispatcher_on_signal` が `_DISPATCHER_SLOT_PIDS` 各 PID へ `kill -TERM`（11592-11599）。`kill -0` で生存確認後に送信
-- 3.2 — `git -C "$REPO_DIR" worktree prune`（11604）を 1 回実行（既存 idiom と同一）
-- 3.3 — fd 200 flock（489-490）は未変更。ハンドラ末尾 `exit` でメインプロセス終了時に OS が解放（解放契約維持）
-- 3.4 — trap はトップレベル（11614-11615）にのみ配置。既存サブシェル内ローカル trap（1174/1515/3128/3461/4748 行付近）の差分は diff hunk（@@ 10197 / @@ 11566 のみ）に含まれず未変更
-- 3.5 — シグナル未受信時は trap 不発。既存 `_dispatcher_run` → `exit 0`（11803）/ `exit $DISPATCHER_RC`（11800）経路を温存
-- NFR 1.1/1.2/1.3 — env var 名 / exit code 意味（0/1） / ログ命名規約 すべて未変更
+- 1.1 — 非ゼロ exit 時の `tail -c 2000 "$stderr_tmp"` 転記（issue-watcher.sh:10231）を温存。同期リダイレクト化により一時ファイル確定後に読むため末尾欠落なし
+- 1.2 — `"$SLOT_INIT_HOOK" 2>"$stderr_tmp"`（10212）で非同期プロセス置換 `2> >(tee ...)` を排除。フック終了 = ファイル確定で flush レースを解消（diff hunk @@10197 で旧 tee 行が新リダイレクト行に置換されたことを確認）
+- 1.3 — 正常終了時の `rm -f "$stderr_tmp"`（10241）を温存。ERROR ログは `rc -ne 0` 時のみ（10228-10238）で正常時に追加エラー出力なし
+- 1.4 — フック終了後 `if [ -s "$stderr_tmp" ]; then cat "$stderr_tmp" >&2 || true; fi`（10216-10218）で stderr を運用者へ転記。旧 `tee >&2` と同等の観測性を維持
+- 1.5 — `... 2>"$stderr_tmp" || rc=$?`（10212）と末尾 `return 1 / return 0`（10245-10247）を未変更。exit code 意味（0=成功/非ゼロ=失敗）を保持
+- 2.1 — 既存 `exec > >(tee -a "$SLOT_LOG") 2>&1`（11098）の dual-write を温存（現状維持判断）。stdout（cron mailer）+ slot ログファイルの両書き出しを維持
+- 2.2 — 親 Dispatcher 終端 `wait` で subshell + tee 子プロセス終了を待ち合わせ、ファイル内容を最終確定。表示順序の乱れは requirements 記載どおり機能影響なし（display quality）
+- 2.3 — `SLOT_LOG="$LOG_DIR/slot-${IDD_SLOT_NUMBER}-${NUMBER}-${TS}.log"`（11096）の命名規約を未変更
+- 3.1 — `_dispatcher_on_signal` が `_DISPATCHER_SLOT_PIDS` 各 PID へ `kill -0` 生存確認後に `kill -TERM`（11589-11598）
+- 3.2 — `git -C "$REPO_DIR" worktree prune`（11604 付近）を 1 回実行（既存 idiom と同一）
+- 3.3 — fd 200 flock（489-490）は未変更。ハンドラ末尾 `exit`（11608 付近）でメインプロセス終了時に OS が解放（解放契約維持）
+- 3.4 — trap はトップレベル（`trap '_dispatcher_on_signal INT' INT` / `... TERM` 11614-11615 付近）のみ配置。既存サブシェル内ローカル trap（1174/1515/3128/3461/4748 行付近の rebase/revert/checkout 復帰）は diff hunk（@@10197 / @@11566 のみ）に含まれず未変更
+- 3.5 — シグナル未受信時は trap 不発。既存 `_dispatcher_run`（11795）→ `exit $DISPATCHER_RC`（11800）/ `exit 0`（11804）経路を温存
+- NFR 1.1 — 既存 env var 名（REPO / REPO_DIR / LOG_DIR / LOCK_FILE / SLOT_INIT_HOOK / PARALLEL_SLOTS）の名前・意味は未変更
+- NFR 1.2 — 正常完了 exit 0 / 致命的失敗 exit 1 / 他インスタンス実行中スキップ exit 0（490-493）の意味を未変更。シグナル中断時の 130/143 は trap 不在時に bash デフォルトと整合する追加で既存規約に抵触しない
+- NFR 1.3 — Issue ログ / slot ログのパス命名規約を未変更
 - NFR 2.1 — 追加処理は trap 発火時のみ。通常 cron 再実行で副作用なし（冪等）
 - NFR 2.2 — `_DISPATCHER_SIGNAL_HANDLED` ガード（11586-11589）で再入時 prune 二重実行を防止
-- NFR 3.1 — shellcheck 非 SC2317 findings 件数 1→1 で不変（既存 SC2012 のみ、変更箇所外の 4448 行）。SC2317 件数 40→40 で不変（新規ハンドラへ `# shellcheck disable=SC2317` を 1 行付与）。`bash -n` SYNTAX_OK
+- NFR 3.1 — 独立再実行で確認: `shellcheck` findings は main と HEAD で同一（SC2012 1 件 + SC2317 40 件、いずれも変更箇所外 or trap false positive）。新規ハンドラへの `# shellcheck disable=SC2317` 付与で件数増を回避。`bash -n` SYNTAX_OK
 
 ## Findings
 
@@ -35,6 +38,6 @@
 
 ## Summary
 
-Req 1（stderr 同期捕捉）/ Req 3（Dispatcher シグナル trap）は全 AC を実装で充足し、exit code 取得（`|| rc=$?`）・stderr 観測性（cat 転記）・flock fd 200 解放契約・既存サブシェル trap・通常完了経路のいずれも非破壊で温存されている。重点確認項目 (A)(B)(C) はすべて問題なし: 同期リダイレクト化で exit code 取得と stderr 観測性は保たれ、trap はトップレベル限定で既存サブシェル trap と fd 200 に未介入、`_DISPATCHER_SIGNAL_HANDLED` で prune 二重実行を防止。Req 2 は「dual-write に tee が構造上必須・親終端 wait で内容確定・機能影響なし」を理由とする現状維持判断で AC 2.1〜2.3 を充足とみなせる（残る表示順序の同期化は別 Issue 候補として記録済み、本判定の reject 対象外）。shellcheck 新規 findings ゼロ・bash -n クリーンで NFR 3.1 も満たす。
+Req 1（stderr 同期捕捉）と Req 3（Dispatcher シグナル trap）は全 AC を実装で充足し、独立に diff・該当行・shellcheck・bash -n を再検証した結果、exit code 取得 / stderr 観測性 / flock fd 200 解放契約 / 既存サブシェル trap / 通常完了経路のいずれも非破壊で温存されている。Req 2 は dual-write に tee が構造上必須・親終端 wait で内容確定・機能影響なし（display quality）を理由とする現状維持判断で、観測可能挙動を定める AC 2.1〜2.3（既存挙動の保持）は充足。shellcheck 新規 findings ゼロ・bash -n クリーンで NFR 3.1 も満たす。boundary 制約（tasks.md）は本 Issue に存在せず、変更は watcher script に限定されており逸脱なし。
 
 RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -10197,13 +10197,25 @@ _hook_invoke() {
 
   # IDD_SLOT_NUMBER / IDD_SLOT_WORKTREE / PARALLEL_SLOTS / REPO / REPO_DIR を export
   # して子プロセスに引き継ぐ。直接 exec のみ（Req 5.5: shell 展開なし）。
+  #
+  # Issue #170 Req 1.2: stderr 捕捉は同期リダイレクト `2>"$stderr_tmp"` で行う。
+  # 旧実装の非同期プロセス置換 `2> >(tee -a "$stderr_tmp" >&2)` は、フック終了直後の
+  # `tail -c 2000` 読み出しと tee の flush の間にレースを生じ、失敗ログ末尾が欠落
+  # しうる。同期リダイレクトでフック終了時に一時ファイルが確定したのち、Req 1.4 を
+  # 満たすため `cat "$stderr_tmp" >&2` で stderr を従来どおり運用者へ流す。
   if [ -n "$stderr_tmp" ]; then
     IDD_SLOT_NUMBER="$n" \
       IDD_SLOT_WORKTREE="$wt" \
       PARALLEL_SLOTS="$PARALLEL_SLOTS" \
       REPO="$REPO" \
       REPO_DIR="$REPO_DIR" \
-      "$SLOT_INIT_HOOK" 2> >(tee -a "$stderr_tmp" >&2) || rc=$?
+      "$SLOT_INIT_HOOK" 2>"$stderr_tmp" || rc=$?
+    # フック終了後（一時ファイル確定後）に同期で stderr へ転記する。
+    # `set -euo pipefail` 下で cat 失敗が誤って _hook_invoke を致命化しないよう
+    # `|| true` でガードする（Req 1.4: stderr 観測性維持 / NFR 3.1）。
+    if [ -s "$stderr_tmp" ]; then
+      cat "$stderr_tmp" >&2 || true
+    fi
   else
     IDD_SLOT_NUMBER="$n" \
       IDD_SLOT_WORKTREE="$wt" \
@@ -11553,6 +11565,54 @@ EOF
 # サブシェル fork 後、_slot_release で fd を閉じてもこの map で「どの slot が誰の
 # 子プロセスか」を後で再特定できる。
 declare -A _DISPATCHER_SLOT_PIDS
+
+# ── Issue #170 Req 3: Dispatcher のシグナル捕捉（SIGINT / SIGTERM）──
+# cron/launchd からの中断や手動 Ctrl-C 時、fork 済み slot worker（サブシェル）が
+# 孤立して `.broken-*` worktree が蓄積するのを防ぐための最小実装。
+#
+# 本 trap は Dispatcher トップレベル（メインスクリプト本体）に置く。サブシェル
+# `( _slot_run_issue ... ) &` 内には伝播しない（trap はサブシェルでリセットされる）ため、
+# 既存のサブシェル内ローカル EXIT trap（rebase/revert/checkout の base branch 復帰）の
+# 挙動は一切変更しない（Req 3.4）。flock fd 200 は本プロセス終了時に OS が解放するため、
+# 多重起動防止ロックの解放契約も従来どおり維持される（Req 3.3）。
+#
+# NFR 2.2: 同一シグナルが処理中に再送されても worktree prune を二重実行しないよう
+# ガードフラグ _DISPATCHER_SIGNAL_HANDLED で 1 回に制限する。
+_DISPATCHER_SIGNAL_HANDLED=0
+# shellcheck disable=SC2317  # trap 経由で間接呼び出しされるため到達不能に見えるが正しく実行される
+_dispatcher_on_signal() {
+  local sig="$1"
+  # 再入ガード（NFR 2.2）: 既に処理済みなら何もしない。
+  if [ "$_DISPATCHER_SIGNAL_HANDLED" -ne 0 ]; then
+    return 0
+  fi
+  _DISPATCHER_SIGNAL_HANDLED=1
+  dispatcher_warn "シグナル ${sig} を受信。fork 済み slot worker を終了し worktree prune を実行します"
+
+  # Req 3.1: fork 済みの slot worker 子プロセスへ終了シグナルを送る。
+  local n pid
+  for n in "${!_DISPATCHER_SLOT_PIDS[@]}"; do
+    pid="${_DISPATCHER_SLOT_PIDS[$n]}"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      kill -TERM "$pid" 2>/dev/null || true
+    fi
+  done
+  # 子プロセスの終了を回収（孤立防止）。reap 失敗は致命化させない。
+  wait 2>/dev/null || true
+
+  # Req 3.2 / NFR 2.2: worktree prune を 1 回だけ実行する。
+  git -C "$REPO_DIR" worktree prune >/dev/null 2>&1 || true
+
+  # 中断由来の終了 exit code は 128+signal（bash 慣例）。SIGINT=130 / SIGTERM=143。
+  local rc=143
+  case "$sig" in
+    INT) rc=130 ;;
+    TERM) rc=143 ;;
+  esac
+  exit "$rc"
+}
+trap '_dispatcher_on_signal INT' INT
+trap '_dispatcher_on_signal TERM' TERM
 
 # 完了した子プロセスを slot_pid map から prune する。
 # `kill -0 <pid>` が失敗（プロセス不在）なら slot は空いたとみなす。


### PR DESCRIPTION
## 概要

`local-watcher/bin/issue-watcher.sh` に存在する 3 件のシェル堅牢化課題を修正する。

- **(A) Req 1（最優先・実装）**: SLOT_INIT_HOOK の stderr 捕捉を非同期プロセス置換 `2> >(tee -a "$stderr_tmp" >&2)` から同期リダイレクト `2>"$stderr_tmp"` へ変更し、フック終了直後の `tail -c 2000` 読み出しと flush の間に生じていたレース（失敗ログ末尾の欠落）を解消する。
- **(B) Req 2（低優先・現状維持 + 判断記録）**: slot ログの `exec > >(tee -a "$SLOT_LOG") 2>&1` は dual-write に構造上必須で機能影響もないため現状維持とし、判断理由を impl-notes に記録した。
- **(C) Req 3（低優先・最小実装）**: Dispatcher トップレベルに SIGINT/SIGTERM trap を追加（子プロセス kill + `git worktree prune` 1 回、再入ガードで二重 prune 防止）。既存サブシェル trap・flock fd 200 解放契約は非干渉。

## 対応 Issue

Closes #170

## 関連 PR

- 設計 PR: なし（本 Issue は requirements.md のみ。design PR ゲートなし）

## 変更内容

- **(A) Req 1（AC 1.1〜1.5）**: `_hook_invoke` 内の stderr 捕捉を同期リダイレクトへ変更。フック終了後に `cat "$stderr_tmp" >&2 || true` で stderr 観測性を維持。exit code 取得・`tail -c 2000` 転記・`rm -f` の既存ロジックを温存。
- **(B) Req 2（AC 2.1〜2.3）**: 変更なし。既存 `tee -a "$SLOT_LOG"` dual-write と親 Dispatcher 終端 `wait` により AC を充足とみなす（判断理由は impl-notes 参照）。
- **(C) Req 3（AC 3.1〜3.5 / NFR 2.2）**: `_DISPATCHER_SIGNAL_HANDLED` ガードフラグと `_dispatcher_on_signal()` ハンドラ関数を追加。`trap '_dispatcher_on_signal INT' INT` / `trap '_dispatcher_on_signal TERM' TERM` をトップレベルに設置。

## 受入基準チェック

- [x] AC 1.1: フック非ゼロ exit 時に stderr 末尾 2000 バイトをログ転記 ← Req 1 スモーク TAIL_OK
- [x] AC 1.2: フック終了を待ってから一時ファイル読み出し（flush レースなし） ← 同期リダイレクト採用
- [x] AC 1.3: 正常終了時は一時ファイル削除・追加エラー出力なし ← 既存 `rm -f` / 条件分岐温存
- [x] AC 1.4: stderr を従来どおり運用者から観測可能に保持 ← `cat "$stderr_tmp" >&2`
- [x] AC 1.5: exit code を 0=成功/非ゼロ=失敗で呼び出し元へ返す ← `|| rc=$?` 温存
- [x] AC 2.1〜2.3: dual-write / 終了後確定 / パス命名規約 ← 現状維持（機能影響なし）
- [x] AC 3.1: fork 済み slot worker へ終了シグナル送信 ← `_DISPATCHER_SLOT_PIDS` 各 PID へ `kill -TERM`
- [x] AC 3.2: worktree prune 1 回実行 ← `git -C "$REPO_DIR" worktree prune`
- [x] AC 3.3: flock fd 200 解放契約維持 ← fd 200 未変更・ハンドラ末尾 exit で OS 解放
- [x] AC 3.4: 既存サブシェル内ローカル trap の挙動を変更しない ← trap はトップレベルのみ
- [x] AC 3.5: 通常完了時の挙動・exit code を導入前と同一に保つ ← 既存 exit 経路温存
- [x] NFR 1.1/1.2/1.3: env var 名 / exit code 意味 / ログ命名規約 すべて未変更
- [x] NFR 2.2: 同一シグナル再送で prune 二重実行しない ← `_DISPATCHER_SIGNAL_HANDLED` ガード（スモーク GUARD_OK）
- [x] NFR 3.1: shellcheck 新規 findings ゼロ ← NO_CODE_DIFF

## テスト結果

```
1. shellcheck（NFR 3.1）:
   shellcheck local-watcher/bin/issue-watcher.sh
   新規 findings ゼロ（NO_CODE_DIFF）
   SC2317（info 級 / trap ハンドラ false positive）: 40 件 → 40 件（新規ハンドラへ disable directive 付与で増加なし）
   非 SC2317 findings: 1 件 → 1 件（既存 SC2012 のみ、変更箇所外）

2. 構文チェック:
   bash -n local-watcher/bin/issue-watcher.sh → SYNTAX_OK

3. cron-like 最小 PATH 依存解決:
   env -i HOME=$HOME PATH=/usr/bin:/bin bash -c 'command -v claude gh jq flock git'
   gh / jq / flock / git → 解決 OK（スクリプト冒頭 PATH prepend で実 cron 環境では claude も解決）

4. Req 1 レース解消スモーク:
   即異常終了フックの stderr 末尾（200 行 > 2000 バイト）を同期捕捉 → tail -c 2000 で末尾行確認
   TAIL_OK（末尾欠落なし）/ RC_OK（exit code 7 保持）

5. Req 3 再入ガードスモーク:
   ハンドラを 3 回（TERM/TERM/INT）呼んでも prune 相当処理が 1 回のみ実行
   GUARD_OK
```

## 後方互換性確認

- env var 名（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `SLOT_INIT_HOOK` / `PARALLEL_SLOTS` 等）: 変更なし
- exit code 意味（正常完了 0 / 致命的失敗 1 / 他インスタンス実行中スキップ 0）: 変更なし（シグナル中断時のみ bash 慣例 130/143 を追加）
- ログ出力先パス命名規約（`slot-<slot番号>-<Issue番号>-<タイムスタンプ>.log`）: 変更なし

## 実装上の判断

- **Req 2 現状維持**: dual-write には tee が構造上必須で確実な低リスク同期手法がなく、機能影響もないため現状維持。詳細は `docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/impl-notes.md` 参照
- **SC2317 disable directive の新規導入**: 本 repo は従来 SC2317 を disable directive なしで許容していたが、新規 trap ハンドラの件数増を NFR 3.1（新規警告ゼロ）に照らして回避するため、新規関数 1 か所のみに付与
- **Req 3 の exit code（130/143）**: 中断由来の終了は bash 慣例 128+signal とした。NFR 1.2 の既存 exit code（0/1）はシグナルを受けない通常完了時の話であり、シグナル中断時の exit code は従来定義がなかった（130/143 は bash デフォルトと整合）

## 確認事項 / レビュワーへの依頼

1. **Req 2 現状維持判断の妥当性**: 「dual-write に tee が構造上必須・親終端 wait で内容確定・機能影響なし」を理由とする現状維持判断で AC 2.1〜2.3 を充足とみなせるかはレビュワー / 人間の最終判断を求める
2. **shellcheck disable=SC2317 の新規導入**: 本 repo の従来スタイル（directive 不使用）からの逸脱だが影響は新規関数に限定される。このスタイル変更を許容するかをレビュワーに確認する
3. **シグナル中断 exit code を 130/143 とした点**: NFR 1.2 の既存定義（0/1）の範囲外だが bash デフォルトと整合する。Reviewer approve 済み（RESULT: approve）

## Reviewer 判定

Reviewer（claude-opus-4-7、2026-05-23T11:24:37Z）: **RESULT: approve**（全 AC・NFR 充足確認、Findings なし）
詳細: `docs/specs/170-bug-watcher-tee-stderr-flush-dispatcher/review-notes.md`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
関連 Issue での決定事項の履歴は #170 のコメントを参照してください。