### PR TITLE
feat(#168): macOS で timeout 不在時に gtimeout へ透過フォールバック

### DIFF
--- a/docs/specs/168-bug-watcher-macos-brew-install-coreutils/review-notes.md
+++ b/docs/specs/168-bug-watcher-macos-brew-install-coreutils/review-notes.md
@@ -1,48 +1,67 @@
 # Review Notes
 
-<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T00:00:00Z -->
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T12:00:00Z -->
 
 ## Reviewed Scope
 
 - Branch: claude/issue-168-impl-bug-watcher-macos-brew-install-coreutils
-- HEAD commit: 9fed857（実装本体 d5dfb7c / impl-notes 9fed857）
-- Compared to: 7f6c99e..HEAD
-- 変更ファイル: `local-watcher/bin/issue-watcher.sh`（+30 行）, `README.md`（macOS 依存節 + Phase A migration note）, `docs/specs/168-.../impl-notes.md`
+- HEAD commit: 610d36f8dad1efc7a3e566637f60c0fa0beeac1f（実装本体 d5dfb7c / impl-notes 9fed857 / spec docs 610d36f）
+- Compared to: main..HEAD
+- 変更ファイル: `local-watcher/bin/issue-watcher.sh`（+30 行）, `README.md`（macOS 依存節 + Phase A migration note）, `docs/specs/168-.../requirements.md`, `impl-notes.md`, `review-notes.md`
 
 ## Feature Flag Protocol 採否確認
 
-- `CLAUDE.md` に `## Feature Flag Protocol` 節は存在しない → **opt-out 扱い**（既定）。
-  flag 観点の細目は適用せず、通常の 3 カテゴリ判定のみを実施した（Req 4.2 / NFR 1.1 準拠）。
+- 対象 repo の `CLAUDE.md` に `## Feature Flag Protocol` 節は **存在しない**
+  （`.claude/rules/` 一覧表に `feature-flag.md` の行があるのみで、採否宣言節は不在）。
+  → **opt-out 扱い**（既定 / Req 1.3）。flag 観点の細目は適用せず、通常の 3 カテゴリ判定のみを実施した。
+
+## tasks.md / design.md の不在について
+
+- 本 Issue は bug 修正で Architect ステージを経ておらず、`tasks.md` / `design.md` は存在しない。
+  したがって `_Boundary:_` アノテーションは無い。boundary 逸脱判定は「変更ファイルが Issue
+  スコープと整合するか」に基づき実施した（後述「Boundary 確認」参照）。
 
 ## Verified Requirements
 
-- 1.1 — `issue-watcher.sh:451-455` の `timeout()` シェル関数定義。timeout 不在 / gtimeout 存在時に `timeout` 呼び出しが gtimeout に解決されることを独立スモークで確認（`GTIMEOUT_CALLED`）
-- 1.2 — `issue-watcher.sh:470-474` の専用チェック。フォールバック関数定義後は `command -v timeout` が function として true を返し前提チェックを通過（独立スモークで `command -v timeout -> timeout` を確認）。impl-notes の dry run でも前提チェック通過を確認
-- 1.3 — フォールバック定義（`:451`）が前提ツールチェックループ（`:457` の `for cmd in gh jq claude git flock`）および timeout 専用チェック（`:470`）より前に配置されている（行順で確認）
-- 2.1 — コマンド置換 `$(timeout ...)` が gtimeout に解決（独立スモークで `GTIMEOUT_CALLED`）
-- 2.2 — サブシェル `( ... )` およびバックグラウンド fork `( ... ) &` が gtimeout に解決（独立スモークで両者とも `GTIMEOUT_CALLED`。シェル関数は fork した子シェルへ継承される）
-- 2.3 — `bash -c` 経由の子 bash で `timeout` が gtimeout に解決（`export -f timeout` の効果。独立スモークで `bash -c "timeout 5 echo BASHC"` -> `GTIMEOUT_CALLED args=5 echo BASHC` を確認）
+- 1.1 — `issue-watcher.sh:453` の `timeout()` シェル関数定義。timeout 不在 / gtimeout 存在時に `timeout` 呼び出しが gtimeout に解決されることを **独立スモークで再現確認**（`command -v timeout -> timeout`、各呼び出しが `GTIMEOUT_CALLED`）
+- 1.2 — `issue-watcher.sh:467-471` の専用チェック。フォールバック関数定義後は `command -v timeout` が function として true を返し前提チェックを通過（独立スモークで `command -v timeout -> timeout` を確認）
+- 1.3 — フォールバック定義（`:453`）が前提ツールチェックループ（`:460` の `for cmd in gh jq claude git flock`）および timeout 専用チェック（`:467`）より前に配置されていることを行番号で確認（453 < 460 < 467）
+- 2.1 — コマンド置換 `$(timeout 5 echo X)` が `GTIMEOUT_CALLED args=5 echo X` に解決（独立スモークで確認）
+- 2.2 — サブシェル `( ... )` およびバックグラウンド fork `( ... ) &` がいずれも gtimeout に解決（独立スモークで両者とも `GTIMEOUT_CALLED` を確認。シェル関数は fork した子シェルへ継承される）
+- 2.3 — `bash -c "timeout 5 echo X"` が gtimeout に解決（`export -f timeout` の効果。独立スモークで `GTIMEOUT_CALLED args=5 echo X` を確認）
 - 2.4 — `--kill-after=10` 等のオプションが `"$@"` 透過で gtimeout にそのまま引き渡される（独立スモークで `args=--kill-after=10 5 echo X` を確認）
-- 3.1 — `issue-watcher.sh:470-474` の専用チェックが両不在時に stderr へ「timeout コマンドが見つかりません」を出力（独立スモークで確認）
+- 3.1 — `issue-watcher.sh:467-471` の専用チェックが両不在時に stderr へ「timeout コマンドが見つかりません」を出力（独立スモークで確認）
 - 3.2 — 同チェックが `exit 1`（非ゼロ）で終了（独立スモークで `exit_code=1` を確認）
-- 3.3 — エラーメッセージに「macOS では 'brew install coreutils' で gtimeout を導入すると自動検出されます」を含む（`issue-watcher.sh:472`、独立スモークで確認）
-- 4.1 — `README.md` macOS 依存節（前提条件）および Phase A migration note に `timeout` 不在時の gtimeout 自動検出フォールバックを記載（diff で確認）
+- 3.3 — エラーメッセージに「macOS では 'brew install coreutils' で gtimeout を導入すると自動検出されます」を含む（`issue-watcher.sh:469`、独立スモークで確認）
+- 4.1 — `README.md` macOS 依存節（前提条件）および Phase A migration note に `timeout` 不在時の gtimeout 自動検出フォールバック・手動シンボリックリンク不要の旨を記載（diff で確認）
 - 4.2 — `README.md` の両箇所に `brew install coreutils` 案内を記載（diff で確認）
 - NFR 1.1 — `timeout` 存在時はフォールバック関数を定義しない（独立スモークで `type -t timeout = file`、関数未定義を確認）
-- NFR 1.2 — 既存環境での起動可否・exit code・ログ出力は不変。diff は新規 timeout ブロックの追加のみで、既存ロジックの書き換えはない（追加された `exit` は新エラーパスの `exit 1` のみで、既存前提チェックの慣習に一致）
-- NFR 1.3 — env var 名（`MERGE_QUEUE_GIT_TIMEOUT` / `STAGE_A_VERIFY_TIMEOUT` / `STAGEC_VERIFY_TIMEOUT_SECS` 等）の変更なし（diff に env var rename を含まないことを確認）
-- NFR 2.1 — gtimeout はフォールバック条件（timeout 不在かつ gtimeout 存在）でのみ利用。新規必須依存を増やさない（`if` ガードで確認）
+- NFR 1.2 — diff は新規 timeout フォールバックブロック + 専用チェックの追加のみで、既存ロジックの書き換えはない。共通前提チェックループから `timeout` を外した点は、専用チェックで等価以上のチェック（function 判定込み）を継続しており起動可否・exit code・ログ出力契約を破壊しない
+- NFR 1.3 — env var rename が diff に含まれないことを `grep -E "TIMEOUT|REPO|LOG_DIR|LOCK_FILE"` で確認（`no env var changes`）。`MERGE_QUEUE_GIT_TIMEOUT` 等の既存変数名は不変
+- NFR 2.1 — gtimeout はフォールバック条件（timeout 不在かつ gtimeout 存在）の `if` ガード内でのみ参照。新規必須依存を増やさない
 
 ## Boundary 確認（追加観点）
 
-- `verify_pushed_or_retry`（`issue-watcher.sh:8561` 定義、`:8570` で `command -v timeout` 分岐）および `verify_stagec_pr_or_retry`（`:8702` 定義、`:8714` で分岐）は **関数本体内の実行時評価** であり、フォールバック関数定義（`:451`、スクリプトロード時）より後に評価される。順序問題なし
-- macOS（timeout 不在 / gtimeout あり）ではこれらヘルパーが `command -v timeout` を function として true 判定し `(timeout 30)` 経由（実体 gtimeout）になる。これは Req 2（全パスで有効）の方向と整合する望ましい変化。Linux では従来通り file として true を返し挙動不変
-- exit code 意味 / cron 登録文字列 / ラベル遷移契約 / 既存 env var 名のいずれにも変更なし。silent fail は作っていない（両不在時は stderr + 非ゼロ exit で停止 / Req 3）
+- 変更ファイルは `local-watcher/bin/issue-watcher.sh`（フォールバック実装）と `README.md`
+  （Req 4 のドキュメント化）に限定され、いずれも Issue #168 のスコープ（macOS gtimeout
+  フォールバック + その明文化）と整合する。Out of Scope（install.sh / setup.sh の自動導入、
+  GitHub Actions 側、汎用 g- プレフィックス対応）への手出しは無い
+- `verify_pushed_or_retry` および Stage C verify ヘルパーの `command -v timeout` 分岐は
+  **実行時評価**であり、ロード時のフォールバック関数定義より後に評価される。macOS では
+  function 判定で `(timeout 30)` 経由（実体 gtimeout）になり Req 2 の方向と整合、Linux では
+  file 判定で挙動不変。順序問題なし
+- exit code 意味 / cron 登録文字列 / ラベル遷移契約 / 既存 env var 名のいずれにも変更なし。
+  silent fail は作っていない（両不在時は stderr + 非ゼロ exit で停止 / Req 3）
 
 ## missing test 確認
 
-- 本リポジトリは unit test フレームワークを持たず、手動スモークが検証手段（CLAUDE.md「テスト・検証」節）。impl-notes 記載の Scenario 1〜3 + dry run が全 AC を観測可能な形でカバーしている
-- Reviewer 側でも Scenario 1（全 timeout 呼び出しパス: コマンド置換 / サブシェル / bg fork / オプション付き / bash -c）・Scenario 2（NFR 1.1）・Scenario 3（Req 3.1/3.2/3.3）を独立再実行し、AC との対応を裏取りした。検証根拠の欠落は無い
+- 本リポジトリは unit test フレームワークを持たず、手動スモークが検証手段（CLAUDE.md
+  「テスト・検証」節が判定の正本）。impl-notes 記載の Scenario 1〜3 + dry run が全 AC を
+  観測可能な形でカバーしている
+- Reviewer 側でも独立に Scenario 1（コマンド置換 / サブシェル / bg fork / オプション付き /
+  bash -c の全パス）・Scenario 2（NFR 1.1）・Scenario 3（Req 3.1/3.2/3.3）を再実行し、
+  AC ごとの観測挙動を裏取りした。加えて `bash -n`（SYNTAX_OK）と `shellcheck -S warning`
+  （警告ゼロ）も確認。検証根拠の欠落は無い
 
 ## Findings
 
@@ -50,6 +69,9 @@
 
 ## Summary
 
-Requirement 1〜4 / NFR 1〜2 の全 AC が実装でカバーされ、独立スモークテストで AC ごとの観測可能な挙動を再現確認した。boundary 逸脱・env var / exit code 後方互換の破壊・silent fail はいずれも検出されず、Linux 既存環境での挙動不変も確認できた。
+Requirement 1〜4 / NFR 1〜2 の全 numeric AC が実装でカバーされ、Reviewer 独立スモークテストで
+AC ごとの観測可能な挙動（gtimeout 解決 / 既存環境での非定義 / 両不在時の明示エラー）を再現
+確認した。boundary 逸脱・env var / exit code 後方互換の破壊・silent fail・missing test は
+いずれも検出されず、Linux 既存環境での挙動不変も確認できた。
 
 RESULT: approve


### PR DESCRIPTION
## 概要

macOS では GNU coreutils の `timeout` が標準搭載されておらず、`brew install coreutils` で導入しても
`gtimeout` という名前でインストールされる。既存の `issue-watcher.sh` は `timeout` を必須コマンドとして
ハードコードしていたため、`gtimeout` が利用可能な macOS 環境でも watcher が「`timeout` が見つかりません」
で起動できない不具合が発生していた。

本 PR は以下の修正を行う:
- `timeout` 不在かつ `gtimeout` 存在時に `gtimeout` へ透過フォールバックするシェル関数を前提チェック前に定義
- `timeout` / `gtimeout` ともに不在の場合は `brew install coreutils` 案内付きで明示エラー停止
- README の macOS 依存節と Phase A migration note に gtimeout 自動検出フォールバックを明記

Linux など `timeout` が存在する既存環境では挙動は一切変わらない。

## 対応 Issue

Closes #168

## 関連 PR

- 設計 PR: なし（bug 修正 Issue のため Architect ステージなし）

## 実装内容

- (Req 1.1 / 1.3) `local-watcher/bin/issue-watcher.sh` の前提ツールチェック直前に gtimeout フォールバック関数を定義
  - `timeout` 不在かつ `gtimeout` 存在時のみ `timeout()` シェル関数を定義し `export -f timeout` で子 bash にも継承
- (Req 1.2) 前提ツールチェックから `timeout` を分離し、フォールバック関数定義後に `command -v timeout` を判定する専用チェックへ移行
- (Req 3.1 / 3.2 / 3.3) `timeout` / `gtimeout` ともに不在時は stderr にエラーメッセージ（`brew install coreutils` 案内を含む）を出力し exit 1 で停止
- (Req 4.1 / 4.2) `README.md` の macOS 依存節および Phase A migration note に gtimeout 自動検出フォールバック・手動シンボリックリンク不要の旨を記載
- (NFR 1.1) `timeout` が PATH 上に存在する環境（Linux など）ではフォールバック関数を定義しない（挙動不変）

## 受入基準チェック

- [x] Req 1.1: While `timeout` 不在かつ `gtimeout` 存在時, the watcher shall `timeout` 呼び出しを `gtimeout` に解決する ← Scenario 1 スモーク（コマンド置換 / サブシェル / bg fork / オプション付き / bash -c の全パスで `GTIMEOUT_CALLED`）
- [x] Req 1.2: When 前提ツールチェック実行時に `timeout` 不在 / `gtimeout` 利用可能, the watcher shall 前提チェックを通過し起動を継続 ← dry run でトリアージテンプレート不在チェックに到達
- [x] Req 1.3: The watcher shall フォールバック設定を前提ツールチェックより前に確立する ← 行番号で確認（453 < 460 < 467）
- [x] Req 2.1〜2.4: 全 timeout 呼び出しパス（コマンド置換 / サブシェル / bg fork / bash -c / オプション付き）でフォールバックが有効 ← Scenario 1 スモークで全パスを実証
- [x] Req 3.1〜3.3: `timeout` / `gtimeout` ともに不在時に stderr エラー + `brew install coreutils` 案内 + exit 1 ← Scenario 3 スモーク
- [x] Req 4.1〜4.2: README の macOS 依存節・Phase A migration note に自動検出フォールバックと `brew install coreutils` 案内を記載 ← diff 確認済み
- [x] NFR 1.1〜1.3: `timeout` 存在環境でフォールバック関数未定義、env var 名不変、exit code / ログ出力 / ラベル遷移契約不変 ← Scenario 2 スモーク + shellcheck 警告数不変（43 件）

## テスト結果

```
静的解析:
- bash -n local-watcher/bin/issue-watcher.sh → SYNTAX_OK
- shellcheck local-watcher/bin/issue-watcher.sh → 警告数 43 件（変更前後で同一、新規警告ゼロ）
  追加した timeout() 関数の SC2317（unreachable 誤検知）は # shellcheck disable=SC2317 で justify 済み

手動スモークテスト（擬似 gtimeout を /tmp に配置して検証）:
Scenario 1（timeout 不在 / gtimeout のみ）: 全パス GTIMEOUT_CALLED で解決 → PASS
  - コマンド置換 $(timeout 5 echo X)
  - サブシェル ( timeout 5 echo X )
  - バックグラウンド fork ( timeout 5 echo X ) &
  - オプション付き timeout --kill-after=10 5 echo X → args=--kill-after=10 5 echo X
  - bash -c 'timeout 5 echo X' → GTIMEOUT_CALLED（export -f の効果）
Scenario 2（timeout 存在 / NFR 1.1）: type -t timeout = file（フォールバック関数未定義） → PASS
Scenario 3（timeout・gtimeout ともに不在 / Req 3.1〜3.3）: exit code 1、stderr に brew install coreutils 案内 → PASS
dry run: 前提チェック通過後 triage テンプレート不在で exit 1（前提チェックロジック不変を確認） → PASS

Reviewer 独立スモーク: Scenario 1〜3 全 AC を独立再実行で裏取り済み（review-notes.md 参照）
```

## 実装上の判断

- `export -f timeout` の採用: Req 2.3（`bash -c` 経由検証コマンド内での timeout 呼び出し）を観測可能な形で満たし、将来の `STAGE_A_VERIFY_COMMAND` 内 timeout 利用に対する防御的措置として採用。現状の全パスは `export -f` なしでも動作するが、安全側に倒して併用した
- timeout を前提チェックループから分離: `brew install coreutils` 案内付き専用エラーメッセージ（Req 3.3）を提供するため、共通ループ（gh / jq / claude / git / flock 対象）から `timeout` を分離。共通ループの汎用メッセージは他コマンドに対して従来通り維持

## 後方互換性チェック

- 既存 env var 名（`MERGE_QUEUE_GIT_TIMEOUT` / `STAGE_A_VERIFY_TIMEOUT` 等）: **不変**
- exit code 意味: **不変**（`timeout` 存在環境では変更なし。両不在時は明示エラー停止）
- cron 登録文字列: **不変**
- ラベル遷移契約: **不変**
- Linux / `timeout` 存在環境での挙動: **完全不変**（Scenario 2 で実証）

## 確認事項 / レビュワーへの依頼

- Reviewer 独立スモークで全 AC の裏取りが完了し `RESULT: approve` を確認。詳細は `docs/specs/168-bug-watcher-macos-brew-install-coreutils/review-notes.md` を参照

base ブランチ検証: （PR 作成後に記載）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #168 のコメントを参照してください。
