### PR TITLE
fix(watcher): _worktree_reset の per-slot git fetch を削除し ref ロック競合を回避 (#167)

### DIFF
--- a/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/impl-notes.md
+++ b/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/impl-notes.md
@@ -1,0 +1,100 @@
+# 実装ノート (#167)
+
+## 概要
+
+`local-watcher/bin/issue-watcher.sh` の `_worktree_reset()`（per-slot worktree を
+`origin/$BASE_BRANCH` の最新へ強制リセットする関数）から、ステップ 1 の per-slot
+`git -C "$wt" fetch origin --prune` を削除した（人間が確定した方針 (a)）。
+
+origin 参照の最新化は、親プロセスがサイクル冒頭（`issue-watcher.sh:527` の
+`cd "$REPO_DIR"; git fetch origin --prune`）で 1 回だけ実行済みであり、複数 slot worktree は
+同一 `$REPO_DIR` の `.git` オブジェクト DB / refs を共有してその `origin/$BASE_BRANCH` 参照を
+読むため、per-slot fetch なしでも reset 起点を確保できる。これにより `PARALLEL_SLOTS>1` で
+複数 slot がほぼ同時に fetch して発生していた ref ロック（`refs/remotes/origin/<branch>.lock`
+/ `packed-refs.lock`）の取得競争が解消され、競合に負けた側の fetch 非 0 終了起因の偽陽性
+`claude-failed` が起きなくなる。
+
+## 変更内容（行レベル）
+
+対象: `local-watcher/bin/issue-watcher.sh` の `_worktree_reset()`（変更前 10114-10132 行目）
+
+- **削除**: ステップ 1 の `if ! git -C "$wt" fetch origin --prune >/dev/null 2>&1; then return 1; fi`
+  と直前のコメント `# 1. 最新の origin を取得`
+- **追加**: per-slot fetch を削除した理由・並行 ref ロック競合回避の意図・親プロセス
+  サイクル冒頭 fetch（527 行目）への依拠・ref stale 許容を説明する `NOTE (Issue #167)`
+  コメントブロック
+- **温存**: `if [ ! -d "$wt" ]; then return 1; fi` ガード、`git reset --hard origin/$BASE_BRANCH`
+  とその失敗時 `return 1`、`git clean -fdx` とその失敗時 `return 1`、末尾 `return 0`
+- 残った reset / clean ステップのコメント番号を 1./2. に振り直し（挙動変更なし）
+
+`_worktree_reset` 以外の `git fetch` 呼び出し（527 / 1546 / 2072 / 3492 / 4779 行目等）には
+一切触れていない（Out of Scope 準拠）。
+
+## 検証結果
+
+| 検証 | 実施 | 結果 |
+|---|---|---|
+| `bash -n local-watcher/bin/issue-watcher.sh`（構文） | 実施 | OK（`BASH_N_OK`） |
+| `shellcheck local-watcher/bin/issue-watcher.sh` | 実施 | 新規警告なし。コード別件数は変更前後で完全一致（SC2012 x1, SC2317 x40）。いずれも本変更領域(10106-10140行)外の既存 info 警告 |
+| CLAUDE.md 記載 dry run（`REPO=owner/test REPO_DIR=...`） | 試行（部分） | 完了せず。詳細は下記 |
+| `_worktree_reset` ロジック単体検証（実 git worktree） | 実施 | 全 4 ケース期待通り（下記） |
+
+### dry run について
+
+CLAUDE.md 記載の `REPO=owner/test REPO_DIR=/tmp/test-repo $HOME/bin/issue-watcher.sh` を
+使い捨て git repo で試行したが、サイクル冒頭の親プロセス側 `git fetch origin --prune`
+（527 行目）が origin remote 未設定により `fatal: 'origin' does not appear to be a git
+repository` で exit 128 となり、`処理対象の Issue なし` 到達前に終了した。これは origin remote
+と `gh` 認証を伴う実 remote が必要なためで、本変更箇所（10114 行目以降の `_worktree_reset`）
+には到達しない早期 exit であり、本修正とは無関係。完全な dry run は実 remote + `gh` 認証
+環境（E2E）でのみ可能。
+
+### `_worktree_reset` ロジック単体検証
+
+bare repo を疑似 origin とし、`$REPO_DIR` 相当の clone から detached worktree を作って
+fetch 削除後のロジックを検証（実 `git` を使用）:
+
+- CASE1 正常系: dirty/untracked/ignored を作成 → `rc=0`、reset 後 `status --porcelain` 空、
+  HEAD = `origin/main` 一致（Req 2.1 / 2.2 / 3.1）
+- CASE2 worktree パス不在: `rc=1`（Req 3.2 の「worktree パス不在」）
+- CASE3 reset 失敗（非 git ディレクトリ）: `rc=1`（Req 3.2 の「reset 失敗」）
+- CASE4 親プロセス fetch のみで最新化: origin に新コミット push → 親相当 fetch のみ実行
+  （slot 側 fetch なし）→ `rc=0`、HEAD = 新 `origin/main` 一致。per-slot fetch なしでも
+  reset 起点が確保できることを実証（Req 2.3 / NFR 1.1 / 方針 (a) の妥当性）
+
+## 受入基準と検証の対応
+
+| AC | 担保 |
+|---|---|
+| 1.1 / 1.2 / 1.3（ref ロック競合起因の偽陽性失敗を発生させない） | per-slot `git fetch` 削除により、複数 slot 同時実行時の ref ロック取得競争自体が `_worktree_reset` から消える（コード差分で担保）。並列同時実行の競合発生は実環境 E2E でのみ最終確認可能 |
+| 2.1（HEAD を origin/$BASE_BRANCH 最新へ強制一致） | CASE1 / CASE4（HEAD 一致確認） |
+| 2.2（tracked/untracked/ignored を消去し clean 化） | CASE1（`status --porcelain` 空確認。`reset --hard` + `clean -fdx` 温存） |
+| 2.3（親 fetch 完了下で共有 origin 参照を起点に reset） | CASE4（slot fetch なし・親 fetch のみで最新 origin/main へ reset 成功） |
+| 3.1（成功時 exit 0） | CASE1 / CASE4（rc=0） |
+| 3.2（パス不在・reset 失敗・clean 失敗で exit 1） | CASE2（パス不在）/ CASE3（reset 失敗）。clean 失敗時 return 1 はコード温存（人工再現は困難なため未実行ケース） |
+| 3.3（PARALLEL_SLOTS 未設定/1 で導入前と同一結果） | reset/clean ステップを完全温存。直列時は元々競合が起きず、削除した fetch 分の最新化は親 527 行目で代替（CASE4 で代替の妥当性を実証） |
+| NFR 1.1（ref stale 許容） | 削除方針自体が ref stale を許容（NOTE コメントに明記）。clean 起点確保を成功扱い |
+| NFR 2.1（exit code 意味不変） | CASE1-4 で 0/1 契約維持を確認 |
+| NFR 2.2（リセット後 worktree 状態不変） | CASE1（clean + HEAD 一致）で導入前と同一状態を確認 |
+
+## 後方互換性の確認
+
+- **exit code 契約**: 0=成功 / 1=失敗 を維持。`[ ! -d "$wt" ]` ガード、reset 失敗 return 1、
+  clean 失敗 return 1、末尾 return 0 すべて温存（CASE1-4 で確認）
+- **直列挙動（PARALLEL_SLOTS=1 / 未設定）**: reset/clean ロジックは無変更。直列では元々
+  ref ロック競合は起きず、削除した fetch による最新化は親プロセスのサイクル冒頭 fetch
+  （527 行目）で代替される。CASE4 で代替の妥当性を実証
+- **他 fetch 箇所**: 親 527 行目を含む `_worktree_reset` 外の `git fetch` は未変更
+- **既存 env var / ラベル / cron 登録文字列 / ログ出力**: 影響なし
+
+## Feature Flag Protocol
+
+CLAUDE.md に `## Feature Flag Protocol` 節が存在しないため opt-out として解釈。通常フロー
+（単一実装パス）で実装。flag 分岐は導入していない。
+
+## 確認事項
+
+- なし（修正方針は Issue コメントで人間が「方針 (a)」を確定済み。requirements.md の
+  Open Questions も「なし」）。
+
+STATUS: complete

--- a/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/requirements.md
+++ b/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/requirements.md
@@ -1,0 +1,63 @@
+# Requirements Document
+
+## Introduction
+
+`local-watcher/bin/issue-watcher.sh` の `_worktree_reset()` は各 slot worker が起動時に呼び出し、当該 slot worktree を `origin/$BASE_BRANCH` の最新状態へ強制リセットする。現状この関数は内部で `git fetch origin --prune` を実行するが、複数 slot worktree は同一 `$REPO_DIR` の `.git` オブジェクト DB / refs を共有するため、`PARALLEL_SLOTS>1` で複数 slot がほぼ同時に fetch すると ref ロック（`refs/remotes/origin/<branch>.lock` / `packed-refs.lock`）の取得競争が起き、競合に負けた側の fetch が非 0 終了し得る。`set -euo pipefail` 下では `_worktree_reset` が失敗扱いとなり、呼び出し元が無実の Issue に偽陽性の `claude-failed` ラベルとエラーコメントを付与する。
+
+本要件は、人間が確定した修正方針（per-slot fetch を削除し、親プロセスがサイクル冒頭で実行する fetch に依拠する）に基づき、並列実行時の偽陽性失敗を解消しつつ、`_worktree_reset` の契約（exit code、reset 後の worktree 状態）と直列実行時の挙動を後方互換に保つことを目的とする。
+
+## Requirements
+
+### Requirement 1: 並列実行時の偽陽性 claude-failed の解消
+
+**Objective:** As an idd-claude 運用者, I want PARALLEL_SLOTS>1 で複数 slot を同時実行しても ref ロック競合起因の偽陽性失敗が起きないこと, so that 無実の Issue に誤った `claude-failed` ラベルとエラーコメントが付かないようにする
+
+#### Acceptance Criteria
+
+1. While PARALLEL_SLOTS が 2 以上に設定されている状態で複数 slot worker が同時に worktree リセットを実行している間, the Watcher shall ref ロック競合に起因する worktree リセットの失敗を発生させない
+2. If 複数 slot worker が同一サイクル内でほぼ同時に worktree リセットを実行する, the Watcher shall いずれの slot にも ref ロック競合のみを理由とした `claude-failed` ラベルを付与しない
+3. If 複数 slot worker が同一サイクル内でほぼ同時に worktree リセットを実行する, the Watcher shall いずれの Issue にも ref ロック競合のみを理由とした失敗エラーコメントを投稿しない
+
+### Requirement 2: worktree リセットによる clean 起点状態の確保
+
+**Objective:** As an idd-claude 運用者, I want per-slot fetch 削除後も各 slot worktree が origin/$BASE_BRANCH を起点とした clean な状態でリセットされること, so that 各 slot が前回 Issue の残存変更や成果物に影響されず新規 Issue を処理できる
+
+#### Acceptance Criteria
+
+1. When slot worker が worktree リセットを実行する, the Watcher shall 当該 worktree の HEAD を origin/$BASE_BRANCH の最新コミットへ強制的に一致させる
+2. When slot worker が worktree リセットを実行する, the Watcher shall 当該 worktree から tracked / untracked / ignored のすべての変更を消去し作業ツリーを clean な状態にする
+3. While 親プロセスがサイクル冒頭で origin の fetch を完了している状態で, the Watcher shall slot worktree が共有する origin/$BASE_BRANCH 参照を起点として worktree リセットを実行する
+
+### Requirement 3: _worktree_reset の契約維持と後方互換性
+
+**Objective:** As an idd-claude メンテナ, I want _worktree_reset の exit code 契約と直列実行時の挙動が本修正導入前と同一であること, so that 既稼働の cron / launchd 運用と直列ユーザーが影響を受けない
+
+#### Acceptance Criteria
+
+1. When worktree リセットが HEAD 一致と作業ツリー clean 化に成功する, the Watcher shall 成功を示す exit code 0 を返す
+2. If worktree リセットの過程で worktree パス不在・reset 失敗・clean 失敗のいずれかが発生する, the Watcher shall 失敗を示す exit code 1 を返す
+3. While PARALLEL_SLOTS が未設定または 1 に設定されている状態で, the Watcher shall 本修正導入前と同一の worktree リセット結果（origin/$BASE_BRANCH 最新かつ clean）を確保する
+
+## Non-Functional Requirements
+
+### NFR 1: ref stale の許容範囲
+
+1. Where 親プロセスのサイクル冒頭 fetch 完了後に slot worker の起動が遅延した状況において, the Watcher shall slot worktree の origin 参照がやや古い状態であっても worktree リセットを clean 起点確保の目的において成功として扱う
+
+### NFR 2: 後方互換性
+
+1. The Watcher shall `_worktree_reset` の戻り値の意味（0=成功 / 1=失敗）を本修正導入前後で変更しない
+2. The Watcher shall リセット完了後の worktree 状態（origin/$BASE_BRANCH 最新コミット + clean）を本修正導入前後で変更しない
+
+## Out of Scope
+
+- 方針 (b) retry-with-backoff（fetch リトライ）による解決
+- 方針 (c) flock による per-slot fetch の直列化による解決
+- 親プロセスがサイクル冒頭（issue-watcher.sh:527）で実行する `git fetch origin --prune` のロジック変更
+- `_worktree_reset` 以外の `git fetch` 呼び出し箇所の変更
+- ref stale を解消するための slot 起動時 fetch の再導入・stale 検出機構の追加
+- worktree 作成（`git worktree add`）ロジックの変更
+
+## Open Questions
+
+- なし（修正方針は Issue コメントで人間が「方針 (a) を採用」と確定済み。per-slot fetch 削除後の origin 参照は親プロセスのサイクル冒頭 fetch に依拠し、ref stale は許容範囲とする方針も合意済み）

--- a/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/review-notes.md
+++ b/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/review-notes.md
@@ -5,32 +5,39 @@
 ## Reviewed Scope
 
 - Branch: claude/issue-167-impl-bug-watcher-parallel-slots-1-worktree-re
-- HEAD commit: b9f22bd4516666ee67c526f0a18595caabdf16f2
+- HEAD commit: b6c2d9bcbda6a49a6caec21fa7fe1e854130243e
 - Compared to: main..HEAD
-- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しないため opt-out として解釈。flag 観点の確認は行わない（通常の 3 カテゴリ判定のみ）
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しないため opt-out として解釈（impl-notes でも opt-out 宣言）。flag 観点の確認は行わず、通常の 3 カテゴリ判定のみ実施
+- 設計フェーズ: 本 Issue は small fix のため tasks.md / design.md は存在しない。boundary 判定は requirements.md の Out of Scope と impl-notes の対象範囲で実施
 
 ## Verified Requirements
 
-- 1.1 — `_worktree_reset()`（issue-watcher.sh:10114-10139）から per-slot `git fetch origin --prune` を削除。複数 slot 同時実行時の ref ロック取得競争元が関数から消滅。diff で担保
+- 1.1 — `_worktree_reset()`（issue-watcher.sh:10114-10139）から per-slot `git -C "$wt" fetch origin --prune` を削除。複数 slot 同時実行時の ref ロック取得競争元が関数から消滅。diff で担保
 - 1.2 — 同上。fetch 削除により ref ロック競合起因の関数失敗が発生せず、競合のみを理由とした `claude-failed` 付与経路が断たれる
-- 1.3 — 同上。失敗エラーコメント投稿の前提となる関数失敗が起きない
-- 2.1 — `git reset --hard "origin/${BASE_BRANCH}"`（10131 行目）温存。HEAD を origin 最新へ強制一致。impl-notes CASE1 / CASE4 で確認
-- 2.2 — `git reset --hard` + `git clean -fdx`（10135 行目）温存。tracked/untracked/ignored を消去。impl-notes CASE1（status --porcelain 空）で確認
-- 2.3 — 親プロセスのサイクル冒頭 fetch（issue-watcher.sh:526-527 `cd "$REPO_DIR"; git fetch origin --prune`）が未変更であることを grep で確認。slot worktree は共有 .git の origin/$BASE_BRANCH 参照を起点に reset。impl-notes CASE4 で実証
-- 3.1 — 末尾 `return 0`（10138 行目）温存。成功時 exit 0
-- 3.2 — `[ ! -d "$wt" ]` ガード（10116 行目）、reset 失敗 `return 1`（10132 行目）、clean 失敗 `return 1`（10136 行目）すべて温存。失敗時 exit 1。impl-notes CASE2/CASE3 で確認
-- 3.3 — reset/clean ロジック無変更。直列時は元々競合が起きず、削除した fetch 分の最新化は親 527 行目で代替。CASE4 で代替妥当性を実証
-- NFR 1.1 — fetch 削除方針自体が ref stale を許容。NOTE コメント（10119-10129 行目）に明記。clean 起点確保を成功扱い
-- NFR 2.1 — exit code 0/1 の意味不変。CASE1-4 で契約維持を確認
-- NFR 2.2 — リセット後 worktree 状態（origin/$BASE_BRANCH 最新 + clean）不変。CASE1 で確認
+- 1.3 — 同上。失敗エラーコメント投稿の前提となる関数失敗が起きない（並列同時実行の実競合発生は E2E でのみ最終確認可能だが、根本原因の除去はコード差分で担保）
+- 2.1 — `git reset --hard "origin/${BASE_BRANCH}"`（issue-watcher.sh:10131）温存。HEAD を origin 最新へ強制一致。impl-notes CASE1 / CASE4 で確認
+- 2.2 — `git reset --hard` + `git clean -fdx`（issue-watcher.sh:10135）温存。tracked/untracked/ignored を消去。impl-notes CASE1（status --porcelain 空）で確認
+- 2.3 — 親プロセスのサイクル冒頭 fetch（issue-watcher.sh:527 `cd "$REPO_DIR"; git fetch origin --prune`）が main と HEAD で同一であることを確認（diff に含まれない）。slot worktree は共有 .git の origin/$BASE_BRANCH 参照を起点に reset。impl-notes CASE4 で実証
+- 3.1 — 末尾 `return 0`（issue-watcher.sh:10138）温存。成功時 exit 0
+- 3.2 — `[ ! -d "$wt" ]` ガード（10116）、reset 失敗 `return 1`（10132）、clean 失敗 `return 1`（10136）すべて温存。失敗時 exit 1。impl-notes CASE2/CASE3 で確認
+- 3.3 — reset/clean ロジック無変更。直列時は元々 ref ロック競合が起きず、削除した fetch 分の最新化は親 527 行目で代替。impl-notes CASE4 で代替妥当性を実証
+- NFR 1.1 — fetch 削除方針自体が ref stale を許容。NOTE コメント（10119-10129）に明記。clean 起点確保を成功扱い
+- NFR 2.1 — exit code 0/1 の意味不変。impl-notes CASE1-4 で契約維持を確認
+- NFR 2.2 — リセット後 worktree 状態（origin/$BASE_BRANCH 最新 + clean）不変。impl-notes CASE1 で確認
 
 ## Boundary 確認
 
-- 差分は `local-watcher/bin/issue-watcher.sh` の `_worktree_reset()`（10116-10137 行目）に閉じている。diff stat はスクリプト本体 19 行のみ
-- 親プロセスのサイクル冒頭 fetch（527 行目）は未変更（grep で確認。10127 行目の `git fetch origin --prune` 出現は新規 NOTE コメント内の記述のみ）
-- `_worktree_reset` 以外の `git fetch` 呼び出し箇所は未変更（Out of Scope 準拠）
-- 採用された修正方針は人間確定の方針 (a)（per-slot fetch 削除 + 親 fetch 依拠）であり、方針 (b)(c) 非採用は要件通り。boundary 逸脱なし
-- `bash -n` 構文チェック OK。後方互換性（exit code 契約 / `[ ! -d "$wt" ]` ガード / reset --hard / clean -fdx / PARALLEL_SLOTS=1 挙動）を確認
+- 差分は `local-watcher/bin/issue-watcher.sh` の `_worktree_reset()`（10116-10138）に閉じている。実コードの変更は (1) per-slot fetch ブロックの削除、(2) NOTE コメント追加、(3) 残ステップのコメント番号 1./2. への振り直しのみ（reset/clean の挙動変更なし）
+- 親プロセスのサイクル冒頭 fetch（527 行目）は main / HEAD で同一（diff に出現せず）。10127 行目の `git fetch origin --prune` 出現は新規 NOTE コメント内の記述のみで実行コードではない
+- `_worktree_reset` 以外の `git fetch` 呼び出し箇所、worktree 作成ロジックは未変更（Out of Scope 準拠）
+- 採用された修正方針は人間確定の方針 (a)（per-slot fetch 削除 + 親 fetch 依拠）。方針 (b) retry-with-backoff / (c) flock は非採用（Out of Scope 準拠）。boundary 逸脱なし
+- `bash -n` 構文チェック OK。変更領域（10110-10140）に新規 shellcheck 警告なしを reviewer 側でも再確認
+
+## テスト確認（missing test 観点）
+
+- 本リポジトリは unit test フレームワークを持たず、CLAUDE.md「テスト・検証」節では静的解析（`bash -n` / shellcheck）+ 手動スモークテスト + 実 git ロジック検証が検証手段の正本
+- impl-notes に `bash -n`（OK）、shellcheck（新規警告なし・既存件数完全一致）、実 git の bare repo を用いた 4 CASE 単体検証（CASE1 正常系 / CASE2 パス不在 / CASE3 reset 失敗 / CASE4 親 fetch のみで最新化）が記録され、各 AC との対応表も明示
+- dry run の未完了は origin remote 未設定による早期 exit（527 行目）が原因で本変更箇所に到達しないため、本修正と無関係。CLAUDE.md テスト規約に照らし missing test 該当なし
 
 ## Findings
 
@@ -38,6 +45,6 @@
 
 ## Summary
 
-全 AC（1.1-1.3 / 2.1-2.3 / 3.1-3.3 / NFR 1.1 / NFR 2.1-2.2）に対応する実装と検証が揃っている。変更は `_worktree_reset()` に閉じ、親 fetch・他 fetch 箇所・後方互換契約は温存。本リポジトリは unit test フレームワーク無しのため、impl-notes 記載の `bash -n` / shellcheck（新規警告なし）/ 実 git による 4 CASE 単体検証で検証手段は妥当。boundary 逸脱・missing test・AC 未カバーいずれも検出されず。
+全 AC（1.1-1.3 / 2.1-2.3 / 3.1-3.3 / NFR 1.1 / NFR 2.1-2.2）に対応する実装と検証が揃っている。変更は `_worktree_reset()` に閉じ、親 fetch・他 fetch 箇所・後方互換契約（exit code 0/1・reset --hard・clean -fdx・PARALLEL_SLOTS=1 挙動）はすべて温存。Out of Scope（retry/flock 非採用・親 fetch 未変更・他 fetch 未変更・worktree 作成未変更）も準拠。AC 未カバー・missing test・boundary 逸脱いずれも検出されず。
 
 RESULT: approve

--- a/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/review-notes.md
+++ b/docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/review-notes.md
@@ -1,0 +1,43 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-167-impl-bug-watcher-parallel-slots-1-worktree-re
+- HEAD commit: b9f22bd4516666ee67c526f0a18595caabdf16f2
+- Compared to: main..HEAD
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しないため opt-out として解釈。flag 観点の確認は行わない（通常の 3 カテゴリ判定のみ）
+
+## Verified Requirements
+
+- 1.1 — `_worktree_reset()`（issue-watcher.sh:10114-10139）から per-slot `git fetch origin --prune` を削除。複数 slot 同時実行時の ref ロック取得競争元が関数から消滅。diff で担保
+- 1.2 — 同上。fetch 削除により ref ロック競合起因の関数失敗が発生せず、競合のみを理由とした `claude-failed` 付与経路が断たれる
+- 1.3 — 同上。失敗エラーコメント投稿の前提となる関数失敗が起きない
+- 2.1 — `git reset --hard "origin/${BASE_BRANCH}"`（10131 行目）温存。HEAD を origin 最新へ強制一致。impl-notes CASE1 / CASE4 で確認
+- 2.2 — `git reset --hard` + `git clean -fdx`（10135 行目）温存。tracked/untracked/ignored を消去。impl-notes CASE1（status --porcelain 空）で確認
+- 2.3 — 親プロセスのサイクル冒頭 fetch（issue-watcher.sh:526-527 `cd "$REPO_DIR"; git fetch origin --prune`）が未変更であることを grep で確認。slot worktree は共有 .git の origin/$BASE_BRANCH 参照を起点に reset。impl-notes CASE4 で実証
+- 3.1 — 末尾 `return 0`（10138 行目）温存。成功時 exit 0
+- 3.2 — `[ ! -d "$wt" ]` ガード（10116 行目）、reset 失敗 `return 1`（10132 行目）、clean 失敗 `return 1`（10136 行目）すべて温存。失敗時 exit 1。impl-notes CASE2/CASE3 で確認
+- 3.3 — reset/clean ロジック無変更。直列時は元々競合が起きず、削除した fetch 分の最新化は親 527 行目で代替。CASE4 で代替妥当性を実証
+- NFR 1.1 — fetch 削除方針自体が ref stale を許容。NOTE コメント（10119-10129 行目）に明記。clean 起点確保を成功扱い
+- NFR 2.1 — exit code 0/1 の意味不変。CASE1-4 で契約維持を確認
+- NFR 2.2 — リセット後 worktree 状態（origin/$BASE_BRANCH 最新 + clean）不変。CASE1 で確認
+
+## Boundary 確認
+
+- 差分は `local-watcher/bin/issue-watcher.sh` の `_worktree_reset()`（10116-10137 行目）に閉じている。diff stat はスクリプト本体 19 行のみ
+- 親プロセスのサイクル冒頭 fetch（527 行目）は未変更（grep で確認。10127 行目の `git fetch origin --prune` 出現は新規 NOTE コメント内の記述のみ）
+- `_worktree_reset` 以外の `git fetch` 呼び出し箇所は未変更（Out of Scope 準拠）
+- 採用された修正方針は人間確定の方針 (a)（per-slot fetch 削除 + 親 fetch 依拠）であり、方針 (b)(c) 非採用は要件通り。boundary 逸脱なし
+- `bash -n` 構文チェック OK。後方互換性（exit code 契約 / `[ ! -d "$wt" ]` ガード / reset --hard / clean -fdx / PARALLEL_SLOTS=1 挙動）を確認
+
+## Findings
+
+なし
+
+## Summary
+
+全 AC（1.1-1.3 / 2.1-2.3 / 3.1-3.3 / NFR 1.1 / NFR 2.1-2.2）に対応する実装と検証が揃っている。変更は `_worktree_reset()` に閉じ、親 fetch・他 fetch 箇所・後方互換契約は温存。本リポジトリは unit test フレームワーク無しのため、impl-notes 記載の `bash -n` / shellcheck（新規警告なし）/ 実 git による 4 CASE 単体検証で検証手段は妥当。boundary 逸脱・missing test・AC 未カバーいずれも検出されず。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -10116,15 +10116,22 @@ _worktree_reset() {
   if [ ! -d "$wt" ]; then
     return 1
   fi
-  # 1. 最新の origin を取得
-  if ! git -C "$wt" fetch origin --prune >/dev/null 2>&1; then
-    return 1
-  fi
-  # 2. detached HEAD を origin/$BASE_BRANCH に強制移動
+  # NOTE (Issue #167): ここで以前行っていた per-slot の
+  #   `git -C "$wt" fetch origin --prune`
+  # は削除した。複数 slot worktree は同一 $REPO_DIR の .git オブジェクト DB / refs を
+  # 共有するため、PARALLEL_SLOTS>1 で複数 slot がほぼ同時に fetch すると
+  # refs/remotes/origin/<branch>.lock / packed-refs.lock の取得競争が起き、
+  # 競合に負けた側の fetch が非 0 終了する。set -euo pipefail 下では本関数が失敗扱いと
+  # なり、無実の Issue に偽陽性の claude-failed ラベルとエラーコメントが付いていた。
+  # origin 参照の最新化は親プロセスがサイクル冒頭（本ファイル冒頭付近の
+  # `cd "$REPO_DIR"; git fetch origin --prune`）で 1 回だけ実行済みであり、slot worktree は
+  # その origin/$BASE_BRANCH 参照を共有して読むため、per-slot fetch なしでも reset 起点は
+  # 確保できる（親 fetch から slot 起動までの遅延による ref stale は許容範囲）。
+  # 1. detached HEAD を origin/$BASE_BRANCH に強制移動
   if ! git -C "$wt" reset --hard "origin/${BASE_BRANCH}" >/dev/null 2>&1; then
     return 1
   fi
-  # 3. untracked + ignored を消去（前回 Issue の build artifact / node_modules を残さない）
+  # 2. untracked + ignored を消去（前回 Issue の build artifact / node_modules を残さない）
   if ! git -C "$wt" clean -fdx >/dev/null 2>&1; then
     return 1
   fi


### PR DESCRIPTION
## 概要

`PARALLEL_SLOTS>1` で複数 slot worker が同時に `_worktree_reset()` を呼び出す際、各 slot が個別に `git fetch origin --prune` を実行していたため、共有 `.git` の ref ロック（`refs/remotes/origin/<branch>.lock` / `packed-refs.lock`）の取得競争が発生し、競合に負けた側の fetch が非 0 終了して偽陽性 `claude-failed` を誘発していた。

本 PR は `_worktree_reset()` の per-slot `git fetch` を削除し、親プロセスがサイクル冒頭で実行する既存の fetch（issue-watcher.sh:527）に依拠する修正を適用する。reset/clean ロジックは完全温存し、exit code 契約（0=成功/1=失敗）と後方互換性を維持する。

## 対応 Issue

Closes #167

## 関連 PR

- 設計 PR: なし（small fix のため設計フェーズは省略）

## 実装内容

- (Req 1.1-1.3 / Req 2.3) `_worktree_reset()` から per-slot `git -C "$wt" fetch origin --prune` とその直前コメントを削除し、ref ロック競合の根本原因を除去
- (Req 2.1 / 2.2) `git reset --hard "origin/${BASE_BRANCH}"` と `git clean -fdx` を完全温存し、worktree の clean 起点確保を維持
- (Req 3.1 / 3.2 / 3.3) `[ ! -d "$wt" ]` ガード・各失敗時 `return 1`・末尾 `return 0` をすべて温存し、exit code 契約と直列実行挙動の後方互換を保持
- (NFR 1.1) per-slot fetch 削除方針自体が ref stale を許容する旨を NOTE コメントブロックで明記

## 受入基準チェック

- [x] Req 1.1: `While PARALLEL_SLOTS が 2 以上の状態で複数 slot が worktree リセット実行中, the Watcher shall ref ロック競合起因の失敗を発生させない` — per-slot fetch 削除により競合源が消滅（コード差分で担保）
- [x] Req 1.2: `If 複数 slot がほぼ同時に worktree リセットを実行する, the Watcher shall ref ロック競合のみを理由とした claude-failed を付与しない` — 同上
- [x] Req 1.3: `If 複数 slot がほぼ同時に worktree リセットを実行する, the Watcher shall 失敗エラーコメントを投稿しない` — 同上
- [x] Req 2.1: `When slot worker が worktree リセットを実行する, the Watcher shall HEAD を origin/$BASE_BRANCH 最新へ強制一致させる` — `git reset --hard` 温存・CASE1/CASE4 で確認
- [x] Req 2.2: `When slot worker が worktree リセットを実行する, the Watcher shall 変更を消去し clean な状態にする` — `git clean -fdx` 温存・CASE1 で確認
- [x] Req 2.3: `While 親プロセスが fetch 完了している状態で, the Watcher shall 共有 origin 参照を起点として worktree リセットを実行する` — CASE4（親 fetch のみで最新化）で実証
- [x] Req 3.1: `When リセットが成功する, the Watcher shall exit code 0 を返す` — 末尾 `return 0` 温存・CASE1/CASE4 で確認
- [x] Req 3.2: `If worktree パス不在・reset 失敗・clean 失敗のいずれかが発生する, the Watcher shall exit code 1 を返す` — 各 `return 1` 温存・CASE2/CASE3 で確認
- [x] Req 3.3: `While PARALLEL_SLOTS が未設定または 1 の状態で, the Watcher shall 導入前と同一の worktree リセット結果を確保する` — reset/clean ロジック無変更・CASE4 で代替妥当性を実証

## テスト結果

```
静的解析:
  bash -n local-watcher/bin/issue-watcher.sh → OK（構文エラーなし）
  shellcheck local-watcher/bin/issue-watcher.sh → 新規警告なし
    （既存 info 警告: SC2012 x1, SC2317 x40 — 変更領域外の既存警告で件数完全一致）

_worktree_reset ロジック単体検証（bare repo + 実 git worktree）:
  CASE1 正常系: rc=0, status --porcelain 空, HEAD=origin/main 一致 — PASS
  CASE2 worktree パス不在: rc=1 — PASS
  CASE3 reset 失敗（非 git ディレクトリ）: rc=1 — PASS
  CASE4 親プロセス fetch のみで最新化: rc=0, HEAD=新 origin/main 一致 — PASS
  （全 4 件 PASS）

dry run（CLAUDE.md 記載）:
  origin remote 未設定によりサイクル冒頭 fetch（527 行目）で早期 exit。
  本変更箇所には到達しないため、本修正と無関係（impl-notes.md に詳述）。
```

## 実装上の判断

- `_worktree_reset()` から per-slot fetch を削除する方針 (a) は Issue コメントで人間が確定済み。方針 (b) retry-with-backoff / (c) flock は Out of Scope として非採用
- per-slot fetch 削除後の origin 参照最新化は、親プロセスのサイクル冒頭 fetch（issue-watcher.sh:527 `cd "$REPO_DIR"; git fetch origin --prune`）で代替。slot 間で共有される `.git` オブジェクト DB / refs を経由するため、per-slot fetch なしでも reset 起点を確保できることを CASE4 で実証
- ref stale（サイクル冒頭 fetch 後に遅延して slot が起動した場合にやや古い origin 参照でリセットされる可能性）は NFR 1.1 で許容範囲と合意済み。NOTE コメントブロックに明記

## 確認事項 / レビュワーへの依頼

- Reviewer の approve 判定（RESULT: approve）の詳細は `docs/specs/167-bug-watcher-parallel-slots-1-worktree-re/review-notes.md` を参照
- 並列同時実行での実競合発生は E2E でのみ最終確認可能。本 PR は根本原因（per-slot fetch）の除去で偽陽性を解消する設計
- base ブランチ検証結果: PR 作成後に `gh pr view` で確認し、`main` と一致することを確認済み

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #167 のコメントを参照してください。
