### PR TITLE
fix(watcher): quota reset 時刻の永続化先を Issue body からローカルファイルへ移行 (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2540,8 +2540,9 @@ quota 超過時に claude CLI は `rate_limit_event (status=exceeded)` を含む
 - 検知時:
   - `claude-claimed` / `claude-picked-up` を除去 → `needs-quota-wait` 付与（atomic
     1 PATCH）。`claude-failed` は **付与しない**
-  - reset 予定時刻を Issue body の hidden marker
-    `<!-- idd-claude:quota-reset:<epoch>:v1 -->` として永続化（1 Issue につき 1 件のみ）
+  - reset 予定時刻を repo slug 単位で分離済みの `LOG_DIR` 配下のローカルファイル
+    `quota-reset-times.json`（Issue 番号 keyed JSON）に永続化（1 Issue につき最新値 1 件のみ）。
+    Issue body への書き込みは行わない（#169。GitHub UI での人間編集との lost update を解消）
   - escalation コメントを 1 件投稿（Stage 種別 / reset epoch / ISO 8601 / grace 値を含む）
 - cron tick 冒頭の **Quota Resume Processor** が `needs-quota-wait` 付き open Issue を
   走査し、現在時刻が `reset 予定時刻 + QUOTA_RESUME_GRACE_SEC` を超えていれば
@@ -2570,18 +2571,36 @@ Anthropic アカウント token を共有する場合は、reset 直後に複数
 
 ### reset 時刻の永続化方式
 
-reset 時刻は **Issue body の末尾に hidden HTML コメント 1 行** として永続化される:
+reset 時刻は **`LOG_DIR` 配下のローカルファイル** `quota-reset-times.json` に
+Issue 番号 keyed の JSON として永続化される（#169）:
 
+```json
+{
+  "<issue_number>": <epoch_seconds>,
+  "<issue_number>": <epoch_seconds>
+}
 ```
-<!-- idd-claude:quota-reset:<epoch_seconds>:v1 -->
-```
 
-- `<epoch_seconds>`: UNIX 秒（10 桁。例: `1745928000`）
-- `:v1`: 将来スキーマ変更時の version tag
-- 1 Issue につき 1 個のみ（書き込み時は既存 marker 行を全削除してから新値を追記）
+- ファイルパス: `$LOG_DIR/quota-reset-times.json`（`LOG_DIR` は `$HOME/.issue-watcher/logs/<repo_slug>`。
+  repo slug 単位で分離済みのため、異なる repo の reset 時刻は同一ファイルに混在しない）
+- `<issue_number>`: GitHub Issue 番号（文字列キー）
+- `<epoch_seconds>`: UNIX 秒（整数。例: `1745928000`）
+- 1 Issue につき最新値 1 件のみ（書き込み時は当該 Issue 番号 key を upsert。`jq` で
+  temp file → `mv` のアトミック書込）
+- 環境変数 `QUOTA_RESET_STATE_FILE` で永続化先パスを上書き可能（既定は上記）
 
-`gh issue view <N> --json body` で読み出し、`gh issue edit <N> --body` で書き込み
-する。GitHub UI には表示されない。
+`jq` でローカルファイルを読み書きする。**Issue body への書き込み（`gh issue edit --body`）は
+行わない**ため、人間が GitHub UI で同 Issue 本文を編集しても watcher の永続化処理が
+それを上書きする lost update は発生しない（#169 で旧 read-modify-write 方式から移行）。
+
+#### 移行期の本文 marker フォールバック読取
+
+本変更デプロイ前に旧方式（Issue body の hidden marker
+`<!-- idd-claude:quota-reset:<epoch>:v1 -->`）で永続化済みの Issue が `needs-quota-wait`
+状態で残っている場合に取り残されないよう、**読取はローカルファイルを優先しつつ、ローカルに
+当該 Issue の有効な値が無ければ Issue body の旧 marker をフォールバックとして読み取る**。
+ローカルファイルと本文 marker の両方に値がある場合はローカルファイルを優先する。
+既存 Issue body に残存する旧 marker の能動的な一括削除は行わない（読取互換のため残置）。
 
 ### 検知 Stage 一覧
 
@@ -2622,20 +2641,22 @@ watcher が `<StageLabel>` 実行中に Claude CLI から `rate_limit_event (sta
 ### 手動介入したい場合
 
 - 即時再開: `needs-quota-wait` ラベルを手動で外すと次サイクルで pickup されます
-- quota 起因でないと判断する場合: 当該 Issue body の `<!-- idd-claude:quota-reset:...:v1 -->` 行を
-  削除した上で `needs-quota-wait` を `claude-failed` に手動付け替えしてください
+- quota 起因でないと判断する場合: `needs-quota-wait` を `claude-failed` に手動付け替えしてください
+  （reset 予定時刻は watcher 環境内のローカルファイルに保持されており、Issue body の編集は不要です）
 ```
 
 ### 自動 resume の条件
 
 - Quota Resume Processor が `gh issue list --label needs-quota-wait --state open` で
-  対象 Issue を取得し、各 Issue について Issue body の hidden marker から reset epoch を
-  読み出す
+  対象 Issue を取得し、各 Issue について reset epoch を読み出す（ローカルファイル
+  `quota-reset-times.json` を優先し、無ければ移行期フォールバックとして Issue body の
+  旧 marker を読む）
 - 現在時刻 ≥ `reset_epoch + QUOTA_RESUME_GRACE_SEC` のとき `--remove-label
   needs-quota-wait` で除去
 - 除去後はラベル状態のみ変更し、claim や Stage 実行を直接トリガーしない（次サイクルの
   Dispatcher が通常 pickup ループの対象として再選定する）
-- 永続化値が読み出せない / 不正値の場合はラベル維持で人間判断に委ねる（自動除去しない）
+- 永続化値が読み出せない / 不正値（破損ファイル含む）の場合はラベル維持で人間判断に委ねる
+  （自動除去しない）
 
 ### Migration Note（既存ユーザー向け）
 

--- a/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/impl-notes.md
+++ b/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/impl-notes.md
@@ -1,0 +1,128 @@
+# 実装ノート (#169)
+
+## 概要
+
+Quota-Aware Watcher (#66) の reset 予定時刻永続化先を、Issue body の hidden marker
+（`gh issue view` → marker 編集 → `gh issue edit --body` の read-modify-write）から、
+repo slug 単位で分離済みの `LOG_DIR` 配下のローカルファイルへ移行した。これにより、人間が
+GitHub UI で同 Issue 本文を編集した場合に watcher の永続化処理がそれを上書きする lost
+update を根本解消した。読取側はローカルファイルを優先しつつ、移行期に旧 marker しか持たない
+Issue が取り残されないよう本文 marker のフォールバック読取を維持する。
+
+design.md / tasks.md は本 spec に存在せず（`requirements.md` のみ確定）、requirements.md の
+AC を直接実装方針に落とした。
+
+## 採用したファイルフォーマット
+
+- **永続化先**: `$LOG_DIR/quota-reset-times.json`（既定。`QUOTA_RESET_STATE_FILE` env で上書き可）
+  - `LOG_DIR` は `$HOME/.issue-watcher/logs/<repo_slug>`（既存定義、line 336）。repo slug 単位で
+    分離済みのため異なる repo の値は混在しない（Req 1.4）
+- **JSON 形状**: `{ "<issue_number>": <reset_epoch_int>, ... }`
+  - Issue 番号を文字列キー、reset epoch を整数値として保持（Req 2.1）
+  - 1 Issue につき key 1 個（upsert で最新値に収束 / Req 2.3, NFR 4.1）
+- **書込**: `jq '. + {($num): $epoch}'` で既存 object に upsert → `mktemp` で同一ディレクトリに
+  temp file 出力 → `mv -f` でアトミック置換（破損リスク低減）
+- **新規 env var**: `QUOTA_RESET_STATE_FILE`（永続化先パス上書き用。既定値あり = 後方互換）。
+  既存 env var（`QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC`）の名前・受理形式・既定値は不変。
+
+## 関数の変更点
+
+- `qa_persist_reset_time`（書込側）
+  - `gh issue view` / `gh issue edit --body` を完全に廃止（Req 1.2, 1.3）
+  - 不正な epoch（非数値）は書き込まず return 1
+  - `mkdir -p` で永続化ディレクトリ確保（防御的。通常は line 507 で作成済み）
+  - 既存ファイルを `jq -e` で読み、破損していれば空 object から初期化して書込を続行
+  - return 契約は不変: 0=persisted / 1=failure（warn only、呼び出し元を fail させない / Req 4.1, 4.2, NFR 1.4）
+- `qa_load_reset_time`（読取側）
+  - ローカルファイル優先（`jq -er '.[$num] | select(type=="number") | floor | tostring'` / Req 3.1, 3.3）
+  - ローカルに有効値が無ければ Issue body の旧 marker をフォールバック読取（Req 3.2, 3.4）
+  - 破損ファイル / 不正値 / 双方不在は数値以外を返さず stdout 空 + return 1（Req 4.4, 4.5, NFR 1.4）
+  - return 契約は不変: 0=found（epoch を stdout）/ 1=absent or malformed
+- `qa_build_escalation_comment`（Req 5）
+  - 「当該 Issue body の `<!-- idd-claude:quota-reset:...:v1 -->` 行を削除した上で…」という
+    本文 marker 削除手順を除去し、`needs-quota-wait` → `claude-failed` 付け替えのみ案内する文面に修正
+  - 検知 Stage / reset epoch / ISO 8601 / grace の明記は従来どおり維持（Req 5.3）
+- `qa_handle_quota_exceeded`（NFR 2.1, 2.2）
+  - 永続化成功時に `reset persisted issue=#N stage=... reset_epoch=... file=...` をログ出力
+  - 失敗 warn 行にも reset_epoch を追加し grep 可能性を強化
+- セクションヘッダコメント（line 555 付近）の永続化方式説明を新方式に更新
+
+## 後方互換の根拠（NFR 1）
+
+- env var 名・受理形式・既定値（`QUOTA_AWARE_ENABLED=true` / `QUOTA_RESUME_GRACE_SEC=60`）不変（NFR 1.1）
+- `QUOTA_AWARE_ENABLED=false` 時の gate 早期 return 経路は未変更（NFR 1.2）
+- ラベル付与/除去タイミング・`claude-failed` 非同時付与の契約は未変更（NFR 1.3）
+- 読取（0=found / 1=absent or malformed）・書込（0=persisted / 1=failure, warn only）の
+  return 契約は維持（NFR 1.4）
+- 旧 marker を持つ既存 `needs-quota-wait` Issue はフォールバック読取で従来どおり自動 resume 可能
+- 新規 env `QUOTA_RESET_STATE_FILE` は既定値ありで未設定環境は従来パスに帰着
+
+## スモークテスト結果
+
+一時 `LOG_DIR` + `gh` モック（本文を返す関数）で `qa_persist_reset_time` /
+`qa_load_reset_time` を抽出評価して検証。全 12 ケース PASS:
+
+| # | 検証内容 | 対応 AC | 結果 |
+|---|---|---|---|
+| 1 | persist 成功時 return 0 | 4.1 | PASS |
+| 2 | 書込→読取で同一 epoch 返却 | 1.1, 3.1, 4.3 | PASS |
+| 3 | persist がローカルファイルへ書込（body 経由でない） | 1.1, 1.2, 1.3 | PASS |
+| 4 | 複数 Issue を番号で区別 | 2.1, 2.2 | PASS |
+| 5 | 同一 Issue 上書きで 1 件に収束（冪等） | 2.3, NFR 4.1 | PASS |
+| 6 | ローカル不在時に本文 marker フォールバック | 3.2, 3.4 | PASS |
+| 7 | ローカル優先（両方ある場合） | 3.3 | PASS |
+| 8 | 破損ファイルで return 1 / stdout 空 | 4.5 | PASS |
+| 9 | 双方不在で return 1 / stdout 空 | 4.4 | PASS |
+| 10 | 不正 epoch 書込で return 1 | 4.1（malformed 非書込） | PASS |
+| 11 | ファイル内文字列値で当該 Issue return 1 | 4.5 | PASS |
+| 12 | 不正値 sibling があっても有効値は読める | 4.3, 4.5 | PASS |
+
+```
+PASS=12 FAIL=0
+```
+
+### shellcheck（NFR 3）
+
+`shellcheck local-watcher/bin/issue-watcher.sh` の警告件数を main と比較:
+
+- main: 29 件（既存 SC2317 info 等）
+- 本ブランチ: 29 件
+
+→ **本変更による新規警告 0 件**（NFR 3.1 充足）。
+
+## 受入基準 → テスト対応表
+
+| AC | 担保 |
+|---|---|
+| 1.1 | スモーク #2, #3（ローカルファイルへ書込み） |
+| 1.2 / 1.3 | 実装上 `gh issue view/edit` 呼出を qa_persist_reset_time から除去（スモーク #3 で body 非依存を傍証） |
+| 1.4 | `LOG_DIR`（repo slug 分離）配下に配置。コードレビューで担保 |
+| 2.1 / 2.2 | スモーク #4 |
+| 2.3 | スモーク #5 |
+| 3.1 / 3.3 | スモーク #2, #7 |
+| 3.2 / 3.4 | スモーク #6 |
+| 4.1 | スモーク #1, #10 |
+| 4.2 | 実装上 return 1 を warn 吸収（qa_handle_quota_exceeded 側は継続 / コードレビュー） |
+| 4.3 | スモーク #2, #12 |
+| 4.4 | スモーク #9 |
+| 4.5 | スモーク #8, #11 |
+| 4.6 | `process_quota_resume` の `continue`（ラベル維持）は未変更。read 1 で除去しない（コードレビュー） |
+| 5.1 / 5.2 | escalation コメントから body marker 削除手順を除去（diff レビュー） |
+| 5.3 | escalation コメントの Stage / epoch / ISO 8601 明記は未変更 |
+| 6.1 / 6.2 / 6.3 | README の永続化方式・escalation 例・フォールバック読取記述を更新 |
+| NFR 1.1〜1.4 | env / exit code / ラベル契約 / return 契約 不変（後方互換の根拠 参照） |
+| NFR 2.1 / 2.2 | qa_handle_quota_exceeded のログ追加 + process_quota_resume 既存ログ |
+| NFR 3.1 | shellcheck 新規警告 0 件 |
+| NFR 4.1 | スモーク #5 |
+
+## 確認事項
+
+- なし。requirements.md の AC・Out of Scope に矛盾は見当たらず、設計上の判断（永続化先
+  ファイル名 `quota-reset-times.json` / Issue 番号 keyed JSON / アトミック書込）はタスク指示の
+  「設計上の要点」に沿って確定した。`QUOTA_RESET_STATE_FILE` env var は override 用に追加した
+  もので、既定値があるため後方互換性に影響しない。
+- 派生タスクの提案: 旧 Issue body 残存 marker のクリーンアップは Out of Scope（読取フォールバック
+  として残置）。将来、移行完了後にフォールバック読取と残存 marker を撤去する cleanup Issue を
+  起票する余地はあるが、本変更の必須要件ではない。
+
+STATUS: complete

--- a/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/requirements.md
+++ b/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/requirements.md
@@ -1,0 +1,108 @@
+# Requirements Document
+
+## Introduction
+
+Quota-Aware Watcher (#66) は quota 超過検知時に reset 予定時刻を Issue body の hidden marker `<!-- idd-claude:quota-reset:<epoch>:v1 -->` として永続化している。この永続化は `qa_persist_reset_time` が Issue body を read（`gh issue view`）→ marker 行を除去・追記 → write（`gh issue edit --body`）する read-modify-write 方式であり、view と edit の間に人間が GitHub UI で同 Issue 本文を編集すると、その編集が watcher の上書きで失われる lost update が起こり得る。quota wait は長時間 Issue で発生しやすく、人間が同じ Issue を編集している確率が高いため実害リスクがある。本変更は reset 予定時刻の永続化先を Issue body から **ローカル watcher 環境内のファイル**（repo slug 単位で分離済みの `LOG_DIR` 配下）へ移し、Issue body への書き込みを廃止することで lost update を根本解消する。移行期に既に `needs-quota-wait` 状態でローカル記録を持たない Issue が存在し得るため、読取側は本文 marker の後方互換読取も維持する。
+
+## Requirements
+
+### Requirement 1: reset 時刻の永続化先をローカルファイルへ移行（lost update の根本解消）
+
+**Objective:** As a 運用者, I want quota reset 予定時刻が Issue body ではなくローカル watcher 環境内に保存されること, so that 人間が GitHub UI で同じ Issue 本文を編集しても watcher の永続化処理が人間の編集を上書きしない
+
+#### Acceptance Criteria
+
+1. When watcher が quota 超過検知時に reset 予定時刻を永続化するとき, the Issue Watcher shall 当該 reset 予定時刻をローカル watcher 環境内のファイルに書き込む
+2. When watcher が reset 予定時刻を永続化するとき, the Issue Watcher shall 当該 Issue body に対する書き込み（`gh issue edit --body` 相当の本文上書き）を行わない
+3. While reset 予定時刻の永続化処理が走っている間, the Issue Watcher shall Issue body の read-modify-write（取得した本文を編集して全体を上書きする処理）を行わない
+4. The Issue Watcher shall reset 予定時刻の永続化先ファイルを repo slug 単位で分離された `LOG_DIR` 配下に配置し、異なる repo の reset 時刻が同一ファイルに混在しない状態を保つ
+
+### Requirement 2: 複数 Issue の reset 時刻を Issue 番号で区別
+
+**Objective:** As a 運用者, I want 同一 repo 内で複数 Issue が同時に quota wait に入っても各 Issue の reset 時刻が区別されること, so that ある Issue の reset 時刻が別 Issue の判定に誤って使われない
+
+#### Acceptance Criteria
+
+1. When 同一 repo の複数 Issue がそれぞれ reset 予定時刻を永続化するとき, the Issue Watcher shall 各 reset 予定時刻を Issue 番号で keying して区別可能な形で保持する
+2. When 後続の cron tick で特定 Issue の reset 予定時刻を読み出すとき, the Issue Watcher shall 当該 Issue 番号に対応する reset 予定時刻のみを返す
+3. When 同一 Issue について新しい reset 予定時刻を永続化するとき, the Issue Watcher shall 当該 Issue の以前の reset 予定時刻を新しい値で置き換え、1 Issue につき最新値 1 件のみが有効である状態を保つ
+
+### Requirement 3: 読取の後方互換（ローカルファイル優先・本文 marker フォールバック）
+
+**Objective:** As a 移行期の運用者, I want 本変更デプロイ前に既に `needs-quota-wait` 状態でローカル記録を持たない Issue でも自動 resume が機能すること, so that デプロイをまたいで quota wait 中の Issue が取り残されない
+
+#### Acceptance Criteria
+
+1. When watcher が特定 Issue の reset 予定時刻を読み出すとき, the Issue Watcher shall まずローカルファイルに当該 Issue の reset 予定時刻があるか参照する
+2. If ローカルファイルに当該 Issue の有効な reset 予定時刻が存在しないとき, the Issue Watcher shall 当該 Issue body 内の既存 marker `<!-- idd-claude:quota-reset:<epoch>:v1 -->` を読取のフォールバックとして参照する
+3. When ローカルファイルと Issue body marker の両方に当該 Issue の reset 予定時刻が存在するとき, the Issue Watcher shall ローカルファイルの値を優先して採用する
+4. The Issue Watcher shall 既存 Issue body に残存する `<!-- idd-claude:quota-reset:<epoch>:v1 -->` marker の読取を本変更後も解釈可能な状態に保つ
+
+### Requirement 4: 読取・書込の return 契約と堅牢性の維持
+
+**Objective:** As a 既存挙動に依存する呼び出し元, I want 永続化先を変えても読取・書込関数の return 契約と安全側挙動が保たれること, so that quota 検知・自動 resume の上位フローが本変更の影響を受けない
+
+#### Acceptance Criteria
+
+1. When reset 予定時刻のローカルファイル書込が成功したとき, the Issue Watcher shall 永続化成功を表す return 0 を呼び出し元に返す
+2. If reset 予定時刻のローカルファイル書込が失敗したとき, the Issue Watcher shall 失敗を warn ログに記録した上で呼び出し元を fail させず、ラベル付け替え等の後続副作用を継続させる
+3. When 特定 Issue の reset 予定時刻が読取に成功したとき, the Issue Watcher shall 当該 epoch（整数）を標準出力に返し、found を表す return 0 を返す
+4. If 特定 Issue の reset 予定時刻がローカルファイル・本文 marker のいずれにも存在しないとき, the Issue Watcher shall 数値以外を返さず、absent を表す return 1 を返す
+5. If 永続化ファイルが破損している、または読み出した値が整数 epoch として解釈できないとき, the Issue Watcher shall 数値以外を返さず、return 1（absent or malformed）として扱う
+6. If reset 予定時刻の読取が return 1（absent or malformed）であるとき, the Issue Watcher shall 当該 Issue の `needs-quota-wait` ラベルを自動除去せず、後続 cron tick の再判定または人間判断に委ねる
+
+### Requirement 5: escalation コメントと新方式の整合
+
+**Objective:** As a quota wait コメントを読む運用者, I want escalation コメントの手動介入手順が「本文 marker を書かない」新方式と矛盾しないこと, so that コメント指示どおりに操作して期待どおり手動介入できる
+
+#### Acceptance Criteria
+
+1. When watcher が quota 超過検知時に escalation コメントを投稿するとき, the Issue Watcher shall 当該コメントに、新方式で存在しない Issue body の `<!-- idd-claude:quota-reset:...:v1 -->` 行を削除するよう求める手順を含めない
+2. Where escalation コメントが quota 起因でないと判断した場合の手動介入手順を案内する, the Issue Watcher shall 新方式で観測可能な操作（`needs-quota-wait` を `claude-failed` に手動付け替えする等）のみを案内し、本文 marker 削除のような新方式で効果を持たない操作を案内しない
+3. When watcher が escalation コメントを投稿するとき, the Issue Watcher shall 検知 Stage 種別と reset 予定時刻（UNIX epoch および ISO 8601）を従来どおり明記する
+
+### Requirement 6: ドキュメント整合
+
+**Objective:** As a 新規 contributor, I want README の Quota-Aware Watcher 記述が新しい永続化方式を反映していること, so that ドキュメントとコードの永続化先の食い違いに惑わされない
+
+#### Acceptance Criteria
+
+1. The Documentation shall README の Quota-Aware Watcher 節の永続化に関する記述を、reset 予定時刻を Issue body marker ではなくローカル watcher 環境内のファイルに保存する旨に更新する
+2. The Documentation shall README に記載された escalation コメント例の手動介入手順を、本文 marker 削除手順を含まない新方式の文面に更新する
+3. Where README に既存 Issue body marker の後方互換読取に関する記述が必要である, the Documentation shall 移行期に本文 marker をフォールバック読取することを README に記載する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性（env var / exit code / ラベル遷移契約）
+
+1. The Issue Watcher shall 既存環境変数 `QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC` の名前・受理形式・既定値（`true` / `60`）を本変更によって変更しない
+2. While `QUOTA_AWARE_ENABLED=false`（明示 opt-out）である間, the Issue Watcher shall 本変更導入前と同一の挙動（quota 検知・永続化・自動 resume をいずれも行わない）を保持する
+3. The Issue Watcher shall `needs-quota-wait` ラベルの付与タイミング（quota 超過検知時）・除去タイミング（reset 予定時刻 + `QUOTA_RESUME_GRACE_SEC` 経過後の Quota Resume Processor による自動除去）・`claude-failed` を同時付与しない契約を本変更によって変更しない
+4. The Issue Watcher shall reset 時刻読取関数の return 契約（0=found / 1=absent or malformed）および書込関数の return 契約（0=persisted / 1=failure, warn only）を本変更によって変更しない
+
+### NFR 2: 観測可能性
+
+1. While `QUOTA_AWARE_ENABLED=true` である間, the Issue Watcher shall reset 予定時刻のローカル永続化成功・失敗および読取の found/absent を `LOG_DIR` 配下のログから事後に判別できる粒度で記録する
+2. The Issue Watcher shall reset 関連ログ行に Issue 番号と reset 予定時刻（UNIX epoch）を含め、grep による事後検索を可能にする
+
+### NFR 3: 静的解析クリーン
+
+1. The Issue Watcher script shall `shellcheck` 実行において本変更による新規警告を 0 件に保つ
+
+### NFR 4: 冪等性
+
+1. When 同一 Issue・同一 epoch で reset 予定時刻の永続化を複数回実行したとき, the Issue Watcher shall 永続化結果を 1 件の最新値に収束させ、重複エントリを残さない
+
+## Out of Scope
+
+- ARG_MAX / コマンドライン長制限への対処（Issue 確認事項 2 で GitHub の 65,536 文字本文上限が一般的な ARG_MAX を十分下回り実害なしと判断済み。本変更では扱わない）
+- 複数マシン / GitHub Actions ランナー間での reset 時刻共有（人間判断で Option A を採用しローカルファイル管理とした結果、クロスマシン共有は対象外）
+- GitHub Actions 版ワークフロー（`.github/workflows/issue-to-pr.yml`）への同等変更
+- 既存 Issue body に残存する `<!-- idd-claude:quota-reset:...:v1 -->` marker の能動的な一括削除・クリーンアップ（読取フォールバックとして残すのみで、削除作業は行わない）
+- quota 検知ロジック（`rate_limit_event` の解析方式・status 判定）の変更（#66 の挙動を流用）
+- 自動 resume の grace period 算出ロジック（`QUOTA_RESUME_GRACE_SEC` の意味・既定値）の変更
+- ローカル永続化ファイルの世代管理 / TTL / 古いエントリの自動 vacuum（resume 済み Issue のエントリ掃除は本変更の必須要件としない）
+
+## Open Questions
+
+なし

--- a/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/review-notes.md
+++ b/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/review-notes.md
@@ -1,47 +1,76 @@
 # Review Notes
 
-<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T00:00:00Z -->
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T12:33:12Z -->
 
 ## Reviewed Scope
 
 - Branch: claude/issue-169-impl-bug-watcher-qa-persist-reset-time-issue
-- HEAD commit: 8a2ef23（実装本体: cac8aa0）
+- HEAD commit: 744e86b（実装本体: cac8aa0）
 - Compared to: main..HEAD
-- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しないため **opt-out**。
-  通常の 3 カテゴリ判定のみ実施（flag 観点は適用しない）
+- Feature Flag Protocol: 対象 repo の `CLAUDE.md` に `## Feature Flag Protocol` 節が存在しない
+  ため **opt-out 扱い**。flag 観点（boundary 逸脱の細目）は適用せず、通常の 3 カテゴリ判定のみ実施。
+- 注: 本 spec には `design.md` / `tasks.md` が存在しない（`requirements.md` のみ確定。impl-notes.md
+  でも明記）。したがって `_Boundary:_` アノテーションは無く、boundary 判定は requirements.md の
+  Out of Scope と変更ファイルパスの突き合わせで実施した。
 
 ## Verified Requirements
 
-- 1.1 — `qa_persist_reset_time` が `$QUOTA_RESET_STATE_FILE`（既定 `$LOG_DIR/quota-reset-times.json`）へ書込（issue-watcher.sh:785-826）/ smoke #2,#3
-- 1.2 / 1.3 — `qa_persist_reset_time` から `gh issue view` / `gh issue edit --body` を完全除去。body の read-modify-write を廃止（diff line 785-826。`gh issue edit --body` は line 780 のコメント内「行わない」記述のみ残存）
-- 1.4 — `LOG_DIR`（`$HOME/.issue-watcher/logs/<repo_slug>`、repo slug 分離済み）配下に配置。他 repo の値は混在しない（issue-watcher.sh:776）
-- 2.1 / 2.2 — Issue 番号を文字列キーとする JSON `{ "<num>": <epoch> }`。読取は `.[$num]` で当該 Issue のみ取得（issue-watcher.sh:846-848）/ smoke #4
-- 2.3 — `jq '. + {($num): $epoch}'` の upsert で 1 Issue 最新値 1 件に収束（issue-watcher.sh:818-821）/ smoke #5
-- 3.1 / 3.3 — `qa_load_reset_time` がローカルファイルを先に参照し、有効値があれば即 return（body marker より優先）（issue-watcher.sh:844-853）/ smoke #2,#7
-- 3.2 / 3.4 — ローカルに有効値が無い場合のみ body の `<!-- idd-claude:quota-reset:<epoch>:v1 -->` をフォールバック読取（issue-watcher.sh:855-868）/ smoke #6
-- 4.1 — 書込成功で return 0、不正 epoch / mkdir / mktemp / jq / mv 失敗で return 1（issue-watcher.sh:789-825）/ smoke #1,#10
-- 4.2 — `qa_handle_quota_exceeded` は persist 失敗を warn ログ化しラベル付与へ継続（呼び出し元を fail させない）（issue-watcher.sh:1063-1069）
-- 4.3 — found 時 epoch を stdout に出力し return 0（issue-watcher.sh:849-851, 865-867）/ smoke #2,#12
-- 4.4 — 双方不在で stdout 空 + return 1（issue-watcher.sh:869）/ smoke #9
-- 4.5 — 破損ファイル（`jq -e` 非0）・非数値値は `^[0-9]+$` ガードで弾き return 1。stdout に数値以外を返さない（issue-watcher.sh:846-849）/ smoke #8,#11
-- 4.6 — `process_quota_resume` は `qa_load_reset_time` が return 1 のとき `continue`（`needs-quota-wait` を除去しない）（issue-watcher.sh:1126-1129）
-- 5.1 / 5.2 — escalation コメントから body marker 削除手順を除去し、`needs-quota-wait` → `claude-failed` 付け替えのみ案内（issue-watcher.sh:900-902）
-- 5.3 — escalation コメントの Stage / reset epoch / ISO 8601 / grace 明記は従来どおり維持（issue-watcher.sh:884-889、未変更）
-- 6.1 — README「reset 時刻の永続化方式」節をローカルファイル方式へ更新（README.md:2573-2602）
-- 6.2 — README の escalation コメント例から body marker 削除手順を除去（README.md:2644-2645）
-- 6.3 — README に移行期の本文 marker フォールバック読取の記述を追加（README.md:2588-2602）
-- NFR 1.1 — `QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC` の名前・受理形式・既定値（`true` / `60`）不変（issue-watcher.sh:376,379、未変更）
-- NFR 1.2 — `QUOTA_AWARE_ENABLED != "true"` の早期 return gate 経路は未変更（issue-watcher.sh:715, 1100）
-- NFR 1.3 — ラベル付与/除去タイミング・`claude-failed` 非同時付与の契約は未変更（diff は persist/load/escalation/log のみ）
-- NFR 1.4 — 読取（0=found / 1=absent or malformed）・書込（0=persisted / 1=failure, warn only）の return 契約維持
-- NFR 2.1 / 2.2 — persist 成功/失敗ログに `issue=#N` と `reset_epoch=` を含め grep 可能（issue-watcher.sh:1065,1068）
-- NFR 3.1 — shellcheck 警告 29 件（main と同数。本変更による新規警告 0 件、再実行で確認）
-- NFR 4.1 — 同一 Issue・同一 epoch の複数回 persist が upsert で 1 件に収束（issue-watcher.sh:818-821）/ smoke #5
+- 1.1 — `qa_persist_reset_time` が `$QUOTA_RESET_STATE_FILE`（既定 `$LOG_DIR/quota-reset-times.json`）へ
+  書込（issue-watcher.sh:789-826）。独立 smoke で readback 一致を確認（persist 100=1700000000 → load 一致）
+- 1.2 / 1.3 — 書込関数 `qa_persist_reset_time`（789-826）から `gh issue view` / `gh issue edit --body`
+  を完全除去。body の read-modify-write を廃止。range 内に残る `gh issue view` は読取側
+  `qa_load_reset_time`（858）のフォールバック read のみで、書込経路に body 上書きなし
+- 1.4 — `LOG_DIR`（`$HOME/.issue-watcher/logs/<repo_slug>`、repo slug 分離済み）配下に配置。
+  他 repo の値は同一ファイルに混在しない（issue-watcher.sh:776）
+- 2.1 / 2.2 — Issue 番号を文字列キーとする JSON `{ "<num>": <epoch> }`。読取は `.[$num]` で当該
+  Issue のみ取得（issue-watcher.sh:847-849）。独立 smoke で issue100/issue200 が別個に取得できることを確認
+- 2.3 — `jq '. + {($num): $epoch}'` の upsert で 1 Issue 最新値 1 件に収束（issue-watcher.sh:818-821）。
+  独立 smoke で upsert 後に最新値のみ・key 1 個を確認
+- 3.1 / 3.3 — `qa_load_reset_time` がローカルファイルを先に参照し、有効値があれば即 return（body
+  marker より優先）（issue-watcher.sh:843-853）。独立 smoke で local-priority（999 をローカルに書くと
+  marker でなくローカル値を返す）を確認
+- 3.2 / 3.4 — ローカルに有効値が無い場合のみ body の `<!-- idd-claude:quota-reset:<epoch>:v1 -->`
+  をフォールバック読取（issue-watcher.sh:855-868）。独立 smoke で fallback-marker（999）を確認
+- 4.1 — 書込成功で return 0、不正 epoch / mkdir / mktemp / jq / mv 失敗で return 1
+  （issue-watcher.sh:789-825）。独立 smoke で persist-ret0 / malformed-persist-ret1 を確認
+- 4.2 — `qa_handle_quota_exceeded` は persist 失敗を warn ログ化しラベル付与へ継続（呼び出し元を
+  fail させない）（issue-watcher.sh:1063-1069）
+- 4.3 — found 時 epoch を stdout に出力し return 0（issue-watcher.sh:850-851, 866-867）。
+  独立 smoke で readback / stringval-sibling 影響なしを確認
+- 4.4 — 双方不在で stdout 空 + return 1（issue-watcher.sh:869）。独立 smoke で absent-ret1 を確認
+- 4.5 — 破損ファイル（`jq -e` 非0）・非数値値は `^[0-9]+$` ガードで弾き return 1。stdout に数値以外を
+  返さない（issue-watcher.sh:843-852, 865）。独立 smoke で corrupt-ret1 / corrupt-stdout-empty /
+  stringval-ret1 を確認
+- 4.6 — `process_quota_resume` は `qa_load_reset_time` が return 1 のとき `continue`
+  （`needs-quota-wait` を除去せずラベル維持）（issue-watcher.sh:1126-1129）
+- 5.1 / 5.2 — escalation コメントから body marker 削除手順を除去し、`needs-quota-wait` →
+  `claude-failed` 付け替えのみ案内する文面に修正（issue-watcher.sh:900-902）
+- 5.3 — escalation コメントの Stage / reset epoch / ISO 8601 / grace 明記は従来どおり維持
+  （issue-watcher.sh:885-889、未変更）
+- 6.1 — README「reset 時刻の永続化方式」節をローカルファイル方式へ更新（README.md diff 2573-2602）
+- 6.2 — README の escalation コメント例から body marker 削除手順を除去（README.md diff 2644-2645）
+- 6.3 — README に移行期の本文 marker フォールバック読取の記述を追加（README.md diff 2586-2602）
+- NFR 1.1 — `QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC` の名前・受理形式・既定値（`true` / `60`）
+  不変（diff に env default 変更なし）
+- NFR 1.2 — `QUOTA_AWARE_ENABLED != "true"` の早期 return gate 経路は未変更（issue-watcher.sh:1100）
+- NFR 1.3 — ラベル付与/除去タイミング・`claude-failed` 非同時付与の契約は未変更（diff は persist /
+  load / escalation 文面 / log 行のみ）
+- NFR 1.4 — 読取（0=found / 1=absent or malformed）・書込（0=persisted / 1=failure, warn only）の
+  return 契約維持（関数 docstring と実装で確認）
+- NFR 2.1 / 2.2 — persist 成功/失敗ログに `issue=#N` と `reset_epoch=` を含め grep 可能
+  （issue-watcher.sh:1065, 1068）
+- NFR 3.1 — `shellcheck local-watcher/bin/issue-watcher.sh` を main と HEAD で再実行し、いずれも
+  29 件（本変更による新規警告 0 件）
+- NFR 4.1 — 同一 Issue・同一 epoch の複数回 persist が upsert で 1 件に収束（issue-watcher.sh:818-821）。
+  独立 smoke の upsert / single-key で確認
 
 ## Boundary 確認
 
-- 変更ファイルは `local-watcher/bin/issue-watcher.sh` / `README.md` / spec 配下のみ。Out of Scope（GitHub Actions 版 / クロスマシン共有 / 旧 marker 一括削除 / quota 検知ロジック / grace 算出）への変更混入なし
-- 新規 env `QUOTA_RESET_STATE_FILE` は既定値ありで未設定環境は従来パス（`$LOG_DIR` 配下）に帰着し後方互換を壊さない
+- 変更ファイルは `local-watcher/bin/issue-watcher.sh` / `README.md` / spec 配下（`docs/specs/169-.../`）
+  のみ。Out of Scope（GitHub Actions 版ワークフロー / クロスマシン共有 / 旧 marker 一括削除 /
+  quota 検知ロジック / grace 算出ロジック）への変更混入なし
+- 新規 env `QUOTA_RESET_STATE_FILE` は既定値ありで未設定環境は従来パス（`$LOG_DIR` 配下）に帰着し、
+  既存 env var 名・後方互換を壊さない（CLAUDE.md「禁止事項」に抵触しない）
 
 ## Findings
 
@@ -49,7 +78,9 @@
 
 ## Summary
 
-requirements.md の全 numeric AC（Req 1〜6 / NFR 1〜4）に対応する実装・スモーク検証・README 更新を確認。
-body read-modify-write の廃止・ローカルファイル優先＋marker フォールバック・return 契約維持・後方互換（env / ラベル / exit code）いずれも充足。boundary 逸脱・missing test・AC 未カバーなし。
+requirements.md の全 numeric AC（Req 1〜6 / NFR 1〜4）に対応する実装を確認し、独立 smoke 15 ケース
+全 PASS・shellcheck 新規警告 0 件・README 更新を裏取りした。body read-modify-write の廃止 /
+ローカルファイル優先＋marker フォールバック / return 契約維持 / 後方互換（env / ラベル / exit code）
+いずれも充足。AC 未カバー・missing test・boundary 逸脱なし。
 
 RESULT: approve

--- a/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/review-notes.md
+++ b/docs/specs/169-bug-watcher-qa-persist-reset-time-issue/review-notes.md
@@ -1,0 +1,55 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-169-impl-bug-watcher-qa-persist-reset-time-issue
+- HEAD commit: 8a2ef23（実装本体: cac8aa0）
+- Compared to: main..HEAD
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しないため **opt-out**。
+  通常の 3 カテゴリ判定のみ実施（flag 観点は適用しない）
+
+## Verified Requirements
+
+- 1.1 — `qa_persist_reset_time` が `$QUOTA_RESET_STATE_FILE`（既定 `$LOG_DIR/quota-reset-times.json`）へ書込（issue-watcher.sh:785-826）/ smoke #2,#3
+- 1.2 / 1.3 — `qa_persist_reset_time` から `gh issue view` / `gh issue edit --body` を完全除去。body の read-modify-write を廃止（diff line 785-826。`gh issue edit --body` は line 780 のコメント内「行わない」記述のみ残存）
+- 1.4 — `LOG_DIR`（`$HOME/.issue-watcher/logs/<repo_slug>`、repo slug 分離済み）配下に配置。他 repo の値は混在しない（issue-watcher.sh:776）
+- 2.1 / 2.2 — Issue 番号を文字列キーとする JSON `{ "<num>": <epoch> }`。読取は `.[$num]` で当該 Issue のみ取得（issue-watcher.sh:846-848）/ smoke #4
+- 2.3 — `jq '. + {($num): $epoch}'` の upsert で 1 Issue 最新値 1 件に収束（issue-watcher.sh:818-821）/ smoke #5
+- 3.1 / 3.3 — `qa_load_reset_time` がローカルファイルを先に参照し、有効値があれば即 return（body marker より優先）（issue-watcher.sh:844-853）/ smoke #2,#7
+- 3.2 / 3.4 — ローカルに有効値が無い場合のみ body の `<!-- idd-claude:quota-reset:<epoch>:v1 -->` をフォールバック読取（issue-watcher.sh:855-868）/ smoke #6
+- 4.1 — 書込成功で return 0、不正 epoch / mkdir / mktemp / jq / mv 失敗で return 1（issue-watcher.sh:789-825）/ smoke #1,#10
+- 4.2 — `qa_handle_quota_exceeded` は persist 失敗を warn ログ化しラベル付与へ継続（呼び出し元を fail させない）（issue-watcher.sh:1063-1069）
+- 4.3 — found 時 epoch を stdout に出力し return 0（issue-watcher.sh:849-851, 865-867）/ smoke #2,#12
+- 4.4 — 双方不在で stdout 空 + return 1（issue-watcher.sh:869）/ smoke #9
+- 4.5 — 破損ファイル（`jq -e` 非0）・非数値値は `^[0-9]+$` ガードで弾き return 1。stdout に数値以外を返さない（issue-watcher.sh:846-849）/ smoke #8,#11
+- 4.6 — `process_quota_resume` は `qa_load_reset_time` が return 1 のとき `continue`（`needs-quota-wait` を除去しない）（issue-watcher.sh:1126-1129）
+- 5.1 / 5.2 — escalation コメントから body marker 削除手順を除去し、`needs-quota-wait` → `claude-failed` 付け替えのみ案内（issue-watcher.sh:900-902）
+- 5.3 — escalation コメントの Stage / reset epoch / ISO 8601 / grace 明記は従来どおり維持（issue-watcher.sh:884-889、未変更）
+- 6.1 — README「reset 時刻の永続化方式」節をローカルファイル方式へ更新（README.md:2573-2602）
+- 6.2 — README の escalation コメント例から body marker 削除手順を除去（README.md:2644-2645）
+- 6.3 — README に移行期の本文 marker フォールバック読取の記述を追加（README.md:2588-2602）
+- NFR 1.1 — `QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC` の名前・受理形式・既定値（`true` / `60`）不変（issue-watcher.sh:376,379、未変更）
+- NFR 1.2 — `QUOTA_AWARE_ENABLED != "true"` の早期 return gate 経路は未変更（issue-watcher.sh:715, 1100）
+- NFR 1.3 — ラベル付与/除去タイミング・`claude-failed` 非同時付与の契約は未変更（diff は persist/load/escalation/log のみ）
+- NFR 1.4 — 読取（0=found / 1=absent or malformed）・書込（0=persisted / 1=failure, warn only）の return 契約維持
+- NFR 2.1 / 2.2 — persist 成功/失敗ログに `issue=#N` と `reset_epoch=` を含め grep 可能（issue-watcher.sh:1065,1068）
+- NFR 3.1 — shellcheck 警告 29 件（main と同数。本変更による新規警告 0 件、再実行で確認）
+- NFR 4.1 — 同一 Issue・同一 epoch の複数回 persist が upsert で 1 件に収束（issue-watcher.sh:818-821）/ smoke #5
+
+## Boundary 確認
+
+- 変更ファイルは `local-watcher/bin/issue-watcher.sh` / `README.md` / spec 配下のみ。Out of Scope（GitHub Actions 版 / クロスマシン共有 / 旧 marker 一括削除 / quota 検知ロジック / grace 算出）への変更混入なし
+- 新規 env `QUOTA_RESET_STATE_FILE` は既定値ありで未設定環境は従来パス（`$LOG_DIR` 配下）に帰着し後方互換を壊さない
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric AC（Req 1〜6 / NFR 1〜4）に対応する実装・スモーク検証・README 更新を確認。
+body read-modify-write の廃止・ローカルファイル優先＋marker フォールバック・return 契約維持・後方互換（env / ラベル / exit code）いずれも充足。boundary 逸脱・missing test・AC 未カバーなし。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -556,8 +556,10 @@ git pull --ff-only origin "$BASE_BRANCH"
 # Quota-Aware Watcher Helpers (#66)
 #   Claude Max の 5 時間ローリング quota 超過を、Stage 実行中の claude CLI が出す
 #   `rate_limit_event` (status=exceeded) JSON で検知する。検知時は当該 Issue を
-#   `needs-quota-wait` 状態にし、reset 予定時刻を Issue body の hidden marker として
-#   永続化。次サイクル以降の Quota Resume Processor が reset+grace 経過した Issue
+#   `needs-quota-wait` 状態にし、reset 予定時刻を repo slug 単位で分離済みの $LOG_DIR
+#   配下のローカルファイル（Issue 番号 keyed JSON）に永続化する（#169。Issue body の
+#   read-modify-write を廃止し lost update を解消。移行期は本文 marker をフォールバック
+#   読取）。次サイクル以降の Quota Resume Processor が reset+grace 経過した Issue
 #   からラベルを除去して通常 pickup ループに戻す。
 #
 #   QUOTA_AWARE_ENABLED=false（明示 opt-out）では本セクションの全関数は呼ばれるが、
@@ -767,38 +769,91 @@ qa_run_claude_stage() {
   return "$claude_rc"
 }
 
-# Issue body の hidden marker として reset 予定時刻を 1 件のみ保持する形で
-# 永続化する（Req 4.1, 4.3）。既存 marker 行があれば全削除してから新値を追記。
+# reset 予定時刻のローカル永続化ファイル（#169）。
+# Issue body の read-modify-write（lost update リスクあり）を廃止し、repo slug 単位で
+# 分離済みの $LOG_DIR 配下に Issue 番号 keyed の JSON で永続化する（Req 1.1〜1.4, 2.x）。
+# JSON 形状: { "<issue_number>": <reset_epoch_int>, ... }（1 Issue 最新値 1 件 / NFR 4.1）。
+# $LOG_DIR は repo ごとに分離されているため、本ファイルに他 repo の値は混在しない（Req 1.4）。
+QUOTA_RESET_STATE_FILE="${QUOTA_RESET_STATE_FILE:-$LOG_DIR/quota-reset-times.json}"
+
+# reset 予定時刻をローカルファイルへ Issue 番号 keyed で永続化する（Req 1.1〜1.4, 2.1, 2.3,
+# 4.1, 4.2, NFR 4.1）。Issue body への書き込み（gh issue edit --body 相当）は一切行わない
+# （Req 1.2, 1.3）。書込はアトミック（temp file → mv）で破損リスクを抑える。
 #
 # Args: $1 = issue number, $2 = reset epoch (integer)
-# Return: 0 = persisted, 1 = gh failure (warn only, do not fail caller)
+# Return: 0 = persisted, 1 = failure (warn only, do not fail caller / Req 4.2)
 qa_persist_reset_time() {
   local issue_number="$1"
   local epoch="$2"
-  local body
-  if ! body=$(gh issue view "$issue_number" --repo "$REPO" --json body --jq '.body' 2>/dev/null); then
+
+  # 不正な epoch（数値以外）は永続化しない（malformed 値を書き込まない / NFR 4.1 整合）
+  if ! [[ "$epoch" =~ ^[0-9]+$ ]]; then
     return 1
   fi
-  # 既存 marker 行を全削除（複数あったとしても落とす）
-  local cleaned
-  cleaned=$(printf '%s\n' "$body" | sed -E '/<!-- idd-claude:quota-reset:[0-9]+:v1 -->/d')
-  # body 末尾を空行 1 つで区切って marker を 1 行追記
-  local new_body
-  new_body=$(printf '%s\n\n<!-- idd-claude:quota-reset:%s:v1 -->' "$cleaned" "$epoch")
-  if ! gh issue edit "$issue_number" --repo "$REPO" --body "$new_body" >/dev/null 2>&1; then
+
+  # 永続化先ディレクトリを確保（$LOG_DIR は通常起動時に mkdir 済みだが防御的に）
+  local state_dir
+  state_dir=$(dirname "$QUOTA_RESET_STATE_FILE")
+  if ! mkdir -p "$state_dir" 2>/dev/null; then
+    return 1
+  fi
+
+  # 既存ファイルを基に Issue 番号 key を upsert する。ファイル不在 / 破損時は空 object から
+  # 初期化（Req 4.5 の破損耐性は読取側で担保するが、書込時も破損を引きずらない）。
+  local base_json="{}"
+  if [ -f "$QUOTA_RESET_STATE_FILE" ]; then
+    local existing
+    if existing=$(jq -e '.' "$QUOTA_RESET_STATE_FILE" 2>/dev/null); then
+      base_json="$existing"
+    fi
+  fi
+
+  # アトミック書込: temp file に出力 → mv で置換（同一 Issue・同一 epoch を複数回実行しても
+  # 1 件の最新値に収束 / NFR 4.1）。temp file は同一ディレクトリに作り mv を atomic に保つ。
+  local tmp_file
+  if ! tmp_file=$(mktemp "${QUOTA_RESET_STATE_FILE}.XXXXXX" 2>/dev/null); then
+    return 1
+  fi
+  if ! printf '%s' "$base_json" | jq \
+      --arg num "$issue_number" \
+      --argjson epoch "$epoch" \
+      '. + {($num): $epoch}' > "$tmp_file" 2>/dev/null; then
+    rm -f "$tmp_file"
+    return 1
+  fi
+  if ! mv -f "$tmp_file" "$QUOTA_RESET_STATE_FILE" 2>/dev/null; then
+    rm -f "$tmp_file"
     return 1
   fi
   return 0
 }
 
-# Issue body から hidden marker を読み出して reset epoch を返す（Req 4.2, 4.4）。
-# marker 不在 / 不正値 / API 失敗いずれの場合も数値以外を返さない。
+# Issue 番号に対応する reset epoch を返す（Req 3.1〜3.4, 4.3, 4.4, 4.5）。
+# 読取順: 1) ローカルファイル（優先 / Req 3.1, 3.3） 2) Issue body の hidden marker
+# `<!-- idd-claude:quota-reset:<epoch>:v1 -->`（移行期フォールバック / Req 3.2, 3.4）。
+# 破損ファイル / 不正値 / 双方不在いずれの場合も数値以外を返さず return 1（Req 4.4, 4.5）。
 #
 # Args: $1 = issue number
 # Stdout: epoch (integer) on success, empty on failure
-# Return: 0 = found, 1 = absent or malformed (caller must skip removal)
+# Return: 0 = found, 1 = absent or malformed (caller must skip removal / Req 4.4)
 qa_load_reset_time() {
   local issue_number="$1"
+
+  # 1) ローカルファイル優先（Req 3.1, 3.3）。破損ファイルは jq -e が非 0 で抜け、
+  #    フォールバックに進む（Req 4.5: malformed を数値として返さない）。
+  if [ -f "$QUOTA_RESET_STATE_FILE" ]; then
+    local local_epoch
+    local_epoch=$(jq -er --arg num "$issue_number" \
+      '.[$num] | select(type == "number") | floor | tostring' \
+      "$QUOTA_RESET_STATE_FILE" 2>/dev/null)
+    if [[ "$local_epoch" =~ ^[0-9]+$ ]]; then
+      printf '%s' "$local_epoch"
+      return 0
+    fi
+  fi
+
+  # 2) フォールバック: Issue body の hidden marker（移行期 / 本変更デプロイ前に
+  #    永続化済みの Issue 向け / Req 3.2, 3.4）。
   local body
   if ! body=$(gh issue view "$issue_number" --repo "$REPO" --json body --jq '.body' 2>/dev/null); then
     return 1
@@ -843,8 +898,8 @@ watcher が \`${stage_label}\` 実行中に Claude CLI から \`rate_limit_event
 ### 手動介入したい場合
 
 - 即時再開: \`needs-quota-wait\` ラベルを手動で外すと次サイクルで pickup されます
-- quota 起因でないと判断する場合: 当該 Issue body の \`<!-- idd-claude:quota-reset:...:v1 -->\` 行を
-  削除した上で \`needs-quota-wait\` を \`claude-failed\` に手動付け替えしてください
+- quota 起因でないと判断する場合: \`needs-quota-wait\` を \`claude-failed\` に手動付け替えしてください
+  （reset 予定時刻は watcher 環境内のローカルファイルに保持されており、Issue body の編集は不要です）
 
 ---
 
@@ -1005,8 +1060,12 @@ qa_handle_quota_exceeded() {
   iso8601=$(qa_format_iso8601 "$epoch")
 
   # 1. 永続化（失敗してもラベル付与に進む。次 tick で再判定可能）
-  if ! qa_persist_reset_time "$issue_number" "$epoch"; then
-    qa_warn "issue=$issue_number stage=$stage_label reset 永続化に失敗（ラベル付与は継続）"
+  #    NFR 2.1, 2.2: 成功 / 失敗を Issue 番号 + reset epoch 付きで $LOG_DIR ログに残し、
+  #    grep による事後検索を可能にする。
+  if qa_persist_reset_time "$issue_number" "$epoch"; then
+    qa_log "reset persisted issue=#$issue_number stage=$stage_label reset_epoch=$epoch file=$QUOTA_RESET_STATE_FILE"
+  else
+    qa_warn "issue=$issue_number stage=$stage_label reset_epoch=$epoch reset 永続化に失敗（ラベル付与は継続）"
   fi
 
   # 2. ラベル付け替え（claude-claimed / claude-picked-up を除去 → needs-quota-wait 付与。


### PR DESCRIPTION
## 概要

Quota-Aware Watcher（#66）において、quota reset 予定時刻の永続化に Issue body の hidden marker を使っていたため、人間が GitHub UI で同 Issue 本文を編集すると watcher の read-modify-write がその編集を上書きする lost update が発生していた（Issue #169）。

本 PR では永続化先を `$LOG_DIR/quota-reset-times.json`（Issue 番号キーの JSON、`QUOTA_RESET_STATE_FILE` env で上書き可）へ移すことで根本解消する。読取側はローカルファイルを優先しつつ、移行期に旧 marker しか持たない Issue が取り残されないよう本文 marker のフォールバック読取を維持する。

関連コミット: `cac8aa0`（実装本体）、`8a2ef23`（impl-notes）、`744e86b`（spec 追加）。

## 対応 Issue

Closes #169

## 関連 PR

- 設計 PR: なし（Architect なしの中〜小規模 bug fix。`requirements.md` のみ確定）

## 実装内容

- (Req 1.1〜1.3) `qa_persist_reset_time` を全面書き換え: `gh issue view` / `gh issue edit --body` を廃止し、`$QUOTA_RESET_STATE_FILE`（既定 `$LOG_DIR/quota-reset-times.json`）への `jq` upsert + `mktemp` → `mv -f` アトミック書込に移行
- (Req 1.4 / 2.1〜2.3) Issue 番号を文字列キーとした JSON `{ "<num>": <epoch> }` 形式で保持。`LOG_DIR` は既存の repo slug 分離済みディレクトリを使用するため異 repo の値は混在しない
- (Req 3.1〜3.4) `qa_load_reset_time` にローカルファイル優先 + 本文 marker フォールバック読取を実装。ローカルに有効値があれば即 return、なければ旧 `<!-- idd-claude:quota-reset:<epoch>:v1 -->` を検索
- (Req 4.1〜4.6) 不正 epoch / 破損 JSON / `mktemp` / `mv` / `jq` 失敗は return 1 + warn ログで吸収。呼び出し元（`qa_handle_quota_exceeded`）は persist 失敗でもラベル付与へ継続
- (Req 5.1〜5.3) `qa_build_escalation_comment` から Issue body marker 削除手順を除去。`needs-quota-wait` → `claude-failed` 付け替えのみ案内する文面に更新
- (Req 6.1〜6.3) README「reset 時刻の永続化方式」節をローカルファイル方式へ更新し、フォールバック読取の記述を追加

## 受入基準チェック

- [x] Req 1.1: `qa_persist_reset_time` が `$QUOTA_RESET_STATE_FILE` へ書込 ← スモーク #2, #3
- [x] Req 1.2 / 1.3: `qa_persist_reset_time` から `gh issue view/edit --body` を完全除去 ← スモーク #3（body 非依存）+ diff
- [x] Req 1.4: `LOG_DIR`（repo slug 分離済み）配下に配置 ← コードレビュー
- [x] Req 2.1 / 2.2: Issue 番号を文字列キーとする JSON 形式 ← スモーク #4
- [x] Req 2.3: 同一 Issue の upsert で 1 件に収束 ← スモーク #5
- [x] Req 3.1 / 3.3: ローカルファイル優先読取 ← スモーク #2, #7
- [x] Req 3.2 / 3.4: ローカル不在時に body marker フォールバック ← スモーク #6
- [x] Req 4.1〜4.6: return 契約 / warn 吸収 / ラベル維持 ← スモーク #1,#8〜#11 + diff
- [x] Req 5.1 / 5.2: escalation コメントから body marker 削除手順を除去 ← diff レビュー
- [x] Req 5.3: Stage / epoch / ISO 8601 / grace の明記を維持 ← diff レビュー
- [x] Req 6.1〜6.3: README 更新 ← diff レビュー
- [x] NFR 1.1〜1.4: env var 名・ラベル遷移・return 契約の後方互換維持 ← コードレビュー
- [x] NFR 2.1 / 2.2: persist 成功/失敗ログに `issue=#N` / `reset_epoch=` を含む ← diff
- [x] NFR 3.1: shellcheck 新規警告 0 件 ← 下記テスト結果
- [x] NFR 4.1: 同一 Issue・同一 epoch の複数回 persist が 1 件に収束 ← スモーク #5

## テスト結果

```
=== 関数スモークテスト（qa_persist_reset_time / qa_load_reset_time）===
PASS=12 FAIL=0

# 検証項目:
#  1 persist 成功時 return 0          (Req 4.1)
#  2 書込→読取で同一 epoch 返却       (Req 1.1, 3.1, 4.3)
#  3 persist がローカルファイルへ書込  (Req 1.1, 1.2, 1.3)
#  4 複数 Issue を番号で区別          (Req 2.1, 2.2)
#  5 同一 Issue 上書きで 1 件に収束    (Req 2.3, NFR 4.1)
#  6 ローカル不在時に body marker フォールバック (Req 3.2, 3.4)
#  7 ローカル優先（両方ある場合）      (Req 3.3)
#  8 破損ファイルで return 1           (Req 4.5)
#  9 双方不在で return 1               (Req 4.4)
# 10 不正 epoch 書込で return 1        (Req 4.1 malformed)
# 11 ファイル内文字列値で return 1     (Req 4.5)
# 12 不正値 sibling があっても有効値は読める (Req 4.3, 4.5)

=== shellcheck ===
main ブランチ:    29 件（既存 SC2317 info 等）
本ブランチ:       29 件
→ 本変更による新規警告 0 件（NFR 3.1 充足）
```

## 実装上の判断

- **永続化先**: Issue コメントで人間承認済みの Option A（`$LOG_DIR` 配下のローカルファイル）を採用。クロスマシン / GitHub Actions 間共有は Out of Scope
- **ファイル形式**: Issue 番号キーの JSON upsert。1 Issue = 1 キーで最新値に収束（冪等）
- **アトミック書込**: `mktemp` → `mv -f` で部分書込による破損を防止
- **フォールバック読取**: 旧 marker を持つ既存 `needs-quota-wait` Issue が移行期に取り残されないよう維持。能動的な marker クリーンアップは行わない（将来の cleanup Issue の余地はあり）
- **`QUOTA_RESET_STATE_FILE` env**: override 用の新規 env として追加。既定値ありで未設定環境は従来パス（`$LOG_DIR` 配下）に帰着し後方互換を壊さない

## 確認事項 / レビュワーへの依頼

- 永続化先の Option A（ローカルファイル）方針は Issue #169 のコメントで承認済み。クロスマシン共有は設計上 Out of Scope
- 旧 Issue body 残存 marker の能動的クリーンアップは Out of Scope（フォールバック読取として残置）。将来、旧 marker が使われなくなった後に cleanup Issue を起票する余地はあるが本 PR の必須要件ではない
- `QUOTA_RESET_STATE_FILE` の override env を追加した点について、将来の命名一貫性の観点で確認をお願いしたい

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
