### PR TITLE
spec(#177): issue-watcher.sh をモジュール分割するエントリポイント+modules 構成の設計

### DIFF
--- a/docs/specs/177-feat-watcher-issue-watcher-sh/design.md
+++ b/docs/specs/177-feat-watcher-issue-watcher-sh/design.md
@@ -1,0 +1,487 @@
+# Design Document
+
+## Overview
+
+`local-watcher/bin/issue-watcher.sh`（約 11,899 行）は単一 Bash スクリプトに肥大化しており、編集時のトークンコスト・デグレリスク・関数単位テストの全てがボトルネックになっている。本設計は、本体を **責務単位のモジュール群**（`local-watcher/bin/modules/*.sh`）へ分割し、`issue-watcher.sh` 本体を「config 定義 → 動的 `source` でモジュールをロード → トップレベル orchestration（lock / git / dispatcher 起動）」を行う薄いエントリポイントに再構成する。
+
+**Purpose**: 約 12,000 行の単一ファイルを責務分割し、AI 協調開発時の編集トークンコストとデグレリスクを下げ、保守性を高める価値を、watcher を保守する開発者に提供する。
+**Users**: watcher を保守する開発者（モジュール単位で編集）と、cron / launchd で起動する運用者（起動コマンドは一切変えずに恩恵を受ける）が利用する。
+**Impact**: 現在の「単一巨大スクリプト」を「エントリポイント + modules/*.sh の動的ロード構成」に変える。**外部から観測される振る舞い（処理結果・ログ書式の契約・ラベル遷移・exit code）は一切変えない差分等価リファクタリング**であり、機能の追加・削除・バグ修正は行わない。
+
+本リファクタリングは self-hosting（dogfooding）対象であり、この変更自体が次回 cron 実行で idd-claude 自身を動かす。したがって後方互換性（既存 env var 名 / cron 登録文字列 / exit code 意味 / ログ出力先 / ラベル遷移契約）と冪等性が最重要要件となる。
+
+### Goals
+- `issue-watcher.sh` を責務単位の `modules/*.sh` に分割し、本体を動的 `source` するエントリポイントにする（Req 1）
+- `install.sh` が `modules/` 配下を `$HOME/bin/modules/` へ既存方針（dry-run / `.bak` / 冪等）と矛盾なく配置する（Req 2）
+- 既存 env var / 起動コマンド / ログ / ラベル遷移 / exit code の完全な後方互換（Req 3 / NFR 1）
+- 既存テスト（`local-watcher/test/` 12 件 + `tests/local-watcher/` 3 件）が分割後も全て成功する（Req 4）
+- エントリポイントと全モジュールが `shellcheck` 警告ゼロ（Req 5）
+- **成功基準**: 分割後に `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/*.sh` が警告ゼロ、`local-watcher/test/*.sh` と `tests/local-watcher/*/*.sh` が全て exit 0、dry-run スモーク（対象 Issue なし）で `処理対象の Issue なし` 正常終了
+
+### Non-Goals
+- モジュール分割を契機とした機能挙動の変更・新機能・バグ修正（純粋な差分等価リファクタリング）
+- GitHub Actions 経路（`.github/workflows/issue-to-pr.yml`）のモジュール化
+- `repo-template/` 配下テンプレートの分割
+- 起動時間短縮等のパフォーマンス最適化目標の数値設定
+- 関数を跨いだロジックの再設計・共通化（移動のみ。リファクタは行わない）
+
+## Architecture
+
+### Existing Architecture Analysis
+
+現状の `issue-watcher.sh` は単一ファイルに以下が同居している。実態調査（`grep -n '^[a-zA-Z_]*() {'`）で確認した構造:
+
+- **トップレベル orchestration（行 32〜553、副作用あり）**: `set -euo pipefail` / PATH export / config・env var 定義（行 53〜436）/ `_idd_flag` 正規化ループ（行 417〜433）/ gtimeout フォールバック関数定義（行 451〜455）/ 前提ツールチェック（行 460〜505）/ `mkdir LOG_DIR` / base-branch echo / **flock ロック取得（行 517〜521）/ `cd REPO_DIR` + git fetch/checkout/pull（行 526〜553）**
+- **関数定義群（行 556〜11707、副作用なしの純粋定義）**: 約 230 関数。プレフィックス命名規約で責務がほぼ分離済み（`qa_*` / `mq_*` / `ar_*` / `pp_*` / `po_*` / `pi_*` / `drr_*` / `sav_*` / `sc_*` / `tc_*` / `dispatcher_*` / `_slot_*` / `_resume_*` / `dr_*` 等）
+- **トップレベル末尾の orchestration（行 11661〜11898）**: `declare -A _DISPATCHER_SLOT_PIDS`（行 11661）/ signal trap 登録（行 11708〜11709）/ `_dispatcher_run` 呼び出し + exit（行 11889〜11898）
+
+**尊重すべき制約**:
+- 関数群はプレフィックス命名でドメインがほぼ自明に分かれており、これがモジュール境界の自然な駆動軸になる
+- トップレベル副作用（flock / git）は関数定義より**前**に実行されるが、関数定義は純粋（副作用なし）なので、**「全モジュール source → 副作用 orchestration → dispatcher 起動」の順に並べ替えても挙動は等価**（関数は呼ばれた時点で定義済みであればよい）
+- 既存テストは本体ファイルから awk で個別関数を抽出 / 文字列を grep する。**抽出元パスが変わると壊れる**（後述「既存テスト互換戦略」が本設計の最重要判断）
+- グローバル変数（`LOG` / `WT` / `rc` / `NUMBER` / `BRANCH` / `REPO` 等）は関数間で暗黙共有される。`source` は同一シェルプロセスに読み込むため**変数スコープは共有され、分割しても挙動は不変**。ただし source 順序依存（あるモジュールがトップレベルで別モジュールの関数/変数を参照する）が無いことを確認する必要がある
+
+### Architecture Pattern & Boundary Map
+
+**採用パターン**: Entry-point + Sourced Library Modules（bash の標準的なモジュール分割パターン）。本体は orchestration のみを持ち、ロジックは `source` した modules に委譲する。
+
+```mermaid
+flowchart TD
+    cron["cron / launchd / 手動実行<br/>REPO=... $HOME/bin/issue-watcher.sh"] --> entry
+
+    subgraph entry["issue-watcher.sh (エントリポイント)"]
+      direction TB
+      cfg["1. set -euo / PATH / config・env var 定義<br/>+ _idd_flag 正規化"]
+      load["2. SCRIPT_DIR 解決 → modules/*.sh を動的 source<br/>（マニフェスト順 / 欠落は exit 非0）"]
+      checks["3. gtimeout fallback / 前提ツールチェック / mkdir / base-branch echo"]
+      sideeffect["4. flock ロック / cd REPO_DIR / git fetch・checkout・pull / trap 登録"]
+      dispatch["5. _dispatcher_run 呼び出し → exit"]
+      cfg --> load --> checks --> sideeffect --> dispatch
+    end
+
+    load -.source.-> mods
+    subgraph mods["local-watcher/bin/modules/*.sh（純粋な関数定義のみ）"]
+      direction LR
+      m_qa["quota-aware.sh"]
+      m_mq["merge-queue.sh"]
+      m_ar["auto-rebase.sh"]
+      m_pp["promote-pipeline.sh"]
+      m_pi["pr-iteration.sh"]
+      m_drr["design-review-release.sh"]
+      m_gates["impl-gates.sh<br/>(sav/sc/tc)"]
+      m_impl["impl-pipeline.sh"]
+      m_disp["dispatcher.sh<br/>(slot/resume/dep)"]
+    end
+
+    dispatch --> m_disp
+```
+
+**Architecture Integration**:
+- **採用パターン**: Entry-point + Sourced Library Modules。bash で外部依存を増やさず（Node/Python 不要）、`source` による同一プロセス読み込みで変数スコープ共有を維持できるため、差分等価を最も安全に達成できる
+- **ドメイン／機能境界**: 既存のプレフィックス命名規約（`qa_*` / `mq_*` 等）をそのままモジュール境界に採用する。新しい責務分割を発明せず、既存の暗黙境界を明示化するだけにとどめる（投機的抽象化の排除）
+- **既存パターンの維持**: ロガー命名（`*_log` / `*_warn` / `*_error`）/ env var 名 / ラベル定数名 / ログ書式は一切変更しない
+- **新規コンポーネントの根拠**: 新規追加するのは「モジュールローダ（エントリポイント内のループ）」「モジュールマニフェスト（ロード順の定義）」「テスト用共通抽出ヘルパー」の 3 点のみ。いずれも分割を成立させる最小限の足場であり、機能追加ではない
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Frontend / CLI | bash 4+ | エントリポイント / 全モジュール / テスト | 既存と同一。Node/Python 追加なし |
+| Backend / Services | `gh` / `git` | GitHub 操作（既存呼び出しを移動するのみ） | 振る舞い不変 |
+| Data / Storage | ローカル file（`$LOG_DIR` 配下 JSON）/ `$LOCK_FILE` | quota reset 永続化・多重起動防止（移動のみ） | 出力先・パス不変 |
+| Messaging / Events | GitHub ラベル遷移 | 状態機械（移動のみ） | ラベル名・遷移契約不変 |
+| Infrastructure / Runtime | cron / launchd / `$HOME/bin/` | 起動経路（不変）/ `$HOME/bin/modules/` 新設 | install.sh が modules/ を配置 |
+| 静的解析 | `shellcheck` | エントリ + 全モジュールの警告ゼロ検証 | `source` directive で SC1090/SC1091 を解決 |
+
+## File Structure Plan
+
+### Directory Structure
+
+```
+local-watcher/bin/
+├── issue-watcher.sh            # エントリポイント。config / env var 定義 + 動的 source +
+│                               #   orchestration（flock / git / trap / _dispatcher_run）。
+│                               #   関数定義は持たず、modules/ をロードして呼び出すだけにする。
+│                               #   配置先 ~/bin/issue-watcher.sh は不変（cron 登録文字列を壊さない）。
+├── triage-prompt.tmpl          # 既存。変更なし
+├── *.tmpl                      # 既存テンプレート群。変更なし
+└── modules/                    # 新設。issue-watcher.sh から動的 source される純粋な関数定義群。
+    │                           #   配置先 ~/bin/modules/。各ファイル冒頭に用途/配置先/依存/参照先コメント。
+    ├── quota-aware.sh          # qa_* / build_partial_escalation_comment / process_quota_resume（行 577〜1159 相当）
+    ├── merge-queue.sh          # mq_* / process_merge_queue / mqr_* / process_merge_queue_recheck（1160〜2405 相当）
+    ├── auto-rebase.sh          # ar_* / process_auto_rebase（1463〜2254 相当）
+    ├── promote-pipeline.sh     # pp_* / po_* / process_promote_pipeline（path-overlap 含む。2406〜3714 相当）
+    ├── pr-iteration.sh         # pi_* / build_recovery_hint / process_pr_iteration（3715〜5238 相当）
+    ├── design-review-release.sh# drr_* / process_design_review_release（5239〜5526 相当）
+    ├── impl-gates.sh           # sav_* / stage_a_verify_* / sc_* / stage_checkpoint_* / tc_* /
+    │                           #   _normalize_slug / slug guard 群（5527〜6470 + slug 系）
+    ├── impl-pipeline.sh        # rv_* / pt_* / per-task / debugger / build_*_prompt / run_*_stage /
+    │                           #   parse_review_result / verify_pushed_or_retry / verify_stagec_pr_or_retry /
+    │                           #   mark_issue_* / run_impl_pipeline（6471〜9829 相当）
+    └── dispatcher.sh           # dispatcher_* / pclp_* / check_existing_impl_pr / _worktree_* /
+                                #   _slot_* / slot_* / _resume_* / dr_* / _dispatcher_*（9830〜11886 相当）
+```
+
+> 注: 行範囲は実態調査時点の目安であり、Developer は関数名（プレフィックス）を移動の正本とする。1 関数は 1 モジュールにのみ属する（重複定義を作らない）。`_dispatcher_run` の呼び出しと `declare -A _DISPATCHER_SLOT_PIDS` / trap 登録は**エントリポイント側**に残す（orchestration のため。dispatcher.sh は関数定義のみ）。
+
+### テスト互換のための新規ファイル
+
+```
+local-watcher/test/
+├── lib/
+│   └── extract.sh              # 新設。共通抽出ヘルパー。エントリポイント + modules/*.sh の
+│                               #   全体を走査して関数を抽出 / 文字列を grep する SOURCE_FILES 集合を提供
+└── *.sh                        # 既存 12 件。各 extract_function / grep の対象を SOURCE_FILES 経由に置換
+tests/local-watcher/
+├── stage-a-verify/extract-driver.sh   # 既存。抽出対象を modules/impl-gates.sh に解決
+└── tasks-count/extract-driver.sh      # 既存。抽出対象を modules/impl-gates.sh に解決
+```
+
+### Modified Files
+- `local-watcher/bin/issue-watcher.sh` — 関数定義を全て modules/ へ移動。残すのは config / env var 定義 / `_idd_flag` 正規化 / **モジュールローダ**（新規）/ gtimeout fallback / ツールチェック / flock / git / trap / `_dispatcher_run` 呼び出し / exit。`SCRIPT_DIR` で modules/ を相対解決
+- `install.sh` — local watcher インストール節（行 1216〜1221 付近）に `copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin/modules" "*.sh" "$HOME/bin/modules" --executable` を追加。既存 `copy_glob_to_homebin` / `copy_template_file`（dry-run / `.bak` / 冪等 / ログ書式）をそのまま再利用
+- `local-watcher/test/*.sh`（12 件） — `extract_function` / `grep` の対象を共通ヘルパー `lib/extract.sh` の `SOURCE_FILES` 集合経由に変更
+- `tests/local-watcher/stage-a-verify/extract-driver.sh` / `tests/local-watcher/tasks-count/extract-driver.sh` — `_WATCHER_SH` 抽出を modules/impl-gates.sh 解決に変更（または SOURCE_FILES 集合走査）
+- `README.md` — ディレクトリ構成（行 69〜74）に modules/ を追記、手動コピー手順（行 497〜503）に modules/ コピーを追記、modules 化の migration note を 1 節追加
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Flows |
+|-------------|---------|------------|------------|-------|
+| 1.1 | 起動時に modules/ を全ロードしてから処理開始 | Entry Point / Module Loader | `source` ループ | 動的ロード処理フロー |
+| 1.2 | 起動経路・cwd 非依存で配置位置基準に解決 | Module Loader | `SCRIPT_DIR` 解決 | 動的ロード処理フロー |
+| 1.3 | モジュール欠落/読込不能で非0 exit + 特定可能なエラー | Module Loader | ロード検証 | Error Handling |
+| 1.4 | 全ロード成功時に導入前と同一機能セット提供 | 全 modules | （関数群の移動） | 差分等価 |
+| 2.1 | install.sh が modules/ を $HOME/bin/modules へ配置 | Installer (Module Copy) | `copy_glob_to_homebin` | install フロー |
+| 2.2 | 再実行で冪等 | Installer (Module Copy) | `copy_template_file` | install フロー |
+| 2.3 | --dry-run で実コピーせず同一書式で列挙 | Installer (Module Copy) | `log_action` / DRY_RUN | install フロー |
+| 2.4 | 各操作を既存ログと同一書式で観測可能 | Installer (Module Copy) | `log_action` | install フロー |
+| 3.1 | 全 env var の名称/既定/override を等価維持 | Entry Point (Config) | config ブロック据置 | 差分等価 |
+| 3.2 | 既存 cron/launchd 起動で同一処理サイクル | Entry Point | 起動契約据置 | 差分等価 |
+| 3.3 | ログ出力先/ラベル遷移/exit code を等価維持 | Entry Point / 全 modules | 文字列・定数据置 | 差分等価 |
+| 3.4 | 互換破壊が不可避なら README migration note 明文化 | README | migration note | （後方互換方針） |
+| 4.1 | local-watcher/test/ 全テスト成功 | Test Compat (extract.sh) | SOURCE_FILES 集合 | 既存テスト互換戦略 |
+| 4.2 | tests/local-watcher/ 全テスト成功 | Test Compat (extract-driver) | modules 解決 | 既存テスト互換戦略 |
+| 4.3 | 個別関数抽出が移動先に依らず解決可能 | Test Compat (extract.sh) | 全 SOURCE 走査 | 既存テスト互換戦略 |
+| 4.4 | 解決不能を成功扱いで隠さずテスト失敗化 | Test Compat (extract.sh) | 抽出失敗→exit 非0 | Error Handling |
+| 5.1 | issue-watcher.sh の shellcheck 警告ゼロ | Entry Point | `# shellcheck source=` directive | 静的解析 |
+| 5.2 | 各 module の shellcheck 警告ゼロ | 全 modules | shebang/directive 方針 | 静的解析 |
+| NFR 1.1 | 外部観測振る舞いを差分等価維持 | 全コンポーネント | （移動のみ） | 差分等価 |
+| NFR 1.2 | self-hosting 次サイクルで同一挙動完走 | Entry Point / 全 modules | （移動のみ） | dogfooding 検証 |
+| NFR 2.1 | install.sh 2回実行で結果同一 | Installer (Module Copy) | 冪等コピー | install フロー |
+| NFR 2.2 | 既存上書き/退避方針と矛盾しない配置 | Installer (Module Copy) | `.bak` once-only 据置 | install フロー |
+| NFR 3.1 | 最小 PATH 環境で $HOME 基準解決・profile 非依存 | Entry Point / Module Loader | PATH prepend 据置 + SCRIPT_DIR | 動的ロード処理フロー |
+| NFR 3.2 | cwd / symlink 差異非前提で配置位置から相対解決 | Module Loader | `SCRIPT_DIR` 解決 | 動的ロード処理フロー |
+
+## Components and Interfaces
+
+### Entry Point Layer
+
+#### Module Loader（新規）
+
+| Field | Detail |
+|-------|--------|
+| Intent | エントリポイント起動時に modules/*.sh を自身の配置位置基準で動的 source し、欠落時は停止する |
+| Requirements | 1.1, 1.2, 1.3, NFR 3.1, NFR 3.2 |
+
+**Responsibilities & Constraints**
+- `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` で自身の配置ディレクトリを cwd / symlink 非依存に解決する（NFR 3.2。Issue 本文の設計案を踏襲）
+- マニフェスト（モジュール名の固定順配列）を走査し、`"$SCRIPT_DIR/modules/<name>.sh"` を順に `source` する
+- ロード対象が 1 件でも不在 / 読込不能なら、欠落モジュールのパスを `>&2` に出して非ゼロ exit（Req 1.3）。`set -e` 下でも黙って通過しないよう、`[ -r "$f" ] || { echo ... >&2; exit 1; }` を source 前に明示チェックする
+- **配置位置**: config / env var 定義の後、ツールチェックより前。理由: ツールチェックや orchestration がモジュール内関数を参照しないとしても、ロード失敗を早期に検知して副作用（flock / git）の前に止めるため
+- ロード順は固定（後述の source 順序制約）。並べ替えに依存しない設計を維持する
+
+**Dependencies**
+- Inbound: cron / launchd / 手動実行 — watcher 起動 (Critical)
+- Outbound: 全 modules/*.sh — 関数定義の読み込み (Critical)
+- External: なし（bash builtin の `source` / `cd` / `dirname` のみ）
+
+**Contracts**: Service [ ] / API [ ] / Event [ ] / Batch [ ] / State [x]
+
+##### モジュールロード擬似コード（実装はしない / シグネチャのみ）
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULES_DIR="$SCRIPT_DIR/modules"
+# ロード順は固定（依存の浅い→深い順）。マニフェストはエントリポイントに明示列挙する。
+_IDD_MODULES=( quota-aware merge-queue auto-rebase promote-pipeline \
+               pr-iteration design-review-release impl-gates impl-pipeline dispatcher )
+for _m in "${_IDD_MODULES[@]}"; do
+  _f="$MODULES_DIR/${_m}.sh"
+  if [ ! -r "$_f" ]; then
+    echo "Error: モジュールが見つからない/読込不能: $_f" >&2
+    exit 1
+  fi
+  # shellcheck source=/dev/null
+  source "$_f"
+done
+```
+- Preconditions: `SCRIPT_DIR/modules/` に全マニフェストモジュールが存在し読込可能であること
+- Postconditions: 全モジュールの関数が現プロセスに定義済み。1 件でも失敗なら exit 非0（処理は開始しない）
+- Invariants: ロードは関数定義のみを行い、副作用（flock / git / gh）を発生させない
+
+#### Config / Orchestration（既存。配置据置）
+
+| Field | Detail |
+|-------|--------|
+| Intent | env var 定義・正規化・ツールチェック・lock・git 同期・dispatcher 起動を行う |
+| Requirements | 3.1, 3.2, 3.3, NFR 1.1, NFR 1.2, NFR 3.1 |
+
+**Responsibilities & Constraints**
+- 全 env var 定義（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `TRIAGE_MODEL` / `DEV_MODEL` / 各 processor 設定）と `_idd_flag` 正規化ループはエントリポイントに**そのまま残す**（名称・既定値・override 挙動を 1 文字も変えない）
+- gtimeout フォールバック関数定義（macOS 互換 / #168）はエントリポイントに残す（`export -f` で子 bash に継承させる契約を維持）。**この関数だけはエントリポイントに残る数少ない関数定義**である点に注意（モジュールに移すと export タイミングが変わるため移さない）
+- flock / `cd REPO_DIR` / git fetch・checkout・pull / dirty-tree ガード（行 536〜548）/ trap 登録 / `declare -A _DISPATCHER_SLOT_PIDS` / `_dispatcher_run` 呼び出し / exit はエントリポイントに残す
+- **source 順序制約**: モジュールロードは「副作用 orchestration（flock / git）より前」に置く。関数定義は純粋なので、元コードで関数定義が flock の後に並んでいた事実は挙動に影響しない（呼ばれるのは `_dispatcher_run` 以降のため）
+
+**Dependencies**
+- Inbound: cron / launchd (Critical)
+- Outbound: Module Loader → 全 modules / dispatcher.sh の `_dispatcher_run` (Critical)
+
+**Contracts**: State [x]（ラベル遷移・lock 状態は据置）
+
+### Functional Modules（modules/*.sh）
+
+以下 9 モジュールは全て同一契約を持つ: **純粋な関数定義のみを含み、トップレベル副作用を持たない**。各モジュールは既存のプレフィックス命名規約に従って関数を 1 箇所に集約する。
+
+#### quota-aware.sh
+
+| Field | Detail |
+|-------|--------|
+| Intent | Claude Max quota 検知・reset 永続化・quota resume の関数群を保持 |
+| Requirements | 1.4, 3.3, NFR 1.1 |
+
+**Responsibilities & Constraints**
+- `qa_log` / `qa_warn` / `qa_error` / `qa_format_iso8601` / `qa_detect_rate_limit` / `qa_run_claude_stage` / `qa_persist_reset_time` / `qa_load_reset_time` / `qa_build_escalation_comment` / `build_partial_escalation_comment` / `qa_handle_quota_exceeded` / `process_quota_resume` を保持
+- 共有グローバル（`$REPO` / `$LOG_DIR` / `$NUMBER` 等）は実行時にエントリポイント由来の値を参照する（source による同一スコープ共有のため不変）
+
+**Dependencies**
+- Inbound: impl-pipeline.sh（`qa_run_claude_stage` でステージ実行をラップ）/ dispatcher（quota resume）(Critical)
+- Outbound: なし（同一プロセス内の共有変数のみ）
+
+**Contracts**: Service [x]（既存関数シグネチャを変えない）
+
+##### Service Interface（移動のみ。シグネチャ不変の代表例）
+
+```bash
+# 既存シグネチャをそのまま維持（引数・exit code・stdout/stderr 契約を変えない）
+qa_detect_rate_limit() { :; }          # 入力: claude JSON / 出力: exit code で判定
+qa_run_claude_stage() { :; }           # Stage 実行ラッパ。"$@" を素通し、quota 時に副作用
+qa_persist_reset_time() { :; }         # $LOG_DIR 配下 JSON に reset 時刻を永続化（#169）
+```
+- Preconditions: エントリポイントが env var（`$QUOTA_AWARE_ENABLED` 等）を定義済み
+- Postconditions: 関数の挙動・副作用は移動前と完全一致
+- Invariants: ログ書式 `[date] [REPO] quota-aware: ...` を変えない
+
+#### merge-queue.sh / auto-rebase.sh / promote-pipeline.sh / pr-iteration.sh / design-review-release.sh
+
+| Field | Detail |
+|-------|--------|
+| Intent | 各 processor の関数群（`mq_*` / `ar_*` / `pp_*` `po_*` / `pi_*` / `drr_*`）を責務単位で保持 |
+| Requirements | 1.4, 3.3, NFR 1.1 |
+
+**Responsibilities & Constraints**
+- 各モジュールは対応プレフィックスの全関数と `process_*` エントリ関数を保持する（File Structure Plan 参照）
+- promote-pipeline.sh は `pp_*`（Promote）と `po_*`（Path Overlap）を同居させる。理由: 両者は Phase B/E として近接配置されており、`po_check_dispatch_gate` は dispatcher から呼ばれるが定義群としては promote 系と隣接しているため、分割粒度を増やさず 1 モジュールに consolidate する
+- pr-iteration.sh は `build_recovery_hint`（pi 系から呼ばれる）を含む
+
+**Dependencies**
+- Inbound: dispatcher.sh / Slot Runner（各 `process_*` を 1 サイクルで呼ぶ）(Critical)
+- Outbound: quota-aware.sh の logger / 共有変数（同一プロセス）(Standard)
+
+**Contracts**: Service [x]（各 `process_*` / ヘルパーのシグネチャ不変）
+
+#### impl-gates.sh
+
+| Field | Detail |
+|-------|--------|
+| Intent | Stage A Verify / Stage Checkpoint / Tasks Count / slug 正規化・照合の純粋関数群を保持 |
+| Requirements | 1.4, 3.3, 4.1, 4.2, 4.3, NFR 1.1 |
+
+**Responsibilities & Constraints**
+- `sav_*` / `_sav_*` / `stage_a_verify_*` / `sc_*` / `stage_checkpoint_*` / `tc_*` / `_normalize_slug` / `_slug_mismatch_escalate` / `_stage_checkpoint_assert_slug_match` を保持
+- **テスト被参照が最も多いモジュール**: `stage_a_verify_extract_command`（stage-a-verify driver）/ `tc_log` `tc_count_tasks` `tc_classify`（tasks-count driver）/ `_normalize_slug` `_stage_checkpoint_assert_slug_match`（slug_match_guard / normalize_slug test）が抽出対象。テスト互換戦略の主対象
+- `_resume_branch_assert_slug_match` は dispatcher.sh 側（resume 系）に配置するが `_normalize_slug` をテストから共有抽出するため、テストは SOURCE_FILES 集合で両モジュールを走査する（後述）
+
+**Dependencies**
+- Inbound: impl-pipeline.sh / dispatcher.sh / 既存テスト群 (Critical)
+- Outbound: 共有変数（同一プロセス）(Standard)
+
+**Contracts**: Service [x]
+
+#### impl-pipeline.sh
+
+| Field | Detail |
+|-------|--------|
+| Intent | Stage A/B/C 実装パイプライン本体（Developer/Reviewer/Debugger/per-task ループ）を保持 |
+| Requirements | 1.4, 3.3, 4.1, 4.3, NFR 1.1 |
+
+**Responsibilities & Constraints**
+- `rv_*` / `pt_*` / per-task（`build_per_task_*` / `run_per_task_*`）/ debugger（`detect_*` / `build_debugger_prompt` / `run_debugger_stage` / `validate_debugger_notes`）/ `build_dev_prompt_*` / `build_reviewer_prompt` / `extract_review_result_token` / `parse_review_result` / `run_reviewer_stage` / `verify_pushed_or_retry` / `verify_stagec_pr_or_retry` / `mark_issue_failed` / `mark_issue_needs_decisions` / `handle_partial_status` / `_sav_handle_failure` / `stage_a_verify_run` / `run_impl_pipeline` / `_assert_base_branch_resolved` を保持
+- このモジュールが最大（約 3,000 行相当）。テスト被参照: `verify_pushed_or_retry` / `verify_stagec_pr_or_retry` / `parse_review_result` / `extract_review_result_token`、および grep 対象文字列（`stageA-push-missing` / `stageC-pr-missing` / `verify_stagec_pr_or_retry "$BRANCH" "$NUMBER"` の**呼び出し配線**）を含む
+
+**Dependencies**
+- Inbound: dispatcher.sh の Slot Runner（`run_impl_pipeline` を呼ぶ）(Critical)
+- Outbound: quota-aware.sh / impl-gates.sh / 共有変数 (Critical)
+
+**Contracts**: Service [x]
+
+#### dispatcher.sh
+
+| Field | Detail |
+|-------|--------|
+| Intent | Issue 候補取得・claim・worktree slot・並列 dispatch・resume・依存解決の関数群を保持 |
+| Requirements | 1.4, 3.3, 4.1, NFR 1.1 |
+
+**Responsibilities & Constraints**
+- `dispatcher_*` / `pclp_*` / `check_existing_impl_pr` / `_parallel_validate_slots` / `_worktree_*` / `_slot_*` / `slot_*` / `_resume_*` / `_resume_branch_assert_slug_match` / `dr_*` / `_dispatcher_on_signal` / `_dispatcher_reap_finished_slots` / `_dispatcher_find_free_slot` / `_slot_run_issue` / `_dispatcher_run` を保持（**関数定義のみ**）
+- `declare -A _DISPATCHER_SLOT_PIDS` / `trap` 登録 / `_dispatcher_run` の**呼び出し**はエントリポイントに残す。dispatcher.sh は定義のみ
+- `_slot_run_issue` は impl-pipeline / 各 processor を呼ぶため、ロード順では最後に source する（後述 source 順序制約）
+
+**Dependencies**
+- Inbound: エントリポイント（`_dispatcher_run` 呼び出し）(Critical)
+- Outbound: impl-pipeline.sh / 各 processor module / impl-gates.sh (Critical)
+
+**Contracts**: State [x]（ラベル遷移・slot lock）/ Service [x]
+
+### Test Compatibility Layer（既存テスト互換戦略）
+
+#### 既存テスト互換戦略（採用案: (b) 共通抽出ヘルパー）
+
+本リファクタリングの**最重要設計判断**。Req 4 を満たすため 3 案を比較した。
+
+| 案 | 内容 | テスト改変量 | 後方互換 | 保守性 | 評価 |
+|----|------|-------------|----------|--------|------|
+| (a) テスト側の抽出元を該当 module に変更 | 各テストの `WATCHER_SH` を関数が移動した module に個別 repoint | 中（テストごとに移動先把握が必要） | △（grep 対象が複数 module に跨ると 1 ファイル指定では破綻） | 低（関数を別 module に移すたびテスト修正） | 不採用 |
+| **(b) 共通抽出ヘルパーで「本体 + 全 modules」を走査** | `lib/extract.sh` に `SOURCE_FILES` 集合（エントリ + modules/*.sh）を定義し、各テストの抽出/grep をこの集合横断で行う | 中（各テスト冒頭を共通ヘルパー呼び出しに置換） | ◎（関数がどの module に移っても解決可能） | 高（将来の再分割にも追従） | **採用** |
+| (c) 抽出対象関数を本体に残す | テスト被抽出関数だけ issue-watcher.sh に残置 | 小 | ◎ | 低（分割粒度が歪む / 「純粋分割」目標に反する / 関数が本体と module に分散） | 不採用 |
+
+**採用案 (b) の根拠**:
+- テストは「個別関数の awk 抽出（`extract_function`）」だけでなく「`grep -q` による文字列/呼び出し配線の検証」も行う（例: `stagec_pr_verify_test.sh` は `verify_stagec_pr_or_retry()` 定義・`verify_stagec_pr_or_retry "$BRANCH" "$NUMBER"` 呼び出し・`gh pr view --head` の 3 文字列を grep）。定義と呼び出し配線が**異なる module に分かれる可能性**があるため、(a) の単一ファイル repoint では破綻する。(b) は「エントリ + 全 module を 1 つの仮想ソースとして走査」するため、関数・文字列がどこに移っても解決できる
+- (c) は分割の純粋性を損なう（テスト都合で本体に関数を残すと境界が歪み、Goal の「責務分割」に反する）
+
+**(b) の具体方針**（Developer 向け。実装はしない）:
+- `local-watcher/test/lib/extract.sh` を新設し、以下を提供する:
+  - `IDD_SOURCE_FILES`: エントリポイント + `modules/*.sh` の絶対パス配列（`SCRIPT_DIR` 基準で解決）
+  - `extract_function "<fn>"`: `IDD_SOURCE_FILES` 全体から該当関数を awk 抽出して echo（既存の `extract_function(script, fn)` と互換な出力。複数ファイル走査に拡張）。**抽出 0 件なら exit 非0 を返し、テストが失敗を観測できるようにする（Req 4.4: 解決不能を成功で隠さない）**
+  - `idd_grep_sources "<pattern>"`: `IDD_SOURCE_FILES` 全体を横断 grep（`grep -q` 相当）。配線検証用
+- 既存 12 テストは各自の `extract_function` ローカル定義と `WATCHER_SH` 直接参照を、`lib/extract.sh` の source + 共通関数呼び出しに置換する。**テストのアサーション本体（期待値・ケース）は変更しない**（テストの意図を変えない）
+- ヘルパーは関数移動より**前**に導入する（tasks.md タスク 2）。SOURCE 集合はエントリポイントも含むため、関数が本体に残ったままでも移動後でも同一に解決でき、以降の各移動タスクをテスト緑のまま遷移させられる
+- `tests/local-watcher/stage-a-verify/extract-driver.sh` / `tasks-count/extract-driver.sh` は、`_WATCHER_SH` の awk 抽出を「modules/impl-gates.sh を対象」に変更するか、`lib/extract.sh` の集合走査に合わせる。これらは impl-gates.sh 内の関数のみ抽出するため単一 module 指定でも成立するが、保守性のため SOURCE 集合走査に揃えることを推奨
+
+| Field | Detail |
+|-------|--------|
+| Intent | 全テストが関数の移動先に依らず抽出/grep を解決でき、解決不能をテスト失敗として観測する |
+| Requirements | 4.1, 4.2, 4.3, 4.4 |
+
+**Contracts**: Service [x]（`extract_function` / `idd_grep_sources` のヘルパー契約）
+
+##### Helper Interface（シグネチャのみ）
+
+```bash
+# local-watcher/test/lib/extract.sh
+# IDD_SOURCE_FILES: エントリポイント + modules/*.sh の絶対パス配列を定義する
+extract_function() {            # $1=fn_name。IDD_SOURCE_FILES を横断して関数本体を stdout に出力
+  # 1 件も見つからなければ非0 exit（Req 4.4）
+  :
+}
+idd_grep_sources() {            # $1=pattern。IDD_SOURCE_FILES 横断 grep -q（配線検証用）
+  :
+}
+```
+- Preconditions: 分割後の modules/*.sh が存在する（ヘルパー導入時点では本体も SOURCE 集合に含めるため、移動前でも解決可能）
+- Postconditions: 抽出成功時は関数本体を出力、不在時は非0 exit（成功扱いで隠さない）
+- Invariants: 既存テストのアサーション期待値を変更しない
+
+### Installer Module Copy
+
+| Field | Detail |
+|-------|--------|
+| Intent | install.sh が modules/ を $HOME/bin/modules/ へ既存方針で配置する |
+| Requirements | 2.1, 2.2, 2.3, 2.4, NFR 2.1, NFR 2.2 |
+
+**Responsibilities & Constraints**
+- 既存の local watcher インストール節（`copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.sh"` 等）に `modules/` 用の 1 行を追加する: `copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin/modules" "*.sh" "$HOME/bin/modules" --executable`
+- `copy_glob_to_homebin` は内部で `ensure_dir "$dest_dir"`（modules/ ディレクトリ自動作成）/ nullglob / `copy_template_file`（NEW / SKIP / OVERWRITE + `.bak` once-only + DRY_RUN prefix + `log_action` 統一書式）を既に持つため、**新規ロジックは追加せず再利用するだけ**で Req 2.2/2.3/2.4 / NFR 2.1/2.2 を満たす
+- `--executable` を付ける理由: 既存 `bin/*.sh` 配置と揃える（modules は source されるため実行ビットは必須ではないが、`bin/*.sh` と同一の扱いにして書式・パーミッションの一貫性を保つ）
+
+**Dependencies**
+- Inbound: `install.sh --local` (Critical)
+- Outbound: `copy_glob_to_homebin` / `copy_template_file` / `ensure_dir` / `log_action`（既存）(Critical)
+
+**Contracts**: Batch [x]（インストール時の一括配置）
+
+## Data Models
+
+### Domain Model
+
+本リファクタリングは**新しいデータモデルを導入しない**。既存の状態（GitHub ラベル遷移・`$LOCK_FILE` の flock 状態・`$LOG_DIR` 配下の quota reset JSON・worktree slot lock）はすべて据え置く。
+
+唯一の構造的変更は「関数定義の物理配置がエントリポイント単一ファイルから modules/*.sh へ分散する」ことのみで、ランタイムの変数スコープ（`source` による同一プロセス共有）・グローバル変数の生存期間・関数の可視性は変わらない。
+
+### 共有グローバル変数の所有契約
+
+| 変数 | 定義元 | 共有方法 | 分割後の扱い |
+|------|--------|----------|-------------|
+| `REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / 各 processor env | エントリポイント config | source 前に定義済み | エントリポイントに据置（モジュールは参照のみ） |
+| `NUMBER` / `BRANCH` / `LOG` / `WT` / `rc` 等（実行時の作業変数） | 各 processor / pipeline 関数内で代入 | 同一プロセスのグローバル | モジュール間で従来どおり暗黙共有（挙動不変） |
+| `_DISPATCHER_SLOT_PIDS` | エントリポイント（`declare -A`） | グローバル連想配列 | エントリポイントに据置（trap / dispatcher が参照） |
+
+> 確認事項なし。`source` は同一シェルプロセスにファイルを読み込むため、関数を別ファイルへ移しても `local` 宣言のないグローバル変数の共有は完全に維持される。読み込み順序依存は「関数の**呼び出し**順序」であって「定義順序」ではないため、全モジュールを `_dispatcher_run` 呼び出し前に source すれば充足される。
+
+## Error Handling
+
+### Error Strategy
+本リファクタリングは既存のエラーハンドリングを**移動するのみで変更しない**。新規に追加するエラーハンドリングはモジュールローダの 1 点のみ。
+
+### Error Categories and Responses
+- **Module Load Errors（新規 / Req 1.3）**: モジュール不在 / 読込不能を `[ -r "$f" ]` で検知し、欠落パスを `>&2` に出力して `exit 1`。`set -e` 下でも黙殺されないよう明示 exit。副作用（flock / git）の**前**に検知する配置とすることで、半端な状態での処理開始を防ぐ
+- **Test Resolution Errors（新規 / Req 4.4）**: 共通抽出ヘルパーが関数を 1 件も解決できない場合は非0 exit を返し、テストを失敗として終了させる（成功扱いで隠さない）。既存テストの `if ! declare -F <fn>` ガードと整合する
+- **既存 User/System/Business Errors（据置）**: ツールチェック（gh/jq/claude/git/flock/timeout 不在）の exit 1、dirty working tree ガードの exit 1、quota 超過時の `needs-quota-wait` ラベル付与、各 processor の WARN/ERROR ログ、`claude-failed` / `needs-decisions` 昇格はすべて移動のみで挙動不変
+
+### shellcheck 方針（Req 5.1 / 5.2）
+- **エントリポイントの `source` 呼び出し**: 動的パス（`$SCRIPT_DIR/modules/...`）のため SC1090（non-constant source）が出る。ループ直前に `# shellcheck source=/dev/null` directive を付与して抑止する（個別 module を辿らせない明示方針）。`disable` ではなく `source=/dev/null` を採用する理由は、shellcheck に「外部 source であり追跡不要」を意図表明するため
+- **各 module の shebang**: source 専用ファイルだが、shellcheck が単体検査時に bash として解釈できるよう `#!/usr/bin/env bash` を冒頭に置く。あわせて `# shellcheck shell=bash` を明示し、単体 `shellcheck modules/<name>.sh` で警告ゼロにする
+- **module 内で参照する未定義変数（SC2154）**: エントリポイント由来のグローバル（`$REPO` 等）を参照する箇所で SC2154 が出る可能性。元コードが単一ファイルで警告ゼロだった事実から、移動で新たに出る分は `# shellcheck disable=SC2154`（または module 冒頭の `# shellcheck source=../issue-watcher.sh` directive 検討）で個別に解消する。**Developer は分割後に必ず `shellcheck` を実行し、出た警告のみを最小限の directive で解消する**（先回りの一律 disable は禁止）
+
+## Testing Strategy
+
+- **Unit Tests**:
+  1. `local-watcher/test/normalize_slug_test.sh` / `slug_match_guard_test.sh` — `_normalize_slug` / `_stage_checkpoint_assert_slug_match` が impl-gates.sh から抽出解決でき従来どおり pass する
+  2. `tests/local-watcher/stage-a-verify/extract-driver.sh` — `stage_a_verify_extract_command` が impl-gates.sh から抽出でき全 fixture が pass する
+  3. `tests/local-watcher/tasks-count/extract-driver.sh` — `tc_count_tasks` / `tc_classify` が impl-gates.sh から抽出でき全 fixture + 境界ケースが pass する
+  4. `parse_review_result_test.sh` / `qa_detect_rate_limit_test.sh` — impl-pipeline.sh / quota-aware.sh からの抽出解決
+  5. （新規）共通抽出ヘルパー `lib/extract.sh` の `extract_function` が、存在しない関数名に対して非0 exit を返すこと（Req 4.4 の最小検証）
+- **Integration Tests**:
+  1. `verify_pushed_or_retry_test.sh` — 関数抽出 + grep 配線検証（`stageA-push-missing` 等が SOURCE 集合横断で解決）が pass する
+  2. `stagec_pr_verify_test.sh` / `stagec_pr_verify_retry_test.sh` / `stagec_pr_verify_fallback_test.sh` — 定義・呼び出し配線・`gh pr view`/`gh api` 文字列が複数 module に跨っても `idd_grep_sources` で解決される
+  3. `repo_prefix_log_test.sh` — 全 logger の `[REPO]` prefix 抽出 + dirty-tree 文字列の grep（エントリポイント残置部分）が pass する
+  4. `pi_max_rounds_kind_test.sh` / `pi_detect_quota_soft_fail_test.sh` — pr-iteration.sh からの複数関数抽出が pass する
+- **E2E/Smoke Tests**（CLAUDE.md の手動スモーク準拠）:
+  1. cron-like 最小 PATH での依存解決と起動: `env -i HOME=$HOME PATH=/usr/bin:/bin bash -c '$HOME/bin/issue-watcher.sh'` 相当で、modules/ が `SCRIPT_DIR` 基準で解決され起動する（NFR 3.1 / 3.2）
+  2. dry run（対象 Issue なし）: `REPO=owner/test REPO_DIR=/tmp/test-repo $HOME/bin/issue-watcher.sh` が `処理対象の Issue なし` で exit 0（差分等価 / NFR 1.1）
+  3. モジュール欠落時の停止: `modules/dispatcher.sh` を一時退避して起動すると非0 exit + 欠落パスが stderr に出る（Req 1.3）
+  4. install.sh 冪等性: `/tmp` の scratch repo に `./install.sh --repo /tmp/scratch --local` を 2 回実行し、modules/ が `$HOME/bin/modules/` に配置され 2 回目で SKIP 系ログになる（Req 2.2 / NFR 2.1）。`--dry-run` で実コピーされず `[DRY-RUN]` 列挙のみ（Req 2.3）
+  5. dogfooding: 本 PR を merge 後、自身の cron 実行で 1 サイクルが従来どおり完走する（NFR 1.2）
+
+## Migration Strategy
+
+```mermaid
+flowchart TD
+    s0["分割前: issue-watcher.sh 単一ファイル"] --> s1
+    s1["Step1: modules/ 雛形 + ローダ追加<br/>（関数は本体に残す。雛形のみ配置）"] --> s2
+    s2["Step2: テスト互換ヘルパー(b)を先行導入<br/>（SOURCE 集合 = 本体 + modules。全テスト緑のまま）"] --> s3
+    s3["Step3: processor 系を modules へ移動<br/>各移動後に shellcheck + 全テスト緑を確認"] --> s4
+    s4["Step4: impl-gates / pipeline / dispatcher を modules へ移動"] --> s5
+    s5["Step5: install.sh modules コピー + README 更新"] --> s6
+    s6["分割後: エントリポイント + modules/*.sh<br/>shellcheck 緑 / 全テスト緑 / dry-run 正常"]
+```
+
+- **段階的移動の原則**: 一括移動で全テストが赤になる事故を避けるため、tasks.md は「各タスク完了時点で shellcheck + 全テストが緑」を保てる順序にする。具体的には、**テスト互換ヘルパー(b)を関数移動より前に導入**する（tasks.md タスク 2）。ヘルパーの SOURCE 集合はエントリポイントと modules/ の双方を含むため、関数が本体に残った状態でも移動後でも同一に解決でき、以降の各移動タスク（タスク 3〜6）が抽出元の切替なしにテスト緑のまま遷移できる
+- **後方互換性（Req 3.4）**: 本リファクタリングは外部観測振る舞いを変えないため、破壊的変更は発生しない見込み。ただし「`$HOME/bin/` への配置物が増える（modules/ ディレクトリ新設）」点は README に「modules 化の構成変更」note として明文化する。既存 cron / launchd 登録文字列・env var・exit code は不変であることを README に明記する
+- **install 再実行の必要性**: 既存運用者は本 PR merge 後に `install.sh --local` 再実行（または手動で modules/ をコピー）が必要。再実行しないと `$HOME/bin/issue-watcher.sh` だけ更新され modules/ が無く Req 1.3 で停止する。この手順は README の既存「反映方法」節と同じ枠で案内する（migration note）
+
+## Security Considerations
+
+- 機密情報の新規取り扱いは無い。API キー・トークンの扱いは据え置き
+- `source` の対象は `$SCRIPT_DIR/modules/` 配下の固定マニフェスト名のみ。ユーザー入力や環境変数からパスを組み立てて source しない（任意コード実行リスクを増やさない）
+- `SLOT_INIT_HOOK` 等の既存 hook の扱いは変更しない

--- a/docs/specs/177-feat-watcher-issue-watcher-sh/requirements.md
+++ b/docs/specs/177-feat-watcher-issue-watcher-sh/requirements.md
@@ -1,0 +1,91 @@
+# Requirements Document
+
+## Introduction
+
+`local-watcher/bin/issue-watcher.sh` は約 12,000 行の単一 Bash スクリプトに肥大化しており、保守・拡張・AI 協調開発（編集時のトークンコストとデグレリスク）・関数単位のテストの全てがボトルネックになっている。本機能は、責務ごとにスクリプトを `modules/` 配下へ分割し、`issue-watcher.sh` 本体を起動時に modules を動的ロードするエントリポイント兼ディスパッチャに再構成することで、保守性と開発効率を高める。idd-claude は self-hosting（dogfooding）で本スクリプト自身が次回 cron 実行で自分を動かすため、既存運用（cron / launchd が `$HOME/bin/issue-watcher.sh` を直接起動）との完全な後方互換性と冪等性が最重要要件となる。本リファクタリングは外部から観測される振る舞いを一切変えない（差分等価）ことを前提とする。
+
+## Requirements
+
+### Requirement 1: 動的モジュールロードによる起動
+
+**Objective:** As a 運用者（cron / launchd で watcher を起動する人）, I want `issue-watcher.sh` がモジュール分割後も従来と同一の単一起動コマンドで全機能を読み込んで動作すること, so that 既存の cron / launchd 登録を一切変更せずにモジュール化の恩恵を受けられる
+
+#### Acceptance Criteria
+
+1. When `$HOME/bin/issue-watcher.sh` が起動されたとき, the Issue Watcher shall 自身の配置ディレクトリ配下の `modules/` から必要な全モジュールをロードしてから処理を開始する
+2. The Issue Watcher shall 起動経路（cron / launchd / 手動実行）やカレントディレクトリに依存せず、自身の配置位置を基準に `modules/` を解決する
+3. If ロード対象のモジュールが 1 件でも欠落または読み込み不能であるとき, the Issue Watcher shall 処理を継続せず非ゼロ exit code で停止し、欠落モジュールを特定できるエラーメッセージを標準エラー出力に出す
+4. When 全モジュールのロードが成功したとき, the Issue Watcher shall モジュール化導入前と同一の機能セット（Triage / 各モード / 各 Processor）を提供する
+
+### Requirement 2: インストーラによるモジュール配置
+
+**Objective:** As a 運用者（install.sh でローカル watcher を導入・更新する人）, I want `install.sh` 実行時に `modules/` 配下の全モジュールが `$HOME/bin/modules/` へ過不足なく配置されること, so that 動的ロードが成立し、再実行しても環境が壊れない
+
+#### Acceptance Criteria
+
+1. When `install.sh` がローカル watcher のインストールを実行したとき, the Installer shall `local-watcher/bin/modules/` 配下の全モジュールを `$HOME/bin/modules/` へ配置する
+2. While `install.sh` を再実行したとき, the Installer shall モジュール配置を冪等に扱い、既存のユーザー環境を破壊しない
+3. When `install.sh` が `--dry-run` で実行されたとき, the Installer shall モジュール配置についても実コピーを行わず予定操作のみを既存と同一の分類書式で列挙する
+4. The Installer shall モジュール配置の各操作（新規 / スキップ / 上書き等）を既存のインストールログと同一の書式で観測可能にする
+
+### Requirement 3: 既存設定・起動契約の後方互換性
+
+**Objective:** As a 運用者, I want モジュール分割後も既存の環境変数・起動コマンド・ログ出力先・ラベル遷移・exit code の意味が導入前と完全に等価であること, so that self-hosting 環境を含む既稼働の cron / launchd が無告知の破壊を受けない
+
+#### Acceptance Criteria
+
+1. The Issue Watcher shall 既存の全環境変数（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `TRIAGE_MODEL` / `DEV_MODEL` 等）の名称・デフォルト値・override 挙動をモジュール化導入前と等価に保つ
+2. When 既存の cron / launchd 起動コマンド（`$HOME/bin/issue-watcher.sh` を env var 付きで直接起動）がそのまま実行されたとき, the Issue Watcher shall モジュール化導入前と同一の処理サイクルを実行する
+3. The Issue Watcher shall ログ出力先・ラベル遷移契約・exit code の意味をモジュール化導入前と等価に保つ
+4. If モジュール化に伴い後方互換性を破る変更が不可避であるとき, the Issue Watcher shall その変更を README の migration note として明文化したうえでのみ導入する
+
+### Requirement 4: 既存テストの不破壊
+
+**Objective:** As a 開発者（watcher を保守する人）, I want モジュール分割後も既存のシェルスクリプトテストが全て成功すること, so that リファクタリングがデグレを起こしていないことを観測可能に保証できる
+
+#### Acceptance Criteria
+
+1. When `local-watcher/test/` 配下の全テストが実行されたとき, the Test Suite shall モジュール化構成のもとで全テストが成功する
+2. When `tests/local-watcher/` 配下の全テストが実行されたとき, the Test Suite shall モジュール化構成のもとで全テストが成功する
+3. While 個別関数を検証する既存テストが対象関数を抽出して読み込むとき, the Test Suite shall 関数の移動先にかかわらず対象関数を解決して検証できる
+4. If リファクタリングにより既存テストが対象関数を解決できなくなるとき, the Test Suite shall その不整合を成功扱いで隠さず、テスト失敗として観測可能にする
+
+### Requirement 5: 静的解析クリーン
+
+**Objective:** As a 開発者, I want 分割後のエントリポイントと全モジュールが静的解析で警告ゼロであること, so that モジュール化後もコード品質基準を維持できる
+
+#### Acceptance Criteria
+
+1. When `issue-watcher.sh` に対して `shellcheck` を実行したとき, the Static Analysis shall 警告ゼロを報告する
+2. When `modules/` 配下の各モジュールに対して `shellcheck` を実行したとき, the Static Analysis shall 各モジュールについて警告ゼロを報告する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性・差分等価性
+
+1. The Issue Watcher shall モジュール化導入前後で外部から観測される振る舞い（処理結果・ログ書式の契約・ラベル遷移・exit code）を差分等価に保つ
+2. While self-hosting 環境（idd-claude 自身を対象 repo として cron 実行）で次回サイクルが動作するとき, the Issue Watcher shall モジュール化導入前と同一の挙動でその回の処理を完走する
+
+### NFR 2: 冪等性
+
+1. When `install.sh` を 2 回以上連続して実行したとき, the Installer shall モジュール配置の最終結果を 1 回実行時と同一にする
+2. If モジュール配置先に既存ファイルが存在し内容に差分があるとき, the Installer shall 既存ファイル群（`*.sh` / `*.tmpl` 等）に対する現行の上書き・退避方針と矛盾しない方針で配置を行う
+
+### NFR 3: 起動環境の堅牢性
+
+1. While cron / launchd の最小 PATH 環境で起動されたとき, the Issue Watcher shall `$HOME` を基準にモジュールと依存コマンドを解決し、対話シェルの profile に依存せず動作する
+2. The Issue Watcher shall モジュール解決にユーザーのカレントディレクトリやシンボリックリンク先の差異を前提とせず、自身の配置位置から相対解決する
+
+## Out of Scope
+
+- モジュール分割の具体的な単位・境界（どの関数をどのモジュールに置くか）の確定（`design.md` / Architect の領分）
+- 動的 source の実装方式（source ループの具体コード、`BASH_SOURCE` 解決の実装詳細）
+- 既存テストが対象関数を解決するための具体的な実装手段（本体に関数を残すか / テスト側の抽出元を変えるか / 共通ローダを介すか等の選択）。本要件は「既存テストが移動後も全て成功する」ことを観測可能な AC として求めるに留める
+- 機能挙動そのものの変更・新機能追加・バグ修正（本 Issue は純粋なリファクタリングであり振る舞いを変えない）
+- GitHub Actions 経路（`.github/workflows/issue-to-pr.yml`）のモジュール化（本 Issue はローカル watcher スクリプトの分割が対象）
+- `repo-template/` 配下テンプレートの分割（本 Issue は `local-watcher/bin/issue-watcher.sh` が対象）
+- ファイル分割によるパフォーマンス最適化目標（起動時間短縮等）の数値設定
+
+## Open Questions
+
+なし

--- a/docs/specs/177-feat-watcher-issue-watcher-sh/tasks.md
+++ b/docs/specs/177-feat-watcher-issue-watcher-sh/tasks.md
@@ -1,0 +1,102 @@
+# Implementation Plan
+
+> リファクタリングの性質上、**各タスク完了時点で `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/*.sh` と既存全テスト（`local-watcher/test/*.sh` + `tests/local-watcher/*/*.sh`）が緑**を保てる順序で構成している。一括移動で全テストが赤になる事故を避けるため、**テスト互換ヘルパー（design.md「既存テスト互換戦略」案 (b)）を関数移動より前に導入**する。ヘルパーはエントリポイント + modules/*.sh を 1 つの仮想ソース集合（`IDD_SOURCE_FILES`）として走査するため、関数が本体に残っていても module へ移った後でも同じく解決でき、各移動タスクが緑のまま遷移できる。
+
+- [ ] 1. モジュールローダとマニフェスト・空モジュール雛形の導入
+- [ ] 1.1 `issue-watcher.sh` に `SCRIPT_DIR` 解決 + モジュールマニフェスト配列 + 動的 source ループを追加する
+  - `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` で配置位置を cwd / symlink 非依存に解決（NFR 3.2）
+  - 9 モジュール名の固定順マニフェスト（design.md File Structure Plan 順）をエントリポイントに明示列挙
+  - 各 module を source 前に `[ -r "$f" ]` で検証し、不在/読込不能なら欠落パスを `>&2` 出力して `exit 1`（Req 1.3）
+  - ローダはツールチェックより前・副作用（flock / git）より前に配置（Req 1.1 / NFR 3.1）
+  - `# shellcheck source=/dev/null` directive で SC1090 を抑止（Req 5.1）
+  - `local-watcher/bin/modules/` に 9 個の空モジュール雛形を作成（shebang `#!/usr/bin/env bash` + `# shellcheck shell=bash` + ファイル冒頭コメント: 用途/配置先 `~/bin/modules/<name>.sh`/依存/セットアップ参照先）。この段では関数は本体に残し、雛形のみ追加する（重複定義は作らない）
+  - _Requirements: 1.1, 1.2, 1.3, 5.1, 5.2, NFR 3.1, NFR 3.2_
+  - _Boundary: Module Loader, Entry Point_
+
+- [ ] 2. テスト互換ヘルパー (b) の先行導入
+- [ ] 2.1 `local-watcher/test/lib/extract.sh` を新設し、全テストの抽出/grep を仮想ソース集合経由に切り替える
+  - `IDD_SOURCE_FILES`（エントリポイント + `modules/*.sh` の絶対パス配列）を `SCRIPT_DIR` 基準で定義
+  - `extract_function "<fn>"`（全 SOURCE 横断 awk 抽出。1 件も解決できなければ非0 exit / Req 4.4）と `idd_grep_sources "<pattern>"`（全 SOURCE 横断 grep）を提供
+  - 既存 12 テスト（`local-watcher/test/*.sh`）の各ローカル `extract_function` 定義と `WATCHER_SH` 直接参照を `lib/extract.sh` source + 共通関数呼び出しに置換（アサーション期待値・ケースは変更しない）
+  - `tests/local-watcher/stage-a-verify/extract-driver.sh` / `tasks-count/extract-driver.sh` の抽出も SOURCE 集合走査に揃える
+  - この段では関数はまだ本体に残るが、ヘルパーは本体も走査するため全テストが緑のまま遷移する（以降の移動タスクで赤化させないための足場）
+  - _Requirements: 4.1, 4.2, 4.3, 4.4_
+  - _Boundary: Test Compatibility Layer_
+  - _Depends: 1.1_
+
+- [ ] 3. Processor 系モジュール群 A の移動（quota-aware / merge-queue / auto-rebase）
+- [ ] 3.1 `qa_*` / `build_partial_escalation_comment` / `process_quota_resume` を `modules/quota-aware.sh` へ移動 (P)
+  - 本体から該当関数定義を削除し quota-aware.sh へ移設（シグネチャ・本文を 1 文字も変えない）
+  - 移動後に `shellcheck modules/quota-aware.sh` 警告ゼロ・`qa_detect_rate_limit_test.sh` 緑を確認
+  - _Requirements: 1.4, 3.3, 5.2, NFR 1.1_
+  - _Boundary: quota-aware.sh_
+  - _Depends: 2.1_
+- [ ] 3.2 `mq_*` / `process_merge_queue` / `mqr_*` / `process_merge_queue_recheck` を `modules/merge-queue.sh` へ移動 (P)
+  - _Requirements: 1.4, 3.3, 5.2, NFR 1.1_
+  - _Boundary: merge-queue.sh_
+  - _Depends: 2.1_
+- [ ] 3.3 `ar_*` / `process_auto_rebase` を `modules/auto-rebase.sh` へ移動 (P)
+  - _Requirements: 1.4, 3.3, 5.2, NFR 1.1_
+  - _Boundary: auto-rebase.sh_
+  - _Depends: 2.1_
+
+- [ ] 4. Processor 系モジュール群 B の移動（promote-pipeline / pr-iteration / design-review-release）
+- [ ] 4.1 `pp_*` + `po_*` + `process_promote_pipeline` を `modules/promote-pipeline.sh` へ移動 (P)
+  - Path Overlap（`po_*`）と Promote（`pp_*`）を同一モジュールに consolidate（design.md 根拠）
+  - `po_check_dispatch_gate` は dispatcher から呼ばれるが定義はここに置く（呼び出し配線は本体/dispatcher 側で不変）
+  - _Requirements: 1.4, 3.3, 5.2, NFR 1.1_
+  - _Boundary: promote-pipeline.sh_
+  - _Depends: 2.1_
+- [ ] 4.2 `pi_*` / `build_recovery_hint` / `process_pr_iteration` を `modules/pr-iteration.sh` へ移動 (P)
+  - 移動後に `pi_max_rounds_kind_test.sh` / `pi_detect_quota_soft_fail_test.sh` が SOURCE 集合経由で緑であることを確認
+  - _Requirements: 1.4, 3.3, 5.2, NFR 1.1_
+  - _Boundary: pr-iteration.sh_
+  - _Depends: 2.1_
+- [ ] 4.3 `drr_*` / `process_design_review_release` を `modules/design-review-release.sh` へ移動 (P)
+  - _Requirements: 1.4, 3.3, 5.2, NFR 1.1_
+  - _Boundary: design-review-release.sh_
+  - _Depends: 2.1_
+
+- [ ] 5. impl-gates モジュールの移動とゲート系テストの解決確認
+- [ ] 5.1 `sav_*` / `_sav_*` / `stage_a_verify_*` / `sc_*` / `stage_checkpoint_*` / `tc_*` / `_normalize_slug` / `_slug_mismatch_escalate` / `_stage_checkpoint_assert_slug_match` を `modules/impl-gates.sh` へ移動
+  - 移動後に `normalize_slug_test.sh` / `slug_match_guard_test.sh` / `stage-a-verify/extract-driver.sh` / `tasks-count/extract-driver.sh` が SOURCE 集合経由で緑であることを確認
+  - `shellcheck modules/impl-gates.sh` 警告ゼロを確認
+  - _Requirements: 1.4, 3.3, 4.1, 4.2, 4.3, 5.2, NFR 1.1_
+  - _Boundary: impl-gates.sh_
+  - _Depends: 2.1_
+
+- [ ] 6. impl-pipeline と dispatcher の移動・配線維持とテスト全緑化
+- [ ] 6.1 impl-pipeline 系関数を `modules/impl-pipeline.sh` へ移動する
+  - `rv_*` / `pt_*` / per-task（`build_per_task_*` / `run_per_task_*`）/ debugger 系 / `build_dev_prompt_*` / `build_reviewer_prompt` / `extract_review_result_token` / `parse_review_result` / `run_reviewer_stage` / `verify_pushed_or_retry` / `verify_stagec_pr_or_retry` / `mark_issue_*` / `handle_partial_status` / `_sav_handle_failure` / `stage_a_verify_run` / `run_impl_pipeline` / `_assert_base_branch_resolved` を移設
+  - `parse_review_result_test.sh` / `verify_pushed_or_retry_test.sh` / `stagec_pr_verify_*_test.sh` が、定義・呼び出し配線・`gh pr view`/`gh api` 文字列を `idd_grep_sources` 横断で解決して緑になることを確認
+  - _Requirements: 1.4, 3.3, 4.1, 4.3, 5.2, NFR 1.1_
+  - _Boundary: impl-pipeline.sh_
+  - _Depends: 5.1_
+- [ ] 6.2 dispatcher 系関数を `modules/dispatcher.sh` へ移動する（定義のみ。orchestration はエントリポイント据置）
+  - `dispatcher_*` / `pclp_*` / `check_existing_impl_pr` / `_parallel_validate_slots` / `_worktree_*` / `_slot_*` / `slot_*` / `_resume_*` / `_resume_branch_assert_slug_match` / `dr_*` / `_dispatcher_on_signal` / `_dispatcher_reap_finished_slots` / `_dispatcher_find_free_slot` / `_slot_run_issue` / `_dispatcher_run` を移設
+  - `declare -A _DISPATCHER_SLOT_PIDS` / `trap` 登録 / `_dispatcher_run` の**呼び出し** / `exit` はエントリポイントに残す（dispatcher.sh は関数定義のみ）
+  - dispatcher.sh はマニフェスト最後に source される（impl-pipeline / 各 processor を呼ぶため）。source 順序制約を満たすことを確認
+  - `repo_prefix_log_test.sh`（dirty-tree 文字列はエントリポイント残置 / logger は各 module 横断）含む全テストが緑、`shellcheck` 全緑を確認
+  - _Requirements: 1.4, 3.1, 3.2, 3.3, 4.1, 4.3, 5.1, 5.2, NFR 1.1_
+  - _Boundary: dispatcher.sh, Entry Point_
+  - _Depends: 6.1_
+
+- [ ] 7. install.sh による modules 配置の追加
+- [ ] 7.1 local watcher インストール節に modules/ コピーを追加する
+  - 既存 `copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.sh" ...` の直後に `copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin/modules" "*.sh" "$HOME/bin/modules" --executable` を追加
+  - 既存ヘルパー（`ensure_dir` / `copy_template_file` / `log_action` / DRY_RUN / `.bak` once-only）を再利用し新規ロジックは追加しない（Req 2.2/2.3/2.4 / NFR 2.1/2.2）
+  - スモーク: `/tmp` scratch repo へ `./install.sh --repo /tmp/scratch --local` を 2 回実行し冪等性、`--dry-run` で実コピーなし `[DRY-RUN]` 列挙のみを確認
+  - `shellcheck install.sh` 警告ゼロを確認
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, NFR 2.1, NFR 2.2_
+  - _Boundary: Installer Module Copy_
+  - _Depends: 6.2_
+
+- [ ] 8. README 更新と最終差分等価スモーク検証
+- [ ] 8.1 README にディレクトリ構成・手動コピー手順・modules 化 migration note を追記し、最終スモークを実施する
+  - ディレクトリ構成（`local-watcher/bin/` 配下）に `modules/` を追記
+  - 手動コピー手順に `cp -r .../local-watcher/bin/modules ~/bin/` 相当を追記
+  - 「modules 化の構成変更」migration note を 1 節追加（cron/launchd 登録文字列・env var・exit code は不変。既存運用者は `install.sh --local` 再実行が必要な旨 / Req 3.4）
+  - 最終スモーク: 最小 PATH 起動で modules 解決（NFR 3.1/3.2）、対象 Issue なしで `処理対象の Issue なし` exit 0（NFR 1.1）、modules 欠落時に非0 exit + 欠落パス stderr（Req 1.3）、`shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/*.sh` 全緑（Req 5.1/5.2）
+  - _Requirements: 3.4, 1.3, 5.1, 5.2, NFR 1.1, NFR 1.2, NFR 3.1, NFR 3.2_
+  - _Boundary: Entry Point, Module Loader_
+  - _Depends: 7.1_


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用** です。実装コードは含まれません。
`docs/specs/177-feat-watcher-issue-watcher-sh/` 配下の requirements / design / tasks を merge するためのゲートです。

`local-watcher/bin/issue-watcher.sh`（約 11,899 行の単一スクリプト）を、**エントリポイント + `modules/*.sh` 9 モジュールの動的ロード構成**へ差分等価リファクタリングする設計です。外部から観測される振る舞い（処理結果・ログ書式・ラベル遷移・exit code）は一切変えず、self-hosting（dogfooding）環境での後方互換性と冪等性を最重要要件として設計しています。

## 対応 Issue

Refs #177

## 含まれる成果物

- `docs/specs/177-feat-watcher-issue-watcher-sh/requirements.md` — 要件定義（PM 成果物）
- `docs/specs/177-feat-watcher-issue-watcher-sh/design.md` — 設計書（Architect 成果物）
- `docs/specs/177-feat-watcher-issue-watcher-sh/tasks.md` — 実装タスク分割

## 要件サマリ

| 要件 | 内容 | 受入基準 |
|---|---|---|
| Req 1 | 動的モジュールロードによる起動 | AC1: modules/ から全モジュールをロードして処理開始 / AC2: 起動経路に依存しない modules/ 解決 / AC3: 欠落時は非ゼロ exit + エラーメッセージ / AC4: 分割前と同一機能セット |
| Req 2 | インストーラによるモジュール配置 | AC1: install.sh が modules/ を $HOME/bin/modules/ へ配置 / AC2: 再実行で冪等 / AC3: --dry-run でも modules 配置操作を列挙 / AC4: 操作ログを既存書式で出力 |
| Req 3 | 既存設定・起動契約の後方互換性 | AC1: 全 env var の名称・デフォルト・override 挙動不変 / AC2: 既存 cron/launchd コマンドで同一サイクル実行 / AC3: ログ・ラベル遷移・exit code 不変 / AC4: 後方互換性を破る場合は README migration note 必須 |
| Req 4 | 既存テストの不破壊 | AC1: local-watcher/test/ 12 件が全成功 / AC2: tests/local-watcher/ 3 件が全成功 / AC3: 関数移動後も抽出・解決可能 |
| Req 5 | shellcheck クリーン | AC1: エントリポイント + 全モジュールが shellcheck 警告ゼロ |
| NFR 1 | 差分等価（振る舞い不変） | 外部から観測可能な全挙動がリファクタリング前と等価 |
| NFR 2 | 冪等性 | install.sh の再実行で環境が壊れない |
| NFR 3 | マニフェスト管理 | ロード順序をマニフェストファイルで明示・管理 |

## 設計のキーポイント

### 動的 source ローダとマニフェスト順

エントリポイント（`issue-watcher.sh`）はマニフェストファイル（`local-watcher/bin/modules/00-manifest.txt`）を読み込み、記載順に `source` してモジュールをロードします。これにより source 順序依存を明示的に管理し、欠落時は非ゼロ exit で停止します。

### モジュール境界（既存プレフィックス命名を踏襲）

既存の関数プレフィックス命名（`qa_*` / `mq_*` / `ar_*` / `pp_*` / `po_*` / `pi_*` / `drr_*` / `sav_*` / `sc_*` / `tc_*` / `dispatcher_*` / `_slot_*` / `_resume_*` / `dr_*`）をモジュール境界の駆動軸として採用し、以下 9 モジュールへ分割します:

| モジュール | プレフィックス群 | 主な責務 |
|---|---|---|
| `10-config.sh` | — | env var / config 定義（グローバル変数） |
| `20-utils.sh` | `sc_*`, `tc_*` | 汎用ユーティリティ（ログ・時刻・文字列） |
| `30-git.sh` | `_slot_*`（一部） | git 操作ヘルパー |
| `40-qa.sh` | `qa_*` | Quota / Slot 管理 |
| `50-mq.sh` | `mq_*` | Merge Queue 処理 |
| `60-ar.sh` | `ar_*` | Auto Review 処理 |
| `70-pp.sh` | `pp_*`, `po_*`, `pi_*` | Promote Pipeline / Path Overlap / Iteration |
| `80-drr.sh` | `drr_*`, `sav_*`, `dr_*` | Design Review / Save / Draft 処理 |
| `90-dispatcher.sh` | `dispatcher_*`, `_slot_*`（残）, `_resume_*` | メインディスパッチャ |

### 既存テスト互換戦略（案 b: 共通抽出ヘルパー新設）

既存テストは本体ファイルから `awk` で個別関数を抽出する方式のため、抽出元パスが変わると壊れます。対応として **案 (b): 共通抽出ヘルパー `local-watcher/test/lib/extract.sh` を新設**し、エントリポイント + modules を仮想ソース集合として横断走査する方式を採用します。テスト側 12 件の抽出呼び出し箇所を `extract.sh` 経由に切り替え、`tests/local-watcher/` 配下の extract-driver も同様に改変します。

### Budget overflow: 8 タスクで pass

最上位タスク数 8 件（≤ 10 件閾値）。Budget overflow check pass。

### 後方互換の不変保証

env var 名（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `TRIAGE_MODEL` / `DEV_MODEL` 等）・cron 登録文字列・exit code 意味・ログ出力先・ラベル遷移契約はモジュール化前と完全に等価に保ちます。

## 関連 Issue / PR

<!-- 関連する Issue / PR を Refs 形式で列挙してください。Closes / Fixes / Resolves は使わないこと -->
<!-- 例: Refs #42 (先行する設計議論)、Refs #50 (関連する仕様変更 PR) -->
<!-- 関連項目が無い場合は「なし」と記載してください -->

なし

## レビュー観点

- requirements.md の FR / NFR / AC に過不足はないか
- design.md のモジュール構成・公開 IF が FR をカバーしているか
- 既存コードの再利用が検討されているか、重複実装が混じっていないか
- tasks.md の分割粒度が独立コミット可能か

## 確認事項

1. **既存テスト互換戦略**: 案 (b)（共通抽出ヘルパー `local-watcher/test/lib/extract.sh` を新設し、エントリポイント + modules を仮想ソース集合として横断走査）を採用しています。テスト側 12 件（`local-watcher/test/` 配下）の抽出呼び出し箇所を `extract.sh` 経由に切り替え、`tests/local-watcher/` 配下の extract-driver も改変する方針でよいか確認をお願いします。

2. **モジュール境界と Path Overlap の扱い**: 既存関数プレフィックス命名をそのままモジュール境界に採用しています。`po_*`（Path Overlap）プレフィックス群を `pp_*`（Promote Pipeline）と同一モジュール `70-pp.sh` に consolidate した点について、責務の混在が懸念される場合は別モジュールへの分離をご指摘ください。

3. **これは設計レビュー PR であり実装は含みません。** merge 後に Issue #177 から `awaiting-design-review` ラベルを外すと、次回ポーリングで Developer が自動起動し、実装 PR が別途作成されます。

## 次のステップ

- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
- 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
- やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から `awaiting-design-review` ラベルを外すと実装が自動開始します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
