### PR TITLE
feat(#185): root labels スクリプトへの awaiting-slot 追加と template/root parity 回復

### DIFF
--- a/.github/scripts/idd-claude-labels.sh
+++ b/.github/scripts/idd-claude-labels.sh
@@ -75,6 +75,7 @@ LABELS=(
   "needs-quota-wait|c5def5|【Issue 用】 Claude Max quota 超過で reset 待ち（Quota Resume Processor が自動除去）"
   "staged-for-release|b8e0d2|【Issue 用】 develop に merge 済み、main 到達待ち（multi-branch 運用専用）"
   "st-failed|d73a4a|【Issue 用】 ST failure 検知後 revert 済み（Phase B Promote Pipeline が付与）"
+  "awaiting-slot|c5def5|【Issue 用】 hot file 競合予防で同サイクル dispatch を見送り中（Phase E Path Overlap Checker が付与・除去）"
   "blocked|b60205|【Issue 用】 依存 Issue 未 merge により auto-dev 進行不能"
 )
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ curl -fsSL https://raw.githubusercontent.com/hitoshiichikawa/idd-claude/main/set
   完全コマンドが出力されるので、それをコピペで実行してください
 - **冪等**: 既存ラベルは name / color / description ともに変更されません（既存値は保護）。
   色や説明を上書きしたい場合は手動で `bash .github/scripts/idd-claude-labels.sh --force`
+- **新ラベルの再 install 伝播 (#185)**: template にラベルが追加された後で `install.sh` を
+  再実行すると、最新の `idd-claude-labels.sh` が対象リポジトリへ再配置され、`setup_repo_labels`
+  が全ラベルをループして **未存在のラベルだけを新規作成**します（既存ラベルは skip）。
+  そのため `awaiting-slot` のような後から追加されたラベルも、再 install するだけで既存
+  リポジトリへ確実に伝播します（NFR 1.1 冪等性は維持され、既存ラベルの削除・改名・color 変更は
+  行われません）
 - **`--local` 単独時は走りません**: 対象リポジトリ配置がない場合はラベル処理も発生しません
 - **`--dry-run`**: 実 API 呼び出しせず、これから実行されるコマンドだけを表示します
 

--- a/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/check-label-parity.sh
+++ b/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/check-label-parity.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# 用途: root (.github/scripts/idd-claude-labels.sh) と template
+#       (repo-template/.github/scripts/idd-claude-labels.sh) の name|color 集合 parity 検証
+# 配置先: docs/specs/185-bug-labels-awaiting-slot-live-repo-root/check-label-parity.sh
+# 依存: bash 4+, grep (POSIX ERE), sort, diff
+# セットアップ参照先: docs/specs/185-bug-labels-awaiting-slot-live-repo-root/impl-notes.md
+#
+# 注意: このスクリプトは手動 / 将来の CI 化用の fixture であり、現時点では
+#       どの自動導線（install.sh / watcher / GitHub Actions）からも自動実行されない。
+#       parity の回帰を疑ったときに運用者が手動で実行する想定（NFR 2.1）。
+#
+# Usage:
+#   bash docs/specs/185-bug-labels-awaiting-slot-live-repo-root/check-label-parity.sh
+#
+# Exit code:
+#   0 = root と template の name|color 集合が完全一致（parity OK）
+#   1 = name|color 集合に差分あり（standard error に diff を出力）
+#   2 = 対象スクリプトが見つからない等の前提エラー
+
+set -euo pipefail
+
+# repo root を本スクリプトの位置（docs/specs/185-.../）から 3 階層上に解決する。
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../.." && pwd)
+
+ROOT_LABELS="$REPO_ROOT/.github/scripts/idd-claude-labels.sh"
+TEMPLATE_LABELS="$REPO_ROOT/repo-template/.github/scripts/idd-claude-labels.sh"
+
+# name|color ペアを抽出する正規表現（requirements.md NFR 2.1 / Issue 本文の検証コマンドと同一）。
+#   "<name>|<6 桁 hex color>|  形式の先頭部分のみを取り出し、description の差分は無視する。
+readonly PAIR_REGEX='"[a-z-]+\|[0-9a-f]{6}\|'
+
+for f in "$ROOT_LABELS" "$TEMPLATE_LABELS"; do
+  if [ ! -f "$f" ]; then
+    echo "Error: labels スクリプトが見つかりません: $f" >&2
+    exit 2
+  fi
+done
+
+# 差分を取得（一致すれば空文字列）。
+diff_output=""
+if ! diff_output=$(diff \
+  <(grep -oE "$PAIR_REGEX" "$ROOT_LABELS" | sort) \
+  <(grep -oE "$PAIR_REGEX" "$TEMPLATE_LABELS" | sort)); then
+  echo "Error: root と template の name|color 集合に差分があります（parity NG）:" >&2
+  printf '%s\n' "$diff_output" >&2
+  echo "" >&2
+  echo "  < root:     $ROOT_LABELS" >&2
+  echo "  > template: $TEMPLATE_LABELS" >&2
+  exit 1
+fi
+
+echo "OK: root と template の name|color 集合は完全一致しています（parity OK）"

--- a/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/impl-notes.md
+++ b/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/impl-notes.md
@@ -1,0 +1,127 @@
+# 実装ノート: #185 awaiting-slot ラベルの live repo root 同期
+
+## 概要
+
+self-hosting 運用中の idd-claude 本体 repo で、Phase E Path Overlap Checker が付与する
+`awaiting-slot` ラベルが root の labels スクリプトに存在せず、live repo でラベル作成
+スクリプトを実行しても delay 状態が可視化されなかった双方向ドリフトを解消する。本 spec の
+スコープは (1) root への additive 追加と root/template の name|color parity 回復、
+(2) install.sh 経由の冪等伝播の確認・明文化の 2 点。watcher フォールバック堅牢化（観点 3）は
+#187 に分離済みでスコープ外。
+
+## 実装した変更（ファイルごと）
+
+### 1. `.github/scripts/idd-claude-labels.sh`（fix(labels) c9c5316）
+
+- `LABELS=( ... )` 配列に `awaiting-slot|c5def5|【Issue 用】 hot file 競合予防で同サイクル
+  dispatch を見送り中（Phase E Path Overlap Checker が付与・除去）` を **additive** に追加。
+- 配置位置は template と揃え `st-failed` と `blocked` の間に挿入。
+- description は template の定義（既に #54 由来の `【Issue 用】` prefix を持つ）をそのまま流用。
+- **root の既存ラベル行は一切変更していない**（name / color / description とも不変。#54 regression 防止）。
+
+### 2. `docs/specs/185-.../check-label-parity.sh`（test(labels) 2d02082）
+
+- root と template の labels スクリプトから `"<name>|<6 桁 hex color>|` ペアを抽出して
+  sort + diff し、差分があれば非ゼロ exit + stderr に diff、一致すれば exit 0 を返す
+  standalone スクリプト。
+- #131 の `test-count.sh` パターンに倣い `docs/specs/<番号>-<slug>/` 配下に配置。
+- **このスクリプトは手動 / 将来の CI 化用の fixture であり、現時点ではどの自動導線
+  （install.sh / watcher / GitHub Actions）からも自動実行されない**（冒頭コメントに明記）。
+  consumer repo へ配布されないよう `.github/scripts` ではなく docs/specs 配下に置いた。
+
+### 3. `install.sh`（docs(install) 1f6cf3e）
+
+- `setup_repo_labels "$REPO_PATH"` 呼び出し箇所に、再 install 時に最新の
+  `idd-claude-labels.sh` が再配置され全 LABELS ループで未存在ラベルだけ新規作成される旨の
+  説明コメントを追加（**挙動変更なし・コメントのみ**）。
+
+### 4. `README.md`（docs(install) 1f6cf3e）
+
+- 「GitHub ラベルの自動セットアップ (#85)」節に「新ラベルの再 install 伝播 (#185)」の bullet を
+  追加。既存ラベルは skip され冪等性を維持する旨も明記。
+- なお `awaiting-slot` は README のラベル一覧表（line 462 付近）・手動 `gh label create` 例
+  （line 481 付近）・ラベル付与者一覧（line 900 付近）に既に記載済みだったため、追加記載は不要。
+
+## 追加ラベル定義（name / color / 初期挙動）
+
+| name | color | description | 初期挙動 |
+|---|---|---|---|
+| `awaiting-slot` | `c5def5` | 【Issue 用】 hot file 競合予防で同サイクル dispatch を見送り中（Phase E Path Overlap Checker が付与・除去） | root スクリプト実行時に未存在なら新規作成。既存なら skip（`--force` 時のみ更新）。Phase E Path Overlap Checker が付与・自動除去 |
+
+## install.sh 伝播導線の確認結果（Req 2）
+
+実態調査の結果、伝播導線は **既に main で完備されており不足は無い**（Req 2.4 の補強は不要）:
+
+- `install.sh:1142-1145` の `copy_template_file` が **template の** `idd-claude-labels.sh`
+  （`$REPO_TEMPLATE_DIR/.github/scripts/idd-claude-labels.sh`）を対象 repo へコピーする。
+  template は既に `awaiting-slot` を持つため、**consumer repo は再 install するだけで
+  `awaiting-slot` を取得できる**（本 spec 以前から成立）。
+- `install.sh:1196` の `setup_repo_labels "$REPO_PATH"` が配置済みスクリプトを `--repo` 付きで
+  起動し、`idd-claude-labels.sh` の `for spec in "${LABELS[@]}"` ループが未存在ラベルのみ
+  `gh label create`、既存ラベルは skip する（`--force` なし）。これにより冪等伝播が成立（Req 2.1 / 2.2 / NFR 1.1）。
+- 本 spec の root スクリプトへの `awaiting-slot` 追加は、**idd-claude 本体（self-hosting）の
+  live repo** で root スクリプトを直接実行した場合に `awaiting-slot` が作成されるようにする
+  ためのもの（root スクリプトは dogfooding 用の self コピー）。
+
+## 解釈・判断メモ
+
+- requirements.md のみ存在し design.md / tasks.md は無い（PM フェーズのみで Architect 未起動の
+  小規模 bug fix）。タスク順序はオーケストレーター指示の番号順で消化。
+- **NFR 2 / Open Question の判断**: parity 検証自動化手段は「standalone スクリプト追加 /
+  CI チェック追加 / 手動確認手順の文書化」の選択肢が委ねられていた。オーケストレーター判断に
+  従い **軽量な standalone parity スクリプトを docs/specs 配下に追加**する方針を採用（CI workflow は
+  automation surface を増やさないため追加しない）。スクリプトは手動 / 将来の CI 化用 fixture。
+- **root CLAUDE.md に `## Feature Flag Protocol` 節は無い** → opt-out として解釈し、通常フローで実装。
+- `local-watcher/` および `repo-template/**` は本 spec のスコープ外につき一切編集していない。
+
+## Test plan（実行コマンドと結果）
+
+| 検証 | コマンド | 結果 |
+|---|---|---|
+| name\|color parity diff | `diff <(grep -oE '"[a-z-]+\|[0-9a-f]{6}\|' .github/scripts/idd-claude-labels.sh \| sort) <(grep -oE '"[a-z-]+\|[0-9a-f]{6}\|' repo-template/.github/scripts/idd-claude-labels.sh \| sort)` | 差分ゼロ・exit 0（PARITY OK） |
+| labels スクリプト構文 | `bash -n .github/scripts/idd-claude-labels.sh` | syntax OK |
+| awaiting-slot 出現回数 | `grep -c '^  "awaiting-slot\|c5def5\|' .github/scripts/idd-claude-labels.sh` | 1（重複なし） |
+| shellcheck（labels + install） | `shellcheck .github/scripts/idd-claude-labels.sh install.sh` | exit 0（警告ゼロ） |
+| parity スクリプト happy path | `bash docs/specs/185-.../check-label-parity.sh` | exit 0（parity OK） |
+| parity スクリプト drift path | temp tree（root から awaiting-slot 除去）で実行 | exit 1 + stderr に diff 出力（期待どおり失敗検知） |
+| parity スクリプト shellcheck | `shellcheck docs/specs/185-.../check-label-parity.sh` | exit 0（警告ゼロ） |
+| install.sh 構文 | `bash -n install.sh` | syntax OK |
+| install.sh dry-run スモーク | `bash install.sh --repo /tmp/scratch --dry-run` | labels 配置 + `would run: bash .../idd-claude-labels.sh --repo owner/scratch` を表示・exit 0 |
+| install.sh opt-out 維持 | `bash install.sh --repo /tmp/scratch --dry-run --no-labels` | `SKIP [labels] opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS)` を出力（Req 3.3 / 3.5 不変） |
+
+actionlint は workflow YAML を変更していないため不要。labels スクリプトは live repo を変更
+しないよう直接実行はせず、`bash -n` + parity diff + dry-run スモークで検証した。
+
+## 受入基準カバレッジ（requirement ID → 担保手段）
+
+| AC | 担保手段 |
+|---|---|
+| 1.1（root スクリプトが awaiting-slot 作成を試みる） | root LABELS 配列への additive 追加（c9c5316）。awaiting-slot 出現回数 grep = 1 / dry-run スモークで `would run` 確認 |
+| 1.2（root/template の name+color parity） | parity diff コマンド = 差分ゼロ / `check-label-parity.sh` happy path exit 0 |
+| 1.3（additive のみ・既存ラベル不変） | `git diff main..HEAD -- .github/scripts/idd-claude-labels.sh` が 1 行追加のみ。既存行に変更なし |
+| 1.4（#54 prefix を温存・template 側 prefix 無しに合わせない） | root 既存ラベル行を一切変更していない。追加行も #54 prefix 付き description を採用 |
+| 1.5（parity は name+color 集合一致のみ判定・description 完全一致を要求しない） | `check-label-parity.sh` は `"<name>\|<color>\|` のみ抽出し description を比較対象外とする |
+| 2.1（再実行で未存在ラベルを作成） | install.sh の copy_template_file → setup_repo_labels → LABELS ループ導線確認。dry-run スモークで `would run` 確認 |
+| 2.2（既存ラベル skip・冪等） | `idd-claude-labels.sh` の `--force` なしパスが「already exists (skipped)」分岐。NFR 1 と同じ |
+| 2.3（伝播導線を README / install.sh コメントで明文化） | README「新ラベルの再 install 伝播 (#185)」bullet 追加 + install.sh コメント追加（1f6cf3e） |
+| 2.4（不足があれば補強） | 実態調査で導線は完備と確認。不足なしのため明文化のみ（Option A） |
+| 2.5（削除・改名・color 変更をしない） | install.sh は `--force` なしで起動（既存値保護）。本変更は additive のみ |
+| 3.1（既存ラベルの name/color 不変） | additive 追加のみ。parity diff で既存ペアに差分なし |
+| 3.2（--repo / --force の意味不変） | labels スクリプトの引数処理を変更していない |
+| 3.3（--no-labels / IDD_CLAUDE_SKIP_LABELS opt-out 不変） | dry-run --no-labels スモークで SKIP 出力を確認 |
+| 3.4（REPO 等 env var 名と exit code 意味不変） | install.sh / labels スクリプトの env var・exit code を変更していない |
+| 3.5（opt-out 時はラベル作成せず導入前と同一挙動） | dry-run --no-labels スモークで label 処理 skip を確認 |
+| NFR 1（2 回連続実行で 0 件作成・同一状態） | labels スクリプトの既存ラベル skip 分岐（`--force` なし）で担保。冪等性は導線で確認 |
+| NFR 2.1（parity 検証手段が差分を検出し非ゼロ件で失敗報告） | `check-label-parity.sh` drift path で exit 1 + stderr diff を確認 |
+| NFR 2.2（自動化要否を Open Questions に委ねる旨明示） | requirements.md の Open Questions に明示済み。本実装で standalone スクリプト採用を選択し本ノートに判断を記録 |
+| NFR 3（挙動変更時に README を同一変更内で更新） | README の自動セットアップ節を同一変更（1f6cf3e）で更新 |
+
+## 確認事項
+
+なし。
+
+- requirements.md と実装の間に矛盾は検出されなかった。
+- design.md / tasks.md は存在せず（小規模 bug fix のため PM フェーズのみ）、書き換え対象は無い。
+- スコープ境界（`local-watcher/` 不編集・`repo-template/**` 不編集）を遵守した。
+
+STATUS: complete

--- a/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/requirements.md
+++ b/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/requirements.md
@@ -1,0 +1,75 @@
+# Requirements Document
+
+## Introduction
+
+self-hosting 運用中の idd-claude 本体 repo では、Phase E Path Overlap Checker が delay 状態の Issue に付与する `awaiting-slot` ラベルが live repo に存在せず、delay 状態が運用者に不可視になっていた。原因はラベル定義スクリプトの **双方向ドリフト**にある。template 側 (`repo-template/.github/scripts/idd-claude-labels.sh`) には `awaiting-slot` 定義があるが root コピー (`.github/scripts/idd-claude-labels.sh`) には無く、逆に root の一部ラベルには #54 由来の description prefix（`【Issue 用】` / `【PR 用】`）が付いているが template 側には付いていない。さらに、template にラベルを追加しても既 install 済みの repo に自動伝播しない伝播ギャップがある。本 spec はこの 2 観点（root 同期・install.sh 経由の冪等伝播）を扱い、ラベル parity を name+color 集合レベルで担保する。watcher のフォールバック堅牢化（受入観点 3）は #187 に分離済みでスコープ外とする。
+
+## Requirements
+
+### Requirement 1: root labels スクリプトへの `awaiting-slot` 追加と root/template parity
+
+**Objective:** As a 運用者, I want root の labels スクリプトが `awaiting-slot` を含み template と同じラベル集合を定義していること, so that live repo でラベル作成スクリプトを実行したときに delay 状態が可視化される
+
+#### Acceptance Criteria
+
+1. When 運用者が root の labels スクリプトを実行したとき, the Labels Setup Script shall `awaiting-slot` ラベル（name=`awaiting-slot`, color=`c5def5`）を含むラベル一式の作成を試みる
+2. The Labels Setup Script shall root と template の両 labels スクリプトについて name+color のペア集合が一致すること（name|color レベルの parity）を満たす
+3. When root への `awaiting-slot` 追加を行うとき, the 修正 shall additive（ラベルの新規追加のみ）であり、root に既存の他ラベルの name / color / description を変更しない
+4. While root の既存ラベルが #54 由来の description prefix（`【Issue 用】` / `【PR 用】`）を保持している状態で, the 修正 shall root の description を template 側（prefix 無し）に合わせる書き換えを行わず、#54 の prefix を温存する
+5. The parity 判定 shall description の完全一致を要求せず、name と color の集合一致のみを判定対象とする
+
+### Requirement 2: install.sh 経由の新ラベルの冪等伝播
+
+**Objective:** As a 既に idd-claude を install 済みの運用者, I want install.sh を再実行したときに `awaiting-slot` を含む新規ラベルが既存 repo へ確実に伝播すること, so that template にラベルが追加された後も再 install するだけで live repo のラベル集合が最新化される
+
+#### Acceptance Criteria
+
+1. When 運用者が install.sh を再実行したとき, the Install Script shall 配置済み labels スクリプトを対象 repo に対して起動し、未存在のラベル（`awaiting-slot` を含む）を作成する
+2. While install.sh が既存ラベルを検出している状態で, the Labels Setup Script shall 当該ラベルを skip し、その name / color / description を変更しない（冪等な再実行）
+3. Where install.sh のラベル自動伝播導線がすでに存在する, the spec deliverable shall その導線が `awaiting-slot` を含む新規ラベルを伝播することを README または install.sh 内コメントで明文化する
+4. If install.sh 再実行時の伝播導線に不足が判明したとき, the Install Script shall その不足を補う変更を加え、新規ラベルが伝播するようにする
+5. While install.sh の再実行を行っている状態で, the Install Script shall 既存ラベルの削除・改名・color 変更を一切行わない
+
+### Requirement 3: 後方互換性の維持
+
+**Objective:** As a 既存運用者, I want 本修正が既存の env var / exit code / ラベル名 / CLI interface を不変に保つこと, so that 既稼働の install / cron / labels 運用が壊れない
+
+#### Acceptance Criteria
+
+1. The Labels Setup Script shall 既存ラベルの name と color を不変に保つ（追加のみ・削除や改名をしない）
+2. The Labels Setup Script shall `--repo` / `--force` の CLI オプションの意味と挙動を変更しない
+3. The Install Script shall `--no-labels` フラグおよび `IDD_CLAUDE_SKIP_LABELS` 環境変数の opt-out 挙動を変更しない
+4. The Install Script shall `REPO` を含む既存 env var 名と、ラベルセットアップ関連の exit code の意味を変更しない
+5. While 運用者が opt-out（`--no-labels` / `IDD_CLAUDE_SKIP_LABELS`）を指定している状態で, the Install Script shall ラベル作成を実行せず、本機能導入前と同一の挙動を保つ
+
+## Non-Functional Requirements
+
+### NFR 1: 冪等性
+
+1. When labels スクリプトまたは install.sh のラベル導線を 2 回連続で実行したとき, the system shall 2 回目の実行で既存ラベルを 0 件作成し、ラベル集合を 1 回目と同一状態に保つ
+
+### NFR 2: parity 検証の自動化（should レベル）
+
+1. Where parity 検証の自動化が含まれる, the parity 検証手段 shall root と template の name|color 集合の差分を検出して非ゼロ件の差分があれば失敗を報告する
+2. The parity 検証手段の要否判断 shall requirements 確定時点で「standalone スクリプト / CI チェックを追加するか、手動確認手順の文書化に留めるか」を Open Questions または設計判断に委ねる形で明示する
+
+### NFR 3: ドキュメント整合性
+
+1. When ラベル集合または伝播導線の挙動を変更したとき, the deliverable shall README の該当箇所を同一変更内で更新する
+
+## Out of Scope
+
+- watcher フォールバック堅牢化（受入観点 3、`local-watcher/bin/issue-watcher.sh` の編集。ラベル付与失敗時の説明 sticky comment 投稿）は #187 に分離済みのため本 spec では扱わない
+- root の既存ラベルの description を template 側に合わせる方向の同期（#54 を regression させるため明示的に禁止）
+- template 側へ #54 の description prefix を追記する作業（本 spec は root への additive 追加のみを対象とし、template 側 prefix の retrofit は別判断とする）
+- 既存ラベルの削除・改名・color 変更
+- 新規外部サービス連携やラベル動的変更機構の追加
+- `#177` / `#180` / `#181` のモジュール化作業そのもの（path conflict 回避の調整は運用上配慮するが、本 spec の成果物には含めない）
+
+## Open Questions
+
+- NFR 2.2 の parity 検証自動化について、Issue 本文では「検討」（should レベル）とされている。standalone スクリプト追加 / CI チェック追加 / 手動確認手順の文書化のいずれを採るかは Architect / 人間判断に委ねる（本 spec は parity を name|color 集合レベルで担保することのみを必須とし、自動化手段は選択肢として残す）。
+
+## 関連
+
+- Related: #187

--- a/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/review-notes.md
+++ b/docs/specs/185-bug-labels-awaiting-slot-live-repo-root/review-notes.md
@@ -1,0 +1,59 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-24T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-185-impl-bug-labels-awaiting-slot-live-repo-root
+- HEAD commit: 4ddb072a7318b049d5d0d4a37d28bb98efddbb46
+- Compared to: main..HEAD
+
+差分構成（`git diff --stat main..HEAD`）:
+
+- `.github/scripts/idd-claude-labels.sh`（+1 / additive のみ）
+- `install.sh`（+4 / コメントのみ）
+- `README.md`（+6 / ドキュメント追記）
+- `docs/specs/185-.../check-label-parity.sh`（+53 / 新規 standalone parity スクリプト）
+- `docs/specs/185-.../requirements.md` / `impl-notes.md`（spec 成果物）
+
+design.md / tasks.md は存在しない（PM フェーズのみの小規模 bug fix。Architect 未起動）。
+そのため `_Boundary:_` アノテーションは無く、boundary 判定は requirements.md の
+Out of Scope（`local-watcher/` 不編集・`repo-template/**` 不編集）を境界として代用した。
+
+CLAUDE.md に `## Feature Flag Protocol` 節は存在しない → opt-out 解釈 → flag 観点の確認は
+行わず、通常の 3 カテゴリ判定のみを適用した。
+
+## Verified Requirements
+
+- 1.1 — `.github/scripts/idd-claude-labels.sh:78` に `awaiting-slot|c5def5|...` を additive 追加。`grep awaiting-slot` で root に 1 行存在を確認
+- 1.2 — root/template の name|color 集合 parity を独立に再現確認（`diff <(grep -oE '"[a-z-]+\|[0-9a-f]{6}\|' root) <(... template)` が exit 0）。`check-label-parity.sh` happy path も exit 0
+- 1.3 — `git diff main..HEAD -- .github/scripts/idd-claude-labels.sh` が 1 行追加のみで削除・変更ゼロ。既存ラベル行の name/color/description は不変
+- 1.4 — 追加行は template と同一の `【Issue 用】` #54 prefix 付き description を採用。root 既存ラベルの description 書き換えは無し（#54 prefix 温存）
+- 1.5 — `check-label-parity.sh` の PAIR_REGEX `"[a-z-]+\|[0-9a-f]{6}\|` が name|color のみ抽出し description を比較対象外とすることをコード読みで確認
+- 2.1 — `install.sh:1144` `copy_template_file` が template の labels スクリプトを再配置、`install.sh:1200` `setup_repo_labels "$REPO_PATH"` が起動する導線をコードで確認（template は既に awaiting-slot を持つため再 install で伝播）
+- 2.2 — `idd-claude-labels.sh:131` の `--force` なし `gh label create` が失敗時に `already exists (skipped)` 分岐へ落ちる冪等パスを確認
+- 2.3 — `install.sh:1196-1199` にコメント追記、README「新ラベルの再 install 伝播 (#185)」bullet 追加を diff で確認
+- 2.4 — 既存導線が完備のため documentation のみで補強（Open Question で委ねられた範囲内の妥当判断）
+- 2.5 — install.sh は `--force` なしで setup_repo_labels を起動、本変更は additive のみで削除・改名・color 変更なし
+- 3.1 — additive 追加のみ。parity diff で既存ペアに差分なし
+- 3.2 — labels スクリプトの引数処理（`--repo` / `--force`）に diff なし
+- 3.3 — `install.sh:619-621` の `--no-labels` / `IDD_CLAUDE_SKIP_LABELS` opt-out 分岐に diff なし
+- 3.4 — install.sh / labels スクリプトの env var 名・exit code に diff なし
+- 3.5 — opt-out 分岐は不変のため導入前と同一挙動を維持
+- NFR 1 — `--force` なしの既存ラベル skip 分岐により 2 回連続実行で 0 件作成・同一状態を担保
+- NFR 2.1 — `check-label-parity.sh` drift path（root から awaiting-slot 除去した temp tree）で exit 1 + stderr に diff 出力を独立に再現確認
+- NFR 2.2 — requirements.md Open Questions に自動化要否の委譲を明示。standalone スクリプト採用を impl-notes.md に記録
+- NFR 3 — README 該当節を同一変更（1f6cf3e）で更新
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（Req 1.x / 2.x / 3.x）および NFR 1 / 2.1 / 2.2 / 3 が、観測可能な実装と検証手段で
+カバーされている。root への `awaiting-slot` 追加は additive のみで既存ラベル不変、root/template の
+name|color parity は独立再現で exit 0、parity 検証スクリプトは happy/drift 双方で期待どおり動作。
+boundary（`local-watcher/` / `repo-template/**` 不編集）も diff stat で遵守を確認。reject 対象なし。
+
+RESULT: approve

--- a/install.sh
+++ b/install.sh
@@ -1193,6 +1193,10 @@ CLAUDE_MD_ORG_HINT
   #   - 配置完了直後にラベルを冪等作成して、初回 cron で claim ラベル付与に
   #     失敗しないようにする
   #   - fail-soft: 失敗・skip しても install 全体は exit 0 で完走する
+  #   - 新ラベルの再 install 伝播（Issue #185）: 直前の copy_template_file で最新の
+  #     idd-claude-labels.sh が再配置されるため、template にラベルが追加された後に
+  #     install.sh を再実行すると setup_repo_labels が全 LABELS をループし、未存在の
+  #     ラベル（awaiting-slot 等）だけを新規作成する。既存ラベルは skip され冪等性を保つ。
   setup_repo_labels "$REPO_PATH"
 
   # 履歴持ち込みの検出と警告（Issue #115）


### PR DESCRIPTION
## 概要

self-hosting 運用中の idd-claude 本体 repo で、Phase E Path Overlap Checker が delay 状態の Issue に付与する `awaiting-slot` ラベルが live repo に存在せず、delay 状態が運用者に不可視になっていた双方向ドリフトを解消する。

root の labels スクリプト（`.github/scripts/idd-claude-labels.sh`）に `awaiting-slot`（name=`awaiting-slot`, color=`c5def5`）を additive に追加し、root/template 間の name|color parity を回復した。install.sh 経由の冪等伝播は既存導線で完備されていることを確認し、README および install.sh コメントで明文化した。parity 継続確認用の standalone スクリプト（`check-label-parity.sh`）も `docs/specs/` 配下に追加した。

## 対応 Issue

Closes #185

## 関連 PR

- 設計 PR: なし（PM フェーズのみの小規模 bug fix。Architect 未起動）

## 実装内容

- (Req 1.1 / 1.2 / 1.3 / 1.4 / 1.5) `.github/scripts/idd-claude-labels.sh` に `awaiting-slot|c5def5|【Issue 用】...` を additive 追加し、root/template の name|color parity を回復（既存ラベルの name / color / description は不変）
- (Req 2.3 / NFR 3) install.sh の再 install 伝播導線を README「新ラベルの再 install 伝播 (#185)」bullet および install.sh 内コメントで明文化（挙動変更なし・ドキュメント追加のみ）
- (NFR 2.1) `docs/specs/185-bug-labels-awaiting-slot-live-repo-root/check-label-parity.sh` を追加: root と template の name|color 集合 diff を出力し、差分あれば exit 1 で失敗通知する standalone 検証スクリプト

## 受入基準チェック

- [x] Req 1.1: When 運用者が root の labels スクリプトを実行したとき, the Labels Setup Script shall `awaiting-slot` を含むラベル一式の作成を試みる ← root LABELS 配列への additive 追加（c9c5316）。parity diff + dry-run スモークで確認
- [x] Req 1.2: The Labels Setup Script shall root と template の両 labels スクリプトについて name+color parity を満たす ← `diff <(grep -oE '"[a-z-]+\|[0-9a-f]{6}\|' root) <(... template)` exit 0・`check-label-parity.sh` happy path exit 0
- [x] Req 1.3: When root への追加を行うとき, the 修正 shall additive のみで既存ラベル不変 ← `git diff main..HEAD` が 1 行追加のみ
- [x] Req 1.4: While root 既存ラベルが #54 由来 prefix を保持している状態で, the 修正 shall root の description を書き換えない ← root 既存行に変更なし。追加行も #54 prefix 付き description を採用
- [x] Req 1.5: The parity 判定 shall description 完全一致を要求せず、name と color の集合一致のみを判定対象とする ← `check-label-parity.sh` が `"<name>|<color>|` のみ抽出
- [x] Req 2.1-2.5: install.sh 伝播導線の確認・明文化 ← 既存導線（copy_template_file → setup_repo_labels）が完備。README + install.sh コメント追加で明文化
- [x] Req 3.1-3.5: 後方互換性の維持 ← env var・exit code・CLI オプション・opt-out 挙動に変更なし
- [x] NFR 1: 冪等性 ← `--force` なし起動で既存ラベル skip 分岐が機能
- [x] NFR 2.1: parity 検証スクリプトが差分検出・非ゼロ exit ← drift path で exit 1 + stderr diff を確認
- [x] NFR 3: 挙動変更時に README を同一変更内で更新 ← 1f6cf3e で同時更新

## テスト結果

```
# name|color parity diff
diff <(grep -oE '"[a-z-]+\|[0-9a-f]{6}\|' .github/scripts/idd-claude-labels.sh | sort) \
     <(grep -oE '"[a-z-]+\|[0-9a-f]{6}\|' repo-template/.github/scripts/idd-claude-labels.sh | sort)
→ 差分ゼロ・exit 0（PARITY OK）

# labels スクリプト構文
bash -n .github/scripts/idd-claude-labels.sh
→ syntax OK

# shellcheck（labels + install）
shellcheck .github/scripts/idd-claude-labels.sh install.sh
→ exit 0（警告ゼロ）

# parity スクリプト happy path
bash docs/specs/185-.../check-label-parity.sh
→ exit 0（parity OK）

# parity スクリプト drift path（root から awaiting-slot を除去した temp tree）
→ exit 1 + stderr に diff 出力（期待どおり失敗検知）

# parity スクリプト shellcheck
shellcheck docs/specs/185-.../check-label-parity.sh
→ exit 0（警告ゼロ）

# install.sh dry-run スモーク
bash install.sh --repo /tmp/scratch --dry-run
→ labels 配置 + would run: bash .../idd-claude-labels.sh --repo owner/scratch を表示・exit 0

# install.sh opt-out 維持
bash install.sh --repo /tmp/scratch --dry-run --no-labels
→ SKIP [labels] opt-out (--no-labels / IDD_CLAUDE_SKIP_LABELS) を出力（Req 3.3 / 3.5 不変）
```

## 実装上の判断

- install.sh 伝播導線は既に完備（copy_template_file → setup_repo_labels の 2 段階）。本 spec で Req 2.4 の補強は不要であり、明文化（ドキュメント追加のみ）を選択した
- NFR 2 の parity 検証自動化手段は「standalone スクリプト追加 / CI チェック追加 / 手動確認手順」から選択を委ねられていた。CI workflow 追加は automation surface を増やすため採用せず、`docs/specs/` 配下への standalone スクリプト追加を選択（`#131` の `test-count.sh` パターンに倣う）
- root の既存ラベル description は #54 由来の `【Issue 用】` / `【PR 用】` prefix を保持したまま温存。追加した `awaiting-slot` も同 prefix を採用し、template との description 差分を意図的に維持する

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: `gh pr view <PR番号> --json baseRefName --jq '.baseRefName'` で `main` を確認（PR 作成後に記録）
- Reviewer 判定は `docs/specs/185-bug-labels-awaiting-slot-live-repo-root/review-notes.md` を参照（RESULT: approve）
- watcher フォールバック堅牢化（ラベル付与失敗時の sticky comment 等）は #187 に分離済みでスコープ外

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #185 のコメントを参照してください。