### PR TITLE
fix(watcher): #177 Part 1 のモジュールローダ配線と install.sh modules 配置を追加し壊れた main を復旧

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,9 +502,12 @@ gh api -X PUT repos/owner/repo/branches/main/protection \
 
 ```bash
 # 手動の場合
-mkdir -p ~/bin ~/.issue-watcher/logs
+mkdir -p ~/bin ~/bin/modules ~/.issue-watcher/logs
 cp ~/.idd-claude/local-watcher/bin/issue-watcher.sh  ~/bin/
 cp ~/.idd-claude/local-watcher/bin/triage-prompt.tmpl ~/bin/
+# モジュール（#177 Part 1 以降）: issue-watcher.sh は同階層 modules/ から
+# core_utils.sh 等を source する。欠落すると起動時に exit 1 で停止するため必ずコピーする。
+cp ~/.idd-claude/local-watcher/bin/modules/*.sh ~/bin/modules/
 chmod +x ~/bin/issue-watcher.sh
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1224,6 +1224,15 @@ if $INSTALL_LOCAL; then
   copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.sh"   "$HOME/bin" --executable
   copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin" "*.tmpl" "$HOME/bin"
 
+  # local-watcher/bin/modules/ 配下の *.sh を $HOME/bin/modules/ へ配置（#177 Part 1）。
+  # issue-watcher.sh の動的モジュールローダ（REQUIRED_MODULES）が同階層 modules/ を source する。
+  # 必須モジュール（core_utils.sh 等）が欠落すると watcher は起動時に exit 1 で停止するため、
+  # 本体 *.sh と同じタイミングで冪等配置する。新規モジュール追加時も install.sh 改修は不要。
+  if [ -d "$LOCAL_WATCHER_DIR/bin/modules" ]; then
+    ensure_dir "$HOME/bin/modules"
+    copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin/modules" "*.sh" "$HOME/bin/modules" --executable
+  fi
+
   # macOS: launchd
   if [ "$(uname)" = "Darwin" ]; then
     ensure_dir "$HOME/Library/LaunchAgents"

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -473,6 +473,28 @@ command -v timeout >/dev/null 2>&1 || {
   exit 1
 }
 
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# モジュール動的ロード基盤（#177 Part 1）
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 本体と同階層の modules/ から必須モジュール（低レベル共通ユーティリティ等）を source する。
+# install.sh が local-watcher/bin/modules/ → $HOME/bin/modules/ に配置する。
+# 必須モジュールが欠落していたら、復旧手順を添えて exit 1 で安全停止する（silent fail を作らない）。
+# 配置先解決は $HOME 直書きせず BASH_SOURCE 基準にし、開発 repo 直実行（local-watcher/bin/）と
+# インストール後（$HOME/bin/）の双方で同一ロジックが効くようにする。
+IDD_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/modules"
+REQUIRED_MODULES=( "core_utils.sh" )
+for _idd_mod in "${REQUIRED_MODULES[@]}"; do
+  _idd_mod_path="$IDD_MODULE_DIR/$_idd_mod"
+  if [ ! -f "$_idd_mod_path" ]; then
+    echo "Error: 必須モジュールが見つかりません: $_idd_mod_path" >&2
+    echo "  install.sh --local を再実行して modules/ を配置してください。" >&2
+    exit 1
+  fi
+  # shellcheck source=/dev/null
+  . "$_idd_mod_path"
+done
+unset _idd_mod _idd_mod_path
+
 [ -f "$TRIAGE_TEMPLATE" ] || {
   echo "Error: Triage テンプレートが見つかりません: $TRIAGE_TEMPLATE" >&2
   exit 1

--- a/local-watcher/test/qa_run_claude_stage_test.sh
+++ b/local-watcher/test/qa_run_claude_stage_test.sh
@@ -28,10 +28,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+# #177 Part 1 で低レベル共通ユーティリティ（qa_log 等のロガーを含む）は
+# modules/core_utils.sh へ分離された。関数抽出の探索元に core_utils.sh も含める。
+CORE_UTILS_SH="$SCRIPT_DIR/../bin/modules/core_utils.sh"
 FIXTURE_DIR="$SCRIPT_DIR/fixtures/qa_detect_rate_limit"
 
 if [ ! -f "$WATCHER_SH" ]; then
   echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+if [ ! -f "$CORE_UTILS_SH" ]; then
+  echo "ERROR: cannot find core_utils.sh at $CORE_UTILS_SH" >&2
   exit 2
 fi
 
@@ -49,7 +56,7 @@ extract_function() {
     $0 == fn { in_fn = 1 }
     in_fn { print }
     in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
+  ' "$script" "$CORE_UTILS_SH"
 }
 
 # qa_log / qa_warn / qa_error は qa_run_claude_stage が呼ぶので必ず loaded する

--- a/local-watcher/test/repo_prefix_log_test.sh
+++ b/local-watcher/test/repo_prefix_log_test.sh
@@ -29,9 +29,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+# #177 Part 1 で低レベル共通ユーティリティ（qa_log 等のロガーを含む）は
+# modules/core_utils.sh へ分離された。関数抽出の探索元に core_utils.sh も含める。
+CORE_UTILS_SH="$SCRIPT_DIR/../bin/modules/core_utils.sh"
 
 if [ ! -f "$WATCHER_SH" ]; then
   echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+if [ ! -f "$CORE_UTILS_SH" ]; then
+  echo "ERROR: cannot find core_utils.sh at $CORE_UTILS_SH" >&2
   exit 2
 fi
 
@@ -43,7 +50,7 @@ extract_function() {
     $0 == fn { in_fn = 1 }
     in_fn { print }
     in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
+  ' "$script" "$CORE_UTILS_SH"
 }
 
 # テスト用に REPO を固定値で上書き（cron 起動時の `REPO=owner/your-repo` を模倣）

--- a/local-watcher/test/verify_pushed_or_retry_test.sh
+++ b/local-watcher/test/verify_pushed_or_retry_test.sh
@@ -27,9 +27,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+# #177 Part 1 で低レベル共通ユーティリティ（qa_log 等のロガーを含む）は
+# modules/core_utils.sh へ分離された。関数抽出の探索元に core_utils.sh も含める。
+CORE_UTILS_SH="$SCRIPT_DIR/../bin/modules/core_utils.sh"
 
 if [ ! -f "$WATCHER_SH" ]; then
   echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+if [ ! -f "$CORE_UTILS_SH" ]; then
+  echo "ERROR: cannot find core_utils.sh at $CORE_UTILS_SH" >&2
   exit 2
 fi
 
@@ -42,7 +49,7 @@ extract_function() {
     $0 == fn { in_fn = 1 }
     in_fn { print }
     in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
+  ' "$script" "$CORE_UTILS_SH"
 }
 
 # qa_log / qa_warn / qa_error は verify_pushed_or_retry 内部で呼ばれる


### PR DESCRIPTION
## 背景 / 動機

#177 Part 1（PR #189）は per-task ループの **task 1（core_utils.sh への関数切り出し）のみ完了した中間状態**で merge され、**task 2（source 配線）/ task 3（install.sh modules 配置）が欠落**したまま main に入っていました。

その結果、現 main の `local-watcher/bin/issue-watcher.sh` は `_slot_acquire` / `_worktree_reset` / `_hook_invoke` 等が**未定義**となり、実行すると:
- `_slot_acquire` が 127 → どの slot も取得できず「全 slot ロック中」で何も処理しない
- `_worktree_reset` が 127 → 全 Issue が `worktree-reset` 失敗で `claude-failed` 化

つまり **main の watcher は機能停止状態**でした（稼働中の installed 旧版 monolithic は無事だったため live 影響はなし）。

本 PR は欠落していた配線を補完し、main を動作する状態へ復旧します。

## 変更内容

| commit | 内容 | 対応 task |
|---|---|---|
| `fix(watcher)` | issue-watcher.sh に動的モジュールローダを追加（BASH_SOURCE 基準で同階層 `modules/` から `REQUIRED_MODULES` を source、欠落時は復旧手順付き exit 1） | #177 task 2 |
| `fix(install)` | install.sh に `modules/*.sh` → `$HOME/bin/modules/` の冪等配置を追加 | #177 task 3 |
| `test(watcher)` | 関数抽出テスト 3 件の awk 探索元に `core_utils.sh` を追加 | #177 task 4 |
| `docs(readme)` | 手動インストール手順に `modules/` コピーを追記 | #177 task 6（一部） |

## Test plan（手動スモークテスト）

- ✅ `bash -n` : issue-watcher.sh / core_utils.sh / install.sh いずれも OK
- ✅ `shellcheck -S warning` : 変更ファイル全て警告ゼロ
- ✅ **ローダ成功**: core_utils.sh を source して `_worktree_reset` / `_hook_invoke` / `_slot_acquire` / `_slot_release` / `_worktree_ensure` / `_worktree_path` / `qa_format_iso8601` が全て `declare -F` で解決
- ✅ **欠落ガード**: `modules/` 不在の状態で起動 → exit 1 + 「必須モジュールが見つかりません」+「install.sh --local を再実行」を出力
- ✅ `install.sh --local --dry-run` : `NEW ~/bin/modules/core_utils.sh (chmod +x)` と `OVERWRITE ~/bin/issue-watcher.sh` が計画される
- ✅ テストスイート: 12 件中 **11 pass**（修正前は 9 pass）。`repo_prefix_log_test` / `verify_pushed_or_retry_test` が復帰

## 確認事項（レビュワー判断ポイント）

1. **ローダ配置位置**: 前提ツールチェック直後（config 定数定義後）。core_utils.sh の関数はランタイム（dispatcher）でのみ呼ばれ、source は定義のみ行うため位置は安全。要確認。
2. **`qa_run_claude_stage_test.sh` は依然 FAIL**: ただし**分割前 commit `0d6066d`（現在 installed されている稼働版）でも同じく FAIL** することを確認済み。これは #177 のモジュール分割とは無関係の既存問題（`run_case` 内で die、環境依存の疑い）であり、本 PR のスコープ外。本 PR はロード段階を分割前と同一状態に復元するに留める。別途切り分けが必要なら follow-up issue 化を推奨。
3. **後方互換性**: env var / exit code / ラベル契約は不変。modules 配置は冪等・追加のみ。installed 旧版からの移行は `install.sh --local` 再実行（または README 手動手順）で modules/ が配置される。
4. **デプロイ注意**: 本 PR merge 後、稼働 watcher を最新化するには `install.sh --local` 再実行が必要（issue-watcher.sh と modules/core_utils.sh の両方が配置される）。稼働中プロセスへの上書き競合を避け、watcher idle 時に実施すること。

## 関連

- 原因の per-task ループ defect（中間状態の premature merge を許す問題）は別 issue で起票予定
- 関連: #177（Part1, PR #189 merged）/ #189 が本 regression の混入元