### PR TITLE
docs(watcher): #112 で反転したフラグの stale な「opt-in」コメントを是正

### DIFF
--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -500,8 +500,9 @@ unset _idd_mod _idd_mod_path
   exit 1
 }
 
-# PR Iteration が有効化されている時のみ template の存在を必須化（opt-in gate）。
-# 無効化（既定）時は template 未配置でも watcher 全体を起動できるよう、無条件チェックを避ける。
+# PR Iteration が有効化されている時のみ template の存在を必須化する（#112 以降デフォルト有効）。
+# 明示的に無効化（PR_ITERATION_ENABLED=false）した場合は template 未配置でも watcher 全体を
+# 起動できるよう、無条件チェックを避ける。
 if [ "$PR_ITERATION_ENABLED" = "true" ] && [ ! -f "$ITERATION_TEMPLATE" ]; then
   echo "Error: Iteration テンプレートが見つかりません: $ITERATION_TEMPLATE" >&2
   echo "  install.sh --local 再実行で配置されます。" >&2
@@ -2225,7 +2226,7 @@ mqr_error() {
 }
 
 process_merge_queue_recheck() {
-  # AC 1.2 / 1.3 / 3.1 / 3.3: opt-in gate（MERGE_QUEUE_ENABLED とは独立）
+  # AC 1.2 / 1.3 / 3.1 / 3.3: opt-out gate（#112 以降デフォルト有効 / MERGE_QUEUE_ENABLED とは独立）
   if [ "$MERGE_QUEUE_RECHECK_ENABLED" != "true" ]; then
     return 0
   fi
@@ -3689,8 +3690,8 @@ pi_fetch_candidate_prs() {
 
   # AC 1.2 / 1.3 / 1.4: クライアント側フィルタ（server filter の保険 + head pattern + fork 除外）
   # #35 AC 4.4 / 5.1: design pattern は PR_ITERATION_DESIGN_ENABLED=true のときのみ OR 条件に
-  # 含める。false（既定）なら impl pattern のみで絞り込み、設計 PR は candidate 段階で除外される
-  # （= 本機能導入前と完全同一の挙動）。
+  # 含める。#112 以降デフォルトは true。明示的に false を渡した場合のみ impl pattern だけで
+  # 絞り込み、設計 PR は candidate 段階で除外される（= 設計 PR 拡張 #35 導入前と同一の挙動）。
   echo "$prs_json" | jq \
     --arg impl_pattern "$PR_ITERATION_HEAD_PATTERN" \
     --arg design_pattern "$PR_ITERATION_DESIGN_HEAD_PATTERN" \
@@ -5026,7 +5027,7 @@ pi_run_iteration() {
 #   AC 1.6, 2.1, 2.2, 8.5, 9.1, 9.3, NFR 1.2, NFR 2.3
 # ─────────────────────────────────────────────────────────────────────────────
 process_pr_iteration() {
-  # AC 2.1: opt-in gate
+  # AC 2.1: opt-out gate（#112 以降デフォルト有効。PR_ITERATION_ENABLED=false で無効化）
   if [ "$PR_ITERATION_ENABLED" != "true" ]; then
     return 0
   fi
@@ -5292,7 +5293,7 @@ EOF
 # 設計 PR が merged なら ラベル除去 + コメント投稿を順次実行する。
 # AC 1.1 / 1.4 / 2.1 / 2.7 / 4.1 / 4.4 / 4.5 / 5.2 / 5.5 / 6.1 / 6.2 / 6.3 / 7.5
 process_design_review_release() {
-  # AC 1.1 / 1.4 / 7.5: opt-in gate（無効化時は完全スキップ）
+  # AC 1.1 / 1.4 / 7.5: opt-out gate（#112 以降デフォルト有効。無効化時は完全スキップ）
   if [ "$DESIGN_REVIEW_RELEASE_ENABLED" != "true" ]; then
     return 0
   fi


### PR DESCRIPTION
## 背景

`design iteration が効かない` 調査の中で、`PR_ITERATION_DESIGN_ENABLED` の候補フィルタコメントが「`false（既定）`」と書かれているのに実装は `:-true`（#112 で反転）だった、というコメント↔実装の矛盾を発見。横展開で監査したところ、**#112 で opt-in → デフォルト有効へ反転した 8 フラグのうち、ガード/フィルタ直前のインラインコメントが旧 opt-in 表記のまま取り残されている箇所が複数**ありました。

定義ヘッダ（`# 標準機能としてデフォルト有効化（#112）...`）と README は更新済みでしたが、**ガード行直前の一言コメント**が更新漏れでした。

## 監査結果

| 状態 | 箇所 |
|---|---|
| ✅ 既に正しい | `MERGE_QUEUE_ENABLED`（`opt-out gate`）/ `QUOTA_AWARE_ENABLED`（`opt-out:`）/ `STAGE_CHECKPOINT_ENABLED`・`IMPL_RESUME_PRESERVE_COMMITS`（`=true（既定）`） |
| 🔧 本 PR で是正（stale） | 下記 5 箇所 |
| ⏭️ 据え置き（真に opt-in = 既定 false） | `PROMOTE_PIPELINE_ENABLED` / `AUTO_REBASE_MODE` / `PATH_OVERLAP_CHECK` / `PER_TASK_LOOP_ENABLED` / `DEBUGGER_ENABLED` |

### 是正した 5 箇所（コメントのみ）

1. `PR_ITERATION_ENABLED` — template 必須化コメント（「opt-in gate / 無効化（既定）」）
2. `PR_ITERATION_ENABLED` — `process_pr_iteration` ガード（「opt-in gate」）
3. `MERGE_QUEUE_RECHECK_ENABLED` — `process_merge_queue_recheck` ガード（「opt-in gate」）
4. `PR_ITERATION_DESIGN_ENABLED` — 候補フィルタ（「false（既定）」）
5. `DESIGN_REVIEW_RELEASE_ENABLED` — `process_design_review_release` ガード（「opt-in gate」）

いずれも `MERGE_QUEUE_ENABLED` の `opt-out gate` 表記に揃え、`#112 以降デフォルト有効` を明記。

## Test plan

- ✅ 変更は **全てコメント行のみ**（`git diff` の +/- が全て `#` 始まり、ロジック不変）
- ✅ `bash -n` OK / `shellcheck -S warning` 警告ゼロ
- ✅ 残存 `opt-in gate` 3 件は真に opt-in な機能（PROMOTE/AUTO_REBASE/PATH_OVERLAP）であることを確認

## 確認事項（レビュワー判断ポイント）

1. **据え置き判断の妥当性**: `QUOTA_AWARE` の関数内ブランチラベル（`# opt-out:` / `# opt-in:`、`opt-in 時` 等、L700-706 / L11124 / L11139）は「既定」を誤記しているのではなく**2 系統のブランチを歴史的 opt-in/opt-out で呼び分けている**だけのため本 PR では触っていません。用語統一の観点で是正すべきかは判断を仰ぎます（別 PR でも可）。
2. **順序**: 本 PR は issue-watcher.sh のコメントのみ。進行中の Part 2(#180)/Part 3(#181) modularization と同ファイルだが comment-only で衝突リスクは小。

## 関連
- #196（design iteration 既定変更 issue → 誤前提のため close 済み。本 stale コメントが誤読の一因）
- #112（8 フラグのデフォルト反転）