### PR TITLE
feat(#180): issue-watcher.sh モジュール化 Part 2 (クォータ制御・マージキュー・自動 Rebase の切り出し)

### DIFF
--- a/docs/specs/180-feat-watcher-issue-watcher-sh-part-2-reb/review-notes.md
+++ b/docs/specs/180-feat-watcher-issue-watcher-sh-part-2-reb/review-notes.md
@@ -1,0 +1,84 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-24T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-180-impl-feat-watcher-issue-watcher-sh-part-2-reb
+- HEAD commit: 359042b（chore(watcher): issue-watcher.sh の実行ビット (100755) を復元）
+- Compared to: main..HEAD
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しないため opt-out
+  扱い。通常の 3 カテゴリ判定のみを実施（flag 観点の確認は行わない）。
+
+## Verified Requirements
+
+- 1.1 — `quota-aware.sh` に quota 待機制御 8 関数を集約。`qa_detect_rate_limit` /
+  `qa_run_claude_stage` / `qa_persist_reset_time` / `qa_load_reset_time` /
+  `qa_build_escalation_comment` / `build_partial_escalation_comment` /
+  `qa_handle_quota_exceeded` / `process_quota_resume` が定義済み（本体からは削除済み・重複 0 件）
+- 1.2 — call site `process_quota_resume`（issue-watcher.sh:590）は本体に温存。
+  全 Processor 先頭順序を維持し、Loader source 後に遅延束縛で解決される
+- 1.3 — `process_quota_resume` が main と byte-identical（差分等価移動）
+- 1.4 — `qa_run_claude_stage`（exit 99 sentinel）/ `qa_persist_reset_time` が byte-identical。
+  reset 永続化ロジック不変。`qa_run_claude_stage_test.sh` PASS
+- 2.1 — `merge-queue.sh` に `mq_*` / `process_merge_queue` / `mqr_*` /
+  `process_merge_queue_recheck` を集約（mqr_* は本体由来で core_utils.sh には無いため
+  本モジュールへ。core_utils.sh は無変更）
+- 2.2 — `process_merge_queue` が main と byte-identical、call site issue-watcher.sh:618 温存
+- 2.3 — `process_merge_queue_recheck` が main と byte-identical、call site issue-watcher.sh:615 温存
+- 3.1 — `auto-rebase.sh` に自動 Rebase 10 関数を集約（`ar_*` / `process_auto_rebase`）
+- 3.2 — `ar_classify_diff` / `ar_fetch_candidates` が byte-identical（allowlist パスベース判定不変）
+- 3.3 — `ar_dismiss_all_approvals` が byte-identical（approve 解除条件不変）
+- 3.4 — `ar_escalate_to_failed` が byte-identical（escalation 挙動不変）、call site
+  issue-watcher.sh:624 温存
+- 4.1 — 既存 Module Loader（issue-watcher.sh:484-）が `IDD_MODULE_DIR`（BASH_SOURCE 基準）で
+  解決。`REQUIRED_MODULES` 配列に 3 モジュールを追加
+- 4.2 — `module_loader_missing_test.sh` Case 1 が別 cwd 起動で cwd 非依存解決を検証（PASS）
+- 4.3 — 全モジュール source 後に 3 プロセッサ全関数が解決（本体に重複定義 0 件 / impl-notes
+  dry-run スモークで未定義参照 0 件）。`module_loader_missing_test.sh` Case 3 PASS
+- 4.4 — `module_loader_missing_test.sh` Case 1/2 が欠落モジュール名を含む stderr +
+  exit 1 を検証（PASS）。本体の欠落チェック分岐は main から不変
+- 5.1〜5.5 — install.sh のモジュール配置ブロック（L1227-1233）は Part 1 で既配線（本 PR diff なし）。
+  `copy_glob_to_homebin ".../bin/modules" "*.sh" "$HOME/bin/modules" --executable` が
+  冪等 SKIP・差分上書き・dry-run 列挙・chmod +x・HOME スコープ完結を担保（impl-notes でスモーク検証）
+- 6.1 — `local-watcher/test/` 全 13 本を reviewer 自身で再実行し PASS=13 / FAIL=0 を確認
+- 6.2 — `qa_run_claude_stage_test.sh` / `repo_prefix_log_test.sh` /
+  `qa_detect_rate_limit_test.sh` の `extract_function` が新モジュールを抽出元に追加
+- 6.3 — 移動済みロガー/関数を参照する該当テストが移動先を解決して通過（再実行で確認）
+- NFR 1.1〜1.7 — 移動 26 関数すべてが main と byte-identical（独自スクリプトで機械検証）。
+  call site の順序・内容も main と一致。core_utils.sh は無変更。
+  env 名・exit code・ログ書式・ラベル遷移・cron 登録文字列は不変
+- NFR 2.1 — install.sh は既存 `copy_glob_to_homebin`→`classify_action` 経由で再実行 SKIP（冪等）
+- NFR 3.1 — モジュール欠落時 stderr エラー + exit 1（silent fail なし）。
+  shellcheck -S warning は変更全ファイルで rc=0
+
+## 機械検証の要点（差分等価リファクタの裏取り）
+
+- main:issue-watcher.sh から抽出した 26 プロセッサ関数定義と、各モジュールへ移動した定義を
+  awk 抽出 + 文字列比較し、全 26 関数が IDENTICAL であることを確認（ロジック改変の混入なし）
+- 当該 26 関数定義は本体から完全に削除され、本体に重複定義は 0 件
+- core_utils.sh のロガー（`qa_log` / `mq_log` / `ar_log` / `qa_format_iso8601`）は 3 新規
+  モジュールで再定義されていない（design.md Non-Goal 準拠）
+- 3 新規モジュールに top-level `set` 宣言なし（規約準拠）
+- `local-watcher/test/` 全 13 本を再実行し PASS=13 / FAIL=0、shellcheck -S warning rc=0
+
+## Findings
+
+なし（reject の根拠となる AC 未カバー / missing test / boundary 逸脱はいずれも検出されず）
+
+参考（reject 対象外・informational）:
+- HEAD の chore commit（359042b）で `issue-watcher.sh` の実行ビットが 100755 に復元されている。
+  観測挙動は不変（cron はデプロイ済みコピーを呼び、install.sh が `--executable` で chmod +x、
+  launchd は bash 経由起動、テストも bash 経由）。NFR 1.6 の cron/launchd 登録文字列も不変。
+- impl-notes #1（Part 1 基盤は main HEAD で既配線済み）/ #3（Req 5.3 の上書き保護ヘルパ解釈）
+  は人間レビュー判断事項として記録済み。成果物（差分等価な module 分割）は AC を満たしており、
+  Reviewer の 3 カテゴリ判定では reject 事由にならない。
+
+## Summary
+
+3 プロセッサ（quota-aware / merge-queue / auto-rebase）の抽出は全 26 関数 byte-identical で
+差分等価が機械検証でき、call site の順序・内容も main と一致。全 numeric AC（1.1〜6.3 /
+NFR 1.1〜3.1）に対応する実装・テストを確認。テスト 13 本全 PASS、shellcheck warning ゼロ、
+core_utils.sh 無変更。boundary 逸脱・AC 未カバー・missing test のいずれも検出されず。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

`local-watcher/bin/issue-watcher.sh`（約 11,697 行）から、クォータ待機制御・マージキュー・
自動 Rebase の 3 プロセッサを独立モジュール（`quota-aware.sh` / `merge-queue.sh` /
`auto-rebase.sh`）へ差分等価で切り出したリファクタリング（Part 2）。
本体は 9,969 行に縮小し、移動した約 1,728 行（26 関数）は `local-watcher/bin/modules/` 配下に
再配置した。既存の Module Loader 基盤（`REQUIRED_MODULES` 配列・欠落時 exit 1）を拡張する形で実装し、
観測可能挙動（環境変数・exit code・ログ書式・ラベル遷移・cron 登録文字列）は一切変更していない。

## 対応 Issue

Closes #180

## 関連 PR

- 設計 PR: #190（merged）

## 実装内容

- (Req 1 / Task 2) Quota-Aware Processor を `modules/quota-aware.sh` へ切り出し（8 関数）
- (Req 2 / Task 3) Merge-Queue Processor を `modules/merge-queue.sh` へ切り出し（8 関数）
- (Req 3 / Task 4) Auto-Rebase Processor を `modules/auto-rebase.sh` へ切り出し（10 関数）
- (Req 4 / Task 1) 既存 Module Loader の `REQUIRED_MODULES` 配列に 3 モジュールを追加
- (Req 5 / Task 5) install.sh のモジュール配置ブロックが新 3 モジュールを冪等配置することを検証（Part 1 で既配線）
- (Req 6 / Task 6) 既存テスト 4 本（`qa_run_claude_stage_test.sh` / `repo_prefix_log_test.sh` / `qa_detect_rate_limit_test.sh` / `verify_pushed_or_retry_test.sh`）の `extract_function` 参照先を移動先モジュールに追従修正
- (NFR 1.1〜1.7 / Task 7) shellcheck -S warning rc=0・スモーク検証・README 更新
- (Req 4.4 / Task 7.1) モジュール欠落 fail-fast の専用回帰テスト追加（`module_loader_missing_test.sh`、deferrable を余力で実施）

## 受入基準チェック

- [x] Req 1.1: The watcher shall クォータ待機制御の各関数を独立した 1 つのモジュールファイルに集約して提供する ← `quota-aware.sh`（8 関数集約）/ byte-identical 機械検証
- [x] Req 1.2〜1.4: メインサイクル・Resume 処理から同一解決、quota sentinel exit 99 不変 ← `qa_run_claude_stage_test.sh` PASS / dry-run スモーク
- [x] Req 2.1〜2.3: マージキュー制御の集約・定期サイクル・再チェックの同一解決 ← `merge-queue.sh` byte-identical / call site 温存
- [x] Req 3.1〜3.4: 自動 Rebase の集約・allowlist 判定・approve 解除・escalation 不変 ← `auto-rebase.sh` byte-identical / `ar_*` 関数 10 本
- [x] Req 4.1〜4.4: SCRIPT_DIR 基準 source・最小 PATH 解決・未定義参照ゼロ・欠落時 stderr + exit 1 ← `module_loader_missing_test.sh` 7 ケース PASS / 最小 PATH スモーク
- [x] Req 5.1〜5.5: install.sh が `modules/*.sh` を `$HOME/bin/modules/` へ冪等配置 ← scratch HOME スモーク（NEW/SKIP/DRY-RUN/chmod +x/sudo 不要）
- [x] Req 6.1〜6.3: 既存テスト全 13 本 PASS、移動後定義から解決、FAIL 3 本を Green に戻す ← `local-watcher/test/` 全 13 本 PASS（Reviewer 再実行確認済み）
- [x] NFR 1.1〜1.7: 26 関数 byte-identical・env 名/exit code/ログ書式/ラベル遷移/cron 登録不変 ← 機械検証スクリプトで全 26 関数 IDENTICAL

## テスト結果

```
local-watcher/test/ 全 13 本
PASS=13 / FAIL=0

（Reviewer 独立再実行で確認。shellcheck -S warning rc=0）

対象テスト:
- qa_run_claude_stage_test.sh        PASS（extract_function を quota-aware.sh に追従）
- repo_prefix_log_test.sh            PASS（mq_*/qa_* ロガーを core_utils.sh / mqr_* を merge-queue.sh に追従）
- qa_detect_rate_limit_test.sh       PASS（extract_function を quota-aware.sh に追従）
- verify_pushed_or_retry_test.sh     PASS（変更不要、既に PASS）
- module_loader_missing_test.sh      PASS（新規 7 ケース: 欠落 fail-fast / cwd 非依存 / 全モジュール正常通過）
- 残り 8 本                          PASS（既存テスト変更なし）
```

## 実装上の判断

- manifest 配列名は既存 `REQUIRED_MODULES` を踏襲（design 疑似コードの `WATCHER_MODULES` にはリネームしない）。後方互換・差分最小化を優先
- source 順序は core_utils → quota-aware → merge-queue → auto-rebase。bash 遅延束縛により機能的には任意だが、可読性のため低レベル順に並べた
- 関数移動は `sed`/`awk` による行範囲 cut & paste で実施し、編集ミスによるロジック改変を避けた。全関数 byte-identical を機械検証

詳細は `docs/specs/180-feat-watcher-issue-watcher-sh-part-2-reb/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- **base ブランチ検証**: `gh pr view <PR> --json baseRefName` で `main` を確認済み（下記「base 検証」参照）
- Reviewer（claude-opus-4-7）は全 AC を独立再実行で検証し `RESULT: approve`（`docs/specs/180-feat-watcher-issue-watcher-sh-part-2-reb/review-notes.md` 参照）
- **impl-notes #3（Req 5.3 上書き保護ヘルパ解釈）**: `copy_glob_to_homebin` は `copy_template_file`（OVERWRITE no-backup）経由でツールスクリプトと同格扱い。設計書の `copy_with_hybrid_overwrite`（`.bak` once-only）記述と実装が異なる点は人間レビュー判断事項として記録。`modules/` をツールスクリプトと同格に扱う（template 同期 = OVERWRITE が正）か、`.bak` 退避が必要かご確認ください
- **impl-notes #4（`quota-aware.sh` top-level 代入）**: `QUOTA_RESET_STATE_FILE=...` 代入 1 行がモジュール内 top-level に残存（差分等価維持のため移動。Loader が Config ブロック後に走るため `$LOG_DIR` は解決済みで問題なし）。設計書の「各モジュールは関数定義のみ」との微差として記録

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #180 のコメントを参照してください。
