### PR TITLE
fix(#187): awaiting-slot 付与失敗時も遅延理由 sticky comment を投稿するよう修正

### DIFF
--- a/docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/impl-notes.md
+++ b/docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/impl-notes.md
@@ -1,0 +1,151 @@
+# 実装ノート（Issue #187）
+
+## 概要
+
+Phase E Path Overlap Checker の `po_apply_awaiting_slot`（`local-watcher/bin/modules/promote-pipeline.sh`）が、
+awaiting-slot ラベル付与に失敗すると early `return 1` してしまい、後続の sticky comment 投稿コードに到達しない
+バグを修正した。これにより、ラベル付与に失敗したケースでも「なぜ Issue が止まっているか」を Issue 上の
+コメントから読み取れるようにし、dispatch 見送り理由の可視性を回復した。
+
+実害（誤 dispatch）は発生しないため、スコープは可視性の回復に限定した（要件 Out of Scope に準拠）。
+
+## Feature Flag Protocol 採否確認
+
+`CLAUDE.md` を確認したが `## Feature Flag Protocol` 節は存在しない。よって opt-out 解釈となり、
+通常フロー（単一実装パス）で実装した（`.claude/rules/feature-flag.md` は読み込まない）。
+
+## 修正した関数と before/after の構造
+
+### `po_apply_awaiting_slot`（promote-pipeline.sh 430-507 付近）
+
+**before:**
+
+```bash
+# ラベル付与（冪等。既付与でも error にならない）
+if ! gh issue edit "$issue_number" --repo "$REPO" \
+    --add-label "$LABEL_AWAITING_SLOT" >/dev/null 2>&1; then
+  return 1          # ← ここで早期終了し、以降の sticky comment 投稿に到達しない
+fi
+po_log "awaiting-slot added candidate=#${issue_number}"
+# （以降に sticky comment 組み立て・投稿/更新コード）
+```
+
+**after:**
+
+```bash
+# ラベル付与（冪等。既付与でも error にならない）。
+# #187: ラベル付与に失敗しても early return せず、警告ログを残した上で sticky comment
+# 投稿へ処理を継続する。
+if gh issue edit "$issue_number" --repo "$REPO" \
+    --add-label "$LABEL_AWAITING_SLOT" >/dev/null 2>&1; then
+  po_log "awaiting-slot added candidate=#${issue_number}"
+else
+  po_warn "issue=#${issue_number} awaiting-slot ラベル付与に失敗（見送り理由コメントの投稿は継続）"
+fi
+# （以降の sticky comment 組み立て・投稿/更新コードは無変更で必ず到達する）
+```
+
+変更は冒頭のラベル付与ブロックのみ。sticky comment 本文フォーマット・marker
+（`<!-- idd-claude:awaiting-slot:v1 -->`）・冪等な PATCH/create ロジックは一切変更していない
+（要件 1.4 / NFR 2.1 / Out of Scope）。
+
+### 戻り値の変化と呼び出し側への影響
+
+- before: ラベル付与失敗時 `return 1`、それ以外は `return 0`
+- after: ラベル付与の成否に関わらず、本文組み立て後の投稿/更新を経て `return 0`（コメント取得失敗の
+  best-effort 経路も従来どおり `return 0`）
+
+呼び出し側 `po_check_dispatch_gate`（531-595）は overlap 検出時に
+`if ! po_apply_awaiting_slot ...; then po_warn ...; fi` の **後** に**無条件で `return 1`（dispatch skip）** する
+構造（584 行）。dispatch skip は `po_apply_awaiting_slot` の戻り値に依存していないため、戻り値が
+常に 0 に変わっても dispatch skip の維持に影響しない（NFR 1.2）。`if ! ... then po_warn` 分岐は
+ラベル付与失敗時に呼ばれなくなる（関数内部で WARN するため）が、overlap 検出ログ（573/577 行）と
+dispatch skip（584 行）は不変。
+
+## 追加したテストファイルと検証 AC の対応
+
+追加ファイル: `local-watcher/test/po_apply_awaiting_slot_test.sh`
+（既存 `pi_max_rounds_kind_test.sh` の per-test `*_SH` source + `awk` extract_function イディオムを踏襲。
+`gh` / `po_log` / `po_warn` を stub し、呼び出し有無・引数・戻り値を観測）
+
+| AC | 検証ケース |
+|---|---|
+| Req 1.1 / 1.2（ラベル付与成否に依存せず sticky comment 投稿/更新を試行） | Case A（ラベル付与失敗 → 新規 comment 投稿 1 回）、Case B（ラベル付与失敗 + 既存 marker → PATCH 1 回）、Case E（ラベル付与失敗 + コメント取得失敗 → best-effort 新規投稿 1 回） |
+| Req 1.4 / NFR 2.1（既存 marker があれば追加投稿せず PATCH 更新） | Case B（label fail）、Case D（label success）双方で「新規 comment 0 回 / PATCH 1 回」、PATCH 対象 comment id (555111) を検証 |
+| Req 3.1（ラベル付与失敗時に候補 Issue 番号を含む WARN ログ） | Case A（#42 を含む WARN）、Case E（#99 を含む WARN） |
+| Req 2.3（ラベル/コメント投稿失敗でも当該サイクルを異常終了させない） | Case E（ラベル付与失敗 + コメント取得失敗でも戻り値 0） |
+| Req 2.4 / NFR 1.2（戻り値の意味が dispatch skip 維持に影響しない） | Case A / B（label fail でも戻り値 0） |
+| NFR 2.1（ラベル付与成功時の従来挙動が回帰しない） | Case C（label success → 新規 comment 1 回 / WARN 無し / 付与成功 LOG 有り）、Case D（label success + 既存 marker → PATCH 冪等更新） |
+
+合計 19 アサーション、全 PASS。
+
+## 実行したスモークテスト結果
+
+### Red → Green 観測
+
+- `git stash`（修正前コード）で新規テストを実行 → **9 FAIL / 10 PASS**（label-failure 系の AC が全て失敗、
+  label-success 系の回帰テストは pass）。バグを確実に捕捉していることを確認。
+- `git stash pop`（修正後コード）で再実行 → **19 PASS / 0 FAIL**。
+
+### shellcheck
+
+```
+shellcheck local-watcher/bin/modules/promote-pipeline.sh local-watcher/test/po_apply_awaiting_slot_test.sh
+=> exit 0（警告ゼロ）
+```
+
+修正本体は新たな警告を増やしていない。新規テストは SC2034（遅延束縛グローバル）・SC2317（間接呼び出し
+stub）を既存テストと同じ inline `# shellcheck disable` で抑止し clean。
+
+### 既存テスト suite 全件（local-watcher/test/*_test.sh）
+
+全 14 suite を実行し全て PASS（新規 po_apply_awaiting_slot_test.sh 含む）:
+
+| test | result |
+|---|---|
+| module_loader_missing_test.sh | PASS (7) |
+| normalize_slug_test.sh | PASS (11) |
+| parse_review_result_test.sh | PASS (19) |
+| pi_detect_quota_soft_fail_test.sh | PASS (13) |
+| pi_max_rounds_kind_test.sh | PASS (24) |
+| po_apply_awaiting_slot_test.sh（新規） | PASS (19) |
+| qa_detect_rate_limit_test.sh | PASS (10) |
+| qa_run_claude_stage_test.sh | PASS (23) |
+| repo_prefix_log_test.sh | PASS (36) |
+| slug_match_guard_test.sh | PASS (13) |
+| stagec_pr_verify_fallback_test.sh | PASS (35) |
+| stagec_pr_verify_retry_test.sh | PASS (42) |
+| stagec_pr_verify_test.sh | PASS (8) |
+| verify_pushed_or_retry_test.sh | PASS (17) |
+
+## 後方互換性の確認
+
+- **戻り値**: `po_apply_awaiting_slot` は修正後も `0` を返す経路のみ（致命 return 1 を除去）。呼び出し側の
+  dispatch skip は `po_apply_awaiting_slot` の戻り値ではなく 584 行の無条件 `return 1` で決まるため不変
+  （NFR 1.2）。
+- **dispatch skip**: overlap 検出時の `return 1`（po_check_dispatch_gate 584）は無変更。overlap 判定・
+  in-flight 列挙・clear ロジックも無変更（要件 Out of Scope 準拠）。
+- **ラベル遷移契約**: `LABEL_AWAITING_SLOT` の付与/除去ラベル名・marker・本文フォーマットは無変更
+  （要件 2.4）。
+- **env var 名・ログ出力先**: `po_log`（stdout）/ `po_warn`（stderr）の出力先・既存 env var 名は無変更
+  （要件 2.4 / NFR 1.1）。新たに出力する WARN は path-overlap prefix を共有する `po_warn` 経由。
+- **opt-in gate**: `PATH_OVERLAP_CHECK` の gate（po_check_dispatch_gate 536）は無変更。`true` 以外では
+  本修正経路に到達しないため、無効時は導入前と完全同一（NFR 1.1）。
+- **冪等性**: 既存 marker 検索 → PATCH/create ロジックは無変更のため、連続サイクルでも sticky comment は
+  1 件に保たれる（NFR 2.1。Case B / D で検証）。
+
+## requirements / design で曖昧だった点とその解釈
+
+- Req 2.3「次サイクルでの再評価に委ねる」: 本修正では関数が異常終了（return 1）しなくなることで充足。
+  ラベル付与失敗の事実は WARN ログに残し、次サイクルで `po_check_dispatch_gate` が再度 overlap 判定 →
+  未付与なら再度 `po_apply_awaiting_slot` を呼ぶ既存フローに委ねる（追加のリトライ機構は実装しない）。
+- Out of Scope の「受入観点 (2) の軽量フォールバック（欠落ラベル検出 → WARN / 自動ラベル作成）」は
+  別 Issue 扱いのため本修正では実装していない（過剰修正の回避）。
+
+## 確認事項（Reviewer 判断ポイント）
+
+- なし。要件 / design.md（本 Issue は design.md / tasks.md なしのバグ修正）と矛盾は検出されなかった。
+  修正は要件で指定された最小スコープ（`po_apply_awaiting_slot` 冒頭のラベル付与ブロックのみ）に限定し、
+  sticky comment フォーマット・overlap 判定・呼び出し側 dispatch skip は不変であることをテストで担保した。
+
+STATUS: complete

--- a/docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/requirements.md
+++ b/docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/requirements.md
@@ -1,0 +1,62 @@
+# Requirements Document
+
+## Introduction
+
+Phase E Path Overlap Checker（`PATH_OVERLAP_CHECK=true` 時）は、in-flight Issue と編集 path が重複する候補 Issue の dispatch を見送り、その理由を `awaiting-slot` ラベルと説明用 sticky comment（marker `<!-- idd-claude:awaiting-slot:v1 -->`）で運用者に提示する。現状の `po_apply_awaiting_slot`（`local-watcher/bin/modules/promote-pipeline.sh`）は冒頭でラベル付与を試み、失敗すると即座に終了するため、sticky comment 投稿コードに到達しない。結果として、ラベル付与に失敗したケースでは「なぜ Issue が止まっているか」が Issue 上から一切読み取れず、dispatch 見送りが運用者に不可視となる。本要件は、コメント投稿の到達性をラベル付与の成否から切り離し、見送り理由の可視性を確保するバグ修正を定義する。実害（誤 dispatch）は発生しないため、スコープは可視性の回復に限定する。
+
+## Requirements
+
+### Requirement 1: dispatch 見送り理由の可視性確保
+
+**Objective:** As a idd-claude 運用者, I want awaiting-slot 付与に失敗したときでも見送り理由が Issue 上に提示されること, so that 止まっている Issue の原因を Issue 画面から把握できる
+
+#### Acceptance Criteria
+
+1. When overlap が検出され awaiting-slot 付与のために sticky comment 投稿処理が呼ばれたとき, the Path Overlap Checker shall ラベル付与の成否に依存せず sticky comment の投稿または更新を試行する
+2. If awaiting-slot ラベルの付与に失敗したとき, the Path Overlap Checker shall sticky comment の投稿または更新を引き続き試行する
+3. When sticky comment を投稿するとき, the Path Overlap Checker shall 重複した top-level path と現状の awaiting 状態を運用者が判読できる本文を提示する
+4. While 同一 Issue に marker 付き sticky comment が既に存在するとき, the Path Overlap Checker shall 新規コメントを追加投稿せず既存コメントを更新する
+
+### Requirement 2: 見送り判定と後方互換性の維持
+
+**Objective:** As a idd-claude 運用者, I want 本修正が既存の dispatch 見送り判定と運用契約を変えないこと, so that 既に稼働中の cron / watcher 挙動が壊れない
+
+#### Acceptance Criteria
+
+1. While `PATH_OVERLAP_CHECK` が `true` 以外（未設定 / off / 不正値）のとき, the Path Overlap Checker shall overlap 判定を行わず本修正導入前と同一の挙動を保つ
+2. When overlap が検出されたとき, the Path Overlap Checker shall ラベル付与およびコメント投稿の成否に関わらず当該サイクルで該当候補の dispatch を見送る
+3. If awaiting-slot 付与またはコメント投稿に失敗したとき, the Path Overlap Checker shall 当該サイクルを失敗で異常終了させず次サイクルでの再評価に委ねる
+4. The Path Overlap Checker shall 既存の環境変数名・ログ出力先・ラベル名・ラベル遷移契約を変更せず維持する
+
+### Requirement 3: 失敗時の運用者向けログ可視性
+
+**Objective:** As a idd-claude 運用者, I want awaiting-slot 付与やコメント投稿が失敗したことがログに残ること, so that Issue 上のコメントとログの双方から見送り経緯を追跡できる
+
+#### Acceptance Criteria
+
+1. If awaiting-slot 付与またはコメント投稿に失敗したとき, the Path Overlap Checker shall 当該候補 Issue 番号を含む警告を運用者向けログに出力する
+2. When overlap が検出されたとき, the Path Overlap Checker shall 重複 path を含む検出ログを既存と同一の形式で出力する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性（観測可能な不変性）
+
+1. While `PATH_OVERLAP_CHECK` が無効のとき, the Path Overlap Checker shall 本修正導入前と完全に同一のログ出力・ラベル操作・dispatch 判定を行う
+2. The Path Overlap Checker shall dispatch 見送りを示す呼び出し側への戻り値の意味（見送り = skip）を本修正前と同一に保つ
+
+### NFR 2: 冪等性
+
+1. When 同一候補に対し連続サイクルで sticky comment 投稿が試行されたとき, the Path Overlap Checker shall Issue に対し sticky comment を 1 件に保ち重複投稿しない
+
+## Out of Scope
+
+- 受入観点 (2) の軽量フォールバック（欠落ラベル検出 → 1 度だけ WARN する仕組み、自動ラベル作成等）の実装。これは #185 のコメントで「2.B につき別 issue を起票」と人間が判断済みであり、別 Issue で扱う。本 Issue では過剰修正（自動ラベル作成の常時実行など）を行わない
+- 編集 path の重複判定ロジック（`po_compute_overlap` 等）の変更
+- in-flight Issue 列挙ロジック（`po_collect_inflight_issues` 等）の変更
+- awaiting-slot ラベルの除去ロジック（`po_clear_awaiting_slot`）の挙動変更
+- sticky comment 本文フォーマットの仕様変更（表示内容は既存仕様を踏襲する。本修正は投稿到達性の回復に限定）
+- リファクタリング・新機能追加（本 Issue はバグ修正であり、スコープを広げない）
+
+## Open Questions
+
+- なし（編集対象ファイルが `local-watcher/bin/modules/promote-pipeline.sh` であること、受入観点 (2) を別 Issue に分離することは #185 / #187 のコメントで人間が確定済み。本要件はその決定を反映している）

--- a/docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/review-notes.md
+++ b/docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/review-notes.md
@@ -1,0 +1,51 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-24T13:02:03Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-187-impl-bug-watcher-awaiting-slot-phase-e-185-3
+- HEAD commit: 5f2cd824e17d17cfd449b5f1d097c5d527d1b83f
+- Compared to: main..HEAD（実装本体は bbe3bc3、要件/ノートは 5f2cd82）
+
+本 Issue は Architect 非経由のため tasks.md / design.md は存在しない。requirements.md の
+AC を正本としてレビューした。境界の照合は requirements.md が編集対象に指定した
+`local-watcher/bin/modules/promote-pipeline.sh` を正本とする。CLAUDE.md に
+`## Feature Flag Protocol` 節は存在しないため opt-out 解釈（通常の 3 カテゴリ判定のみ。
+flag 観点は適用しない）。
+
+## Verified Requirements
+
+- 1.1 — ラベル付与の成否に依存せず sticky comment 投稿/更新へ到達する構造へ組み替え（promote-pipeline.sh:440-507、early return 廃止）。テスト Case A/B/E（po_apply_awaiting_slot_test.sh）
+- 1.2 — ラベル付与失敗（gh issue edit rc!=0）でも投稿/更新を継続（同 440-445 で else 分岐）。Case A（新規 create 1 回）/ Case E（コメント取得失敗でも best-effort で create 1 回）で検証
+- 1.3 — 重複 top-level path と awaiting 状態を提示する本文（promote-pipeline.sh:467-481、overlap_section + 説明文）。本文フォーマットは無変更で踏襲（Out of Scope 準拠）
+- 1.4 — 既存 marker `<!-- idd-claude:awaiting-slot:v1 -->` 検出時は新規投稿せず PATCH 更新（promote-pipeline.sh:491-505）。Case B（label fail）/ Case D（label success）で「新規 comment 0 回 / PATCH 1 回」、PATCH 対象 id (555111) を検証
+- 2.1 — `PATH_OVERLAP_CHECK = "true"` 厳密一致 opt-in gate（promote-pipeline.sh:541）。本 diff 対象外で無変更
+- 2.2 — overlap 検出時はラベル/コメント成否に関わらず dispatch skip。呼び出し側 po_check_dispatch_gate:589 の無条件 `return 1` が決定し、本 diff 対象外で無変更
+- 2.3 — 失敗でもサイクルを異常終了させない。po_apply_awaiting_slot は致命 return 1 を廃止し常に 0 を返す。Case E（ラベル付与失敗 + コメント取得失敗でも rc=0）で検証
+- 2.4 — env var 名 / ログ出力先 / ラベル名 / ラベル遷移契約は無変更。diff はラベル付与ブロック（435-445）に限定。`LABEL_AWAITING_SLOT` / marker / 本文は不変
+- 3.1 — ラベル付与失敗時に候補 Issue 番号を含む WARN（promote-pipeline.sh:444、`po_warn ... #${issue_number}`）。Case A（#42）/ Case E（#99）で検証
+- 3.2 — overlap 検出ログ（promote-pipeline.sh:578/582）は本 diff 対象外で形式不変
+- NFR 1.1 — `PATH_OVERLAP_CHECK` 無効時は gate（541）で早期 return 0。本修正経路に到達せず導入前と完全同一
+- NFR 1.2 — 戻り値の意味（dispatch skip）は呼び出し側 584-589 で確定。po_apply_awaiting_slot の戻り値が常に 0 へ変わっても skip 判定に影響しないことを確認
+- NFR 2.1 — sticky comment 冪等性（既存 marker → PATCH、無ければ create）は無変更。Case B/D で 1 件維持を検証
+
+## 検証実行
+
+- `bash local-watcher/test/po_apply_awaiting_slot_test.sh` → PASS: 19, FAIL: 0（reviewer 再実行で確認）
+- `shellcheck local-watcher/bin/modules/promote-pipeline.sh local-watcher/test/po_apply_awaiting_slot_test.sh` → exit 0（警告ゼロ）
+- `git diff main..HEAD -- local-watcher/bin/modules/promote-pipeline.sh` で変更が 435-445 行のラベル付与ブロックに限定され、overlap 判定 / in-flight 列挙 / clear ロジック / 本文フォーマット / marker / 呼び出し側 dispatch skip が不変であることを確認
+
+## Findings
+
+なし
+
+## Summary
+
+全 AC（1.1〜1.4 / 2.1〜2.4 / 3.1〜3.2 / NFR 1.1〜1.2 / NFR 2.1）に対応する実装が存在し、
+観測可能な挙動（ラベル付与失敗時もコメント投稿を試行 / 失敗時 WARN / 既存 marker の PATCH 冪等更新 /
+ラベル成功時の回帰）に対応テストが揃っている。変更はラベル付与ブロックに限定され、戻り値の意味
+（dispatch skip）・env var・ラベル名・marker・本文フォーマットは不変で後方互換性を維持している。
+boundary 逸脱・AC 未カバー・missing test いずれも検出されなかった。
+
+RESULT: approve

--- a/local-watcher/bin/modules/promote-pipeline.sh
+++ b/local-watcher/bin/modules/promote-pipeline.sh
@@ -432,12 +432,17 @@ po_apply_awaiting_slot() {
   local overlap_json="$2"
   local holders_map_json="${3:-}"
 
-  # ラベル付与（冪等。既付与でも error にならない）
-  if ! gh issue edit "$issue_number" --repo "$REPO" \
+  # ラベル付与（冪等。既付与でも error にならない）。
+  # #187: ラベル付与に失敗しても early return せず、警告ログを残した上で sticky comment
+  # 投稿へ処理を継続する。これによりラベルが付与できなかったケースでも「なぜ Issue が
+  # 止まっているか」を Issue 上のコメントから読み取れるようにする（Req 1.1 / 1.2 / 3.1）。
+  # コメント投稿/更新はラベル付与の成否に依存せず必ず試行する。
+  if gh issue edit "$issue_number" --repo "$REPO" \
       --add-label "$LABEL_AWAITING_SLOT" >/dev/null 2>&1; then
-    return 1
+    po_log "awaiting-slot added candidate=#${issue_number}"
+  else
+    po_warn "issue=#${issue_number} awaiting-slot ラベル付与に失敗（見送り理由コメントの投稿は継続）"
   fi
-  po_log "awaiting-slot added candidate=#${issue_number}"
 
   # sticky comment 本文の組み立て
   # holders_map_json が与えられた場合は表形式（| 重複 path | 保持中の Issue |）で

--- a/local-watcher/test/po_apply_awaiting_slot_test.sh
+++ b/local-watcher/test/po_apply_awaiting_slot_test.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/promote-pipeline.sh の Issue #187（awaiting-slot
+#       付与失敗時も見送り理由コメントを投稿する）で組み替えた
+#       po_apply_awaiting_slot を fixture で検証するスモークテスト。
+#
+#       対象関数: po_apply_awaiting_slot（Phase E Path Overlap Checker / #18, #187）
+#
+#       検証する AC（docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/requirements.md）:
+#         - Req 1.1 / 1.2: ラベル付与の成否に依存せず sticky comment 投稿/更新を試行する
+#         - Req 1.4 / NFR 2.1: 既存 marker 付きコメントがあれば追加投稿せず PATCH で更新する
+#         - Req 3.1: ラベル付与失敗時は候補 Issue 番号を含む警告ログを出力する
+#         - Req 2.4 / NFR 1.1: 関数の戻り値は 0（呼び出し側の dispatch skip 維持に影響しない）
+#
+#       既存テスト（pi_max_rounds_kind_test.sh 等）と同じ per-test の *_SH source +
+#       awk extract_function イディオムを踏襲する。gh / po_log / po_warn を stub して
+#       呼び出し有無・呼び出し引数を記録する方式で挙動を観測する。
+#
+# 配置先: local-watcher/test/po_apply_awaiting_slot_test.sh
+# 依存:   bash 4+, awk, jq
+# 実行:   bash local-watcher/test/po_apply_awaiting_slot_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMOTE_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/promote-pipeline.sh"
+
+if [ ! -f "$PROMOTE_PIPELINE_SH" ]; then
+  echo "ERROR: cannot find promote-pipeline.sh at $PROMOTE_PIPELINE_SH" >&2
+  exit 2
+fi
+
+# 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
+# eval で読み込む。トップレベル副作用は回避する。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# 対象関数 + 本文整形ヘルパー（po_format_holders_table_md）を実物で読み込む。
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_apply_awaiting_slot")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_format_holders_table_md")"
+
+if ! declare -F po_apply_awaiting_slot >/dev/null; then
+  echo "ERROR: po_apply_awaiting_slot not loaded" >&2
+  exit 2
+fi
+if ! declare -F po_format_holders_table_md >/dev/null; then
+  echo "ERROR: po_format_holders_table_md not loaded" >&2
+  exit 2
+fi
+
+# グローバル env（遅延束縛で extract_function 経由の関数本体から参照される）
+# shellcheck disable=SC2034  # 抽出した po_apply_awaiting_slot 本体が遅延束縛で参照
+REPO="owner/test-repo"
+# shellcheck disable=SC2034  # 同上（po_apply_awaiting_slot が $LABEL_AWAITING_SLOT を参照）
+LABEL_AWAITING_SLOT="awaiting-slot"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  case "$haystack" in
+    *"$needle"*)
+      echo "PASS: $label"
+      PASS_COUNT=$((PASS_COUNT + 1))
+      ;;
+    *)
+      echo "FAIL: $label"
+      echo "  expected to contain: $(printf '%q' "$needle")"
+      echo "  actual             : $(printf '%q' "$haystack")"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      ;;
+  esac
+}
+
+# ─── 各テストケースで使う stub の状態 ───
+# gh の振る舞いはケースごとに環境変数で制御する:
+#   GH_EDIT_RC               : `gh issue edit` の終了コード（0=成功 / 非0=失敗）
+#   GH_VIEW_RC               : `gh issue view` の終了コード
+#   GH_VIEW_COMMENTS_JSON    : `gh issue view --json comments` が返す JSON
+# 記録ファイル（呼び出しトレース）:
+#   $GH_CALL_LOG  : gh の各呼び出しを 1 行ずつ記録
+#   $WARN_LOG     : po_warn の出力を記録
+#   $LOG_LOG      : po_log の出力を記録
+
+reset_stub_state() {
+  GH_EDIT_RC="${1:-0}"
+  GH_VIEW_RC="${2:-0}"
+  GH_VIEW_COMMENTS_JSON="${3:-'{"comments": []}'}"
+  GH_CALL_LOG="$(mktemp)"
+  WARN_LOG="$(mktemp)"
+  LOG_LOG="$(mktemp)"
+}
+
+cleanup_stub_state() {
+  rm -f "$GH_CALL_LOG" "$WARN_LOG" "$LOG_LOG"
+}
+
+# po_log / po_warn stub: 出力を記録ファイルへ
+# stub は extract_function で読み込んだ対象関数から間接的に呼ばれるため SC2317 を抑止する。
+# shellcheck disable=SC2317
+po_log()  { echo "$*" >>"$LOG_LOG"; }
+# shellcheck disable=SC2317
+po_warn() { echo "$*" >>"$WARN_LOG"; }
+
+# gh stub: サブコマンドを判定して記録 + 制御された終了コードを返す
+# shellcheck disable=SC2317  # 対象関数から間接的に呼ばれる stub
+gh() {
+  local sub="${1:-}"
+  local sub2="${2:-}"
+  case "$sub" in
+    issue)
+      case "$sub2" in
+        edit)
+          echo "gh issue edit $*" >>"$GH_CALL_LOG"
+          return "${GH_EDIT_RC:-0}"
+          ;;
+        view)
+          echo "gh issue view $*" >>"$GH_CALL_LOG"
+          if [ "${GH_VIEW_RC:-0}" -ne 0 ]; then
+            return "${GH_VIEW_RC}"
+          fi
+          printf '%s' "${GH_VIEW_COMMENTS_JSON}"
+          return 0
+          ;;
+        comment)
+          echo "gh issue comment $*" >>"$GH_CALL_LOG"
+          return 0
+          ;;
+        *)
+          echo "gh issue $* (unhandled)" >>"$GH_CALL_LOG"
+          return 0
+          ;;
+      esac
+      ;;
+    api)
+      echo "gh api $*" >>"$GH_CALL_LOG"
+      return 0
+      ;;
+    *)
+      echo "gh $* (unhandled)" >>"$GH_CALL_LOG"
+      return 0
+      ;;
+  esac
+}
+
+count_calls() {
+  local pattern="$1"
+  local n
+  # grep -c は no-match 時に exit 1 を返し set -e / pipefail と衝突するため、
+  # マッチ行を grep で取り出し（no-match でも true 化）wc -l で件数を数える。
+  n=$( { grep "$pattern" "$GH_CALL_LOG" 2>/dev/null || true; } | wc -l)
+  # wc -l は前後空白を含むことがあるため整数化
+  echo "$((n))"
+}
+
+OVERLAP='["local-watcher/","README.md"]'
+HOLDERS='{"local-watcher/":[39,40],"README.md":[40]}'
+
+echo "--- po_apply_awaiting_slot cases (Issue #187 Req 1.1 / 1.2 / 1.4 / 3.1 / 2.4) ---"
+
+# ── Case A: ラベル付与失敗でも sticky comment 投稿が試行される（Req 1.1 / 1.2） ──
+# gh issue edit を失敗（rc=1）させ、既存 marker コメントは無い状態（新規 create 経路）
+reset_stub_state 1 0 '{"comments": []}'
+rc=0
+po_apply_awaiting_slot 42 "$OVERLAP" "$HOLDERS" || rc=$?
+assert_eq "Req 2.4: ラベル付与失敗でも関数戻り値は 0（呼び出し側 dispatch skip に影響しない）" \
+  "0" "$rc"
+edit_count=$(count_calls "gh issue edit")
+comment_count=$(count_calls "gh issue comment")
+assert_eq "Req 1.2: ラベル付与（gh issue edit）が 1 回試行される" "1" "$edit_count"
+assert_eq "Req 1.1 / 1.2: ラベル付与失敗でも sticky comment 新規投稿が試行される" \
+  "1" "$comment_count"
+# Req 3.1: 警告ログに候補 Issue 番号 #42 を含む
+warn_out="$(cat "$WARN_LOG")"
+assert_contains "Req 3.1: ラベル付与失敗時に候補 Issue 番号を含む警告ログを出す" \
+  "$warn_out" "#42"
+cleanup_stub_state
+
+# ── Case B: ラベル付与失敗 + 既存 marker コメント有り → 追加投稿せず PATCH 更新（Req 1.4 / NFR 2.1） ──
+EXISTING_COMMENTS='{"comments":[{"body":"## ⏸️ Dispatch を見送り中\n\n<!-- idd-claude:awaiting-slot:v1 -->","url":"https://github.com/owner/test-repo/issues/42#issuecomment-555111"}]}'
+reset_stub_state 1 0 "$EXISTING_COMMENTS"
+rc=0
+po_apply_awaiting_slot 42 "$OVERLAP" "$HOLDERS" || rc=$?
+assert_eq "Req 2.4: 既存 marker 有り + ラベル付与失敗でも戻り値 0" "0" "$rc"
+patch_count=$(count_calls "gh api .*PATCH")
+comment_count=$(count_calls "gh issue comment")
+assert_eq "Req 1.4 / NFR 2.1: 既存 marker 有りなら新規 comment 投稿は 0 回" "0" "$comment_count"
+assert_eq "Req 1.4 / NFR 2.1: 既存 marker 有りなら PATCH で 1 回更新する" "1" "$patch_count"
+# PATCH 対象 comment id（555111）が解決されていること
+patch_call="$(grep 'gh api' "$GH_CALL_LOG" || true)"
+assert_contains "Req 1.4: PATCH 対象は既存 comment id (555111)" "$patch_call" "555111"
+cleanup_stub_state
+
+# ── Case C: ラベル付与成功時の従来挙動（新規 create）が回帰しない（NFR 2.1） ──
+reset_stub_state 0 0 '{"comments": []}'
+rc=0
+po_apply_awaiting_slot 7 "$OVERLAP" "$HOLDERS" || rc=$?
+assert_eq "NFR 2.1: ラベル付与成功時の戻り値 0" "0" "$rc"
+edit_count=$(count_calls "gh issue edit")
+comment_count=$(count_calls "gh issue comment")
+assert_eq "NFR 2.1: ラベル付与成功時にラベル付与が 1 回" "1" "$edit_count"
+assert_eq "NFR 2.1: ラベル付与成功 + 既存 marker 無し → 新規 comment 1 回" "1" "$comment_count"
+# 成功時は WARN を出さず、付与成功 LOG を出す
+warn_out="$(cat "$WARN_LOG")"
+log_out="$(cat "$LOG_LOG")"
+assert_eq "NFR 2.1: ラベル付与成功時は WARN を出さない" "" "$warn_out"
+assert_contains "NFR 2.1: ラベル付与成功時に付与成功ログを出す" "$log_out" "awaiting-slot added candidate=#7"
+cleanup_stub_state
+
+# ── Case D: ラベル付与成功 + 既存 marker 有り → 冪等更新（PATCH、追加投稿しない）（NFR 2.1 / Req 1.4） ──
+reset_stub_state 0 0 "$EXISTING_COMMENTS"
+rc=0
+po_apply_awaiting_slot 42 "$OVERLAP" "$HOLDERS" || rc=$?
+assert_eq "NFR 2.1: ラベル成功 + 既存 marker 有りでも戻り値 0" "0" "$rc"
+patch_count=$(count_calls "gh api .*PATCH")
+comment_count=$(count_calls "gh issue comment")
+assert_eq "Req 1.4 / NFR 2.1: ラベル成功 + 既存 marker 有りなら新規 comment 0 回" "0" "$comment_count"
+assert_eq "Req 1.4 / NFR 2.1: ラベル成功 + 既存 marker 有りなら PATCH 1 回" "1" "$patch_count"
+cleanup_stub_state
+
+# ── Case E: ラベル付与失敗 + コメント取得失敗 → best-effort で新規 create を試行、戻り値 0（Req 2.3 / 1.2） ──
+reset_stub_state 1 1 ''
+rc=0
+po_apply_awaiting_slot 99 "$OVERLAP" "$HOLDERS" || rc=$?
+assert_eq "Req 2.3: ラベル付与失敗 + コメント取得失敗でも戻り値 0（異常終了しない）" "0" "$rc"
+comment_count=$(count_calls "gh issue comment")
+assert_eq "Req 1.2: コメント取得失敗時も best-effort で新規 comment 投稿を試行" "1" "$comment_count"
+warn_out="$(cat "$WARN_LOG")"
+assert_contains "Req 3.1: ラベル付与失敗の警告に候補 Issue 番号 #99 を含む" "$warn_out" "#99"
+cleanup_stub_state
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Phase E Path Overlap Checker（`PATH_OVERLAP_CHECK=true` 時）において、`awaiting-slot` ラベルの付与に失敗すると early `return 1` してしまい、後続の sticky comment 投稿コードに到達しないバグを修正した。

これにより、ラベル付与に失敗したケースでも「なぜ Issue が止まっているか」の理由が Issue 上のコメントから読み取れるようになり、dispatch 見送りの不可視状態を解消する。修正対象は `po_apply_awaiting_slot`（`local-watcher/bin/modules/promote-pipeline.sh`）のラベル付与ブロックのみで、overlap 判定・呼び出し側 dispatch skip・sticky comment 本文フォーマットは無変更。

## 対応 Issue

Closes #187

## 関連 PR

- 設計 PR: なし（本 Issue は Architect 非経由のバグ修正。requirements.md + impl-notes.md のみ）

## 実装内容

- (Req 1.1 / 1.2) `po_apply_awaiting_slot` 冒頭のラベル付与ブロックを `if/else` 構造に組み替え、付与失敗時の early `return 1` を廃止し、sticky comment 投稿コードへ必ず到達するようにした
- (Req 3.1) ラベル付与失敗時に候補 Issue 番号を含む `po_warn` ログを出力するようにした
- (Req 2.3 / NFR 1.2) 関数の戻り値を常に `0` とすることで、呼び出し側の dispatch skip（`po_check_dispatch_gate:584` 無条件 `return 1`）が変化しないことを確認した

## 受入基準チェック

- [x] Req 1.1: When overlap が検出され sticky comment 投稿処理が呼ばれたとき, the Path Overlap Checker shall ラベル付与の成否に依存せず sticky comment の投稿または更新を試行する ← Case A/B/E（po_apply_awaiting_slot_test.sh）
- [x] Req 1.2: If awaiting-slot ラベルの付与に失敗したとき, the Path Overlap Checker shall sticky comment の投稿または更新を引き続き試行する ← Case A（新規 create 1 回）/ Case E（best-effort create 1 回）
- [x] Req 1.4: While 同一 Issue に marker 付き sticky comment が既に存在するとき, the Path Overlap Checker shall 新規コメントを追加投稿せず既存コメントを更新する ← Case B（label fail）/ Case D（label success）: 新規 0 回 / PATCH 1 回
- [x] Req 2.3: If 失敗したとき, the Path Overlap Checker shall 当該サイクルを異常終了させない ← Case E（戻り値 0）
- [x] Req 3.1: If 付与またはコメント投稿に失敗したとき, the Path Overlap Checker shall 候補 Issue 番号を含む警告をログに出力する ← Case A（#42 含む WARN）/ Case E（#99 含む WARN）
- [x] NFR 1.2: The Path Overlap Checker shall dispatch 見送り戻り値の意味を本修正前と同一に保つ ← Case A/B（label fail でも戻り値 0）/ 呼び出し側 584 行の無条件 return 1 は不変

## テスト結果

```
bash local-watcher/test/po_apply_awaiting_slot_test.sh
PASS: 19, FAIL: 0

shellcheck local-watcher/bin/modules/promote-pipeline.sh local-watcher/test/po_apply_awaiting_slot_test.sh
=> exit 0（警告ゼロ）

既存テスト suite 全 14 件 all PASS（po_apply_awaiting_slot_test.sh 新規含む）
```

## 実装上の判断

- 修正範囲は `po_apply_awaiting_slot` 冒頭のラベル付与ブロック（if 条件の反転 + else 分岐追加）に限定。sticky comment 本文フォーマット・marker・冪等な PATCH/create ロジックは一切変更しない（Out of Scope 準拠）
- `po_apply_awaiting_slot` の戻り値が常に `0` となっても、呼び出し側の dispatch skip は `po_check_dispatch_gate:584` の無条件 `return 1` で決まるため影響なし（NFR 1.2 充足。impl-notes.md 参照）
- 受入観点 (2) の軽量フォールバック（欠落ラベル検出 → WARN / 自動ラベル作成）は別 Issue 扱いのため実装しない（Over-fix の回避）

## 確認事項 / レビュワーへの依頼

- base 検証: `gh pr view` で `baseRefName` を確認し `main` と一致していることを確認済み（後述）
- Reviewer の独立レビュー結果（approve）: `docs/specs/187-bug-watcher-awaiting-slot-phase-e-185-3/review-notes.md` を参照

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #187 のコメントを参照してください。
