### PR TITLE
docs(watcher): #112 反転フラグの stale な opt-in コメントを是正（#197 の作り直し / モジュール化後対応）

### DIFF
--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -522,8 +522,9 @@ unset _idd_mod _idd_mod_path
   exit 1
 }
 
-# PR Iteration が有効化されている時のみ template の存在を必須化（opt-in gate）。
-# 無効化（既定）時は template 未配置でも watcher 全体を起動できるよう、無条件チェックを避ける。
+# PR Iteration が有効化されている時のみ template の存在を必須化する（#112 以降デフォルト有効）。
+# 明示的に無効化（PR_ITERATION_ENABLED=false）した場合は template 未配置でも watcher 全体を
+# 起動できるよう、無条件チェックを避ける。
 if [ "$PR_ITERATION_ENABLED" = "true" ] && [ ! -f "$ITERATION_TEMPLATE" ]; then
   echo "Error: Iteration テンプレートが見つかりません: $ITERATION_TEMPLATE" >&2
   echo "  install.sh --local 再実行で配置されます。" >&2
@@ -805,7 +806,7 @@ EOF
 # 設計 PR が merged なら ラベル除去 + コメント投稿を順次実行する。
 # AC 1.1 / 1.4 / 2.1 / 2.7 / 4.1 / 4.4 / 4.5 / 5.2 / 5.5 / 6.1 / 6.2 / 6.3 / 7.5
 process_design_review_release() {
-  # AC 1.1 / 1.4 / 7.5: opt-in gate（無効化時は完全スキップ）
+  # AC 1.1 / 1.4 / 7.5: opt-out gate（#112 以降デフォルト有効。無効化時は完全スキップ）
   if [ "$DESIGN_REVIEW_RELEASE_ENABLED" != "true" ]; then
     return 0
   fi

--- a/local-watcher/bin/modules/merge-queue.sh
+++ b/local-watcher/bin/modules/merge-queue.sh
@@ -338,7 +338,7 @@ mqr_error() {
 }
 
 process_merge_queue_recheck() {
-  # AC 1.2 / 1.3 / 3.1 / 3.3: opt-in gate（MERGE_QUEUE_ENABLED とは独立）
+  # AC 1.2 / 1.3 / 3.1 / 3.3: opt-out gate（#112 以降デフォルト有効 / MERGE_QUEUE_ENABLED とは独立）
   if [ "$MERGE_QUEUE_RECHECK_ENABLED" != "true" ]; then
     return 0
   fi

--- a/local-watcher/bin/modules/pr-iteration.sh
+++ b/local-watcher/bin/modules/pr-iteration.sh
@@ -69,8 +69,8 @@ pi_fetch_candidate_prs() {
 
   # AC 1.2 / 1.3 / 1.4: クライアント側フィルタ（server filter の保険 + head pattern + fork 除外）
   # #35 AC 4.4 / 5.1: design pattern は PR_ITERATION_DESIGN_ENABLED=true のときのみ OR 条件に
-  # 含める。false（既定）なら impl pattern のみで絞り込み、設計 PR は candidate 段階で除外される
-  # （= 本機能導入前と完全同一の挙動）。
+  # 含める。#112 以降デフォルトは true。明示的に false を渡した場合のみ impl pattern だけで
+  # 絞り込み、設計 PR は candidate 段階で除外される（= 設計 PR 拡張 #35 導入前と同一の挙動）。
   echo "$prs_json" | jq \
     --arg impl_pattern "$PR_ITERATION_HEAD_PATTERN" \
     --arg design_pattern "$PR_ITERATION_DESIGN_HEAD_PATTERN" \
@@ -1406,7 +1406,7 @@ pi_run_iteration() {
 #   AC 1.6, 2.1, 2.2, 8.5, 9.1, 9.3, NFR 1.2, NFR 2.3
 # ─────────────────────────────────────────────────────────────────────────────
 process_pr_iteration() {
-  # AC 2.1: opt-in gate
+  # AC 2.1: opt-out gate（#112 以降デフォルト有効。PR_ITERATION_ENABLED=false で無効化）
   if [ "$PR_ITERATION_ENABLED" != "true" ]; then
     return 0
   fi


### PR DESCRIPTION
## 背景

旧 #197（#112 反転フラグの stale コメント是正）は、**Part 2/3 のモジュール化で対象コメントの大半が `modules/` へ移設**されたため CONFLICTING になり close しました。本 PR は**現 main 構成（issue-watcher.sh + modules/pr-iteration.sh + modules/merge-queue.sh）に対して同じ是正を再適用**します。

## 是正内容（5 箇所・コメントのみ）

#112 でデフォルト有効化された 4 フラグのガード/フィルタ直前コメントが旧 opt-in 表記のまま残っていたのを opt-out 基調へ:

| ファイル | 箇所 | 旧 → 新 |
|---|---|---|
| issue-watcher.sh | PR_ITERATION template 必須化 | 「opt-in gate / 無効化（既定）」→ 「#112 以降デフォルト有効。明示無効化時のみ…」 |
| issue-watcher.sh | `process_design_review_release` | 「opt-in gate」→ 「opt-out gate（#112 以降デフォルト有効）」 |
| modules/pr-iteration.sh | PR_ITERATION_DESIGN 候補フィルタ | 「false（既定）」→ 「#112 以降デフォルト true。明示 false 時のみ…」 |
| modules/pr-iteration.sh | `process_pr_iteration` | 「opt-in gate」→ 「opt-out gate（#112 以降デフォルト有効）」 |
| modules/merge-queue.sh | `process_merge_queue_recheck` | 「opt-in gate」→ 「opt-out gate（#112 以降デフォルト有効）」 |

## 据え置き（真に opt-in＝既定 false）
`PATH_OVERLAP_CHECK` / `PROMOTE_PIPELINE_ENABLED`（modules/promote-pipeline.sh）/ `PER_TASK_LOOP_ENABLED` / `DEBUGGER_ENABLED`（issue-watcher.sh）の opt-in gate 表記は正しいため変更なし。

## Test plan
- ✅ 変更は**全てコメント行のみ**（`git diff` の +/- が全て `#` 始まり・ロジック不変）
- ✅ `bash -n`（本体 + pr-iteration.sh + merge-queue.sh）OK / `shellcheck -S warning` 警告ゼロ
- ✅ 反転フラグの stale 表記が残っていないことを grep 確認（残るは真 opt-in のみ）

## 確認事項
- コメントのみのため挙動・exit code・ラベル契約は不変。
- この stale コメントは実際に誤読の原因になった（#196 を「design iteration 無効」と誤起票 → close）ため、是正の実益あり。

## 関連
- #197（本 PR の前身。モジュール化前ブランチで CONFLICTING → close）
- #112（8 フラグのデフォルト反転）/ #180・#181（コメント移設元の Part 2/3）