### PR TITLE
fix(watcher): Dependency Resolver が merged 済み依存を closed unmerged と誤判定する不具合を修正

### DIFF
--- a/docs/specs/204-bug-watcher-dependency-resolver-146-merg/impl-notes.md
+++ b/docs/specs/204-bug-watcher-dependency-resolver-146-merg/impl-notes.md
@@ -1,0 +1,125 @@
+# 実装ノート (#204)
+
+## 概要
+
+Dependency Resolver（#146）の `dr_resolve_one` が merge 済み依存を `closed unmerged` と
+永久誤判定する false-block バグを是正し、あわせて `dr_extract_deps` がコードフェンス・
+引用ブロック内の依存マーカーを誤抽出する同根の堅牢性問題（Req 4）も修正した。
+
+design.md / tasks.md は本 Issue には存在しない（Architect フェーズ未経由）。requirements.md
+を入力として直接実装した。
+
+## バグの根因
+
+`gh issue view <N> --json closedByPullRequestsReferences` が返す PR ノードには
+`merged` フィールドが**存在しない**（`id` / `number` / `repository` / `url` のみ）。
+旧 `dr_resolve_one` は `jq '[.closedByPullRequestsReferences[]? | select(.merged == true)] | length'`
+で集計していたため、merge 済み PR でも常に 0 件 → `closed unmerged` を返し、merge 済み
+依存に対して永久 `blocked` 再付与が起きていた（実害: #187 が merge 済み #177/#180/#181 に
+永久ブロック）。
+
+## 変更点
+
+### Req 1, 2, 3（`dr_resolve_one` の merge 判定是正）
+
+- 取得経路を `gh issue view --json` から **GraphQL** に変更。`check_existing_impl_pr`
+  （L4979-）に確立済みの `closedByPullRequestsReferences(first:20, includeClosedPrs:true){ nodes { state } }`
+  パターンを踏襲し、PR ノードの `state == "MERGED"` を 1 件以上検出すれば `resolved` と判定。
+- `gh api graphql` 呼び出しを `dr_gh_graphql_closed_by` 関数に切り出し、回帰テストが
+  GraphQL レスポンスを mock 注入できる薄い indirection とした（関数の差し替えで実 API を
+  叩かずに判定ロジックを検証できる）。
+- 安全側挙動（Req 2.1, 2.2）: gh 非 0 rc / GraphQL HTTP200 errors / jq parse 失敗 /
+  issue.state が null・空 / 集計結果が非数値 / 未知 state → すべて `api error`。
+- `$REPO` を `owner` / `repo` に分解（L4962-4969 のパターン踏襲）。owner/repo 形式でない
+  場合も `api error`。
+- timeout は既存 `DRR_GH_TIMEOUT`（default `${MERGE_QUEUE_GIT_TIMEOUT:-60}`）を流用。
+  **新規 env var は導入していない**（Req 3.5 / NFR 3.1）。
+- verdict 語彙（`resolved` / `open` / `closed unmerged` / `api error`）・ラベル契約
+  （`blocked` 付与 / `claude-claimed` 除去）・ログ書式（`dr_log` / `dr_warn`）・env var 名は
+  すべて不変（Req 3.1〜3.5）。`dr_resolve_one` は stdout で verdict 1 行を返す契約も維持。
+
+### Req 4（`dr_extract_deps` の誤検出防止）
+
+- awk による markdown 前処理を追加。(a) ` ``` ` / `~~~` で開閉されるコードフェンス内の行、
+  (b) 行頭（任意個の空白許容）が `>` で始まる引用ブロック行を、依存マーカーマッチの前に
+  除去する。実依存宣言行のみから `#N` を抽出する。
+- フェンスマーカー行自体（言語タグ付き ` ```bash ` 等を含む）も抽出対象外。フェンスは
+  開→閉のトグルで管理。
+- 重複排除・決定的順序（`sort -u -n` による数値昇順 uniq）は維持。関数の純粋性
+  （副作用なし・stdout に番号集合）も不変。
+
+## requirement ID → テスト対応表
+
+回帰テスト: `docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh`
+（実 API を叩かず `dr_gh_graphql_closed_by` を stub 差し替え + dr_* 関数ブロックを awk 抽出して source）。
+
+| Req ID | 担保するテストケース |
+|---|---|
+| 1.1 | `Req1.1 CLOSED+MERGED PR` → resolved / `Req1.1 CLOSED+(CLOSED,MERGED) 混在` → resolved |
+| 1.2 | `Req1.2 CLOSED+CLOSED PR(未merge)` → closed unmerged |
+| 1.3 | `Req1.3 CLOSED+PR 0件` → closed unmerged |
+| 1.4 | `Req1.4 OPEN issue` → open |
+| 1.5 | `Req5.4 旧 .merged 式は誤って 0 件` / `Req5.4 新 .state 式は正しく 1 件`（観測経路是正の固定） |
+| 2.1 | `Req2.1 gh 失敗 rc!=0` / `Req2.1 GraphQL errors` → api error |
+| 2.2 | `Req2.2 issue=null 想定外構造` / `Req2.2 壊れた JSON` / `未知の issue state` → api error |
+| 2.3 / 2.4 | caller `dr_check_dependencies`（L6063-）の既存ロジックで担保。本修正で挙動不変（unresolved/api_error が 1 件でも block、全 resolved で続行）。回帰は verdict 語彙の不変性で間接担保 |
+| 3.1 | verdict 語彙 4 種に限定（テストの assert 値が 4 語彙のみ） |
+| 3.2 / 3.3 | `dr_apply_block` / caller の冪等ガードは本修正で未変更（diff なし）。既存挙動保全 |
+| 3.4 | `dr_log` / `dr_warn` 書式不変（関数本体未変更）。テストでは副作用ログを stub で捨てる |
+| 3.5 | 新規 env var を導入していないこと（grep で `DRR_GH_TIMEOUT` 流用を確認） |
+| 4.1 | `Req4.1 実依存行から抽出` |
+| 4.2 | `Req4.2 コードフェンス内は除外` / `Req4.2 フェンスのみ→空` / `Req4.2 チルダフェンス除外` |
+| 4.3 | `Req4.3 引用ブロック除外` / `Req4.3 インデント引用除外` |
+| 4.4 | `Req4.4 重複排除+昇順` |
+| 4.5 | `Req4.5 依存なし→空` / `空入力→空` |
+| 5.1 | `Req1.1 CLOSED+MERGED PR` |
+| 5.2 | `Req1.2 CLOSED+CLOSED PR(未merge)` |
+| 5.3 | `Req1.4 OPEN issue` |
+| 5.4 | `Req5.4 旧 .merged 式は誤って 0 件` → `Req5.4 新 .state 式は正しく 1 件`（Red→Green を同一 fixture で固定） |
+
+NFR:
+- NFR 1.1（依存記法 0 件で副作用 0）: `dr_check_dependencies` 冒頭の `skip_no_deps` 早期 return は
+  未変更。`dr_extract_deps` が空を返せば gh 呼び出し 0 回（テスト `Req4.5` / `空入力→空` で抽出が空になることを担保）。
+- NFR 1.2（`needs-decisions` 不変更）: `dr_apply_block` 未変更で担保。
+- NFR 2.1 / 2.2（構造化ログ / 警告ログ）: `dr_log` / `dr_warn` 書式不変。
+- NFR 3.1（API 呼び出し線形）: `dr_resolve_one` は依存 1 件あたり `gh api graphql` を 1 回のみ呼ぶ（GraphQL 1 リクエストで state + PR nodes を取得）。
+
+## 実装上の判断・確認事項
+
+- **Req 4 を本修正に含めた**: requirements.md Open Questions の推奨どおり本 PR に含めた。
+  merge 判定バグ（Req 1〜3）と誤抽出（Req 4）は「依存解決の堅牢性不足による false-block」
+  という同根の症状で、awk 前処理の追加は小規模・純粋関数の契約を崩さず、別 Issue 分離が
+  必要なほどの実装複雑度には至らなかったため。分離提案はしない。
+- **検証スクリプトの source 方式**: watcher 本体は末尾に main 実行コード（`_dispatcher_run`）を
+  持ち `BASH_SOURCE` ガードが無いため直接 source できない。テストは `dr_log()` 〜
+  `dr_check_dependencies()` 末尾までの関数定義ブロックを awk で抽出し、mock スタブと一緒に
+  source する方式を採った。この marker（`dr_log() {` 開始 / `dr_check_dependencies` 末尾 `}`）
+  は watcher のリファクタでずれ得るため、テスト側に「抽出失敗時 FATAL」ガードを入れてある。
+- **GraphQL クエリの `first: 20`**: `check_existing_impl_pr` と同値。1 Issue を閉じる PR が
+  20 件を超えるケースは idd-claude 運用では非現実的なため十分なマージン。
+- **caller `dr_check_dependencies` は未変更**: Req 2.3 / 2.4 / 3.2 / 3.3 のブロック確定・
+  冪等 skip ロジックは本修正で触っていない（diff なし）。verdict 語彙が不変なので caller の
+  case 文も影響を受けない。
+
+## 派生タスク候補（次 Issue 化の検討）
+
+- requirements.md の関数ヘッダコメントが `Req 1.1〜1.5, 1.7` のように #146 当時の旧 ID を
+  参照している箇所が残る（本修正で触れた範囲は #204 ID に更新したが、`dr_format_unresolved_comment`
+  等は #146 ID のまま）。ドキュメント整合の軽微な追従。本修正のスコープ外。
+
+## 検証結果
+
+- 回帰テスト: `bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh`
+  → 全 21 ケース pass（exit 0）。
+- `shellcheck local-watcher/bin/issue-watcher.sh` → 警告は 10 件すべて既存の SC2317（info,
+  間接呼び出しロガーの unreachable 誤検知）のみ。main ベースラインと同数で**新規警告ゼロ**。
+- `shellcheck docs/specs/204-.../test-dependency-resolver.sh` → clean（exit 0）。
+- `bash -n local-watcher/bin/issue-watcher.sh` → syntax OK。
+
+## コミット
+
+- `d13a3db` fix(watcher): dr_resolve_one が merged 依存を closed unmerged と誤判定する不具合を修正（Req 1/2/3）
+- `ef560bf` fix(watcher): dr_extract_deps がコードフェンス/引用内の依存マーカーを誤抽出する不具合を修正（Req 4）
+- `67a33c2` test(watcher): Dependency Resolver の merge 判定 / 依存抽出の回帰テストを追加（Req 5）
+
+STATUS: complete

--- a/docs/specs/204-bug-watcher-dependency-resolver-146-merg/requirements.md
+++ b/docs/specs/204-bug-watcher-dependency-resolver-146-merg/requirements.md
@@ -1,0 +1,98 @@
+# Requirements Document
+
+## Introduction
+
+Dependency Resolver（#146 で実装）は `Depends on: #N` を宣言した Issue の依存先 Issue が merge 済みかを判定し、未解決なら `blocked` ラベルを付与して自動処理を中止する。しかし依存先が CLOSED の場合のマージ判定で、PR ノードの merge 状態を取得できない取得経路を使っているため、merge 済みでも常に「未 merge で閉じられた」と誤判定する。この結果、依存先がすべて merge 済みでも対象 Issue は永久に `blocked` が再付与され、自動処理が二度と再開しない false-block が発生している（実害: #187 が merge 済みの #177 / #180 / #181 に永久ブロックされた）。本修正は CLOSED 依存のマージ判定を正しい観測経路に是正し、後方互換契約（verdict 文字列・ラベル契約・ログ書式・env var）を不変に保つことを目的とする。あわせて、依存抽出が説明文・コード例の依存マーカーを誤検出して false-block を起こす同根の堅牢性問題も対象に含める。
+
+## Requirements
+
+### Requirement 1: CLOSED 依存のマージ状態判定の是正
+
+**Objective:** As a watcher 運用者, I want CLOSED な依存 Issue が merge 済みで閉じられたかを正しく判定してほしい, so that merge 済み依存に対する永久 false-block が解消される
+
+#### Acceptance Criteria
+
+1. When 依存先 Issue が CLOSED でありかつ少なくとも 1 件の merge 済み PR で閉じられたとき, the Dependency Resolver shall その依存を `resolved` と判定する
+2. When 依存先 Issue が CLOSED でありかつ閉じた PR がいずれも merge されていないとき, the Dependency Resolver shall その依存を `closed unmerged` と判定する
+3. When 依存先 Issue が CLOSED でありかつ紐づく PR が 1 件も存在しないとき, the Dependency Resolver shall その依存を `closed unmerged` と判定する
+4. When 依存先 Issue が OPEN のとき, the Dependency Resolver shall その依存を `open` と判定する
+5. The Dependency Resolver shall 依存先の merge 状態を、PR ノードの merge 状態（merged / closed-unmerged の区別）を観測可能な経路から取得する
+
+### Requirement 2: 判定失敗時の安全側挙動
+
+**Objective:** As a watcher 運用者, I want 依存状態の取得に失敗したときも安全側に倒れてほしい, so that 取得失敗が merge 済み扱いの誤った自動処理続行につながらない
+
+#### Acceptance Criteria
+
+1. If 依存先 Issue の状態取得に失敗したとき, the Dependency Resolver shall その依存を `api error` と判定する
+2. If 取得した応答が想定外の構造で merge 状態を解釈できないとき, the Dependency Resolver shall その依存を `api error` と判定する
+3. When いずれかの依存が `open` / `closed unmerged` / `api error` のいずれかと判定されたとき, the Dependency Resolver shall 対象 Issue を block 確定として扱う
+4. When すべての依存が `resolved` と判定されたとき, the Dependency Resolver shall 対象 Issue を block せず後続処理を続行させる
+
+### Requirement 3: 後方互換契約の維持
+
+**Objective:** As a 既存 consumer repo の運用者, I want 本修正が外部から観測可能な契約を一切変えないことを保証してほしい, so that 既稼働の cron / ラベル運用 / ログ解析を壊さずに修正を取り込める
+
+#### Acceptance Criteria
+
+1. The Dependency Resolver shall 依存判定の結果語彙を `resolved` / `open` / `closed unmerged` / `api error` の 4 種に限定し、新規語彙を追加しない
+2. When 対象 Issue が block 確定したとき, the Dependency Resolver shall `blocked` ラベルを付与しかつ `claude-claimed` ラベルを除去する
+3. While 対象 Issue に既に `blocked` ラベルが付与されているとき, the Dependency Resolver shall ラベル再付与・コメント再投稿を行わず冪等に skip する
+4. The Dependency Resolver shall 構造化ログの書式（`dr_log` / `dr_warn` の出力形式と verdict キー）を本修正前と同一に保つ
+5. The Dependency Resolver shall 既存の環境変数名を変更・削除せず、新規の必須環境変数を導入しない
+
+### Requirement 4: 依存抽出の誤検出防止
+
+**Objective:** As a Issue 起票者, I want 説明文・コード例・引用に含まれる依存マーカーが実依存として誤抽出されないでほしい, so that 例示目的で依存記法を書いた Issue が誤って false-block されない
+
+#### Acceptance Criteria
+
+1. When Issue 本文の実依存宣言行に依存記法が記述されているとき, the Dependency Resolver shall その行から依存 Issue 番号を抽出する
+2. Where 依存記法が markdown コードフェンスで囲まれたブロック内に現れるとき, the Dependency Resolver shall その記法を実依存として抽出しない
+3. Where 依存記法が引用ブロック（行頭が引用記号の行）に現れるとき, the Dependency Resolver shall その記法を実依存として抽出しない
+4. The Dependency Resolver shall 抽出した依存 Issue 番号集合を重複排除しかつ決定的な順序で出力する
+5. When 本文中に依存記法がいずれの抽出対象行にも存在しないとき, the Dependency Resolver shall 依存抽出結果を空とし副作用なしで後続処理を続行させる
+
+### Requirement 5: 回帰の固定
+
+**Objective:** As a 保守担当, I want 本バグの再発を検知する回帰テストが固定されていてほしい, so that 将来の変更で同種の false-block が再混入したときに検知できる
+
+#### Acceptance Criteria
+
+1. The 検証スイート shall 「CLOSED + merge 済み PR で閉じた依存」が `resolved` と判定されることを確認するケースを含む
+2. The 検証スイート shall 「CLOSED + 未 merge（手動 close）依存」が `closed unmerged` と判定されることを確認するケースを含む
+3. The 検証スイート shall 「OPEN 依存」が `open` と判定されることを確認するケースを含む
+4. The 検証スイート shall 本修正前のコードでケース 1 が誤判定（`closed unmerged`）となり修正後に正される Red→Green 遷移を確認できる構成を含む
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性（既存挙動の保全）
+
+1. When 依存記法が Issue 本文に 1 件も存在しないとき, the Dependency Resolver shall gh API 呼び出し・ラベル変更・コメント投稿を 0 回とし本修正前と同一の pickup 挙動を維持する
+2. The Dependency Resolver shall `blocked` ラベル付与時に `needs-decisions` ラベルの状態を変更しない
+
+### NFR 2: 可観測性
+
+1. The Dependency Resolver shall 各 Issue の依存チェック結果について、抽出した依存・解決済み依存・未解決依存・最終 verdict を含む構造化ログを 1 行以上出力する
+2. If 依存状態取得が失敗したとき, the Dependency Resolver shall 対象 Issue 番号と失敗事由を含む警告ログを標準エラー出力に出力する
+
+### NFR 3: 性能・運用負荷
+
+1. The Dependency Resolver shall 1 つの依存先 Issue のマージ状態判定に要する外部 API 呼び出しを、依存件数に対し線形（依存 1 件あたり定数回）に保つ
+
+## Out of Scope
+
+- 既存 Issue 本文の依存記法を canonical 表記へ書き換える retrofit（`.claude/rules/issue-dependency.md` の「既存 Issue の retrofit は不要」方針に従う）
+- `blocked` 解除後の自動再開フロー自体の変更（依存解消後に `blocked` を手動除去して次 tick で再合流する既存運用は不変）
+- GitHub Actions 版ワークフロー（`issue-to-pr.yml`）側の依存判定（本 Issue はローカル watcher の Dependency Resolver が対象）
+- 逆ブロッキング（`Blocks: #N`）の検出。canonical では被ブロッキング側 `Depends on:` のみを対象とする既存方針を踏襲
+- `Parent:` / `Sibling:` / `Related:` / `Split from:` など非ブロッキング関係種別の判定（従来通り block 対象外）
+- watcher 全体のラベル状態遷移・slot 直列化（#187 / #198 / #200 の path 管理）の再設計
+
+## Open Questions
+
+確認事項:
+
+- 副次スコープ（Requirement 4: `dr_extract_deps` の誤検出防止）の扱いについて: Issue 本文の推奨に従い本修正に **含める** 判断とした。理由は (a) merge 判定バグ（Req 1〜3）と誤検出（Req 4）はいずれも「依存解決の堅牢性不足による false-block」という同根の症状であり、本 Issue 自身が説明文中の依存マーカーを誤抽出されて block された実害がある、(b) #146 実装の `dr_extract_deps` は元々 NFR 1.4 でコードフェンス/引用内の誤検出を「スコープ外（運用者が手動でラベル除去して復旧）」と明記していたため、本修正で堅牢性を引き上げることが既存 NFR の正当な更新になる、(c) 両者は同一関数群（`dr_*`）の小規模修正であり 1 PR で完結できる粒度である。ただし Req 4 のコードフェンス/引用判定は新規の本文パース挙動を伴うため、もし Architect が実装複雑度を高すぎると判断した場合は Req 4 のみを別 Issue（`Depends on: #204`）に分離する選択肢を許容する。分離可否は Architect の設計判断に委ねる。
+- Requirement 1.5 のマージ状態取得経路について: Issue は GraphQL 直叩き（`closedByPullRequestsReferences ... { nodes { number state } }` の `state == "MERGED"` 判定、同ファイル L4979-4991 に確立済みパターンあり）を推奨経路として提示している。具体的な取得手段の選定は design.md（Architect）の領分とし、本要件では「PR の merge 状態を観測可能な経路から取得する」観点のみを固定した。代替の `gh pr view` 個別問い合わせ方式（API 呼び出し増）を採るかは設計判断に委ねる。
+- それ以外の不明点はなし。

--- a/docs/specs/204-bug-watcher-dependency-resolver-146-merg/review-notes.md
+++ b/docs/specs/204-bug-watcher-dependency-resolver-146-merg/review-notes.md
@@ -1,0 +1,57 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-204-impl-bug-watcher-dependency-resolver-146-merg
+- HEAD commit: d28e146d4f4d20677c204291605bd4489f38ed88
+- Compared to: main..HEAD
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しない → opt-out 解釈。flag 観点の細目は適用せず、通常の 3 カテゴリ判定のみ実施。
+
+## Verified Requirements
+
+- 1.1 — `dr_resolve_one` CLOSED 分岐で `nodes[].state == "MERGED"` を 1 件以上検出すれば `resolved`（issue-watcher.sh:6000-6018）。テスト `Req1.1 CLOSED+MERGED PR` / `Req1.1 CLOSED+(CLOSED,MERGED) 混在` で pass
+- 1.2 — MERGED 0 件（PR が CLOSED のみ）で `closed unmerged`。テスト `Req1.2 CLOSED+CLOSED PR(未merge)` で pass
+- 1.3 — 紐づく PR 0 件（空配列）で `closed unmerged`（`nodes[]?` + length 0 経路）。テスト `Req1.3 CLOSED+PR 0件` で pass
+- 1.4 — `issue.state == "OPEN"` → `open`（case OPEN 分岐 issue-watcher.sh:5995 付近）。テスト `Req1.4 OPEN issue` で pass
+- 1.5 — 取得経路を `gh issue view --json`（`.merged` 不在）から GraphQL `closedByPullRequestsReferences(first:20, includeClosedPrs:true){nodes{state}}` に是正（`dr_gh_graphql_closed_by` issue-watcher.sh:5896-5948）。観測可能経路 `state == "MERGED"` で判定
+- 2.1 — gh rc!=0 / GraphQL HTTP200 errors を検査し `api error`（issue-watcher.sh で `gh_rc` 判定 + `.errors` 検査）。テスト `Req2.1 gh 失敗 rc!=0` / `Req2.1 GraphQL errors` で pass
+- 2.2 — issue.state null/空・jq parse 失敗・集計が非数値 → `api error`（state null ガード + `[[ =~ ^[0-9]+$ ]]` ガード）。テスト `Req2.2 issue=null 想定外構造` / `Req2.2 壊れた JSON` / `未知の issue state` で pass
+- 2.3 — caller `dr_check_dependencies`（issue-watcher.sh:6150-6157）で unresolved_lines が空でなければ block 確定。本修正で未変更（diff なし）、verdict 語彙整合で担保
+- 2.4 — 全件 resolved で `return 0`（後続続行、issue-watcher.sh:6159-6161）。本修正で未変更
+- 3.1 — verdict 語彙は `resolved` / `open` / `closed unmerged` / `api error` の 4 種に限定。caller の case 文（issue-watcher.sh:6125-6147）も同 4 語彙を消費しており新規語彙なし
+- 3.2 — block 時の `blocked` 付与 + `claude-claimed` 除去は `dr_apply_block`（未変更、diff なし）で担保
+- 3.3 — 既存 `blocked` 付与時の冪等 skip は `dr_check_dependencies` 冒頭ガード（issue-watcher.sh:6098-6101、未変更）で担保
+- 3.4 — `dr_log` / `dr_warn` 関数本体は diff に含まれず書式不変
+- 3.5 — 新規必須 env var なし。timeout は既存 `DRR_GH_TIMEOUT`（`MERGE_QUEUE_GIT_TIMEOUT` フォールバック）を流用。env var 名の変更・削除なし
+- 4.1 — 実依存宣言行から `#N` を抽出（`Depends on:` / `前提依存:` / `Blocked by:`）。テスト `Req4.1 実依存行から抽出` で pass
+- 4.2 — awk でコードフェンス（``` / ~~~）開閉トグルし内部行とマーカー行を除外。テスト `Req4.2 コードフェンス内は除外` / `フェンスのみ→空` / `チルダフェンス除外` で pass
+- 4.3 — awk で行頭（空白許容）`>` の引用行を除外。テスト `Req4.3 引用ブロック除外` / `インデント引用除外` で pass
+- 4.4 — `sort -u -n` で重複排除 + 数値昇順。テスト `Req4.4 重複排除+昇順` で pass
+- 4.5 — 抽出対象行に記法なしで空 stdout + 副作用なし。テスト `Req4.5 依存なし→空` / `空入力→空` で pass
+- 5.1 — 検証スイートに `Req1.1 CLOSED+MERGED PR` → resolved ケースあり
+- 5.2 — `Req1.2 CLOSED+CLOSED PR(未merge)` → closed unmerged ケースあり
+- 5.3 — `Req1.4 OPEN issue` → open ケースあり
+- 5.4 — 同一 fixture（CLOSED+MERGED）で旧式 `.merged==true` が 0 件・新式 `.state=="MERGED"` が 1 件であることを assert する Red→Green ガードあり（test-dependency-resolver.sh:157-169）
+- NFR 1.1 — 依存記法 0 件で `dr_extract_deps` が空 → `dr_check_dependencies` 早期 return（gh 呼び出し 0 回）。早期 return 経路は未変更
+- NFR 1.2 — `needs-decisions` 状態は `dr_apply_block`（未変更）で変更されない
+- NFR 2.1 / 2.2 — 構造化ログ（`dr_log`）と警告ログ（`dr_warn` を stderr へ）の書式不変
+- NFR 3.1 — `dr_resolve_one` は依存 1 件あたり `gh api graphql` を 1 回のみ呼ぶ（state + PR nodes を 1 リクエストで取得）。依存件数に対し線形
+
+## 独立検証ログ
+
+- `git diff --stat main..HEAD`: 変更は impl-notes.md / test-dependency-resolver.sh / issue-watcher.sh の 3 ファイルのみ。`requirements.md` 等の仕様書き換えなし
+- `git diff main..HEAD -- local-watcher/bin/issue-watcher.sh`: 変更 hunk は `dr_extract_deps` / 新規 `dr_gh_graphql_closed_by` / `dr_resolve_one` に限定。`dr_check_dependencies` / `dr_apply_block` への変更なし（boundary 内）
+- `bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh` → `All 21 cases passed.` exit 0 を確認（reviewer 自身で再実行）
+- Out of Scope（既存 Issue retrofit / Actions workflow / 逆ブロッキング `Blocks:` / 非ブロッキング関係種別 / watcher 全体の path 管理）への侵食は差分に存在しない
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric AC（Req 1.1〜5.4 / NFR 1〜3）に対応する実装が確認でき、回帰テスト 21 ケースが全 pass。verdict 語彙・ラベル契約・ログ書式・env var の後方互換が保たれ、boundary 逸脱・missing test・AC 未カバーはいずれも検出されなかった。
+
+RESULT: approve

--- a/docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
+++ b/docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# 用途: Dependency Resolver (#146) の merge 判定 (dr_resolve_one) と依存抽出
+#       (dr_extract_deps) の回帰テスト（#204 false-block 再発防止）
+# 配置先: docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
+# 依存: bash 4+, jq, sed
+# セットアップ参照先: docs/specs/204-bug-watcher-dependency-resolver-146-merg/impl-notes.md
+#
+# Usage:
+#   bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
+#
+# Exit code:
+#   0 = すべてのケースが期待通り
+#   1 = いずれかのケースが不一致（standard error にどれが失敗したか出力）
+#
+# 設計:
+#   - 実 GitHub API を叩かず、`gh api graphql` ラッパ `dr_gh_graphql_closed_by` を
+#     テスト側で stub に差し替えて GraphQL レスポンスを mock 注入する。
+#   - watcher 本体 issue-watcher.sh は末尾に main 実行コードを持つため source できない。
+#     よって `dr_*` 関数定義ブロック（dr_log 〜 dr_check_dependencies）のみを sed で
+#     抽出し、本テスト harness 内で source する（Req 5.x）。
+#   - dr_warn / dr_log は副作用ログを stderr/stdout に出すため、テスト中は捨てる。
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+WATCHER="$SCRIPT_DIR/../../../local-watcher/bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER" ]; then
+  echo "[FATAL] watcher script not found: $WATCHER" >&2
+  exit 1
+fi
+
+# ── dr_* 関数ブロックを抽出して source ──
+# 先頭 marker: `dr_log() {`、末尾 marker: `dr_check_dependencies` の関数末尾の `}`。
+# 関数群は連続して定義されているため、dr_log() の行から dr_check_dependencies() の
+# 直後に来る次トップレベル定義の手前までを抽出する。ここでは安全のため
+# `dr_log()` 〜 `dr_check_dependencies` 本体終端の `^}` までを抽出する。
+EXTRACTED=$(mktemp)
+trap 'rm -f "$EXTRACTED"' EXIT
+
+awk '
+  /^dr_log\(\) \{/ { capture = 1 }
+  capture { print }
+  capture && /^dr_check_dependencies\(\) \{/ { in_check = 1 }
+  in_check && /^\}$/ { capture = 0; in_check = 0 }
+' "$WATCHER" > "$EXTRACTED"
+
+if ! grep -q '^dr_resolve_one() {' "$EXTRACTED"; then
+  echo "[FATAL] dr_resolve_one を抽出できませんでした（watcher のリファクタで marker がずれた可能性）" >&2
+  exit 1
+fi
+
+# テスト用の環境（REPO は owner/repo 形式が前提）。
+# これらは source した dr_* 関数内で参照されるため shellcheck は未使用と誤検知する。
+# shellcheck disable=SC2034
+REPO="owner/repo"
+# shellcheck disable=SC2034
+DRR_GH_TIMEOUT=60
+# shellcheck disable=SC2034
+MERGE_QUEUE_GIT_TIMEOUT=60
+
+# shellcheck disable=SC1090
+source "$EXTRACTED"
+
+# 抽出ブロックは dr_log / dr_warn / dr_error を定義しているため、source 後に上書きして
+# テスト中の副作用ログを捨てる（ログ書式の検証は本テストのスコープ外 / Req 3.4 は
+# 書式不変の契約であり、別途 grep ベースで担保される）。
+dr_log() { :; }
+dr_warn() { :; }
+dr_error() { :; }
+
+# ── mock 注入の仕組み ──
+# dr_gh_graphql_closed_by を上書きし、グローバル変数 MOCK_RESPONSE / MOCK_RC で
+# 振る舞いを制御する。MOCK_RC != 0 のときは gh 失敗を模す。
+MOCK_RESPONSE=""
+MOCK_RC=0
+dr_gh_graphql_closed_by() {
+  printf '%s' "$MOCK_RESPONSE"
+  return "$MOCK_RC"
+}
+
+fail_count=0
+pass_count=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "[OK]   $label -> '$actual'"
+    pass_count=$((pass_count + 1))
+  else
+    echo "[FAIL] $label: expected '$expected', got '$actual'" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+# GraphQL レスポンス生成ヘルパ。
+# $1 = issue state (OPEN|CLOSED), 残り = PR ノードの state 列（MERGED|CLOSED|OPEN）。
+make_response() {
+  local state="$1"; shift
+  local nodes_json="[]"
+  if [ "$#" -gt 0 ]; then
+    nodes_json=$(printf '%s\n' "$@" \
+      | jq -R '{number: 0, state: .}' \
+      | jq -s '.')
+  fi
+  jq -n --arg state "$state" --argjson nodes "$nodes_json" '
+    {data: {repository: {issue: {state: $state, closedByPullRequestsReferences: {nodes: $nodes}}}}}'
+}
+
+echo "=== dr_resolve_one: merge 判定 ==="
+
+# Req 5.1: CLOSED + merge 済み PR → resolved
+MOCK_RC=0
+MOCK_RESPONSE=$(make_response CLOSED MERGED)
+assert_eq "Req1.1 CLOSED+MERGED PR" "resolved" "$(dr_resolve_one 177)"
+
+# Req 5.1 補強: CLOSED + (CLOSED PR, MERGED PR 混在) → resolved（1 件でも MERGED なら）
+MOCK_RESPONSE=$(make_response CLOSED CLOSED MERGED)
+assert_eq "Req1.1 CLOSED+(CLOSED,MERGED) 混在" "resolved" "$(dr_resolve_one 178)"
+
+# Req 5.2: CLOSED + 未 merge（手動 close, PR が CLOSED のみ） → closed unmerged
+MOCK_RESPONSE=$(make_response CLOSED CLOSED)
+assert_eq "Req1.2 CLOSED+CLOSED PR(未merge)" "closed unmerged" "$(dr_resolve_one 179)"
+
+# Req 1.3: CLOSED + 紐づく PR が 0 件 → closed unmerged
+MOCK_RESPONSE=$(make_response CLOSED)
+assert_eq "Req1.3 CLOSED+PR 0件" "closed unmerged" "$(dr_resolve_one 180)"
+
+# Req 5.3: OPEN → open
+MOCK_RESPONSE=$(make_response OPEN)
+assert_eq "Req1.4 OPEN issue" "open" "$(dr_resolve_one 181)"
+
+echo "=== dr_resolve_one: 安全側挙動 (Req 2) ==="
+
+# Req 2.1: gh api graphql 失敗（非 0 rc） → api error
+MOCK_RC=1
+MOCK_RESPONSE="gh: rate limit exceeded"
+assert_eq "Req2.1 gh 失敗 rc!=0" "api error" "$(dr_resolve_one 999)"
+MOCK_RC=0
+
+# Req 2.1: GraphQL HTTP200 + errors → api error
+MOCK_RESPONSE='{"errors":[{"message":"Could not resolve to a node","type":"NOT_FOUND"}]}'
+assert_eq "Req2.1 GraphQL errors" "api error" "$(dr_resolve_one 998)"
+
+# Req 2.2: 想定外構造（issue が null） → api error
+MOCK_RESPONSE='{"data":{"repository":{"issue":null}}}'
+assert_eq "Req2.2 issue=null 想定外構造" "api error" "$(dr_resolve_one 997)"
+
+# Req 2.2: jq parse 不能（壊れた JSON） → api error
+MOCK_RESPONSE='not a json at all {{{'
+assert_eq "Req2.2 壊れた JSON" "api error" "$(dr_resolve_one 996)"
+
+# 未知の state → api error（安全側）
+MOCK_RESPONSE=$(make_response WEIRD_STATE)
+assert_eq "未知の issue state" "api error" "$(dr_resolve_one 995)"
+
+echo "=== Red->Green ガード (Req 5.4) ==="
+# 旧実装相当: gh issue view --json closedByPullRequestsReferences の PR ノードは
+# `merged` フィールドを持たず `state` のみ持つ。旧 jq は `.merged == true` で集計して
+# いたため、CLOSED+MERGED ケースでも 0 件 → "closed unmerged" を誤って返していた。
+# 本テストは「旧 jq 式が誤判定すること」を明示的に固定し、新実装(.state=="MERGED")が
+# 正すことを保証する。
+OLD_JQ_FILTER='[.data.repository.issue.closedByPullRequestsReferences.nodes[]? | select(.merged == true)] | length'
+NEW_JQ_FILTER='[.data.repository.issue.closedByPullRequestsReferences.nodes[]? | select(.state == "MERGED")] | length'
+MERGED_RESP=$(make_response CLOSED MERGED)
+old_count=$(printf '%s' "$MERGED_RESP" | jq "$OLD_JQ_FILTER")
+new_count=$(printf '%s' "$MERGED_RESP" | jq "$NEW_JQ_FILTER")
+assert_eq "Req5.4 旧 .merged 式は誤って 0 件" "0" "$old_count"
+assert_eq "Req5.4 新 .state 式は正しく 1 件" "1" "$new_count"
+
+echo "=== dr_extract_deps: 誤検出防止 (Req 4) ==="
+
+# Req 4.1: 実依存宣言行から #N を抽出
+body_real=$'依存関係:\n\n- Depends on: #12 #34\n- 前提依存: #56\n'
+expected_real=$'12\n34\n56'
+assert_eq "Req4.1 実依存行から抽出" "$expected_real" "$(dr_extract_deps "$body_real")"
+
+# Req 4.2: コードフェンス内の依存マーカーは抽出しない
+body_fence=$'説明:\n\n```markdown\nDepends on: #999\n```\n\n- Depends on: #12\n'
+assert_eq "Req4.2 コードフェンス内は除外" "12" "$(dr_extract_deps "$body_fence")"
+
+# Req 4.2 補強: コードフェンスのみ（実依存なし） → 空
+body_fence_only=$'例:\n\n```\nBlocked by: #999\n```\n'
+assert_eq "Req4.2 フェンスのみ→空" "" "$(dr_extract_deps "$body_fence_only")"
+
+# Req 4.2 補強: チルダフェンス (~~~) も除外
+body_tilde=$'~~~\nDepends on: #888\n~~~\n- Depends on: #7\n'
+assert_eq "Req4.2 チルダフェンス除外" "7" "$(dr_extract_deps "$body_tilde")"
+
+# Req 4.3: 引用ブロック（行頭 >）内の依存マーカーは抽出しない
+body_quote=$'> Depends on: #999\n\n- Depends on: #21\n'
+assert_eq "Req4.3 引用ブロック除外" "21" "$(dr_extract_deps "$body_quote")"
+
+# Req 4.3 補強: 引用 + 先頭スペース付きの引用記号
+body_quote_indent=$'   > 前提依存: #777\nDepends on: #5\n'
+assert_eq "Req4.3 インデント引用除外" "5" "$(dr_extract_deps "$body_quote_indent")"
+
+# Req 4.4: 重複排除 + 決定的順序（数値昇順）
+body_dup=$'- Depends on: #34 #12\n- Blocked by: #12\n- Depends on: #5\n'
+expected_dup=$'5\n12\n34'
+assert_eq "Req4.4 重複排除+昇順" "$expected_dup" "$(dr_extract_deps "$body_dup")"
+
+# Req 4.5: 依存記法が抽出対象行に無い → 空（フェンス/引用のみ）
+body_none=$'通常の本文。依存はありません。\n'
+assert_eq "Req4.5 依存なし→空" "" "$(dr_extract_deps "$body_none")"
+
+# NFR: 空入力 → 空
+assert_eq "空入力→空" "" "$(dr_extract_deps "")"
+
+echo ""
+if [ "$fail_count" -gt 0 ]; then
+  echo "$fail_count case(s) failed, $pass_count passed." >&2
+  exit 1
+fi
+echo "All $pass_count cases passed."

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -5782,27 +5782,55 @@ dr_error() {
 # 空入力・記法非存在では空 stdout を返す（return 0）。
 # 副作用なし（純粋関数）。
 #
-# 検出する記法（`.claude/rules/issue-dependency.md` と整合 / Req 1.1〜1.5, 1.7）:
+# 検出する記法（`.claude/rules/issue-dependency.md` と整合 / Req 4.1, 4.4）:
 #   - canonical: `Depends on: #N` （行頭の `- ` などの list prefix を許容）
 #   - alias 日本語: `前提依存: #N`
 #   - alias 英語慣習: `Blocked by: #N`
 #
 # 1 行に複数の Issue 番号がスペース区切り / カンマ区切りで列挙される場合も対応する
-# （Req 1.4）。`grep -oE '#[0-9]+'` で行内の番号を全列挙し、`sort -u` で uniq 化
-# （Req 1.5）。
+# （Req 4.4）。`grep -oE '#[0-9]+'` で行内の番号を全列挙し、`sort -u -n` で uniq 化
+# （Req 4.4）。
 #
-# 誤検出許容範囲（NFR 1.4）: markdown コードフェンス内・引用ブロック内の
-# 同記法も検出してしまう可能性があるが、本機能のスコープ外（誤検出時は運用者が
-# `blocked` ラベルを手動除去で復旧する設計）。
+# 誤検出防止（Req 4.2, 4.3 / #204）: markdown コードフェンス（``` または ~~~ で
+# 開閉されるブロック）内および引用ブロック（行頭が任意個の空白に続く `>` で始まる行）
+# 内の依存マーカーは実依存として抽出しない。例示目的でコード例・引用に依存記法を
+# 書いた Issue が誤って false-block されるのを防ぐ。これらの行は markdown 前処理
+# （awk）で除去してからマーカーマッチを行う。
 dr_extract_deps() {
   local body="$1"
+
+  # ── markdown 前処理: コードフェンス内・引用ブロック行を除去（Req 4.2, 4.3）──
+  # awk でフェンス開閉をトグル管理し、フェンス内行と引用行（行頭空白 + `>`）を捨てる。
+  # フェンスマーカーは行頭（任意個の空白を許容）の ``` または ~~~ で開始する行。
+  # 言語タグ（```bash 等）や閉じフェンスも同じ判定で扱う（開→閉のトグル）。
+  local filtered
+  filtered=$(printf '%s\n' "$body" | awk '
+    {
+      line = $0
+      # 行頭の空白を除いた先頭部分を取り出してフェンス / 引用を判定する。
+      stripped = line
+      sub(/^[ \t]+/, "", stripped)
+      # コードフェンス開閉トグル（``` または ~~~ で始まる行）。
+      if (stripped ~ /^(```|~~~)/) {
+        in_fence = !in_fence
+        next            # フェンスマーカー行自体も依存抽出の対象外
+      }
+      if (in_fence) {
+        next            # フェンス内の本文行は除外（Req 4.2）
+      }
+      if (stripped ~ /^>/) {
+        next            # 引用ブロック行は除外（Req 4.3）
+      }
+      print line
+    }
+  ')
 
   # 行抽出: canonical + alias の 3 パターン。
   # `-E` で ERE、`-i` は使わず大文字小文字を厳密にし誤検出を減らす（既存運用で
   # `Depends on:` / `Blocked by:` は大文字始まり前提）。`前提依存:` は UTF-8
   # バイト列として直接マッチ（grep -E で安全）。
   local matched_lines
-  matched_lines=$(printf '%s\n' "$body" \
+  matched_lines=$(printf '%s\n' "$filtered" \
     | grep -E '(Depends on:|前提依存:|Blocked by:)' || true)
 
   if [ -z "$matched_lines" ]; then
@@ -5810,7 +5838,7 @@ dr_extract_deps() {
   fi
 
   # 行ごとに `#[0-9]+` を全列挙し、`#` を剥がして数字のみにし uniq 化。
-  # `sort -u -n` で数値昇順 + uniq（出力決定性を確保）。
+  # `sort -u -n` で数値昇順 + uniq（出力決定性を確保 / Req 4.4）。
   printf '%s\n' "$matched_lines" \
     | grep -oE '#[0-9]+' \
     | sed -E 's/^#//' \

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -5853,34 +5853,112 @@ ${items}
 EOF_DR_COMMENT
 }
 
+# 引数:
+#   $1 = owner（$REPO の owner 部）
+#   $2 = repo 名（$REPO の repo 部）
+#   $3 = 依存 Issue 番号（数字のみ）
+# stdout = `gh api graphql` の生レスポンス（JSON 文字列）。失敗時は stderr 本文。
+# return = gh api graphql の exit code をそのまま返す。
+# 副作用 = なし（呼び出し元がエラーログを担当）。
+#
+# 本ラッパは dr_resolve_one から `gh api graphql` 呼び出しを切り出したもので、
+# 回帰テストが GraphQL レスポンスを mock 注入できるよう薄い indirection を提供する
+# （実 API を叩かずに dr_resolve_one の判定ロジックを検証するため / Req 5.x）。
+# timeout は既存の DRR_GH_TIMEOUT（新規 env var を導入しない / Req 3.5, NFR 3.1）。
+dr_gh_graphql_closed_by() {
+  local owner="$1"
+  local repo_name="$2"
+  local dep_num="$3"
+
+  # GraphQL クエリ: Issue 視点の `closedByPullRequestsReferences` で linked PR の
+  # state を取得する（PR ノードに `state` フィールドは存在するが、`gh issue view
+  # --json closedByPullRequestsReferences` の REST 経路では `merged` フィールドが
+  # 返らないため誤判定していた / 本 bug の根因）。
+  # `includeClosedPrs: true` で CLOSED/MERGED の PR も含めて返させる。
+  # `first: 20` は check_existing_impl_pr と同じく十分なマージン。
+  # shellcheck disable=SC2016  # `$owner` / `$repo` / `$number` は GraphQL 変数記法であり bash 展開ではない（`-F` で値を渡す）
+  local query='query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      issue(number: $number) {
+        state
+        closedByPullRequestsReferences(first: 20, includeClosedPrs: true) {
+          nodes {
+            number
+            state
+          }
+        }
+      }
+    }
+  }'
+
+  timeout "${DRR_GH_TIMEOUT:-${MERGE_QUEUE_GIT_TIMEOUT:-60}}" \
+    gh api graphql \
+      -f query="$query" \
+      -F owner="$owner" \
+      -F repo="$repo_name" \
+      -F number="$dep_num" 2>&1
+}
+
 # 引数 $1 = 依存 Issue 番号（数字のみ）。
 # stdout = 区分文字列 1 行: "resolved" | "open" | "closed unmerged" | "api error"。
 # return = 常に 0（判定結果は stdout で返す）。
 # 副作用 = API エラー / jq parse 失敗時のみ dr_warn でログ（Req 6.2）。
 #
-# `gh issue view <N> --repo "$REPO" --json state,closedByPullRequestsReferences` を
-# 実行し、`jq` で以下を判定:
-#   - state == "OPEN"  → "open"（unresolved / Req 2.3）
-#   - state == "CLOSED" かつ closedByPullRequestsReferences[].merged のいずれかが
-#     true → "resolved"（Req 2.2）
-#   - state == "CLOSED" かつ上記が全て false / 空配列 → "closed unmerged"（Req 2.4）
-#   - gh / jq 失敗 / 未知の state → "api error"（Req 2.5 / NFR 4.2 安全側）
+# `dr_gh_graphql_closed_by` で Issue の state と
+# `closedByPullRequestsReferences.nodes[].state` を取得し、以下を判定:
+#   - issue.state == "OPEN"  → "open"（unresolved / Req 1.4 / 旧 2.3）
+#   - issue.state == "CLOSED" かつ PR ノードの state に "MERGED" が 1 件以上
+#     → "resolved"（Req 1.1）
+#   - issue.state == "CLOSED" かつ "MERGED" が 0 件（空配列・全 CLOSED 含む）
+#     → "closed unmerged"（Req 1.2, 1.3）
+#   - gh / jq 失敗 / GraphQL errors / 未知の state → "api error"
+#     （Req 2.1, 2.2 / NFR 4.2 安全側）
 #
-# timeout は呼び出し元のサイクル全体タイムアウトに従う（個別 timeout は導入しない:
-# 通常は数秒で帰る + watcher 全体 timeout で吸収）。
+# 旧実装は `gh issue view --json closedByPullRequestsReferences` の PR ノードに
+# 存在しない `.merged` フィールドを参照していたため、merge 済み依存も常に
+# `closed unmerged` と誤判定していた（#204 の根因 / Req 1.5）。
+#
+# timeout は DRR_GH_TIMEOUT に従う（個別の新規 env var は導入しない / Req 3.5）。
 dr_resolve_one() {
   local dep_num="$1"
-  local json
-  if ! json=$(gh issue view "$dep_num" --repo "$REPO" \
-        --json state,closedByPullRequestsReferences 2>&1); then
-    dr_warn "issue=#${dep_num} gh issue view 失敗: ${json}"
+
+  # $REPO は "owner/repo" 形式（既存 watcher 全体の前提）。GraphQL 引数に分解する。
+  local owner repo_name
+  owner="${REPO%%/*}"
+  repo_name="${REPO##*/}"
+  if [ -z "$owner" ] || [ -z "$repo_name" ] || [ "$owner" = "$REPO" ]; then
+    dr_warn "issue=#${dep_num} REPO env が owner/repo 形式でない: ${REPO:-<empty>}"
+    echo "api error"
+    return 0
+  fi
+
+  local response gh_rc
+  response=$(dr_gh_graphql_closed_by "$owner" "$repo_name" "$dep_num") && gh_rc=0 || gh_rc=$?
+
+  if [ "$gh_rc" -ne 0 ]; then
+    dr_warn "issue=#${dep_num} gh api graphql 失敗 (rc=${gh_rc}): ${response}"
+    echo "api error"
+    return 0
+  fi
+
+  # GraphQL は HTTP 200 でも errors を返すケースがあるため明示的に検査する（Req 2.1）。
+  if printf '%s' "$response" | jq -e '.errors // empty | length > 0' >/dev/null 2>&1; then
+    dr_warn "issue=#${dep_num} GraphQL errors を検出"
     echo "api error"
     return 0
   fi
 
   local state
-  if ! state=$(printf '%s' "$json" | jq -r '.state' 2>/dev/null); then
-    dr_warn "issue=#${dep_num} jq parse 失敗（state 取り出し）"
+  if ! state=$(printf '%s' "$response" \
+        | jq -r '.data.repository.issue.state' 2>/dev/null); then
+    dr_warn "issue=#${dep_num} jq parse 失敗（issue.state 取り出し）"
+    echo "api error"
+    return 0
+  fi
+  # state が null（issue ノードが取れていない等の想定外応答）→ 安全側で api error
+  # （Req 2.2: 想定外構造で merge 状態を解釈できない場合）。
+  if [ -z "$state" ] || [ "$state" = "null" ]; then
+    dr_warn "issue=#${dep_num} issue.state が取得できない応答構造（state=${state:-<empty>}）"
     echo "api error"
     return 0
   fi
@@ -5891,13 +5969,20 @@ dr_resolve_one() {
       return 0
       ;;
     CLOSED)
-      # closedByPullRequestsReferences[].merged が true のものを 1 件以上検出すれば
-      # resolved。空配列 or 全 false は closed unmerged（Req 2.2, 2.4）。
+      # closedByPullRequestsReferences.nodes[].state に "MERGED" が 1 件以上あれば
+      # resolved。空配列 or 全て MERGED 以外（CLOSED 等）は closed unmerged
+      # （Req 1.1, 1.2, 1.3）。
       local merged_count
-      if ! merged_count=$(printf '%s' "$json" \
-            | jq '[.closedByPullRequestsReferences[]? | select(.merged == true)] | length' \
+      if ! merged_count=$(printf '%s' "$response" \
+            | jq '[.data.repository.issue.closedByPullRequestsReferences.nodes[]? | select(.state == "MERGED")] | length' \
             2>/dev/null); then
         dr_warn "issue=#${dep_num} jq parse 失敗（closedByPullRequestsReferences 集計）"
+        echo "api error"
+        return 0
+      fi
+      # 想定外応答で集計結果が数値でない場合も安全側で api error（Req 2.2）。
+      if ! [[ "$merged_count" =~ ^[0-9]+$ ]]; then
+        dr_warn "issue=#${dep_num} closedByPullRequestsReferences 集計結果が数値でない: ${merged_count}"
         echo "api error"
         return 0
       fi


### PR DESCRIPTION
## 概要

Issue #204 で報告された Dependency Resolver の永久 false-block バグを修正します。

`gh issue view --json closedByPullRequestsReferences` が返す PR ノードには `merged` フィールドが存在しないため、`select(.merged==true)` が常に 0 件となり、CLOSED 依存が merge 済みでも `closed unmerged` と誤判定されていました。これにより #187 が merge 済みの #177 / #180 / #181 に永久ブロックされる実害が発生しています。

修正は `dr_gh_graphql_closed_by` 関数を新設し、GraphQL で `closedByPullRequestsReferences { nodes { state } }` を取得して `state == "MERGED"` で判定する経路に切り替えます。あわせて、説明文・コード例・引用ブロック内の依存マーカーを誤抽出して false-block を起こす `dr_extract_deps` の堅牢性問題も同一 PR で対処します。

## 対応 Issue

Closes #204

## 関連 PR

- 設計 PR: なし（小〜中規模バグ修正のため Architect は起動せず）

## 実装内容

- (Req 1 / Task 1) `dr_gh_graphql_closed_by` を新設し、GraphQL `state == "MERGED"` 判定に切り替え
- (Req 4 / Task 2) `dr_extract_deps` の awk ロジックにコードフェンス・引用ブロック除外を追加
- (Req 5 / Task 3) 回帰テスト `test-dependency-resolver.sh` を新設（21 ケース）

## 受入基準チェック

- [x] Req 1.1: When CLOSED + 少なくとも 1 件の MERGED PR, the Dependency Resolver shall `resolved` と判定する ← `Req1.1 CLOSED+MERGED PR` / `Req1.1 CLOSED+(CLOSED,MERGED)混在` pass
- [x] Req 1.2: When CLOSED + 全 PR が未 merge, the Dependency Resolver shall `closed unmerged` と判定する ← `Req1.2 CLOSED+CLOSED PR(未merge)` pass
- [x] Req 1.3: When CLOSED + PR 0 件, the Dependency Resolver shall `closed unmerged` と判定する ← `Req1.3 CLOSED+PR 0件` pass
- [x] Req 1.4: When OPEN, the Dependency Resolver shall `open` と判定する ← `Req1.4 OPEN issue` pass
- [x] Req 2.1: If gh 失敗（rc!=0）または GraphQL errors, the Dependency Resolver shall `api error` と判定する ← `Req2.1 gh 失敗 rc!=0` / `Req2.1 GraphQL errors` pass
- [x] Req 3.1〜3.5: verdict 語彙・ラベル契約・ログ書式・env var 名すべて不変 ← diff で確認済み（`dr_check_dependencies` / `dr_apply_block` / `dr_log` / `dr_warn` に変更なし）
- [x] Req 4.2: コードフェンス内の依存マーカーを誤抽出しない ← `Req4.2 コードフェンス内は除外` / `チルダフェンス除外` pass
- [x] Req 4.3: 引用ブロック内の依存マーカーを誤抽出しない ← `Req4.3 引用ブロック除外` / `インデント引用除外` pass
- [x] Req 5.4: 旧式 `.merged==true` が 0 件・新式 `.state=="MERGED"` が 1 件の Red→Green 遷移を確認 ← test-dependency-resolver.sh:157-169 pass

## テスト結果

```
# bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
All 21 cases passed.

# shellcheck local-watcher/bin/issue-watcher.sh
（main ベースラインと同数の既存 warning のみ、新規 warning/error 0 件）
```

## 実装上の判断

- **GraphQL 取得経路**: `gh issue view --json closedByPullRequestsReferences` は PR ノードに `merged` フィールドを含まないため、GraphQL `closedByPullRequestsReferences(first:20, includeClosedPrs:true){nodes{state}}` を直叩きする `dr_gh_graphql_closed_by` を新設した。同ファイル内の確立済みパターン（L4979-4991）を踏襲。
- **Req 4（依存抽出誤検出防止）の同梱**: Issue 本文の Open Questions に記載の通り、merge 判定バグ（Req 1〜3）と誤検出（Req 4）は「依存解決の堅牢性不足による false-block」という同根の症状であり、1 PR で完結できる粒度と判断して同梱した（Reviewer も approve 済み）。
- **timeout 流用**: 新規 env var は導入せず、既存の `DRR_GH_TIMEOUT`（`MERGE_QUEUE_GIT_TIMEOUT` フォールバック）を GraphQL 呼び出しにも流用した。

## 確認事項 / レビュワーへの依頼

- `dr_gh_graphql_closed_by` で `first:20` に上限を設けているため、PR が 20 件を超える Issue では最初の 20 件のみ判定される。実運用では稀だが、上限引き上げの要否を確認してほしい（現状はページネーションなし）。
- Reviewer（Reviewer エージェント）は全 21 ケース pass・AC 全件カバー・boundary 逸脱なしを確認し `RESULT: approve` 済み（`review-notes.md` 参照）。

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #204 のコメントを参照してください。
