### PR TITLE
fix(#204): Dependency Resolver の merged 依存誤判定を GraphQL state 観測経路へ是正

### DIFF
--- a/docs/specs/204-bug-watcher-dependency-resolver-146-merg/review-notes.md
+++ b/docs/specs/204-bug-watcher-dependency-resolver-146-merg/review-notes.md
@@ -5,28 +5,29 @@
 ## Reviewed Scope
 
 - Branch: claude/issue-204-impl-bug-watcher-dependency-resolver-146-merg
-- HEAD commit: d28e146d4f4d20677c204291605bd4489f38ed88
+- HEAD commit: 044370a051f0cc1a95365c318f07758ae4b4bc6f
 - Compared to: main..HEAD
 - Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が存在しない → opt-out 解釈。flag 観点の細目は適用せず、通常の 3 カテゴリ判定のみ実施。
+- 備考: 本 Issue は Architect フェーズ未経由のため design.md / tasks.md は存在しない（impl-notes.md に明記）。`_Boundary:_` アノテーションが無いため、boundary 判定は requirements.md の対象範囲（Dependency Resolver = `dr_*` 関数群）と Out of Scope への波及有無で照合した。
 
 ## Verified Requirements
 
-- 1.1 — `dr_resolve_one` CLOSED 分岐で `nodes[].state == "MERGED"` を 1 件以上検出すれば `resolved`（issue-watcher.sh:6000-6018）。テスト `Req1.1 CLOSED+MERGED PR` / `Req1.1 CLOSED+(CLOSED,MERGED) 混在` で pass
-- 1.2 — MERGED 0 件（PR が CLOSED のみ）で `closed unmerged`。テスト `Req1.2 CLOSED+CLOSED PR(未merge)` で pass
+- 1.1 — `dr_resolve_one` CLOSED 分岐で `nodes[].state == "MERGED"` を 1 件以上検出すれば `resolved`（issue-watcher.sh:5997-6018）。テスト `Req1.1 CLOSED+MERGED PR` / `Req1.1 CLOSED+(CLOSED,MERGED) 混在` で pass
+- 1.2 — MERGED 0 件（PR が CLOSED のみ）で `closed unmerged`（issue-watcher.sh:6020）。テスト `Req1.2 CLOSED+CLOSED PR(未merge)` で pass
 - 1.3 — 紐づく PR 0 件（空配列）で `closed unmerged`（`nodes[]?` + length 0 経路）。テスト `Req1.3 CLOSED+PR 0件` で pass
-- 1.4 — `issue.state == "OPEN"` → `open`（case OPEN 分岐 issue-watcher.sh:5995 付近）。テスト `Req1.4 OPEN issue` で pass
-- 1.5 — 取得経路を `gh issue view --json`（`.merged` 不在）から GraphQL `closedByPullRequestsReferences(first:20, includeClosedPrs:true){nodes{state}}` に是正（`dr_gh_graphql_closed_by` issue-watcher.sh:5896-5948）。観測可能経路 `state == "MERGED"` で判定
-- 2.1 — gh rc!=0 / GraphQL HTTP200 errors を検査し `api error`（issue-watcher.sh で `gh_rc` 判定 + `.errors` 検査）。テスト `Req2.1 gh 失敗 rc!=0` / `Req2.1 GraphQL errors` で pass
-- 2.2 — issue.state null/空・jq parse 失敗・集計が非数値 → `api error`（state null ガード + `[[ =~ ^[0-9]+$ ]]` ガード）。テスト `Req2.2 issue=null 想定外構造` / `Req2.2 壊れた JSON` / `未知の issue state` で pass
-- 2.3 — caller `dr_check_dependencies`（issue-watcher.sh:6150-6157）で unresolved_lines が空でなければ block 確定。本修正で未変更（diff なし）、verdict 語彙整合で担保
-- 2.4 — 全件 resolved で `return 0`（後続続行、issue-watcher.sh:6159-6161）。本修正で未変更
+- 1.4 — `issue.state == "OPEN"` → `open`（case OPEN 分岐 issue-watcher.sh:5995-5996）。テスト `Req1.4 OPEN issue` で pass
+- 1.5 — 取得経路を `gh issue view --json`（`.merged` 不在）から GraphQL `closedByPullRequestsReferences(first:20, includeClosedPrs:true){nodes{state}}` に是正（`dr_gh_graphql_closed_by` issue-watcher.sh:5884-5921）。観測可能経路 `state == "MERGED"` で判定
+- 2.1 — gh rc!=0 / GraphQL HTTP200 errors を検査し `api error`（issue-watcher.sh:5958-5969）。テスト `Req2.1 gh 失敗 rc!=0` / `Req2.1 GraphQL errors` で pass
+- 2.2 — issue.state null/空・jq parse 失敗・集計が非数値 → `api error`（state null ガード issue-watcher.sh:5986-5990 + `[[ =~ ^[0-9]+$ ]]` ガード issue-watcher.sh:6012-6015）。テスト `Req2.2 issue=null 想定外構造` / `Req2.2 壊れた JSON` / `未知の issue state` で pass
+- 2.3 — caller `dr_check_dependencies`（issue-watcher.sh:6150 以降）で unresolved_lines が空でなければ block 確定。本修正で未変更（diff なし）、verdict 語彙整合で担保
+- 2.4 — 全件 resolved で `return 0`（後続続行）。本修正で未変更
 - 3.1 — verdict 語彙は `resolved` / `open` / `closed unmerged` / `api error` の 4 種に限定。caller の case 文（issue-watcher.sh:6125-6147）も同 4 語彙を消費しており新規語彙なし
 - 3.2 — block 時の `blocked` 付与 + `claude-claimed` 除去は `dr_apply_block`（未変更、diff なし）で担保
 - 3.3 — 既存 `blocked` 付与時の冪等 skip は `dr_check_dependencies` 冒頭ガード（issue-watcher.sh:6098-6101、未変更）で担保
 - 3.4 — `dr_log` / `dr_warn` 関数本体は diff に含まれず書式不変
 - 3.5 — 新規必須 env var なし。timeout は既存 `DRR_GH_TIMEOUT`（`MERGE_QUEUE_GIT_TIMEOUT` フォールバック）を流用。env var 名の変更・削除なし
-- 4.1 — 実依存宣言行から `#N` を抽出（`Depends on:` / `前提依存:` / `Blocked by:`）。テスト `Req4.1 実依存行から抽出` で pass
-- 4.2 — awk でコードフェンス（``` / ~~~）開閉トグルし内部行とマーカー行を除外。テスト `Req4.2 コードフェンス内は除外` / `フェンスのみ→空` / `チルダフェンス除外` で pass
+- 4.1 — 実依存宣言行から `#N` を抽出（`Depends on:` / `前提依存:` / `Blocked by:`）（issue-watcher.sh:5840-5847）。テスト `Req4.1 実依存行から抽出` で pass
+- 4.2 — awk でコードフェンス（``` / ~~~）開閉トグルし内部行とマーカー行を除外（issue-watcher.sh:5808-5831）。テスト `Req4.2 コードフェンス内は除外` / `フェンスのみ→空` / `チルダフェンス除外` で pass
 - 4.3 — awk で行頭（空白許容）`>` の引用行を除外。テスト `Req4.3 引用ブロック除外` / `インデント引用除外` で pass
 - 4.4 — `sort -u -n` で重複排除 + 数値昇順。テスト `Req4.4 重複排除+昇順` で pass
 - 4.5 — 抽出対象行に記法なしで空 stdout + 副作用なし。テスト `Req4.5 依存なし→空` / `空入力→空` で pass
@@ -34,16 +35,16 @@
 - 5.2 — `Req1.2 CLOSED+CLOSED PR(未merge)` → closed unmerged ケースあり
 - 5.3 — `Req1.4 OPEN issue` → open ケースあり
 - 5.4 — 同一 fixture（CLOSED+MERGED）で旧式 `.merged==true` が 0 件・新式 `.state=="MERGED"` が 1 件であることを assert する Red→Green ガードあり（test-dependency-resolver.sh:157-169）
-- NFR 1.1 — 依存記法 0 件で `dr_extract_deps` が空 → `dr_check_dependencies` 早期 return（gh 呼び出し 0 回）。早期 return 経路は未変更
+- NFR 1.1 — 依存記法 0 件で `dr_extract_deps` が空 → `dr_check_dependencies` 早期 return（gh 呼び出し 0 回、issue-watcher.sh:6106-6110）。早期 return 経路は未変更
 - NFR 1.2 — `needs-decisions` 状態は `dr_apply_block`（未変更）で変更されない
 - NFR 2.1 / 2.2 — 構造化ログ（`dr_log`）と警告ログ（`dr_warn` を stderr へ）の書式不変
-- NFR 3.1 — `dr_resolve_one` は依存 1 件あたり `gh api graphql` を 1 回のみ呼ぶ（state + PR nodes を 1 リクエストで取得）。依存件数に対し線形
+- NFR 3.1 — `dr_resolve_one` は依存 1 件あたり `gh api graphql` を 1 回のみ呼ぶ（state + PR nodes を 1 リクエストで取得、issue-watcher.sh:5955）。依存件数に対し線形
 
 ## 独立検証ログ
 
-- `git diff --stat main..HEAD`: 変更は impl-notes.md / test-dependency-resolver.sh / issue-watcher.sh の 3 ファイルのみ。`requirements.md` 等の仕様書き換えなし
-- `git diff main..HEAD -- local-watcher/bin/issue-watcher.sh`: 変更 hunk は `dr_extract_deps` / 新規 `dr_gh_graphql_closed_by` / `dr_resolve_one` に限定。`dr_check_dependencies` / `dr_apply_block` への変更なし（boundary 内）
-- `bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh` → `All 21 cases passed.` exit 0 を確認（reviewer 自身で再実行）
+- `git diff --stat main..HEAD`: 変更は impl-notes.md / requirements.md / review-notes.md / test-dependency-resolver.sh / issue-watcher.sh のみ。仕様書（requirements.md）への実装由来書き換えなし（PM 成果物）
+- `git diff main..HEAD -- local-watcher/bin/issue-watcher.sh`: 変更 hunk は `dr_extract_deps` / 新規 `dr_gh_graphql_closed_by` / `dr_resolve_one` の 3 関数に限定。`dr_check_dependencies` / `dr_apply_block` への変更なし（boundary 内）
+- `bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh` → `All 21 cases passed.` exit 0 を reviewer 自身で再実行・確認
 - Out of Scope（既存 Issue retrofit / Actions workflow / 逆ブロッキング `Blocks:` / 非ブロッキング関係種別 / watcher 全体の path 管理）への侵食は差分に存在しない
 
 ## Findings
@@ -52,6 +53,6 @@
 
 ## Summary
 
-requirements.md の全 numeric AC（Req 1.1〜5.4 / NFR 1〜3）に対応する実装が確認でき、回帰テスト 21 ケースが全 pass。verdict 語彙・ラベル契約・ログ書式・env var の後方互換が保たれ、boundary 逸脱・missing test・AC 未カバーはいずれも検出されなかった。
+requirements.md の全 numeric AC（Req 1.1〜5.4 / NFR 1〜3）に対応する実装が確認でき、回帰テスト 21 ケースが全 pass。merge 判定の根因（PR ノードに存在しない `.merged` 参照）を GraphQL `state == "MERGED"` 観測経路へ是正し、Req 4 の誤抽出防止も同関数群内に閉じて実装。verdict 語彙・ラベル契約・ログ書式・env var の後方互換が保たれ、boundary 逸脱・missing test・AC 未カバーはいずれも検出されなかった。
 
 RESULT: approve


### PR DESCRIPTION
## 概要

Dependency Resolver（#146 で実装）の `dr_resolve_one` が、merge 済みで閉じられた依存 Issue を `closed unmerged` と誤判定し、対象 Issue に永久 `blocked` が再付与されて自動処理が再開しない false-block バグを是正する。

根因は `gh issue view --json closedByPullRequestsReferences` が返す PR ノードに `.merged` フィールドが存在しないにもかかわらず `.merged == true` で集計していたこと。取得経路を GraphQL `closedByPullRequestsReferences(first:20, includeClosedPrs:true){nodes{state}}` に切り替え、`state == "MERGED"` を 1 件以上検出した場合のみ `resolved` と判定する是正を行った。

あわせて、`dr_extract_deps` がコードフェンスや引用ブロック内の依存マーカーを誤抽出して false-block を起こす同根の堅牢性問題（Req 4）も本 PR で修正した。verdict 語彙・ラベル契約・ログ書式・env var の後方互換契約はすべて不変に保たれている。

## 対応 Issue

Closes #204

## 関連 PR

- 設計 PR: なし（本 Issue は Architect フェーズ未経由のため design.md / tasks.md は存在しない）

## 実装内容

- (Req 1/2/3) `dr_resolve_one` の merge 判定経路を GraphQL `state == "MERGED"` 観測に是正。失敗時は安全側の `api error` に倒れる（gh rc!=0 / GraphQL errors / jq parse 失敗 / 未知 state のすべてをカバー）。後方互換契約（verdict 語彙・ラベル・ログ書式・env var）は不変
- (Req 4) `dr_extract_deps` に awk 前処理を追加し、コードフェンスおよび引用ブロック内に現れる依存マーカーを実依存として誤抽出しないよう修正
- (Req 5) `test-dependency-resolver.sh` に回帰テスト 21 ケースを追加。実 API を叩かず `dr_gh_graphql_closed_by` を stub 差し替えする方式で Req 1〜5 / NFR 1〜3 のすべてを担保

## 受入基準チェック

- [x] Req 1.1: When CLOSED+MERGED PR で閉じた依存 → resolved ← `Req1.1 CLOSED+MERGED PR`
- [x] Req 1.2: When CLOSED+PR 未 merge → closed unmerged ← `Req1.2 CLOSED+CLOSED PR(未merge)`
- [x] Req 1.3: When CLOSED+PR 0 件 → closed unmerged ← `Req1.3 CLOSED+PR 0件`
- [x] Req 1.4: When OPEN issue → open ← `Req1.4 OPEN issue`
- [x] Req 1.5: 取得経路を GraphQL state 観測に是正 ← `Req5.4 旧 .merged 式誤判定 / 新 .state 式正判定`
- [x] Req 2.1: gh 失敗 / GraphQL errors → api error ← `Req2.1 gh 失敗 rc!=0` / `Req2.1 GraphQL errors`
- [x] Req 2.2: issue=null / 壊れた JSON / 未知 state → api error ← 対応テスト 3 ケース
- [x] Req 2.3/2.4: unresolved 1 件でも block / 全 resolved で続行 ← caller `dr_check_dependencies` 未変更で担保
- [x] Req 3.1〜3.5: 後方互換契約すべて不変 ← diff に新規語彙・ラベル変更・ログ書式変更・env var 変更なし
- [x] Req 4.1: 実依存行から抽出 ← `Req4.1 実依存行から抽出`
- [x] Req 4.2: コードフェンス内除外 ← `Req4.2 コードフェンス内は除外` 他 2 ケース
- [x] Req 4.3: 引用ブロック除外 ← `Req4.3 引用ブロック除外` / `インデント引用除外`
- [x] Req 4.4: 重複排除+昇順 ← `Req4.4 重複排除+昇順`
- [x] Req 4.5: 依存なしで空+副作用なし ← `Req4.5 依存なし→空` / `空入力→空`
- [x] Req 5.1〜5.4: 回帰テストで Red→Green 遷移を固定

## テスト結果

```
bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
All 21 cases passed.
```

（Developer および Reviewer の両者が独立して実行・確認済み。詳細は review-notes.md の「独立検証ログ」節を参照）

## 実装上の判断

- **Req 4 を本修正に含めた**: requirements.md Open Questions の推奨どおり本 PR に含めた。merge 判定バグ（Req 1〜3）と誤抽出（Req 4）は「依存解決の堅牢性不足による false-block」という同根の症状であり、awk 前処理の追加は小規模・純粋関数の契約を崩さず、別 Issue 分離が必要なほどの実装複雑度には至らなかったため
- **GraphQL indirection 関数 `dr_gh_graphql_closed_by`**: 実 API を叩かずに回帰テストが mock 注入できる薄い境界として切り出した。クエリ `first: 20` は既存 `check_existing_impl_pr` と同値（idd-claude 運用で PR が 20 件超える実績なし）
- **caller `dr_check_dependencies` は未変更**: Req 2.3/2.4/3.2/3.3 のブロック確定・冪等 skip ロジックに diff なし。verdict 語彙が不変なので caller の case 文も影響を受けない
- **shellcheck**: 既存の SC2317（info 級、間接呼び出しロガーの unreachable 誤検知）10 件は main ベースラインと同数。新規警告ゼロ

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: PR 作成後に `gh pr view --json baseRefName --jq '.baseRefName'` が `main` と一致することを確認する（結果は本 PR に追記）
- Reviewer の独立 approve 判定の詳細は `docs/specs/204-bug-watcher-dependency-resolver-146-merg/review-notes.md` を参照してください（RESULT: approve）
- 派生タスク候補（スコープ外・次 Issue 化の検討）: `dr_format_unresolved_comment` 等の関数ヘッダコメントに #146 当時の旧 ID 参照が一部残存。本 PR のスコープ外

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #204 のコメントを参照してください。
