### PR TITLE
fix(harness): Tasks Count Gate の計数を design-review-gate canonical regex に整合（最上位・未完了のみ、子/完了/deferrable を除外）

### DIFF
--- a/docs/specs/216-fix-harness-tasks-count-gate-design-revi/requirements.md
+++ b/docs/specs/216-fix-harness-tasks-count-gate-design-revi/requirements.md
@@ -1,0 +1,83 @@
+# Requirements Document
+
+## Introduction
+
+Tasks Count Gate (#147) は、local watcher の design モード完了直後・Developer pickup 前に
+`tasks.md` のタスク件数を機械的に再カウントし、件数レンジに応じて normal / warn / escalate を
+適用する harness 側の安全網である。現状の harness 計数 (`tc_count_tasks`) は全 checkbox 行
+（子タスク `1.1`・完了 `[x]`・deferrable `*` を含む）を計上するのに対し、Architect の正準計数
+（`design-review-gate.md` Budget overflow check）は最上位 numeric ID の未完了タスクのみを数える。
+この乖離により、Architect が「budget 内（≤10 最上位）」と確定した設計を harness が「≥11（全
+checkbox）」と誤って escalate する。本変更は、正準を `design-review-gate.md` に置いたまま harness
+計数のみをそれに整合させ、閾値は一切変えずに二重計上を解消する。
+
+## Requirements
+
+### Requirement 1: harness タスク計数の正準整合
+
+**Objective:** As a watcher 運用者, I want harness のタスク計数を Architect の正準計数と同一規約にしたい, so that 同じ tasks.md で Architect と harness が矛盾する判定（一方は budget 内・他方は escalate）を出さなくなる
+
+#### Acceptance Criteria
+
+1. The Tasks Count Gate shall 最上位 numeric ID の未完了タスク行（`- [ ]` で始まり整数 ID + `.` + 半角スペースで続く行、正準 regex `^- \[ \]\*? [0-9]+\. ` に一致する行）のみを計数対象とする
+2. When tasks.md に子タスク行（`- [ ] 1.1` のような小数階層 ID）が含まれているとき, the Tasks Count Gate shall それらを計数対象から除外する
+3. When tasks.md に完了済みタスク行（`- [x]` または `- [x]*` で始まる行）が含まれているとき, the Tasks Count Gate shall それらを計数対象から除外する
+4. Where 最上位 deferrable テストタスク行（`- [ ]*` で始まり整数 ID + `.` で続く行）が含まれている場合, the Tasks Count Gate shall 正準 regex `^- \[ \]\*? [0-9]+\. ` の一致挙動に厳密一致させて当該行を計数対象に含める
+5. When 同一の tasks.md を Architect の Budget overflow check 計数（正準 regex `^- \[ \]\*? [0-9]+\. `）と harness の計数の両方で評価したとき, the Tasks Count Gate shall Architect 計数と同一の件数を返す
+
+### Requirement 2: 計数変更後の分類・抑止挙動の維持
+
+**Objective:** As a watcher 運用者, I want 計数の意味が「最上位・残作業ベース」に変わっても安全網としての分類・抑止が維持されること, so that 真に過大な Issue が引き続き Developer の turn budget 超過から守られる
+
+#### Acceptance Criteria
+
+1. The Tasks Count Gate shall 最上位・未完了ベースで算出した件数を normal / warn / escalate の分類対象とする
+2. While impl-resume などで一部タスクが `- [x]` 済みの状態, when harness が件数を分類するとき, the Tasks Count Gate shall 残る未完了の最上位タスク件数で normal / warn / escalate を判定する
+3. When 最上位の未完了タスクが真にエスカレーション閾値（既定 11 件）以上であるとき, the Tasks Count Gate shall 計数変更後も引き続き escalate と分類する
+4. The Tasks Count Gate shall normal / warn / escalate を分ける閾値（既定 `TC_WARN_LOWER`=8 / `TC_WARN_UPPER`=10 / `TC_ESCALATE_LOWER`=11）を本変更によって変更しない
+
+### Requirement 3: 計数定義のドキュメント一元化と相互参照
+
+**Objective:** As a 将来の保守者, I want harness と Architect で別実行基盤に置かれた同一の計数規約が文書上で一致し相互参照されること, so that 一方だけが更新されて計数が再び乖離する事故を検知できる
+
+#### Acceptance Criteria
+
+1. The 計数規約 shall harness 側（`issue-watcher.sh` の `tc_count_tasks` 周辺コメント）と Architect 側（`design-review-gate.md` の Budget overflow check）の双方で同一の正準 regex として明記される
+2. The harness 側ドキュメント shall 正準が `design-review-gate.md` の Budget overflow check 計数である旨と、そこへの相互参照を含める
+3. When 計数の意味（最上位・未完了のみ、子/完了/deferrable の扱い）を説明するとき, the README の Tasks Count Gate 節 shall design-review-gate.md の正準計数と整合した記述に更新される
+4. The 回帰テスト（fixture / driver） shall 子タスク・完了 `[x]`・deferrable を含む tasks.md に対して最上位・未完了ベースの期待件数を検証する
+
+### Requirement 4: per-issue override / per-task-loop からの独立性
+
+**Objective:** As a watcher 運用者, I want 本計数修正が #214（per-issue override）や #21（per-task-loop）と独立して成立すること, so that 未実装機能の有無に依存せず計数の整合だけが先行して導入できる
+
+#### Acceptance Criteria
+
+1. Where per-issue override シグナル（#214）が未実装または当該 Issue に未付与の場合, the Tasks Count Gate shall override の存在を前提とせず最上位・未完了ベースの計数で判定する
+2. The 本変更 shall per-task-loop（#21）の挙動を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性と互換性影響の明示
+
+1. When `TC_ENABLED` が `true` 以外であるとき, the Tasks Count Gate shall 本変更後も評価を一切行わず本機能導入前と同一の挙動を保つ
+2. The README shall 計数変更により一部 Issue の判定が escalate から warn / normal に移ることが意図した挙動である旨を migration note として明記する
+3. The 本変更 shall 既存 env var 名（`TC_ENABLED` / `TC_WARN_LOWER` / `TC_WARN_UPPER` / `TC_ESCALATE_LOWER`）とエスカレーションコメントの識別マーカー文字列（`<!-- idd-claude:tasks-count-overflow ... -->`）を変更しない
+
+### NFR 2: 計数の決定性
+
+1. When 同一内容の tasks.md を複数回評価したとき, the Tasks Count Gate shall 毎回同一の件数を返す（環境状態に依存しない決定的計数）
+
+## Out of Scope
+
+- 閾値の既定値変更（`TC_WARN_LOWER`=8 / `TC_WARN_UPPER`=10 / `TC_ESCALATE_LOWER`=11 は不変。本変更は計数定義のみ修正する）
+- per-issue override 弁の実装（#214）。本計数修正は #214 と独立に成立させる
+- per-task-loop（#21）の挙動変更
+- Architect `design-review-gate.md` 側の計数 regex の変更（こちらを正準とし harness を寄せる）
+- `tc_classify` の閾値ロジックそのものの変更（分類対象となる件数の意味のみが最上位・未完了ベースに変わる）
+- 外部 Feature Flag SaaS 連携や新規外部サービス呼び出しの追加
+
+## Open Questions
+
+- design-review-gate.md の散文矛盾: 正準 regex `^- \[ \]\*? [0-9]+\. ` は最上位 deferrable `- [ ]*` に一致する（＝計数に含む）一方で、design-review-gate.md の散文は「`- [ ]*`（deferrable テストタスク）は本カウントでは数えません」と記載しており自己矛盾している。本 Issue は Architect 側 regex 変更をスコープ外とするため、harness は正準 regex の一致挙動に厳密一致させる（Req 1.4）方針を確定とする。ただし散文側の clarification（regex に合わせて「最上位 deferrable は含む」と書き換えるか、regex を `^- \[ \]\? ...` 相当へ将来見直すか）を本 PR で行うかは人間判断に委ねる。本要件では「harness が正準 regex と同一件数を返す」ことを正準とし、散文修正の要否はエスカレーションする。
+- 計数定義の二重管理リスク: bash（harness）と LLM ルール（Architect）は実行基盤が異なり共有コードを持てないため、本要件は同一 regex を両所に明記し相互参照する「ドキュメントで担保」方式（Req 3.1 / 3.2）を確定とする。将来両所が乖離した際に機械的に検知する仕組み（例: regex 文字列の一致を検査する lint）を導入するかは本 Issue のスコープ外であり、必要性の判断を人間に委ねる。

--- a/docs/specs/216-fix-harness-tasks-count-gate-design-revi/review-notes.md
+++ b/docs/specs/216-fix-harness-tasks-count-gate-design-revi/review-notes.md
@@ -1,0 +1,57 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-216-impl-fix-harness-tasks-count-gate-design-revi
+- HEAD commit: 5cbc6aa（docs(specs): #216 実装ノートを追加）
+- Compared to: origin/main...HEAD（コミット 4 本: c0b5ca1 / 532b831 / ffb0e1c / 5cbc6aa）
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節が **存在しない** → opt-out 扱い。flag 観点の確認は行わず通常の 3 カテゴリ判定のみを適用。
+
+## Verified Requirements
+
+- 1.1 — `local-watcher/bin/issue-watcher.sh:1394` の `tc_count_tasks` が `grep -cE '^- \[ \]\*? [0-9]+\. '` に変更され、最上位 numeric ID の未完了タスク行のみを計数。
+- 1.2 — 子タスク `1.1` 除外。canonical regex は `[0-9]+\. `（整数 + `.` + 空白）を要求するため `1.1` は不一致。fixture `tasks-toplevel-vs-flat.md`（子 1.1/1.2/5.1/6.1 等を除外して 7 件）/ `tasks-mixed-checkbox.md`（子 1.1/1.2 除外で 4 件）で実測確認。
+- 1.3 — 完了 `- [x]` / `- [x]*` 除外。checkbox 部を `\[ \]` に固定。`tasks-toplevel-vs-flat.md`（完了 3./2.1/4.1/7.1 を除外）/ `tasks-mixed-checkbox.md`（完了 5./1.1/2.1 を除外）で実測確認。
+- 1.4 — 最上位 deferrable `- [ ]*` を計数に含む。`\]\*?` がアスタリスクを許容。`tasks-toplevel-vs-flat.md` の task 8（`- [ ]* 8.`）/ `tasks-mixed-checkbox.md` の task 2（`- [ ]* 2.`）が canonical grep でマッチすることを実測確認。
+- 1.5 — `tc_count_tasks` == `grep -cE '^- \[ \]\*? [0-9]+\. '` の件数。3 fixture で直接 grep と driver 値が一致（mixed=4 / toplevel=7 / 11=11）。
+- 2.1 — extract-driver.sh の classification 列が新 count で normal/warn/escalate に分岐（17 ケース全 pass）。
+- 2.2 — impl-resume の残作業ベース判定は「完了 `- [x]` 除外」で構造的に成立。`tasks-toplevel-vs-flat.md` が完了行を除外して残未完了 7 件を返すことで担保。
+- 2.3 — `tasks-11.md`（11 件）が変更後も escalate を維持（driver pass）。
+- 2.4 — 閾値（`TC_WARN_LOWER`=8 / `TC_WARN_UPPER`=10 / `TC_ESCALATE_LOWER`=11）および `tc_classify` ロジックに差分なし（diff 確認済み）。境界 classify(0/7/8/9/10/11/50) が従来通り pass。
+- 3.1 — `issue-watcher.sh` の `tc_count_tasks` コメントと `design-review-gate.md` の双方に同一 regex `^- \[ \]\*? [0-9]+\. ` を明記。
+- 3.2 — harness コメントに「正準は design-review-gate.md の Budget overflow check」である旨と相互参照を明記。`design-review-gate.md:68` に harness への逆参照を 1 段落追記（additive のみ）。
+- 3.3 — README「Tasks Count Gate」節をカウント対象記述を canonical 整合に更新。
+- 3.4 — 回帰 fixture `tasks-toplevel-vs-flat.md`（新規）/ `tasks-mixed-checkbox.md` が 4 種 checkbox + 子 + 完了 + deferrable を含み最上位・未完了ベース期待件数を検証。
+- 4.1 — `tc_count_tasks` は tasks.md のみを入力とする純粋関数。override シグナル（#214）を参照しない（diff に該当トークンなし）。
+- 4.2 — per-task-loop（#21）関連コードに変更なし（diff に該当トークンなし）。
+- NFR 1.1 — `tc_should_run` の opt-out 分岐は未変更（diff になし）。`tc_count_tasks` は gate 通過後にのみ呼ばれる。
+- NFR 1.2 — README に migration note 追記（escalate → warn/normal への意図した移行を明記）。
+- NFR 1.3 — env var 名・マーカー文字列 `<!-- idd-claude:tasks-count-overflow ... -->`・exit code 意味に差分なし（diff / grep で確認）。
+- NFR 2.1 — `tc_count_tasks` は環境状態に依存しない pure grep。perf-driver で count=20000 / elapsed=2ms / PASS。
+
+## Out-of-Scope 遵守の確認
+
+- `design-review-gate.md` の変更は **相互参照ブロックの追記のみ**（additive）で、canonical regex 文字列・件数セマンティクス・閾値表は **書き換えられていない**（diff で全行確認）。スコープ外の改変なし。
+- 閾値既定値・`tc_classify` ロジックの変更なし。
+
+## Findings
+
+なし
+
+## 検証実行ログ（判定根拠）
+
+- `bash tests/local-watcher/tasks-count/extract-driver.sh` → summary: pass=17 fail=0 total=17 / exit=0
+- `bash tests/local-watcher/tasks-count/perf-driver.sh` → count=20000 / elapsed=2ms / PASS / exit=0
+- 直接 grep 突合: mixed-checkbox=4 / toplevel-vs-flat=7（旧計数 15）/ tasks-11=11 → いずれも driver 値と一致。
+
+## Open Questions / 確認事項の扱い
+
+impl-notes.md の確認事項 3 点（design-review-gate.md 散文の deferrable 自己矛盾 / 計数二重管理の lint 化要否 / 他 fixture への影響なし）は requirements.md の Open Questions に対応し、いずれも「人間判断にエスカレーション」または「影響なし」として整理済み。実装は requirements.md が確定した正準 regex の一致挙動に厳密整合しており、未解決事項は approve を妨げない性質（散文修正の要否は本 PR スコープ外と要件で確定済み）。
+
+## Summary
+
+全 numeric ID（Req 1.1〜1.5 / 2.1〜2.4 / 3.1〜3.4 / 4.1〜4.2 / NFR 1.1〜1.3 / 2.1）に対応する実装・回帰テストを確認。canonical regex 整合・子/完了除外・最上位 deferrable 包含が fixture と実測 grep で一致し、閾値・env var・マーカー・exit code は不変。design-review-gate.md はスコープ外改変なし。boundary 逸脱・AC 未カバー・missing test いずれも検出せず。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

Tasks Count Gate (#147) の harness 側計数 (`tc_count_tasks`) が、子タスク・完了済み・全
checkbox を計上する旧 regex を使っていたため、Architect が「budget 内（≤10 最上位）」と
確定した設計を harness が「≥11（全 checkbox）」と誤って escalate する問題があった。本 PR は
harness 計数の regex を Architect 正準（`design-review-gate.md` Budget overflow check:
`^- \[ \]\*? [0-9]+\. `）に整合させ、二重計上を解消する。閾値・env var 名・マーカー文字列・
exit code 意味・ラベル遷移契約は一切変更しない。

## 対応 Issue

Closes #216

## 関連 PR

- 設計 PR: なし（本 Issue は Architect 設計ゲートを経由していない小〜中規模 Issue）

## 実装内容

- (Req 1.1 / Task 1) `local-watcher/bin/issue-watcher.sh` の `tc_count_tasks` grep regex を
  旧 `^- \[[ x]\]\*? [0-9]+(\.[0-9]+)*\.? ` → canonical `^- \[ \]\*? [0-9]+\. ` に変更。
  最上位 numeric ID の未完了タスク行のみを計数対象とする
- (Req 1.2 / 1.3) 子タスク行（`1.1` 等）および完了済み行（`- [x]`）を計数から除外
- (Req 1.4) 最上位 deferrable（`- [ ]* N.`）は canonical regex の `\]\*?` により引き続き計数に含む
- (Req 3.1 / 3.2) harness コメントと `design-review-gate.md` の双方に同一 regex を明記し相互参照を追記
- (Req 3.3 / NFR 1.2) README「Tasks Count Gate」節を canonical 整合に更新、migration note 追記
- (Req 3.4) 回帰 fixture `tasks-toplevel-vs-flat.md` を新規追加（子/完了/deferrable 混在）。
  `extract-driver.sh` の期待件数を canonical 計数に更新（tasks-mixed-checkbox: 8 → 4）

## 受入基準チェック

- [x] Req 1.1: The Tasks Count Gate shall 最上位 numeric ID の未完了タスク行のみを計数対象とする ← `tc_count_tasks` regex 変更 + tasks-7/8/10/11 fixture
- [x] Req 1.2: When 子タスク行が含まれているとき shall 計数から除外する ← tasks-toplevel-vs-flat.md / tasks-mixed-checkbox.md（extract-driver pass=17）
- [x] Req 1.3: When 完了済みタスク行が含まれているとき shall 計数から除外する ← tasks-toplevel-vs-flat.md / tasks-mixed-checkbox.md
- [x] Req 1.4: Where 最上位 deferrable が含まれる場合 shall 正準 regex の一致挙動に厳密一致させて計数に含める ← tasks-mixed-checkbox.md（deferrable 2. 含む 4 件）
- [x] Req 1.5: When 同一 tasks.md を Architect 計数と harness 計数の両方で評価したとき shall 同一件数を返す ← 3 fixture で canonical_grep と tc_count_tasks 値が MATCH
- [x] Req 2.3: When 最上位未完了が真に ≥11 のとき shall 引き続き escalate ← tasks-11.md が変更後も escalate（driver pass）
- [x] Req 2.4: The Tasks Count Gate shall 閾値を本変更によって変更しない ← env var / tc_classify ロジック差分なし
- [x] Req 3.1〜3.2: harness / design-review-gate.md の双方に同一 regex を明記・相互参照 ← issue-watcher.sh コメント + design-review-gate.md 追記
- [x] NFR 1.1〜1.3: TC_ENABLED 非 true 挙動不変 / README migration note / env var・マーカー不変 ← diff で確認

## テスト結果

```
# 1. shellcheck（新規 SC2006/SC2215 警告ゼロ。残存は既存の SC2317 info のみ）
$ shellcheck local-watcher/bin/issue-watcher.sh
  → 新規 warning なし（既存の SC2317 info: ログ関数の間接呼び出し、本変更前から存在）
$ shellcheck tests/local-watcher/tasks-count/extract-driver.sh tests/local-watcher/tasks-count/perf-driver.sh
  → クリーン（SHELLCHECK OK）

# 2. fixture/driver 回帰テスト
$ bash tests/local-watcher/tasks-count/extract-driver.sh
  → summary: pass=17 fail=0 total=17 / exit=0

# 3. パフォーマンステスト（NFR 2.1 決定性 / 旧 NFR 3.1 性能）
$ bash tests/local-watcher/tasks-count/perf-driver.sh
  → tc_count_tasks: count=20000 elapsed=2ms / PASS / exit=0

# 4. canonical 整合（Req 1.5）: tc_count_tasks == `grep -cE '^- \[ \]\*? [0-9]+\. '`
  tasks-mixed-checkbox.md : tc_count_tasks=4  canonical_grep=4  MATCH
  tasks-toplevel-vs-flat.md: tc_count_tasks=7  canonical_grep=7  MATCH
  tasks-11.md             : tc_count_tasks=11 canonical_grep=11 MATCH
```

## 実装上の判断

- 最上位 deferrable `- [ ]*` の扱い: requirements.md Req 1.4 に従い、canonical regex `^- \[ \]\*? [0-9]+\. ` の一致挙動に厳密一致させる方針を採用（deferrable を計数に含む）。
- warning / escalation コメント文言: 件数の意味が「最上位・未完了ベース」に変わったことが運用者に伝わるよう、検知件数行にセマンティクス注釈を追記（閾値数値・env var 名・マーカー文字列は不変）。
- perf-driver.sh の生成内容変更: 旧版は子タスク行のみを生成しており canonical regex では count=0 になっていた。計数経路の最悪ケースを実際に計測するため最上位 `$i.` に変更。

詳細は `docs/specs/216-fix-harness-tasks-count-gate-design-revi/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- base ブランチ = main を検証済み（一致）
- Reviewer 判定: approve（docs/specs/216-fix-harness-tasks-count-gate-design-revi/review-notes.md を参照。全 numeric ID に対応する実装・回帰テストを確認済み、AC 未カバー・missing test・boundary 逸脱いずれも検出なし）
- 人間判断ペンディング 1: **design-review-gate.md 散文の deferrable 自己矛盾**。canonical regex `^- \[ \]\*? [0-9]+\. ` は最上位 deferrable `- [ ]*` に一致する（計数に含む）一方、design-review-gate.md / tasks-generation.md の散文は「deferrable は数えません」と記載しており自己矛盾している。本 Issue はスコープ外として harness を regex に厳密整合させた。散文側を「最上位 deferrable は含む」に書き換えるか、将来 regex を `- [ ]` のみにするかは人間判断に委ねる。
- 人間判断ペンディング 2: **計数定義の二重管理 lint 化の要否**。bash（harness）と LLM ルール（Architect）は実行基盤が異なるため、本変更は同一 regex を両所に明記・相互参照する「ドキュメント担保」方式を採った。将来 regex が乖離したときに機械的に検知する lint / smoke の導入要否は人間判断に委ねる。

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #216 のコメントを参照してください。
