### PR TITLE
fix(watcher): stage-a-verify round=1 差し戻しで claude-picked-up を除去し再 pickup 可能化（虚偽 claude-failed ログも是正）

### DIFF
--- a/README.md
+++ b/README.md
@@ -3209,14 +3209,23 @@ flowchart TD
     X1 -->|SKIPPED no-verify-task| OK2[Stage A 完了 + SKIPPED ログ]
     X1 -->|exit 0| OK3[Stage A 完了 + SUCCESS ログ]
     X1 -->|exit 非 0 or timeout| F{stage-a-verify round}
-    F -->|round=1| NI[Issue コメントで Developer 差し戻し]
+    F -->|round=1| NI[Issue コメント + claude-picked-up 除去で再 pickup 可能化]
     F -->|round=2| FAIL[claude-failed ラベル付与 → 人間に委ねる]
-    NI --> RET[return 1 / 次 tick で Stage Checkpoint 経由 再評価]
+    NI --> RET[return 3 保留 / 次 tick で再 pickup → Stage Checkpoint 経由 再評価]
     FAIL --> RET2[return 1 / watcher 当該 Issue 処理打ち切り]
     OK1 --> SB[Stage B round=1]
     OK2 --> SB
     OK3 --> SB
 ```
+
+> **round=1 差し戻し時の再 pickup 可能化（#219）**: round=1 失敗時、watcher は Issue から
+> `claude-picked-up` / `claude-claimed` を除去して bare auto-dev candidate へ戻します。
+> dispatcher の候補クエリは `-label:"claude-picked-up"` を除外条件に持つため、これを残すと
+> 当該 Issue が二度と再 pickup されず「次 tick で再評価」が成立しないためです（round counter
+> sidecar は温存され、次回失敗で round=2 → `claude-failed` に進む）。本経路では
+> `claude-failed` は付与されず、`run_impl_pipeline` は「再 pickup 可能な保留」を表す
+> 戻り値 3 を返します（slot ログは「保留（stage-a-verify 差し戻し / 次 tick 再評価）」と記録し、
+> 誤った「claude-failed 付与済み」は出力しません）。
 
 ### 環境変数
 

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -4249,6 +4249,31 @@ handle_partial_status() {
 #   全モジュールが run_impl_pipeline 実行前に source されるため挙動不変。
 # ─────────────────────────────────────────────────────────────────────────────
 
+# ─── stage_a_verify_round1_defer ───
+#
+# stage-a-verify round=1 差し戻し時に、当該 Issue を再 pickup 可能な bare auto-dev
+# candidate へ戻すためのラベル除去を行う（Issue #219）。`claude-picked-up` を残すと
+# dispatcher の候補クエリ（`-label:"$LABEL_PICKED"`）から除外され二度と再 pickup されず
+# stuck になるため、per-task hold (#198) と同様に claude-picked-up / claude-claimed を
+# 除去して次 tick の再 pickup → Stage Checkpoint resume → stage-a-verify 再評価
+# （round=2 escalate への前進）を成立させる。round counter sidecar は呼び出し側で
+# 温存されるため、次回失敗で round=2 → claude-failed に進む。
+#
+# 入力 (環境変数経由): NUMBER / REPO / LOG / LABEL_PICKED / LABEL_CLAIMED
+# 副作用: gh issue edit（ラベル除去） / $LOG への grep 可能なログ 1 行
+# 戻り値: 0 = ラベル除去成功 / 1 = gh 失敗（fail-open。呼び出し側は return 3 を維持し、
+#         ラベル残置の旨を警告ログに残す。手動除去で復旧可能）
+stage_a_verify_round1_defer() {
+  if gh issue edit "$NUMBER" --repo "$REPO" \
+      --remove-label "$LABEL_PICKED" \
+      --remove-label "$LABEL_CLAIMED" >/dev/null 2>&1; then
+    echo "[$(date '+%F %T')] stage-a-verify: round=1 差し戻し: claude-picked-up 除去 → bare auto-dev candidate へ復帰（次 tick 再 pickup / issue=#$NUMBER）" >> "$LOG"
+    return 0
+  fi
+  echo "[$(date '+%F %T')] stage-a-verify: WARN: round=1 差し戻しで claude-picked-up 除去に失敗（ラベル残置 → 次 tick で候補に上がらない恐れ / 手動除去で復旧可能 / issue=#$NUMBER）" >> "$LOG"
+  return 1
+}
+
 # ─── run_impl_pipeline ───
 #
 # impl / impl-resume モードの Stage 状態機械を実装する。
@@ -4280,8 +4305,9 @@ handle_partial_status() {
 #   （START_STAGE=B|C）でも本ブロックを通すため、Stage Checkpoint resume 経由のフロー
 #   でも gate が機能する。`STAGE_A_VERIFY_ENABLED=false` 明示時は stage_a_verify_run
 #   が即 return 0 して本機能導入前と user-observable に完全同一の挙動になる
-#   （Req 4.1 / NFR 1.1）。失敗時は round=1 で Developer 差し戻し（return 1）、
-#   round=2 で claude-failed escalate（return 1、内部で mark_issue_failed 済）。
+#   （Req 4.1 / NFR 1.1）。失敗時は round=1 で Developer 差し戻し（**return 3 / 再 pickup
+#   可能な保留・claude-failed 未付与**, Issue #219）、round=2 で claude-failed escalate
+#   （return 1、内部で mark_issue_failed 済）。
 #
 # 入力 (環境変数経由): NUMBER, TITLE, BODY, URL, BRANCH, MODE, SPEC_DIR_REL, LOG, REPO,
 #                      DEV_MODEL, DEV_MAX_TURNS, REVIEWER_MODEL, REVIEWER_MAX_TURNS,
@@ -4290,7 +4316,9 @@ handle_partial_status() {
 #                      STAGE_A_VERIFY_COMMAND (#125)
 # 戻り値:
 #   0 = pipeline 成功（Stage C も成功 / PR 作成済み）または TERMINAL_OK 相当の停止
-#   1 = Stage A / A' / B / B' / C / stage-a-verify いずれかで失敗 → claude-failed 既に付与済み
+#   3 = 再 pickup 可能な保留（stage-a-verify round=1 差し戻し / Issue #219）。claude-failed
+#       未付与・claude-picked-up 除去済みで次 tick に再評価される
+#   1 = Stage A / A' / B / B' / C / stage-a-verify round=2 いずれかで失敗 → claude-failed 既に付与済み
 run_impl_pipeline() {
   local prompt_a prompt_redo prompt_c
   local rev_rc
@@ -4614,17 +4642,32 @@ run_impl_pipeline() {
   # gate が機能する（design.md「stage-a-verify と Stage Checkpoint の協調」参照）。
   # `STAGE_A_VERIFY_ENABLED=false` 明示時は stage_a_verify_run が即 return 0 して
   # 本機能導入前と user-observable に完全同一の挙動になる（Req 4.1 / NFR 1.1）。
-  # `stage_a_verify_run` の戻り値 0/1/2 を `run_impl_pipeline` の従来契約
-  # （0 = 成功 / 1 = 失敗）にマップする（NFR 1.3）。round=2 escalate (戻り値 2)
-  # 時は内部で `mark_issue_failed` が発火済みなので外部観測上は claude-failed。
+  # `stage_a_verify_run` の戻り値 0/1/2 を `run_impl_pipeline` の戻り値契約にマップする
+  # （NFR 1.3）:
+  #   - 0 = SUCCESS / SKIPPED / DISABLED → 続行
+  #   - 1 = round=1 差し戻し → run_impl_pipeline は **3（再 pickup 可能な保留）** を返す。
+  #         claude-failed は付与されておらず、ここで claude-picked-up / claude-claimed を
+  #         除去して次 tick の再 pickup を成立させる（Issue #219）。
+  #   - 2 = round=2 escalate → 内部で `mark_issue_failed` 発火済み（claude-failed）。
+  #         run_impl_pipeline は従来どおり 1（失敗）を返す。
   local _sav_rc=0
   stage_a_verify_run || _sav_rc=$?
   case "$_sav_rc" in
     0)
       : ;;  # SUCCESS / SKIPPED / DISABLED → 続行
     1)
-      echo "🔁 #$NUMBER: stage-a-verify 失敗（round=1）→ Developer 差し戻し（次 tick で再試行）" | tee -a "$LOG"
-      return 1
+      # stage-a-verify round=1 差し戻し（次 tick で再評価）。`claude-picked-up` を残すと
+      # dispatcher の候補クエリ（`-label:"$LABEL_PICKED"`）から除外され二度と再 pickup
+      # されず stuck になる（per-task hold #198 と同根 / Issue #219）。ここで
+      # claude-picked-up / claude-claimed を除去して bare auto-dev candidate へ復帰させ、
+      # 次 tick の再 pickup → Stage Checkpoint resume → stage-a-verify 再評価
+      # （round=2 escalate への前進）を成立させる。round counter sidecar は温存するため、
+      # 次回失敗で round=2 → claude-failed に進む。戻り値 3 は呼び出し側で「再 pickup 可能な
+      # 保留」として扱われ、虚偽の「claude-failed 付与済み」ログを出さない。
+      echo "🔁 #$NUMBER: stage-a-verify 失敗（round=1）→ Developer 差し戻し（claude-picked-up 除去 / 次 tick で再評価）" | tee -a "$LOG"
+      # claude-picked-up を除去して再 pickup 可能化（fail-open: 除去失敗でも保留は維持）。
+      stage_a_verify_round1_defer || true
+      return 3
       ;;
     2)
       echo "❌ #$NUMBER: stage-a-verify 連続 2 回失敗 → claude-failed" | tee -a "$LOG"
@@ -6769,16 +6812,33 @@ EOF
         ;;
     esac
   else
-    # impl / impl-resume → Reviewer ゲートを含む stage 分割パイプラインへ
-    if run_impl_pipeline; then
-      echo "✅ #$NUMBER: $MODE 完了（Reviewer ゲート通過 / PR 作成済み）" | tee -a "$LOG"
-      slot_log "$MODE 完了（PR 作成済み）"
-      return 0
-    else
-      echo "❌ #$NUMBER: $MODE 失敗（claude-failed 付与済み）" | tee -a "$LOG"
-      slot_log "$MODE 失敗（claude-failed 付与済み）"
-      return 1
-    fi
+    # impl / impl-resume → Reviewer ゲートを含む stage 分割パイプラインへ。
+    # run_impl_pipeline の戻り値契約:
+    #   0 = 完了 / 良性停止（quota → needs-quota-wait / partial / Stage Checkpoint TERMINAL_OK）
+    #   3 = 再 pickup 可能な保留（stage-a-verify round=1 差し戻し / Issue #219）。
+    #       claude-failed は未付与で claude-picked-up も除去済み → 次 tick で再評価される。
+    #   その他非 0 = 失敗。各 stage 内で `mark_issue_failed` 発火済み（claude-failed 付与済み）。
+    local _impl_rc=0
+    run_impl_pipeline || _impl_rc=$?
+    case "$_impl_rc" in
+      0)
+        echo "✅ #$NUMBER: $MODE 完了（Reviewer ゲート通過 / PR 作成済み）" | tee -a "$LOG"
+        slot_log "$MODE 完了（PR 作成済み）"
+        return 0
+        ;;
+      3)
+        # stage-a-verify round=1 差し戻し。claude-failed は付与されておらず、
+        # 虚偽の「claude-failed 付与済み」を出さない（Issue #219 fix）。
+        echo "⏸️ #$NUMBER: $MODE 保留（stage-a-verify 差し戻し / claude-failed 未付与 / 次 tick で再評価）" | tee -a "$LOG"
+        slot_log "$MODE 保留（stage-a-verify 差し戻し / 次 tick 再評価）"
+        return 0
+        ;;
+      *)
+        echo "❌ #$NUMBER: $MODE 失敗（claude-failed 付与済み）" | tee -a "$LOG"
+        slot_log "$MODE 失敗（claude-failed 付与済み）"
+        return 1
+        ;;
+    esac
   fi
 }
 

--- a/local-watcher/test/stage_a_verify_round1_defer_test.sh
+++ b/local-watcher/test/stage_a_verify_round1_defer_test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# 本テストの fake 依存（gh）は eval で読み込んだ stage_a_verify_round1_defer から
+# 間接的にのみ呼ばれるため unreachable 扱いになり、env var（NUMBER / REPO / LOG /
+# LABEL_PICKED / LABEL_CLAIMED）も eval 済み関数内でのみ参照されるため unused 扱いに
+# なる。いずれも false positive のためファイル全体で抑止する（既存
+# stage_c_existing_pr_guard_test.sh / parse_review_result_test.sh と同じ扱い）。
+# shellcheck disable=SC2317,SC2034
+#
+# 用途: local-watcher/bin/issue-watcher.sh の stage_a_verify_round1_defer
+#       (Issue #219) を fake gh で検証するスモークテスト。
+#
+#       背景: stage-a-verify round=1 差し戻し経路が `claude-picked-up` を除去せず
+#       return していたため、dispatcher の候補クエリ（`-label:"claude-picked-up"`）
+#       から除外され当該 Issue が二度と再 pickup されず stuck になっていた。本関数は
+#       per-task hold (#198) と同様に claude-picked-up / claude-claimed を除去して
+#       bare auto-dev candidate へ復帰させる。
+#
+#       検証観点:
+#         - gh issue edit が claude-picked-up / claude-claimed の両方を --remove-label
+#           で呼ぶ（再 pickup 可能化）
+#         - gh 成功時 return 0 / $LOG に「除去 → bare auto-dev candidate へ復帰」ログ
+#         - gh 失敗時 return 1（fail-open） / $LOG に WARN ログ（ラベル残置の旨）
+#
+# 配置先: local-watcher/test/stage_a_verify_round1_defer_test.sh
+# 依存:   bash 4+, awk
+# 実行:   bash local-watcher/test/stage_a_verify_round1_defer_test.sh
+# 前提:   issue-watcher.sh から stage_a_verify_round1_defer 定義のみを awk で抽出し
+#         eval で current shell に読み込む（トップレベル副作用を回避）。gh はテスト側
+#         で fake を定義し、呼び出し引数を記録する。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "stage_a_verify_round1_defer")"
+
+if ! declare -F stage_a_verify_round1_defer >/dev/null; then
+  echo "ERROR: stage_a_verify_round1_defer not loaded" >&2
+  exit 2
+fi
+
+# ── 共有 env / fake ──────────────────────────────────────────────────────────
+NUMBER=219
+REPO="owner/repo"
+LABEL_PICKED="claude-picked-up"
+LABEL_CLAIMED="claude-claimed"
+
+PASS=0
+FAIL=0
+
+# fake gh: 呼び出し引数を $GH_ARGS_FILE に追記し、$GH_RC を返す。
+GH_RC=0
+gh() {
+  printf '%s\n' "$*" >> "$GH_ARGS_FILE"
+  return "$GH_RC"
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "  ok: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  NG: $label（期待文字列 '$needle' が見つからない）" >&2
+    echo "      実際: $haystack" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_eq() {
+  local actual="$1" expected="$2" label="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "  ok: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "  NG: $label（期待=$expected / 実際=$actual）" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ── ケース 1: gh 成功 → return 0 / 両ラベル除去 / 復帰ログ ────────────────────
+echo "[case1] gh 成功: claude-picked-up + claude-claimed を除去し return 0"
+GH_ARGS_FILE="$(mktemp)"
+LOG="$(mktemp)"
+GH_RC=0
+rc=0
+stage_a_verify_round1_defer || rc=$?
+gh_args="$(cat "$GH_ARGS_FILE")"
+log_body="$(cat "$LOG")"
+assert_eq "$rc" "0" "gh 成功時の戻り値は 0"
+assert_contains "$gh_args" "issue edit 219" "gh issue edit が対象 Issue #219 で呼ばれる"
+assert_contains "$gh_args" "--remove-label claude-picked-up" "claude-picked-up を除去する"
+assert_contains "$gh_args" "--remove-label claude-claimed" "claude-claimed を除去する"
+assert_contains "$log_body" "bare auto-dev candidate へ復帰" "復帰ログが出力される"
+rm -f "$GH_ARGS_FILE" "$LOG"
+
+# ── ケース 2: gh 失敗 → return 1（fail-open） / WARN ログ ─────────────────────
+echo "[case2] gh 失敗: fail-open で return 1 / WARN ログ（ラベル残置）"
+GH_ARGS_FILE="$(mktemp)"
+LOG="$(mktemp)"
+GH_RC=1
+rc=0
+stage_a_verify_round1_defer || rc=$?
+log_body="$(cat "$LOG")"
+assert_eq "$rc" "1" "gh 失敗時の戻り値は 1（fail-open）"
+assert_contains "$log_body" "WARN" "WARN ログが出力される"
+assert_contains "$log_body" "手動除去で復旧可能" "手動復旧の案内ログが出力される"
+rm -f "$GH_ARGS_FILE" "$LOG"
+
+# ── 結果 ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  echo "RESULT: FAIL" >&2
+  exit 1
+fi
+echo "RESULT: PASS"


### PR DESCRIPTION
## 概要

stage-a-verify gate (#125) の **round=1 差し戻し経路が Issue を永久 stuck にする不具合** と、それに伴う **虚偽ログ** を是正する。#219 が impl-resume 中に stage-a-verify round=1 失敗で停止した際、`claude-failed` が付かず `claude-picked-up` のまま再 pickup も escalate もされない状態で実観測された。

## 不具合の内容（2 点）

### ① stuck 状態（機能不具合）
`run_impl_pipeline` の stage-a-verify round=1 失敗経路は「次サイクルで再評価」とコメントしながら、`claude-picked-up` を除去せず return 1 していた。dispatcher の候補クエリ（`issue-watcher.sh:6921` 付近の `-label:"$LABEL_PICKED"`）は claude-picked-up を除外するため、**当該 Issue は二度と再 pickup されず**、round=2（claude-failed escalate）にも到達できず永久停止していた。per-task hold (#198) が同じ理由で claude-picked-up を除去して再 pickup 可能化しているのと**非対称**だった。

### ② 虚偽ログ（cosmetic だが運用を誤導）
呼び出し側 `_slot_run_issue` が `run_impl_pipeline` の return 非 0 を**無条件で**「claude-failed 付与済み」と出力していた。round=1 経路は `mark_issue_failed` を呼ばないため、ログ・Issue コメントが claude-failed を主張するのに実ラベルは claude-picked-up、という矛盾が生じていた。

## 修正内容

- **`stage_a_verify_round1_defer` を新設**: round=1 差し戻し時に claude-picked-up / claude-claimed を除去して bare auto-dev candidate へ復帰させる（fail-open: gh 失敗時は WARN ログを残し保留は維持）。round counter sidecar は温存するため、次 tick の再 pickup → 再失敗で round=2 → claude-failed に正しく前進する
- **`run_impl_pipeline` の戻り値契約に 3 を追加**: round=1 = 「再 pickup 可能な保留」を表す `3` を返す（round=2 escalate は従来どおり `1`）
- **`_slot_run_issue` の戻り値ハンドリングを `case` 化**: `3` を「保留（次 tick 再評価 / claude-failed 未付与）」として扱い、虚偽の「claude-failed 付与済み」を出さない。`0` / その他非 0 の挙動は不変
- **回帰テスト追加**: `local-watcher/test/stage_a_verify_round1_defer_test.sh`（claude-picked-up + claude-claimed の除去 / gh 成功 return 0 / gh 失敗 fail-open return 1 / ログ）
- **README 更新**: Stage A Verify Gate (#125) の状態遷移図と round=1 再 pickup 可能化の補足

## 受入基準チェック

- [x] stage-a-verify round=1 失敗で claude-picked-up / claude-claimed が除去され、次 tick で再 pickup される
- [x] round=1 では claude-failed を付与しない（round counter 温存 → round=2 で escalate）
- [x] round=1 経路で「claude-failed 付与済み」の虚偽ログを出さない（「保留 / 次 tick 再評価」を出力）
- [x] round=2 escalate（claude-failed 付与 + mark_issue_failed）の挙動は不変
- [x] 通常成功 / quota / partial / TERMINAL_OK（return 0）の挙動は不変

## テスト結果（Test plan）

```
$ bash local-watcher/test/stage_a_verify_round1_defer_test.sh
PASS=8 FAIL=0
RESULT: PASS

$ shellcheck local-watcher/bin/issue-watcher.sh local-watcher/test/stage_a_verify_round1_defer_test.sh
# 新規警告ゼロ（SC2317 info 11 件は main ベースラインと同数の false positive）

$ bash -n local-watcher/bin/issue-watcher.sh   # syntax OK

# 既存テストスイート: 私の変更による回帰なし
#   - verify_pushed_or_retry_test.sh: PASS 17/0（main と同一）
#   - qa_run_claude_stage_test.sh: main でも exit=1 の既存 opt-in テスト（変更と無関係）
```

## 後方互換性

- 既存 env var 名 / ラベル名 / cron 登録文字列 / 外部 exit code は不変
- `run_impl_pipeline` は内部関数。戻り値 3 の追加は唯一の呼び出し元 `_slot_run_issue` で吸収
- dispatcher は `_slot_run_issue` の exit code を**無視**する設計（`wait` 直前コメント「Slot Runner 内で claude-failed 化等は完結済のため exit code は無視」）のため、戻り値 1→0/3 の変更は下流に波及しない
- `STAGE_A_VERIFY_ENABLED=false` 明示時の挙動は不変

## 確認事項 / レビュワーへの依頼

- `_slot_run_issue` の round=1 時戻り値が **従来 1 → 本 PR で 0**（保留）に変わります。dispatcher は exit code 無視のため運用影響なしと判断していますが、他に `_slot_run_issue` の戻り値に依存する経路がないか確認をお願いします
- 本 PR は #219（観測元 Issue）とは別の watcher バグ修正です。#219 自体は別途 `claude-failed` に倒して人間判断に委ねています（verify タスクが説明文で実行不能だったため）
- **デプロイ注意**: 本 PR を merge しても、稼働中の `~/bin/issue-watcher.sh` は `install.sh` / `setup.sh` の再実行まで更新されません

## 関連

- Related: #219 #125 #198

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
