### PR TITLE
feat(watcher): #221 path-overlap holder 集合を base 相対化し develop dispatch で staged-for-release を除外

### DIFF
--- a/README.md
+++ b/README.md
@@ -1728,7 +1728,7 @@ Path Overlap Checker は、以下のいずれかのラベルを持つ open Issue
 - `ready-for-review`
 - `needs-iteration`
 - `needs-rebase`
-- `staged-for-release`
+- `staged-for-release`（**base 相対**。下記「holder ラベル集合の base 相対化」参照）
 
 逆に以下のラベルを持つ Issue は in-flight に含めません（Req 4.2）:
 
@@ -1737,6 +1737,32 @@ Path Overlap Checker は、以下のいずれかのラベルを持つ open Issue
 
 候補 Issue 自身は in-flight 比較集合から除外され（Req 4.3）、同一 repo の Issue のみが
 集合対象となります（Req 4.4）。
+
+### holder ラベル集合の base 相対化（#221）
+
+holder（in-flight 集合）の本質は「dispatch 先の base ブランチにまだ取り込まれていない作業」
+です。`staged-for-release` は「`develop` に merge 済み・`main` 到達待ち」（multi-branch 運用専用）
+を意味するため、**dispatch base=`develop` の文脈ではその作業は既に `develop` へ統合済み**であり
+holder から除外できます。そこで Path Overlap Checker は holder ラベル集合を **呼び出し
+コンテキストと branch 設定に応じて決定**します（#221）:
+
+| 文脈 | `BASE_BRANCH` vs `PROMOTION_TARGET_BRANCH` | holder 集合 | `staged-for-release` |
+|---|---|---|---|
+| dispatch | 異なる（multi-branch / gitflow） | 6 ラベル | **除外**（develop 統合済みは holder から外す） |
+| dispatch | 同一（single-branch） | 7 ラベル（full） | 維持（運用上付与されないためゼロ差分） |
+| promote target=`main` | （不問） | 7 ラベル（full） | 維持（まだ `main` に無い in-flight 集合） |
+| 判定不能（不明 context 等） | （不問） | 7 ラベル（full） | 維持（fail-safe / 安全側） |
+
+- **single-branch（`main` only）運用ではゼロ差分**: `staged-for-release` が運用上付与されない
+  ため、`BASE_BRANCH == PROMOTION_TARGET_BRANCH` のとき full 集合を使い、本機能導入前と
+  同一の in-flight 集合 / `awaiting-slot` 判定になります（後方互換）。
+- **gitflow 運用ガイド**: `BASE_BRANCH=develop`（かつ `PROMOTION_TARGET_BRANCH=main`）の
+  multi-branch 運用では、完了して `staged-for-release` を付与したまま open に残った Issue が、
+  同一 top-level path を編集する新規 Issue を不要に `awaiting-slot` へ落とすことがなくなります。
+  この base 相対化は `BASE_BRANCH` / `PROMOTION_TARGET_BRANCH` の設定にのみ連動し、新規の
+  環境変数・フラグは追加しません（Phase B / #89 と同じ 2 変数で multi-branch を判定）。
+- `staged-for-release` 自体の付与運用（誰がいつ付けるか）は本機能のスコープ外で、既存運用
+  （「Issue ラベル一覧」「staged-for-release 状態遷移」節）を前提とします。
 
 ### 自然解消の流れ
 
@@ -1756,6 +1782,9 @@ grep 'path-overlap: overlap detected' $HOME/.issue-watcher/logs/<repo-slug>/*.lo
 
 # awaiting-slot 付与・除去
 grep 'path-overlap: awaiting-slot' $HOME/.issue-watcher/logs/<repo-slug>/*.log
+
+# holder 集合の base 相対除外（#221 / NFR 3.1。multi-branch dispatch でのみ出力）
+grep 'path-overlap: holder-set' $HOME/.issue-watcher/logs/<repo-slug>/*.log
 ```
 
 各イベントで以下の 1 行ログが必ず出力されます（Req 8.1〜8.3）:
@@ -1764,6 +1793,14 @@ grep 'path-overlap: awaiting-slot' $HOME/.issue-watcher/logs/<repo-slug>/*.log
 path-overlap: overlap detected candidate=#<N> paths=<comma-separated>
 path-overlap: awaiting-slot added candidate=#<N>
 path-overlap: awaiting-slot cleared candidate=#<N> (overlap empty)
+```
+
+dispatch 文脈で holder 集合から `staged-for-release` を除外した場合（multi-branch 運用）は、
+除外を判別可能な以下のログが出力されます（#221 / NFR 3.1）。single-branch 運用や除外が
+発生しない場合は出力されません（ゼロ差分）:
+
+```
+path-overlap: holder-set context=dispatch excluded=staged-for-release base=<BASE_BRANCH>
 ```
 
 ### dogfood 確認手順

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/impl-notes.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/impl-notes.md
@@ -1,0 +1,24 @@
+# Implementation Notes
+
+## Implementation Notes
+
+### Task 1
+
+- 採用方針: `local-watcher/bin/modules/promote-pipeline.sh` に `po_resolve_holder_labels`（`$1=context`）を `po_collect_inflight_issues` の直前に新設し、design.md D3 の真理値表どおり dispatch×multi-branch のみ `staged-for-release` を除外、それ以外（dispatch×single-branch / promote / 不明 context）は full 7 ラベル CSV を返す fail-safe を実装した。
+- 重要な判断:
+  - 6 基本ラベルおよび `staged-for-release` はすべて `$LABEL_*` 定数を参照して組み立て、ラベル文字列のハードコード重複を排除した（task 明記の `$LABEL_STAGED_FOR_RELEASE` を含む）。定数未束縛時にも安全側へ倒すため `${LABEL_X:-リテラル既定}` 形式で fallback を付与した（source 順序事故・SC2154 双方への保険）。
+  - branch 比較は `${BASE_BRANCH:-main}` / `${PROMOTION_TARGET_BRANCH:-main}` の既定付き展開で行い、未束縛時は single-branch（== main）扱い → full 集合（安全側）になる。
+  - 判定不能（不明 context / 空 context）は明示分岐を設けず、dispatch×multi-branch 以外を一律 full 集合とする実装で Req 4.1 を満たす（fail-safe full）。
+- 検証: `shellcheck local-watcher/bin/modules/promote-pipeline.sh` は exit 0 / 警告ゼロ（本変更前後で増減なし）。関数単体のスモークで真理値表 5 ケース（dispatch×multi / dispatch×single / promote / 不明 / 空 context）全 PASS を確認。
+- AC との対応（本 task が担保した範囲）:
+  - Req 1.1 / NFR 1.2: dispatch×multi-branch で 6 ラベル CSV を返し、6 基本ラベルを常時含む invariant をスモークで確認。
+  - NFR 1.1: dispatch×single-branch（main/main）で full 集合を返すことを確認（ゼロ差分）。
+  - Req 2.1: promote で full 集合（staged-for-release 維持）を確認。
+  - Req 4.1: 不明 / 空 context で full 集合（fail-safe）を確認。
+  - Req 3.1 / 3.2 / 3.3: context ごとに集合を決定する単一関数として表現し、副作用なし（stdout のみ / グローバル変数は読み取りのみ）。
+  - 注: 上記スモークは本 task の動作確認であり、tasks.md task 4 の正式なユニット/スモーク fixture（`test-holder-labels.sh`）は別 task で追加する。
+- 残存課題（次 task=2 への影響）: なし。task 2 では `po_collect_inflight_issues` の第 2 引数 default を本関数の full 集合と文字列一致させる必要がある。本関数の full CSV は `claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release`（既存 `search_query` の OR 順序と同一）であり、task 2 の default 集合と整合させること。
+
+## 確認事項
+
+- design.md / requirements.md / tasks.md と本実装の間に矛盾は検出していない。本 task のスコープ（新規関数追加のみ）では既存呼び出し経路に影響を与えていない（`po_resolve_holder_labels` は task 3 で初めて `po_check_dispatch_gate` から呼ばれる）。

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/impl-notes.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/impl-notes.md
@@ -19,6 +19,45 @@
   - 注: 上記スモークは本 task の動作確認であり、tasks.md task 4 の正式なユニット/スモーク fixture（`test-holder-labels.sh`）は別 task で追加する。
 - 残存課題（次 task=2 への影響）: なし。task 2 では `po_collect_inflight_issues` の第 2 引数 default を本関数の full 集合と文字列一致させる必要がある。本関数の full CSV は `claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release`（既存 `search_query` の OR 順序と同一）であり、task 2 の default 集合と整合させること。
 
+### Round 2 是正（task 2〜5）
+
+Reviewer round=1 の reject（task 2〜5 未実装で Req 1.1 / 1.2 / 1.3 / 4.2 / NFR 3.1 の観測可能挙動が不成立、task 4 fixture 欠如）に対し、tasks.md task 2〜5 を実装した。
+
+- **task 2（Finding 1 / 2 / 3 / Req 1.2 / 1.4 / 2.2 / 3.2 / 4.2 / NFR 1.1 / 1.2 / 2）**: `po_collect_inflight_issues` に第 2 引数 `holder_labels`（CSV、default = 現行 7 ラベル集合）を追加し、`search_query` を CSV から動的に組み立てるよう変更した。ラベル → OR clause の組み立ては新設ヘルパー `po_build_label_or_clause`（CSV をカンマ分割し各要素を前後空白除去・空要素スキップして `label:"X" OR ...` を生成）に切り出した。第 2 引数省略時の query は変更前のヒアドキュメント固定 query と**文字列完全一致**する（test の Case 5 で検証）。CSV が空 / 不正で OR clause が空になる場合は full 7 ラベル集合へ fallback する（Req 4.2 / Case 5c）。`st-failed` / `awaiting-slot` 除外と `gh issue list` 1 回 / 候補ごと `po_load_edit_paths` 1 回の構造は変更していない（NFR 2）。
+- **task 3（Finding 1 / 4 / Req 1.1 / 1.3 / 3.1 / NFR 3.1）**: `po_check_dispatch_gate` 内で `po_resolve_holder_labels "dispatch"` を呼び holder 集合を解決し、`po_collect_inflight_issues "$candidate" "$holder_labels"` へ注入した（orphan 解消）。NFR 3.1 ログは、解決集合が `po_resolve_holder_labels "promote"`（= full 集合）と**異なる**場合のみ `po_log "holder-set context=dispatch excluded=<staged-for-release> base=<BASE_BRANCH>"` を出力する実装とした。full と一致する single-branch / 判定不能では出力せずゼロ差分を保つ（NFR 1.1）。`po_check_dispatch_gate` のシグネチャ（`$1 candidate` / `$2 labels_json`）と opt-in gate / fail-open / overlap ロジックは不変で、issue-watcher.sh 本体は未変更。
+  - 実装上の判断: full 集合の比較対象を別ハードコードせず `po_resolve_holder_labels "promote"` の戻り値で取得することで、full 集合定義の二重管理を避け、将来 full 集合のラベルが増減しても除外判定が自動追従するようにした。
+- **task 4（Finding 5 / Req 1.1 / 2.1 / 4.1 / NFR 1.1）**: `test-fixtures/test-holder-labels.sh` を新設（ディレクトリごと作成、実行ビット付与、shebang `#!/usr/bin/env bash`）。`gh` をシェル関数でスタブ化し `--search` 引数を捕捉する方式で、実 API を呼ばずに query 構築を検証する。検証ケース: 真理値表 4 ケース + 空 context（Req 1.1 / NFR 1.1 / 2.1 / 4.1）、search_query ゼロ差分（NFR 1.1）、6 ラベル CSV 注入時の SfR 非含有（Req 1.2）、空 CSV fallback（Req 4.2）の計 8 ケース。全 PASS / 非ゼロ exit on fail。
+- **task 5（Req 1.1 / 2.1 / NFR 1.1 / NFR 3.1）**: README の「Path Overlap Checker (Phase E)」節「in-flight 集合の定義」に base 相対化の表と gitflow 運用ガイドを追記し、観測ログ節に `holder-set` 除外ログの grep 例を追記した。single-branch ゼロ差分の後方互換を明記。
+
+#### 検証結果（Round 2）
+
+- `shellcheck local-watcher/bin/modules/promote-pipeline.sh docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/test-holder-labels.sh` → 警告ゼロ（promote-pipeline.sh は本変更前後で警告増減なし。test fixture は SC2034 / SC2317 を file-level disable コメントで抑止。これは source した module の関数が変数を間接参照する / gh スタブが間接呼び出しされる shellcheck の偽陽性であり、実コードに問題はない）。
+- `bash test-holder-labels.sh` → `PASS=8 FAIL=0` / exit 0。
+- search_query ゼロ差分: 変更前のヒアドキュメント固定文字列 `is:open is:issue (label:"claude-claimed" OR ... OR label:"staged-for-release") -label:"st-failed" -label:"awaiting-slot"` と、第 2 引数省略時に組み立てられる query が文字列一致することを test Case 5 で確証（最重要の後方互換ポイント）。
+- module 単体 source smoke: `po_build_label_or_clause` の空 CSV → 空文字列（fallback トリガー）、空白混じり / 重複カンマ → 正しくトリム・スキップを確認。
+
+#### Round 2 の AC 対応テスト一覧（追加・是正分）
+
+| AC | 担保したテスト |
+|---|---|
+| Req 1.1 | test-holder-labels.sh Case 1（dispatch×multi-branch → 6 ラベル CSV）+ task 3 で gate へ注入 |
+| Req 1.2 | test-holder-labels.sh Case 5b（6 ラベル CSV で SfR 非含有 query 構築） |
+| Req 1.3 | dispatch gate が注入集合で overlap=0 → claim 続行する経路（task 3 wiring。観測は dogfood E2E で確認予定） |
+| Req 1.4 | `po_collect_inflight_issues` の OR query が併存ラベル（claude-claimed 等）でヒットする既存挙動を維持（6 ラベルは常時集合内） |
+| Req 2.1 | test-holder-labels.sh Case 3（promote → full 7 ラベル CSV） |
+| Req 2.2 | promote 経路は別経路（`pp_collect_merged_issues`、holder ラベル query 不使用）で挙動不変。default 集合固定で契約保全 |
+| Req 3.1 / 3.2 / 3.3 | `po_resolve_holder_labels` が単一契約として context ごとに集合を決定（Case 1〜4b）。引数注入で副作用なし |
+| Req 4.1 | test-holder-labels.sh Case 4 / 4b（不明 / 空 context → full 集合 fail-safe） |
+| Req 4.2 | test-holder-labels.sh Case 5c（空 CSV → full 集合 fallback） |
+| NFR 1.1 | test-holder-labels.sh Case 2（single-branch → full）+ Case 5（search_query 文字列一致） |
+| NFR 1.2 | 6 基本ラベルを常時含む invariant（Case 1 で SfR のみ差分であることを確認） |
+| NFR 2.1 / 2.2 | `gh issue list` 1 回 / `po_load_edit_paths` 1 回の構造を変更していない（コードレビュー / 構造不変） |
+| NFR 3.1 | task 3 の `holder-set ...` ログ（解決集合 != full 時のみ出力）。multi-branch で除外発生時に判別可能 |
+
 ## 確認事項
 
 - design.md / requirements.md / tasks.md と本実装の間に矛盾は検出していない。本 task のスコープ（新規関数追加のみ）では既存呼び出し経路に影響を与えていない（`po_resolve_holder_labels` は task 3 で初めて `po_check_dispatch_gate` から呼ばれる）。
+- Round 2 で task 2〜5 を実装した結果、`po_resolve_holder_labels` は `po_check_dispatch_gate` から呼ばれる接続済み関数となり、orphan 状態は解消した。
+- design.md L160 等の行番号参照は task 1 commit 後にズレが生じているが、これは impl-notes の記述上の問題であり実装には影響しない（design.md は書き換えていない）。
+
+STATUS: complete

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/review-notes.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/review-notes.md
@@ -1,0 +1,91 @@
+# Review Notes
+
+<!-- idd-claude:review round=2 model=claude-opus-4-7 timestamp=2026-05-25T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-221-impl-feat-watcher-path-overlap-holder-base-de
+- HEAD commit: b6df018（`git diff 151d17b..HEAD` を真の差分として評価）
+- Compared to: 151d17b（merge-base）..HEAD
+- 真の追加分（5 ファイル / +367 -20）:
+  - `local-watcher/bin/modules/promote-pipeline.sh` +136 -20（`po_resolve_holder_labels` /
+    `po_build_label_or_clause` 新設、`po_collect_inflight_issues` 引数化、`po_check_dispatch_gate`
+    からの集合注入 + NFR3 ログ）
+  - `docs/specs/.../test-fixtures/test-holder-labels.sh` +139（新規 fixture）
+  - `README.md` +39（Phase E 節の base 相対化 + 観測ログ追記）
+  - `docs/specs/.../impl-notes.md` +63（Round 2 是正メモ）
+  - `docs/specs/.../tasks.md`（task 2〜5 を `[x]` に更新）
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節なし → opt-out 扱い。
+  flag 観点の確認は行わず通常の 3 カテゴリ判定を適用。
+- impl-notes.md 末尾 `STATUS: complete` を確認。標準判定を適用。
+- ROUND=1 の reject 理由（Finding 1〜5: task 2〜5 未実装）が解消されているかを重点確認した。
+
+## Verified Requirements
+
+- 1.1 — `po_check_dispatch_gate`（promote-pipeline.sh:645）が `po_resolve_holder_labels "dispatch"`
+  を呼び、結果を `po_collect_inflight_issues "$candidate" "$holder_labels"`（同:658）へ第 2 引数で
+  注入。dispatch×multi-branch で `staged-for-release` 除外の 6 ラベル集合が in-flight 列挙クエリに
+  反映される（orphan 解消）。fixture Case 1（PASS）が `BASE_BRANCH=develop`/`PROMOTION_TARGET_BRANCH=main`
+  で 6 ラベル CSV を確認。
+- 1.2 — `po_collect_inflight_issues`（同:320-345）が holder_labels CSV から `po_build_label_or_clause`
+  経由で動的 search_query を組み立て、6 ラベル CSV では `staged-for-release` を含まないクエリになる。
+  fixture Case 5b（PASS）が SfR 非含有 query を確認。SfR 単独 Issue は列挙から脱落する。
+- 1.3 — dispatch gate（multi-branch）が 6 ラベル集合を注入し、SfR 単独 Issue が in-flight union から
+  外れ overlap=0 → claim 続行する経路が成立（promote-pipeline.sh:658-669 の既存 overlap ロジックを
+  通る）。配線は task 3 で確立。
+- 1.4 — OR query が併存ラベルでヒットする既存挙動を維持。6 基本ラベルは常時集合内（NFR 1.2 invariant）
+  のため、`staged-for-release` + `claude-claimed` 併存 Issue は `claude-claimed` 句で列挙され holder 維持。
+- 2.1 — `po_resolve_holder_labels "promote"`（同:233-244）が full 7 ラベル CSV（SfR 維持）を返す。
+  fixture Case 3（PASS）で確認。
+- 2.2 — promote 経路（`pp_collect_merged_issues`、promote-pipeline.sh:802 の `is:merged base:` PR 列挙）は
+  holder ラベルクエリを共有しない別経路（design.md D2）。本変更は当該経路に触れず、default 集合固定で
+  契約保全。挙動不変。
+- 3.1 / 3.2 / 3.3 — `po_resolve_holder_labels` が単一契約として context ごとに集合を決定（真理値表
+  fixture Case 1〜4b で網羅）。stdout 出力のみで副作用なし、引数注入で用途間の判定が相互に独立。
+- 4.1 — 不明 context / 空 context が full 集合へ倒れる fail-safe（同:241-243 の if 非該当時 echo full）。
+  fixture Case 4 / 4b（PASS）で確認。
+- 4.2 — `po_collect_inflight_issues`（同:336-339）が label_clause 空時に full 7 ラベル集合へ fallback。
+  fixture Case 5c（空 CSV）が full クエリへ fallback することを PASS で確認。
+- NFR 1.1 — 第 2 引数省略時の search_query が変更前ヒアドキュメント固定クエリと文字列一致。fixture
+  Case 5（PASS）が `EXPECTED_QUERY`（変更前固定文字列）と捕捉クエリの一致を検証。`po_build_label_or_clause`
+  の OR 句生成順序が default CSV 順序と一致するため文字列等価が成立。
+- NFR 1.2 — 6 基本ラベルを常時含み差分は `staged-for-release` の有無のみ（`po_resolve_holder_labels`
+  の base_labels invariant、fixture Case 1 で SIX_CSV と FULL_CSV の差分が SfR のみであることを確認）。
+- NFR 2.1 / 2.2 — `gh issue list`（同:340）1 回 / 候補ごと `po_load_edit_paths`（同:358）1 回の構造は
+  未変更。変更は search_query 文字列の組み立てのみで API 回数に影響なし。
+- NFR 3.1 — `po_check_dispatch_gate`（同:650-652）が解決集合 != full（= SfR 除外発生）時のみ
+  `po_log "holder-set context=dispatch excluded=... base=..."` を出力。`po_log` は `path-overlap:`
+  prefix を付与（同:45）するため実出力は `path-overlap: holder-set ...` となり README の grep 例 / 出力例と
+  一致。full と一致する single-branch では出力せずゼロ差分を維持。
+
+## Findings
+
+なし（ROUND=1 の Finding 1〜5 はすべて解消済み）。
+
+ROUND=1 で指摘した解消状況:
+- Finding 1（1.1 orphan / 集合未注入）: `po_check_dispatch_gate` から `po_resolve_holder_labels "dispatch"`
+  の結果を第 2 引数注入し、`po_collect_inflight_issues` を動的クエリ化（task 2/3）→ 解消。
+- Finding 2（1.2 / 1.3）: 動的 search_query 化と集合注入により SfR 単独 Issue が列挙脱落 → 解消。
+- Finding 3（4.2）: `po_collect_inflight_issues` に label_clause 空時の full 集合 fallback を実装 → 解消。
+- Finding 4（NFR 3.1）: 除外発生時に `holder-set ...` ログを出力（full 一致時は非出力）→ 解消。
+- Finding 5（missing test）: `test-holder-labels.sh` を新設し 8 ケース全 PASS（真理値表 4 ケース +
+  空 context + search_query ゼロ差分 + 6 ラベル SfR 非含有 + 空 CSV fallback）→ 解消。
+
+## 検証実施
+
+- `bash docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/test-holder-labels.sh`
+  → `PASS=8 FAIL=0` / exit 0。
+- `shellcheck local-watcher/bin/modules/promote-pipeline.sh test-holder-labels.sh` → exit 0（警告ゼロ）。
+- `git diff 151d17b..HEAD -- local-watcher/bin/issue-watcher.sh` → 差分なし（本体不変 / boundary 維持）。
+- fixture のラベル定数名（LABEL_CLAIMED 等）が issue-watcher.sh:60-75 の実定数と同値であることを確認。
+- `po_check_dispatch_gate` シグネチャ（`$1 candidate` / `$2 labels_json`）不変、opt-in gate
+  （`PATH_OVERLAP_CHECK = "true"` 厳密一致）/ fail-open / overlap ロジックは未変更（boundary 逸脱なし）。
+
+## Summary
+
+ROUND=1 の reject 理由（task 2〜5 未実装による Req 1.1/1.2/1.3/4.2/NFR 3.1 の観測可能挙動不成立、
+task 4 fixture 欠如）はすべて解消された。全 numeric ID（Req 1.1〜4.2 / NFR 1.1〜3.1）が実装または
+テストで裏打ちされ、fixture 8 ケース全 PASS・shellcheck クリーン・issue-watcher.sh 本体不変・
+シグネチャ不変を確認。boundary 逸脱なし。approve とする。
+
+RESULT: approve

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
@@ -12,7 +12,7 @@
   - _Requirements: 1.1, 2.1, 3.1, 3.2, 3.3, 4.1, NFR 1.1_
   - _Boundary: po_resolve_holder_labels_
 
-- [ ] 2. `po_collect_inflight_issues` を holder ラベル集合引数で動的クエリ化する
+- [x] 2. `po_collect_inflight_issues` を holder ラベル集合引数で動的クエリ化する
   - 第 2 引数 `holder_labels`（CSV）を追加し、default を現行 7 ラベル集合に固定する
   - `search_query` を holder_labels CSV から動的に `label:"X" OR ...` 形式で組み立てる
   - 引数省略時に組み立てるクエリが現行固定クエリと**文字列一致**することを保証する（後方互換ゼロ差分）

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. holder ラベル集合決定関数 `po_resolve_holder_labels` を新設する
+- [x] 1. holder ラベル集合決定関数 `po_resolve_holder_labels` を新設する
   - `promote-pipeline.sh` に `po_resolve_holder_labels` 関数を追加する（`$1=context`）
   - `dispatch` × multi-branch（`BASE_BRANCH != PROMOTION_TARGET_BRANCH`）→ `staged-for-release` を除いた 6 ラベル CSV
   - `dispatch` × single-branch（`BASE_BRANCH == PROMOTION_TARGET_BRANCH`）→ full 7 ラベル CSV（ゼロ差分）

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
@@ -42,7 +42,7 @@
   - _Boundary: po_resolve_holder_labels, po_collect_inflight_issues_
   - _Depends: 1, 2_
 
-- [ ] 5. README に base 相対 holder と gitflow 運用ガイドを追記する
+- [x] 5. README に base 相対 holder と gitflow 運用ガイドを追記する
   - 「Path Overlap Checker (Phase E)」節「in-flight 集合の定義」に base 相対化の注記（dispatch base=develop では staged-for-release 除外 / promote target=main では維持）を追加
   - gitflow 運用ガイド（`staged-for-release` と Phase E holder の関係 / `BASE_BRANCH` 設定との連動）を追記
   - NFR3 の除外ログ（`holder-set context=dispatch excluded=staged-for-release`）の grep 例を観測ログ節に追記

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
@@ -33,7 +33,7 @@
   - _Boundary: po_check_dispatch_gate_
   - _Depends: 1, 2_
 
-- [ ] 4. holder ラベル集合決定のユニット/スモークテストを追加する
+- [x] 4. holder ラベル集合決定のユニット/スモークテストを追加する
   - `docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/test-holder-labels.sh` を新設
   - `po_resolve_holder_labels` を dispatch×multi-branch / dispatch×single-branch / promote / 不明 context の 4 ケースで検証
   - `po_collect_inflight_issues` の引数省略時 search_query が現行固定クエリと文字列一致することを検証

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/tasks.md
@@ -24,7 +24,7 @@
   - _Boundary: po_collect_inflight_issues_
   - _Depends: 1_
 
-- [ ] 3. `po_check_dispatch_gate` から dispatch 文脈の holder 集合を注入し NFR3 ログを出す
+- [x] 3. `po_check_dispatch_gate` から dispatch 文脈の holder 集合を注入し NFR3 ログを出す
   - `po_resolve_holder_labels "dispatch"` で集合を解決し `po_collect_inflight_issues "$candidate" "$holder_labels"` に渡す
   - 解決集合が full と異なる（staged-for-release 除外）場合に `po_log` で除外を判別可能に出力（例: `holder-set context=dispatch excluded=staged-for-release base=<branch>`）
   - 関数シグネチャ（`$1 candidate`, `$2 labels_json`）は不変に保ち issue-watcher.sh L7025 を変更しない

--- a/docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/test-holder-labels.sh
+++ b/docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/test-holder-labels.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# 用途: #221 holder ラベル集合決定（po_resolve_holder_labels）と動的 search_query 構築
+#       （po_collect_inflight_issues 第 2 引数省略時のゼロ差分）のユニット/スモークテスト。
+# 配置先: docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/
+# 依存: bash 4+, gh（本テストではスタブ化して実 API 呼び出しを避ける）, jq（同 module が
+#       source 時に他関数で参照するが本テストの検証経路では未使用）
+# セットアップ参照先: docs/specs/221-feat-watcher-path-overlap-holder-base-de/design.md
+#                     の Testing Strategy 節
+#
+# 実行: bash test-holder-labels.sh
+#   全ケース PASS で exit 0、いずれか失敗で非ゼロ exit。
+#
+# shellcheck disable=SC2034  # LABEL_* / BASE_BRANCH 等は source した module 内の関数が参照する
+# shellcheck disable=SC2317  # gh() スタブは module 内の関数から間接的に呼ばれる
+set -euo pipefail
+
+# ─── テスト対象モジュールの source ───
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE="${SCRIPT_DIR}/../../../../local-watcher/bin/modules/promote-pipeline.sh"
+
+if [ ! -f "$MODULE" ]; then
+  echo "FATAL: 対象モジュールが見つかりません: $MODULE" >&2
+  exit 2
+fi
+
+# ─── テスト用のラベル定数（本体 Config ブロック相当 / issue-watcher.sh と同値）───
+LABEL_CLAIMED="claude-claimed"
+LABEL_PICKED="claude-picked-up"
+LABEL_AWAITING_DESIGN="awaiting-design-review"
+LABEL_READY="ready-for-review"
+LABEL_NEEDS_ITERATION="needs-iteration"
+LABEL_NEEDS_REBASE="needs-rebase"
+LABEL_STAGED_FOR_RELEASE="staged-for-release"
+LABEL_AWAITING_SLOT="awaiting-slot"
+REPO="owner/test"
+
+# module を source（関数定義のみ取り込む。本体側 set -euo pipefail 宣言は本ファイル冒頭で済）
+# shellcheck source=/dev/null
+. "$MODULE"
+
+# ─── 期待値（design.md D3 真理値表 / 現行固定クエリ）───
+FULL_CSV="claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release"
+SIX_CSV="claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase"
+# 現行固定クエリ（変更前 po_collect_inflight_issues のヒアドキュメントと完全一致）
+EXPECTED_QUERY='is:open is:issue (label:"claude-claimed" OR label:"claude-picked-up" OR label:"awaiting-design-review" OR label:"ready-for-review" OR label:"needs-iteration" OR label:"needs-rebase" OR label:"staged-for-release") -label:"st-failed" -label:"awaiting-slot"'
+
+# ─── アサーションヘルパー ───
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $name"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $name" >&2
+    echo "  expected: [$expected]" >&2
+    echo "  actual:   [$actual]" >&2
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ─── Case 1: po_resolve_holder_labels "dispatch" × multi-branch → 6 ラベル CSV（Req 1.1）───
+BASE_BRANCH="develop"
+PROMOTION_TARGET_BRANCH="main"
+assert_eq "Req1.1 dispatch×multi-branch は staged-for-release を除外した 6 ラベル CSV" \
+  "$SIX_CSV" "$(po_resolve_holder_labels "dispatch")"
+
+# ─── Case 2: po_resolve_holder_labels "dispatch" × single-branch → full 7 ラベル CSV（NFR 1.1）───
+BASE_BRANCH="main"
+PROMOTION_TARGET_BRANCH="main"
+assert_eq "NFR1.1 dispatch×single-branch は full 7 ラベル CSV（ゼロ差分）" \
+  "$FULL_CSV" "$(po_resolve_holder_labels "dispatch")"
+
+# ─── Case 3: po_resolve_holder_labels "promote" → full 7 ラベル CSV（Req 2.1）───
+# promote 文脈は branch 構成に依らず full（staged-for-release 維持）
+BASE_BRANCH="develop"
+PROMOTION_TARGET_BRANCH="main"
+assert_eq "Req2.1 promote は full 7 ラベル CSV（staged-for-release 維持）" \
+  "$FULL_CSV" "$(po_resolve_holder_labels "promote")"
+
+# ─── Case 4: po_resolve_holder_labels "garbage"（不明 context）→ full 7 ラベル CSV（Req 4.1）───
+BASE_BRANCH="develop"
+PROMOTION_TARGET_BRANCH="main"
+assert_eq "Req4.1 不明 context は full 7 ラベル CSV（fail-safe）" \
+  "$FULL_CSV" "$(po_resolve_holder_labels "garbage")"
+
+# ─── Case 4b: 空 context → full 7 ラベル CSV（Req 4.1 補強）───
+assert_eq "Req4.1 空 context は full 7 ラベル CSV（fail-safe）" \
+  "$FULL_CSV" "$(po_resolve_holder_labels "")"
+
+# ─── Case 5: po_collect_inflight_issues 第 2 引数省略時の search_query が現行固定クエリと一致 ───
+# gh をスタブ化して、po_collect_inflight_issues が組み立てた search_query を捕捉する。
+# スタブは `--search <query>` の次引数を CAPTURED_QUERY に書き出し、空の JSON 配列を返す。
+CAPTURED_QUERY_FILE="$(mktemp)"
+trap 'rm -f "$CAPTURED_QUERY_FILE"' EXIT
+
+gh() {
+  # 期待呼び出し: gh issue list --repo "$REPO" --search "<query>" --json number --limit 50
+  local prev=""
+  local arg
+  for arg in "$@"; do
+    if [ "$prev" = "--search" ]; then
+      printf '%s' "$arg" > "$CAPTURED_QUERY_FILE"
+    fi
+    prev="$arg"
+  done
+  # in-flight 0 件の空配列を返す（捕捉が目的なので列挙結果は不要）
+  echo '[]'
+  return 0
+}
+
+# 第 2 引数を省略して呼ぶ（default = 現行 7 ラベル集合 → 現行固定クエリと一致すべき / NFR 1.1）
+po_collect_inflight_issues "999" >/dev/null
+CAPTURED_QUERY="$(cat "$CAPTURED_QUERY_FILE")"
+assert_eq "NFR1.1 引数省略時 search_query が現行固定クエリと文字列一致（ゼロ差分）" \
+  "$EXPECTED_QUERY" "$CAPTURED_QUERY"
+
+# ─── Case 5b: holder_labels に 6 ラベル CSV を渡すと staged-for-release を含まないクエリになる ───
+EXPECTED_QUERY_SIX='is:open is:issue (label:"claude-claimed" OR label:"claude-picked-up" OR label:"awaiting-design-review" OR label:"ready-for-review" OR label:"needs-iteration" OR label:"needs-rebase") -label:"st-failed" -label:"awaiting-slot"'
+po_collect_inflight_issues "999" "$SIX_CSV" >/dev/null
+CAPTURED_QUERY="$(cat "$CAPTURED_QUERY_FILE")"
+assert_eq "Req1.2 6 ラベル CSV では staged-for-release を含まない search_query を組み立てる" \
+  "$EXPECTED_QUERY_SIX" "$CAPTURED_QUERY"
+
+# ─── Case 5c: 空 CSV を渡すと full 集合へ fallback（Req 4.2）───
+po_collect_inflight_issues "999" "" >/dev/null
+CAPTURED_QUERY="$(cat "$CAPTURED_QUERY_FILE")"
+assert_eq "Req4.2 空 CSV は full 集合へ fallback した search_query を組み立てる" \
+  "$EXPECTED_QUERY" "$CAPTURED_QUERY"
+
+# ─── 結果サマリ ───
+echo "----"
+echo "PASS=${PASS_COUNT} FAIL=${FAIL_COUNT}"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/local-watcher/bin/modules/promote-pipeline.sh
+++ b/local-watcher/bin/modules/promote-pipeline.sh
@@ -199,6 +199,53 @@ po_load_edit_paths() {
   echo "$validated"
 }
 
+# ─── Phase E: Holder Label Set Resolver (#221 Req 1.1 / 2.1 / 3.1〜3.3 / 4.1 / NFR1.1) ───
+# 呼び出しコンテキストと branch 設定から、in-flight holder とみなすラベル集合を CSV で返す。
+# holder の本質は「dispatch 先 base ブランチにまだ取り込まれていない作業」であるため、
+# multi-branch（gitflow）運用の dispatch 文脈では develop 統合済みの `staged-for-release` を
+# holder から除外する。それ以外（promote / single-branch / 判定不能）は full 集合を返す。
+#
+# holder 集合決定の真理値表（design.md D3）:
+#   context    | BASE_BRANCH vs PROMOTION_TARGET_BRANCH | 返す集合
+#   dispatch   | != （multi-branch / gitflow）          | 6 ラベル（staged-for-release 除外）… Req 1.1
+#   dispatch   | == （single-branch）                   | 7 ラベル（full / ゼロ差分）       … NFR 1.1
+#   promote    | （不問）                               | 7 ラベル（full / SfR 維持）        … Req 2.1
+#   不明な値    | （不問）                               | 7 ラベル（full / fail-safe）       … Req 4.1
+#
+# invariants: 返す CSV は常に 6 基本ラベル
+#   claude-claimed / claude-picked-up / awaiting-design-review / ready-for-review /
+#   needs-iteration / needs-rebase
+# を含む（NFR 1.2）。コンテキストで変動するのは `staged-for-release` の有無のみ。
+#
+# Args:
+#   $1 = context（"dispatch" | "promote"）
+# Stdout: holder ラベル CSV（空白なしカンマ区切り。dispatch×multi-branch では
+#         staged-for-release を含まない）
+# Return: 0 always（判定不能でも full 集合を返す fail-safe / Req 4.1）
+po_resolve_holder_labels() {
+  local context="${1:-}"
+
+  # 6 基本ラベルは常時集合内（NFR 1.2 invariant）。`$LABEL_*` 定数は本体 Config ブロックで
+  # 束縛済みだが、未束縛時にも安全側へ倒すため `:-` で既定リテラルへ fallback する。
+  local base_labels
+  base_labels="${LABEL_CLAIMED:-claude-claimed},${LABEL_PICKED:-claude-picked-up},${LABEL_AWAITING_DESIGN:-awaiting-design-review},${LABEL_READY:-ready-for-review},${LABEL_NEEDS_ITERATION:-needs-iteration},${LABEL_NEEDS_REBASE:-needs-rebase}"
+
+  # full 集合 = 6 基本ラベル + staged-for-release（ラベル文字列はハードコード重複させず
+  # `$LABEL_STAGED_FOR_RELEASE` 定数を参照する / task 明記）。
+  local staged_label="${LABEL_STAGED_FOR_RELEASE:-staged-for-release}"
+  local full_labels="${base_labels},${staged_label}"
+
+  # dispatch かつ multi-branch（BASE_BRANCH != PROMOTION_TARGET_BRANCH）のみ
+  # staged-for-release を除外する。それ以外は full 集合（fail-safe / 安全側）。
+  if [ "$context" = "dispatch" ] && [ "${BASE_BRANCH:-main}" != "${PROMOTION_TARGET_BRANCH:-main}" ]; then
+    echo "$base_labels"
+    return 0
+  fi
+
+  echo "$full_labels"
+  return 0
+}
+
 # ─── Phase E: In-Flight Collector (#18 Req 4.1〜4.4 / 5.3 / 8.1) ───
 # 現サイクルの in-flight Issue（候補自身を除く）を gh で 1 回列挙し、各 Issue の
 # edit_paths を読み出して **union 配列**と **path → holder Issue 番号配列の map**

--- a/local-watcher/bin/modules/promote-pipeline.sh
+++ b/local-watcher/bin/modules/promote-pipeline.sh
@@ -246,6 +246,41 @@ po_resolve_holder_labels() {
   return 0
 }
 
+# ─── Phase E: Label OR-clause Builder (#221 Req 1.2 / 4.2 / NFR 1.1) ───
+# holder ラベル CSV を `gh issue list --search` 用の OR clause
+# `label:"X" OR label:"Y" OR ...` へ組み立てる。空要素・前後空白は除去し、
+# 有効ラベルが 1 つも無ければ空文字列を返す（caller が full 集合へ fallback / Req 4.2）。
+#
+# 重要（#221 NFR 1.1 ゼロ差分）: 現行 7 ラベル CSV を与えた場合の出力は
+#   label:"claude-claimed" OR label:"claude-picked-up" OR label:"awaiting-design-review"
+#   OR label:"ready-for-review" OR label:"needs-iteration" OR label:"needs-rebase"
+#   OR label:"staged-for-release"
+# と完全一致し、これを (...) で挟んだ search_query が現行固定クエリと文字列一致する。
+#
+# Args: $1 = holder labels CSV
+# Stdout: OR clause 文字列（有効ラベル 0 件なら空文字列）
+# Return: 0 always
+po_build_label_or_clause() {
+  local csv="${1:-}"
+  local clause=""
+  local elem
+  # CSV をカンマで分割。各要素の前後空白を除去し、空要素はスキップする。
+  local IFS=','
+  for elem in $csv; do
+    # 前後の空白（スペース / タブ）を除去
+    elem="${elem#"${elem%%[![:space:]]*}"}"
+    elem="${elem%"${elem##*[![:space:]]}"}"
+    [ -z "$elem" ] && continue
+    if [ -z "$clause" ]; then
+      clause="label:\"${elem}\""
+    else
+      clause="${clause} OR label:\"${elem}\""
+    fi
+  done
+  printf '%s' "$clause"
+  return 0
+}
+
 # ─── Phase E: In-Flight Collector (#18 Req 4.1〜4.4 / 5.3 / 8.1) ───
 # 現サイクルの in-flight Issue（候補自身を除く）を gh で 1 回列挙し、各 Issue の
 # edit_paths を読み出して **union 配列**と **path → holder Issue 番号配列の map**
@@ -268,27 +303,39 @@ po_resolve_holder_labels() {
 # `po_load_edit_paths` を 1 回呼ぶのは従来同様で、その戻り値から union と holders map
 # を同時に構築するだけ。candidate 側の `po_load_edit_paths` も 1 回のまま。
 #
-# in-flight 判定ラベル（Req 4.1）:
-#   claude-claimed, claude-picked-up, awaiting-design-review, ready-for-review,
-#   needs-iteration, needs-rebase, staged-for-release
-# 除外（Req 4.2）: st-failed, awaiting-slot
+# in-flight 判定ラベル（Req 4.1）: 第 2 引数 holder_labels（CSV）で与えられる集合を使う。
+#   default（引数省略時）= 現行 7 ラベル集合 #221 NFR 1.1 ゼロ差分:
+#     claude-claimed, claude-picked-up, awaiting-design-review, ready-for-review,
+#     needs-iteration, needs-rebase, staged-for-release
+#   dispatch×multi-branch 文脈では呼び出し側が staged-for-release を除いた 6 ラベル
+#   集合を渡す（#221 Req 1.2 / 1.4）。
+# 除外（Req 4.2）: st-failed, awaiting-slot（集合非依存で固定維持）
 # 候補自身を除外（Req 4.3）、同 repo のみ（Req 4.4: --repo "$REPO" 固定）
 #
-# Args: $1 = candidate issue number
+# Args:
+#   $1 = candidate issue number
+#   $2 = holder labels CSV（省略時 default = 現行 7 ラベル集合 / 後方互換 #221 NFR 1.1）
 # Stdout: JSON object `{"union": [...], "holders": {path: [issue#, ...]}}`
 # Return: 0 = 列挙 OK / 1 = gh API 失敗（caller は fail-open で empty 扱い + warn）
 po_collect_inflight_issues() {
   local candidate="$1"
+  # #221 task 2: holder ラベル集合を第 2 引数で受ける。default は現行 7 ラベル集合に
+  # 固定（引数を渡さない既存呼び出し = single-branch 運用は現行クエリと完全一致 / NFR 1.1）。
+  local holder_labels="${2:-claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release}"
 
-  # 7 ラベルのいずれかを持ち、`st-failed` / `awaiting-slot` を持たない open Issue を
-  # OR 検索で抽出する。`gh issue list --label A --label B` は AND になるため、
-  # `--search 'label:A OR label:B OR ...'` 形式を使う（既存 Phase B / Phase D が同形式
-  # を採用済）。
+  # 与えられた CSV を `label:"X" OR label:"Y" OR ...` 形式へ動的に組み立てる。
+  # `gh issue list --label A --label B` は AND になるため `--search 'label:A OR ...'`
+  # 形式を使う（既存 Phase B / Phase D が同形式を採用済）。
+  # fail-safe（#221 Req 4.2）: CSV が空 / 不正で有効ラベルが 1 つも得られない場合は
+  # full 7 ラベル集合へ fallback する（holder から誤って外さない安全側）。
+  local label_clause
+  label_clause=$(po_build_label_or_clause "$holder_labels")
+  if [ -z "$label_clause" ]; then
+    label_clause=$(po_build_label_or_clause "claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release")
+  fi
+
   local search_query
-  search_query=$(cat <<EOF
-is:open is:issue (label:"claude-claimed" OR label:"claude-picked-up" OR label:"awaiting-design-review" OR label:"ready-for-review" OR label:"needs-iteration" OR label:"needs-rebase" OR label:"staged-for-release") -label:"st-failed" -label:"awaiting-slot"
-EOF
-)
+  search_query="is:open is:issue (${label_clause}) -label:\"st-failed\" -label:\"awaiting-slot\""
   local issues_json
   if ! issues_json=$(gh issue list --repo "$REPO" \
       --search "$search_query" \
@@ -591,10 +638,24 @@ po_check_dispatch_gate() {
   local cand_paths
   cand_paths=$(po_load_edit_paths "$candidate")
 
+  # #221 task 3: dispatch 文脈の holder ラベル集合を解決する（Req 1.1 / 3.1）。
+  # multi-branch（gitflow）運用では staged-for-release を除外した 6 ラベル、
+  # single-branch / 判定不能では full 7 ラベル集合（fail-safe）。
+  local holder_labels full_labels
+  holder_labels=$(po_resolve_holder_labels "dispatch")
+  full_labels=$(po_resolve_holder_labels "promote")
+  # NFR 3.1: 解決集合が full と異なる（staged-for-release を除外した）場合のみ
+  # 除外を判別可能にログ出力する。full と一致する場合（single-branch 等）は
+  # ログを出さない（ゼロ差分 / NFR 1.1 を壊さない）。
+  if [ "$holder_labels" != "$full_labels" ]; then
+    po_log "holder-set context=dispatch excluded=${LABEL_STAGED_FOR_RELEASE:-staged-for-release} base=${BASE_BRANCH:-main}"
+  fi
+
   # in-flight union + holders map を取得（Req 4.1〜4.4 / 5.3 / 8.1）。
+  # 解決済み holder 集合を注入する（#221 Req 1.1 / 1.3）。
   # 失敗時は fail-open で claim 続行
   local inflight_obj
-  if ! inflight_obj=$(po_collect_inflight_issues "$candidate"); then
+  if ! inflight_obj=$(po_collect_inflight_issues "$candidate" "$holder_labels"); then
     po_warn "issue=#${candidate} in-flight 列挙に失敗、本サイクルは overlap 判定を skip して claim 続行"
     return 0
   fi


### PR DESCRIPTION
## 概要

Phase E Path Overlap Checker の holder ラベル集合を**呼び出しコンテキスト依存**に変更し、
dispatch-time（base=develop）では `staged-for-release` を holder から除外する。
これにより develop merge 済み Issue が open のまま `staged-for-release` で残っても、
新規 develop 作業の `awaiting-slot` 滞留を引き起こさない（claim 解放と main 追跡の両立）。
promote-pipeline（develop→main）側の挙動は完全に不変のまま保持する。

主要実装点:
- `po_resolve_holder_labels` 新設: dispatch / promote コンテキストと branch 設定から holder ラベル集合を base 相対で決定（design.md D3 真理値表）。
- `po_build_label_or_clause` 新設 + `po_collect_inflight_issues` 第 2 引数化: holder ラベル CSV から動的に OR search_query を構築。引数省略時は現行固定クエリと文字列一致（後方互換ゼロ差分）。空/不正 CSV は full 集合へ fail-safe fallback。
- `po_check_dispatch_gate` 更新: `po_resolve_holder_labels "dispatch"` を注入。dispatch×multi-branch（gitflow）で `staged-for-release` 単独 Issue を holder 列挙から除外。NFR3 ログ（`holder-set context=dispatch excluded=staged-for-release base=<branch>`）を除外時のみ出力。
- `test-fixtures/test-holder-labels.sh` 新設（真理値表 4〜5 ケース + search_query 文字列一致 + 空 CSV fallback）。
- `README.md` に base 相対 holder / gitflow 運用ガイド / NFR3 ログ grep 例を追記。

## 対応 Issue

Closes #221

## 関連 PR

- 設計 PR: #222（merged）

## 実装内容

- (Req 1.1 / Task 1) `po_resolve_holder_labels` 新設: dispatch × multi-branch で 6 ラベル集合（SfR 除外）を返す
- (Req 1.2 / Task 2) `po_build_label_or_clause` 新設 + `po_collect_inflight_issues` 第 2 引数化: holder CSV から動的 OR search_query を構築
- (Req 1.3 / Task 3) `po_check_dispatch_gate` に `po_resolve_holder_labels "dispatch"` を注入し集合を配線
- (Req 2.1 / Task 4) `promote` コンテキストで full 7 ラベル集合（SfR 維持）を返す経路を確立
- (NFR 1.1 / NFR 3.1 / Task 4) NFR3 ログ（除外発生時のみ）と search_query ゼロ差分（引数省略時）を実装
- (Task 5) README.md に base 相対 holder / gitflow 運用ガイド / 観測ログ grep 例を追記

## 受入基準チェック

- [x] Req 1.1: When Phase E が base=develop の dispatch-time path-overlap holder を収集するとき, `staged-for-release` を除外する ← `po_check_dispatch_gate` → `po_resolve_holder_labels "dispatch"` の注入 / fixture Case 1 PASS
- [x] Req 1.2: 動的 search_query が `staged-for-release` を含まない ← `po_build_label_or_clause` / fixture Case 5b PASS
- [x] Req 1.3: SfR 単独 Issue が in-flight union から外れ overlap=0 → claim 続行 ← 配線確立 / 既存 overlap ロジック通過
- [x] Req 1.4: 併存ラベル（SfR + claude-claimed 等）の Issue は holder 維持 ← 6 基本ラベル常時集合内 / NFR 1.2 invariant
- [x] Req 2.1: promote コンテキストで full 7 ラベル集合（SfR 維持） ← fixture Case 3 PASS
- [x] Req 2.2: promote 経路は別経路で挙動不変 ← `pp_collect_merged_issues` は `is:merged base:` PR 列挙経路、本変更対象外
- [x] Req 3.1〜3.3: 単一契約 `po_resolve_holder_labels`、stdout のみ、引数注入で用途独立 ← fixture Case 1〜4b 網羅 PASS
- [x] Req 4.1: 不明/空 context は full 集合へ fail-safe ← fixture Case 4/4b PASS
- [x] Req 4.2: label_clause 空時に full 7 ラベル fallback ← fixture Case 5c PASS
- [x] NFR 1.1: 第 2 引数省略時の search_query が変更前固定クエリと文字列一致 ← fixture Case 5 PASS
- [x] NFR 2.1/2.2: API 回数不変（`gh issue list` 1 回 / 候補ごと 1 回の構造未変更）
- [x] NFR 3.1: SfR 除外時のみ `holder-set context=dispatch excluded=...` ログ出力

## テスト結果

```
$ bash docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/test-holder-labels.sh
PASS=8 FAIL=0
```

```
$ shellcheck local-watcher/bin/modules/promote-pipeline.sh docs/specs/221-feat-watcher-path-overlap-holder-base-de/test-fixtures/test-holder-labels.sh
（警告ゼロ / exit 0）
```

```
$ git diff 151d17b..HEAD -- local-watcher/bin/issue-watcher.sh
（差分なし：本体不変 / boundary 維持）
```

## 後方互換性

- 第 2 引数 default = 現行 7 ラベル集合（`po_collect_inflight_issues` 引数省略時）により、single-branch 運用・既存呼び出しはゼロ差分。
- 新規 env var 追加なし。既存ラベル名・cron 登録文字列・exit code 不変。
- `PROMOTE_PIPELINE_ENABLED` 未設定の環境では promote-pipeline.sh 自体がロードされず影響ゼロ。
- README の Phase E 節に base 相対化の運用ガイドを追記済み。

## 実装上の判断

- holder 除外対象を `staged-for-release` のみに限定（`ready-for-review` は PR 未 merge の可能性があるため dispatch holder に残す）。
- promote 側は `is:merged base:` PR 列挙の別経路を使用するため holder ラベルクエリを共有しない（design.md D2）。本変更は当該経路に触れない。
- fail-safe として不明コンテキストは full 集合へ倒す（過剰保守側への安全倒れ）。

## 確認事項 / レビュワーへの依頼

- requirements.md の Open Questions「dispatch 除外対象を `staged-for-release` のみに限定する判断」が設計通りの意図かを最終確認いただきたい。
- promote 側が holder ラベルクエリを共有しない別経路という前提（design.md D2）について、将来的な promote 経路変更時に本前提が崩れないか確認いただきたい。
- `po_check_dispatch_gate` のシグネチャ（`$1 candidate` / `$2 labels_json`）が不変であること、および opt-in gate（`PATH_OVERLAP_CHECK="true"` 厳密一致）/ fail-open / overlap ロジックが未変更であることを確認いただきたい。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
関連 Issue での決定事項の履歴は #221 のコメントを参照してください。