### PR TITLE
docs(claude): root↔repo-template の .claude 二重管理規約を追加し architect.md を同期

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ Reviewer / PjM）は、以下の方針で **内部思考言語と出力言語を
 - **`idd-claude-labels.sh` のラベルセット**: ラベル追加は OK、既存ラベル削除 / 名前変更は deprecation 期間を経てから
 - **モデル ID デフォルト更新**: 既存ユーザが明示 override している前提で、env default のみ更新
 - **README との二重管理**: 挙動を変えたら必ず README の該当箇所も同じ PR で更新する
+- **root `.claude/{agents,rules}/` と `repo-template/.claude/{agents,rules}/` の二重管理**: 両者は別系統（root = idd-claude self-hosting が使用 / `repo-template/` = `install.sh --repo` で consumer repo に配布）。片方だけ更新すると **consumer に変更が届かない**か **idd-claude 自身が古い規約で動く**ドリフトが発生する（実例: #224 の構造化 verify ブロック規約・architect.md が root のみ更新で consumer 未配布／per-task ループ・BLOCKED 規約が repo-template のみで root の Developer・Reviewer に欠落）。`.claude/agents/*.md` / `.claude/rules/*.md` を変更したら **同一 PR で両系統に byte 一致で反映する**こと（逆方向も同様）。agents の base ブランチ参照は両系統とも `<BASE_BRANCH>` プレースホルダに統一し、root にも具体値 `main` を焼き込まない（orchestrator が解決値を prompt の `Compared to:` ヘッダで渡すため idd-claude でも正しく動く）。反映後に `diff -r .claude/agents repo-template/.claude/agents` と `diff -r .claude/rules repo-template/.claude/rules` が空であることを確認する。**CLAUDE.md / README は consumer 固有内容を持つため本規約の対象外**（それぞれ root 用 / `repo-template/` 用に内容が異なってよい）
 - **Phase B Promote Pipeline (#15)**: `PROMOTE_PIPELINE_ENABLED=true` の **明示的 opt-in 制**で、未設定 / `false` の場合は導入前と完全に同一の挙動を保つ。2-branch model（`BASE_BRANCH != PROMOTION_TARGET_BRANCH`）でのみ起動する。`staged-for-release` ラベルは #100 の人間付与運用と同一ラベルを共有し、source 区別はしない。revert / promote はすべて `--force-with-lease` または fast-forward 限定で `--force`（無条件）は使わない
 
 ---

--- a/repo-template/.claude/agents/architect.md
+++ b/repo-template/.claude/agents/architect.md
@@ -206,6 +206,19 @@ interface <ComponentName>Service {
   - _Requirements: 2.1_
   - _Boundary: CheckoutService_
   - _Depends: 1.2_
+
+- [ ]* 2.2 <deferrable な追加テストタスク>
+  - _Requirements: 2.3_
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを
+構造化ブロックで宣言する。
+
+<!-- stage-a-verify -->
+```sh
+<実行可能な verify コマンド。複数行 / && 連結可。例: npm test && npm run lint>
+```
 ```
 
 ## 重要なアノテーション
@@ -214,6 +227,45 @@ interface <ComponentName>Service {
 - `_Boundary:_` — `(P)` タスクでは必須。design.md の Components 名を列挙
 - `_Depends:_` — 非自明な cross-boundary 依存がある場合のみ
 - `(P)` — 並列実行可能を明示（`_Boundary:_` とセット）
+
+## Checkbox 形式の必須化
+
+**すべてのタスク行は `- [ ]`（未完了）または `- [ ]*`（deferrable 印）の checkbox 形式で
+開始すること**。これは Developer の resume 機能（`IMPL_RESUME_PROGRESS_TRACKING=true`、
+Issue #67 / #112 以降の既定）が `- [ ]` → `- [x]` の markdown checkbox 編集を進捗の **正本**
+として読む前提を確実に成立させるためです。markdown header のみ（例: `## T-01: タスク名` /
+`### Task 1` / `#### 1.1 子タスク`）でタスクを表現することは禁止されます。詳細は
+[`tasks-generation.md`](../rules/tasks-generation.md) の「Checkbox 形式の必須化」節を参照。
+
+## 構造化 verify ブロックの宣言
+
+stage-a-verify gate (#125 / #224) のために、実装後に watcher が独立再実行すべき
+build/test/lint コマンドを **構造化 verify ブロック**で `tasks.md` に宣言する。これにより
+watcher はツール名で始まる散文（例: `- shellcheck 警告ゼロを確認`）を誤ってコマンドとして
+実行する誤発火（#160 / #219 / #221）を構造的に避けられる。
+
+宣言手順:
+
+1. `tasks.md` 末尾（推奨 `## Verify` 見出し配下、見出しは任意）にセンチネル
+   `<!-- stage-a-verify -->` を置く
+2. センチネル直後に fenced code block を 1 つ置き、その中身に **実行可能なコマンドそのもの**
+   （散文ではない）を書く。複数行 / `&&` 連結可
+3. well-formed 書式（センチネル厳密一致・直後性・fence 閉じ・中身非空）と非干渉規約の詳細は
+   [`tasks-generation.md`](../rules/tasks-generation.md) の「構造化 verify ブロック」節を参照
+4. verify 対象が無い spec（純ドキュメント変更等）はブロックを省略してよい（watcher は env /
+   ヒューリスティック / SKIPPED に fallback する）
+5. ブロック確定前に、[`design-review-gate.md`](../rules/design-review-gate.md) の
+   「verify block well-formed check」で malformed が無いか自己レビューする
+
+信頼モデル（Architect 定義・Developer 不可侵）:
+
+- 構造化 verify ブロックは **設計成果物**（`tasks.md`）であり、設計 PR の人間レビュー対象に
+  含める（Req 3.1）。Developer の自己採点で検証内容が骨抜きにされないための input 契約である
+- **Developer はブロックを書き換えない**（Req 3.2）。watcher はブロック由来コマンドを Gate 3
+  （keyword 行頭一致 defense-in-depth）を免除して実行するため、ブロックの正しさは設計段階で
+  担保する
+- Developer がブロックの記述内容と矛盾する点を見つけた場合は、ブロック自体を変更せず PR 本文の
+  「確認事項」で指摘する（Req 3.3）
 
 # 行動指針
 
@@ -242,6 +294,12 @@ interface <ComponentName>Service {
 - [ ] `(P)` タスクには `_Boundary:_` が明示されている
 - [ ] **Budget overflow check**: tasks.md の最上位 numeric ID タスク件数が 10 件以下
       （後述「Budget overflow が検出された場合の対応」節を参照）
+- [ ] **tasks.md checkbox enforcement**: tasks.md の全タスク行が checkbox 形式
+      （`- [ ]` または `- [ ]*`）で開始し、markdown header のみのタスク表現が無いこと
+      （Developer の resume 機能が `- [ ]` → `- [x]` の markdown checkbox を進捗の正本として
+      読むため、checkbox 形式が必須。詳細は
+      [`design-review-gate.md`](../rules/design-review-gate.md) の「tasks.md checkbox
+      enforcement check」節を参照）
 
 問題が見つかれば draft を修正し、最大 2 パスで再レビューします。それでも曖昧性が残る場合は
 要件フェーズへ差し戻します（design.md 側で要件を発明しない）。


### PR DESCRIPTION
## 概要

idd-claude の dogfooding で **root `.claude/{agents,rules}/` を直接編集しても `repo-template/.claude/` に伝播せず**、consumer repo に変更が届かない / idd-claude 自身が古い規約で動く、というドリフトが慢性的に発生していた。この根本原因（二重管理の規約欠如）を埋め、あわせて architect.md の安全な伝播漏れを解消する。

## 背景

PR#233（rules 同期）の調査中に、root と repo-template の `.claude/` に広範なドリフトを発見:

- **rules**: tasks-generation.md / design-review-gate.md が root のみ更新（#131/#133/#224）→ PR#233 で同期
- **agents**: architect.md は root のみ #224/#133 追加（consumer 未配布）。一方 developer/reviewer/project-manager/product-manager は **repo-template の方が新しい**（per-task ループ #164・BLOCKED・base ブランチ解決・Issue 依存 canonical 等）→ **双方向ドリフト**

根本原因は「root `.claude/` を変更したら repo-template にも反映する」という二重管理の規約がどこにも無かったこと。

## 変更内容

1. **二重管理規約を追加**（`CLAUDE.md`「idd-claude 特有の設計上の注意」節）
   - `.claude/agents/*.md` / `.claude/rules/*.md` を変更したら **同一 PR で両系統に byte 一致で反映**
   - agents の base ブランチ参照は両系統とも `<BASE_BRANCH>` プレースホルダに統一（root に `main` を焼き込まない。orchestrator が `Compared to:` ヘッダで解決値を渡すため idd-claude でも動作）
   - 検証: `diff -r .claude/agents repo-template/.claude/agents` / `diff -r .claude/rules repo-template/.claude/rules` が空
   - **CLAUDE.md / README は consumer 固有のため対象外**（root 用 / template 用で内容が異なってよい）

2. **architect.md を root → repo-template に同期**
   - root ⊇ template の純増 58 行（#224 構造化 verify ブロック宣言 / #133 checkbox 必須化 / Verify 節）
   - base ブランチ参照ゼロ・template 固有行ゼロのクリーン同期（削除・パラメータ焼き込みなし）

## スコープ外（別タスク）

- **developer / reviewer / project-manager / product-manager の reconciliation**: 双方向ドリフト + `<BASE_BRANCH>` パラメータ化差異があり、union 統合 + root のパラメータ化が必要。慎重な突き合わせを要するため別 Issue（#235）で扱う。
- **`diff -r` スモークチェックの `CLAUDE.md` テスト・検証節への追記**: 上記 reconciliation で baseline が byte 一致になった後に追加する（現時点では 4 agent + rules が未同期で必ず落ちるため、本 PR では入れない）。

## Test plan

```
$ diff -q .claude/agents/architect.md repo-template/.claude/agents/architect.md   # 一致（差分なし）
$ grep -c '二重管理' CLAUDE.md   # 規約追加を確認
```

shellcheck / actionlint 対象の変更なし（markdown のみ）。

## 確認事項

- 二重管理規約で「agents も byte 一致（root も `<BASE_BRANCH>`）」を方針として明文化しました。残り 4 agent の reconciliation（#234）でこの状態に揃え、その PR で `diff -r` スモークを テスト・検証節に追加する想定です。
- 既存の watcher 挙動・ラベル契約・env var に変更はありません（規約文 + architect.md ガイダンスの追従のみ）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

