### PR TITLE
feat(#237): gitignore 運用 repo 向けに worktree reset 後 .claude を注入

### DIFF
--- a/README.md
+++ b/README.md
@@ -2524,6 +2524,49 @@ chmod +x /tmp/slot-init.sh
 SLOT_INIT_HOOK=/tmp/slot-init.sh PARALLEL_SLOTS=2 $HOME/bin/issue-watcher.sh
 ```
 
+### gitignore 運用 repo への `.claude/` 注入（auto-detect / Issue #237）
+
+watcher は各 slot worktree を `git reset --hard origin/<branch>` ＋ `git clean -fdx` で
+強制リセットしてから agent を起動します。このため `.claude/` を **gitignore して
+足場を public repo に出さない運用**の repo では、`.claude/` が commit されておらず
+reset 後の worktree に `.claude/agents` `.claude/rules` が現れず、agent がルール・
+定義を読めない degraded 状態に陥っていました。
+
+これを解消するため、watcher は **worktree reset 完了後・`SLOT_INIT_HOOK` / agent 起動前**の
+タイミングで、`.claude/` の有無を自動判定（auto-detect）して注入します。
+
+| 項目 | 仕様 |
+|---|---|
+| 起動タイミング | per-slot worktree の `git reset --hard origin/<branch> && git clean -fdx` 直後・`SLOT_INIT_HOOK` / Claude 起動前 |
+| 注入条件 | worktree に `.claude/` が **無い** かつ REPO_DIR（`install.sh --repo` が管理するローカルクローン）に `.claude/` が **有る** ときのみ注入する |
+| 注入元 | REPO_DIR（`$REPO_DIR/.claude`）。`install.sh --repo` が最新化したローカルの `.claude/` をコピーする |
+| 注入手段 | `cp -a`（mode / timestamps / symlink を保持。実行権限・シンボリックリンクを壊さない） |
+| 注入対象 | `.claude/` ディレクトリのみ（`.github/scripts/idd-claude-labels.sh` 等の足場ファイルは注入しない） |
+| commit 扱い | 注入した `.claude/` は worktree でも gitignore 対象のまま。watcher は git add / commit しない（gitignore 運用の意図を維持） |
+| 失敗時挙動 | **fail-open**。注入に失敗しても warn ログを出すのみで reset → agent 起動サイクルは継続し、当該 Issue を注入失敗のみで `claude-failed` にしない |
+| env gate | **なし**（auto-detect 方式）。外部サービス呼び出しではなくローカルファイルコピーのため opt-in gate は不要 |
+
+**consumer 側の前提**: gitignore 運用 repo で本機能を活かすには、REPO_DIR
+（watcher が処理するローカルクローン）の `.claude/` を **`install.sh --repo /path/to/repo`**
+で最新化しておいてください。watcher は注入元 `.claude/` の **内容生成・更新は行いません**
+（それは `install.sh` の責務）。注入元に `.claude/` が無い場合は何もしません（NO-OP）。
+
+**後方互換（tracked 運用 repo は NO-OP）**: `.claude/` を commit している tracked 運用 repo
+（idd-claude 自身 / feedman / altpocket 等）では、reset 後の worktree に `.claude/` が
+**必ず存在する**ため auto-detect により注入は走らず、本機能導入前と外形的に同一の
+振る舞い（reset → agent 起動）を保ちます。新規 env var の追加も無く、既存の env var 名・
+ラベル遷移・exit code・ログ書式・worktree reset 契約（`reset --hard` → `clean -fdx` の順序、
+#180 / #198 の data-loss 防止方針）はいずれも変更していません。
+
+注入の実行・スキップ（NO-OP）・失敗は slot 運用ログ（`slot-<N>-<M>-<TS>.log`）から判別できます:
+
+```bash
+# 注入が走ったサイクルを探す
+grep '.claude を REPO_DIR から worktree へ注入' $HOME/.issue-watcher/logs/<owner>-<repo>/*.log
+# 注入失敗（warn）を探す
+grep '.claude の注入に失敗' $HOME/.issue-watcher/logs/<owner>-<repo>/*.log
+```
+
 ### ログ出力
 
 並列実行中もログを slot 単位で追跡できるよう、Dispatcher と各 Slot Worker は識別 prefix 付きで

--- a/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/impl-notes.md
+++ b/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/impl-notes.md
@@ -1,0 +1,132 @@
+# 実装ノート — #237 gitignore 運用 repo 向け worktree reset 後 `.claude/` 注入
+
+## 採用した注入方式と選定理由
+
+**案 A（auto-detect）を採用。env gate は追加しない。**
+
+- 注入条件は「worktree に `.claude/` が **無い** かつ 注入元 REPO_DIR に `.claude/` が **有る**」の
+  ときのみ。
+- tracked 運用 repo（idd-claude 自身 / feedman / altpocket 等）は `.claude/` が commit 済みのため
+  `git reset --hard` 後の worktree に必ず `.claude/` が存在し、auto-detect により注入は走らず
+  **NO-OP**（Req 2.1 / 2.3 を機械的に保証 / Req 2.4 の安全側デフォルトを構造的に満たす）。
+- gitignore 運用 repo は worktree に `.claude/` が無いため注入が走る（Req 1.1）。consumer は
+  `install.sh --repo` で REPO_DIR の `.claude/` を最新化しておけば zero-config で機能する。
+- これは「新しい外部サービス呼び出し」ではなく **ローカルファイルコピー**であるため、CLAUDE.md の
+  「opt-in gate なしで新しい外部サービス呼び出しを有効化」禁止事項には該当しない。auto-detect が
+  既存挙動非変更を構造的に保証するため env gate は不要と判断した。
+
+**env gate（案 B）を採らなかった理由**: env gate を追加すると「gitignore 運用 repo の運用者が
+明示的に true を立てる」操作が必要になり zero-config 性が失われる。auto-detect は tracked 運用 repo を
+NO-OP にしつつ gitignore 運用 repo を自動救済できるため、後方互換性と利便性を両立できる。
+
+## 注入関数の責務・配置・呼び出し位置・注入元 REPO_DIR の捕捉
+
+- **新規関数**: `_worktree_inject_claude`（`local-watcher/bin/modules/core_utils.sh`、
+  `_worktree_reset` の直後に配置）。ファイル冒頭の責務コメントの worktree 管理関数列挙にも追記。
+  - 引数 `$1` = 注入元 REPO_DIR、`$2` = 注入先 worktree 絶対パス。
+  - NO-OP 1: `[ -e "$wt/.claude" ]` → tracked 運用 repo は即 return 0（Req 2.1）。
+  - NO-OP 2: `[ ! -d "$src/.claude" ]` → 注入元無しは即 return 0（Req 2.2）。
+  - コピー: `cp -a "$src/.claude" "$wt/"` で mode / timestamps / symlink を保持（Req 4 / R4.2: `.claude/`
+    ディレクトリのみ・R4.4: `.github/scripts/idd-claude-labels.sh` を含めない）。成功時 `slot_log`。
+- **呼び出し位置**: `local-watcher/bin/issue-watcher.sh` の `_slot_run_issue` 内、`_worktree_reset` 成功
+  かつ `slot_log "worktree reset OK ..."` の直後（`_hook_invoke` / agent 起動の **前**）に
+  `_worktree_inject_claude "$SRC_REPO_DIR" "$WT"` を追加（Req 1.3）。
+- **注入元 REPO_DIR の捕捉**: `_slot_run_issue` は `REPO_DIR="$WT"`（issue-watcher.sh:6799 付近）で
+  REPO_DIR を worktree path に上書きする。注入元となる「consumer のローカル `.claude/`」は
+  **上書き前の元 REPO_DIR** にあるため、上書き行の直前で `local SRC_REPO_DIR="$REPO_DIR"` に捕捉して
+  注入関数へ渡す。変数捕捉は既存パターン（サブシェル内の局所上書き）と整合し最も単純なため採用。
+
+## fail-open の実装方法（`set -euo pipefail` 下での非致命化）
+
+- `_worktree_inject_claude` は **常に return 0** を返す設計にした。コピー失敗時も `slot_warn` を出して
+  return 0（Req 3.1 / 3.2 / 3.3）。これにより `set -euo pipefail` 下でも呼び出し側
+  `_worktree_inject_claude "$SRC_REPO_DIR" "$WT"` が非ゼロで `_slot_run_issue` を倒すことがない。
+- 呼び出し側は `_slot_mark_failed` を呼ばないため、注入失敗のみで `claude-failed` へ遷移しない（Req 3.3）。
+- コピー失敗時は中途半端な `.claude/` が次サイクルの auto-detect を NO-OP 化して不完全状態を温存し
+  うるため、`rm -rf "$wt/.claude" 2>/dev/null || true` でベストエフォート除去してから warn・継続する。
+
+## テスト結果
+
+### shellcheck
+
+- `shellcheck local-watcher/bin/modules/core_utils.sh` → **警告ゼロ（exit 0）**。
+- `shellcheck local-watcher/bin/issue-watcher.sh` → SC2317（info, 未到達誤判定）が **11 件**。これは
+  本変更前後で件数同一（baseline 11 / after 11）で、すべて既存の indirect ロガー関数に対するもの。
+  本変更が新規 SC2317 を導入していないことを `git stash` での before/after 比較で確認済み。
+- `shellcheck docs/.../test-fixtures/test-inject-claude.sh` → **警告ゼロ（exit 0）**。間接呼び出しされる
+  stub `slot_log` / `slot_warn` の SC2317 は `# shellcheck disable=SC2317` で抑制（既存スタイルに倣う）。
+
+### スモークテスト（`test-fixtures/test-inject-claude.sh`）
+
+`_worktree_inject_claude` を単体 source し、`slot_log` / `slot_warn` を stub して隔離検証。
+**全 14 アサーション PASS（exit 0）**:
+
+- Case (a): worktree に `.claude/` 無し + REPO_DIR に `.claude/` 有り → 注入され
+  `.claude/agents` `.claude/rules` が worktree に出現 + 注入ログ出力（R1.1 / R1.2 / R1.4）。
+- Case (b): worktree に `.claude/` 既存（tracked 運用相当）→ 上書きされず注入元 rules も混入しない
+  完全 NO-OP + ログ無し（R2.1）。
+- Case (c): REPO_DIR に `.claude/` 無し → `.claude` を作らず warn も出さない NO-OP・return 0（R2.2）。
+- Case (d): `cp -a` で実行権限（`+x`）と symlink が保持される（R4）。
+- Case (e): 2 回実行しても 2 回目は worktree 既存 `.claude/` を上書きしない冪等動作（R4.1）。
+
+### dry-run 退行確認（reset 契約の順序）
+
+`_worktree_reset` 本体（`reset --hard origin/<base>` → `clean -fdx` の順序、#180 / #198 の data-loss
+防止方針）は **一切変更していない**。注入は `_worktree_reset` 成功後に追加で呼ぶだけで、reset の前段に
+割り込んだり順序を変えたりしていない（NFR 1.2）。`REPO_DIR="$WT"` 上書きの直前に `SRC_REPO_DIR` 捕捉行を
+追加しただけで、既存の REPO_DIR 上書きセマンティクス・後段の `git -C "$REPO_DIR"` 系参照は不変。
+
+## README の更新箇所
+
+`README.md` の `### SLOT_INIT_HOOK` 節の直後に
+`### gitignore 運用 repo への .claude/ 注入（auto-detect / Issue #237）` を新設。
+注入の起動タイミング・条件・注入元 / 手段 / 対象・commit 扱い・fail-open・env gate なし・consumer 前提
+（`install.sh --repo` で `.claude/` 最新化）・後方互換（tracked 運用 repo は NO-OP）・ログ判別 grep 例を記載。
+
+## 後方互換の根拠（tracked 運用 repo が NO-OP になること）
+
+- tracked 運用 repo は `.claude/` を commit 済み → `git reset --hard origin/<base>` で worktree に
+  `.claude/` が **必ず復元される** → `_worktree_inject_claude` 冒頭の `[ -e "$wt/.claude" ]` 判定が
+  真になり即 return 0（注入スキップ）。よって tracked 運用 repo の worktree 内容・ログ・遷移は不変。
+- 新規 env var を追加していないため env 契約は不変。ラベル遷移・exit code・ログ書式・worktree reset
+  契約のいずれも変更していない（NFR 1.1 / 1.2）。
+
+## 変更ファイル一覧
+
+- `local-watcher/bin/modules/core_utils.sh` — `_worktree_inject_claude` 追加 + 冒頭責務コメント更新
+- `local-watcher/bin/issue-watcher.sh` — `SRC_REPO_DIR` 捕捉 + reset 直後の注入呼び出し追加
+- `README.md` — `.claude/` 注入挙動の節を追加
+- `docs/specs/237-feat-watcher-gitignore-repo-worktree-res/test-fixtures/test-inject-claude.sh` — スモークテスト（新規）
+- `docs/specs/237-feat-watcher-gitignore-repo-worktree-res/impl-notes.md` — 本ノート（新規）
+
+## 受入基準ごとのテスト担保
+
+| AC | 担保 |
+|---|---|
+| R1.1 注入実行 | smoke Case (a) |
+| R1.2 agents/rules 参照可能化 | smoke Case (a)（`.claude/agents` `.claude/rules` 出現を assert） |
+| R1.3 reset 後・agent 起動前に実施 | 呼び出し位置（issue-watcher.sh の reset 成功直後・`_hook_invoke` 前）＋コードレビュー |
+| R1.4 注入ログ出力 | smoke Case (a)（`slot_log` 呼び出しを assert） |
+| R2.1 既存 `.claude/` を上書きしない | smoke Case (b) |
+| R2.2 注入元無しは NO-OP | smoke Case (c) |
+| R2.3 tracked 運用 repo の外形不変 | smoke Case (b)（NO-OP）＋後方互換根拠 |
+| R2.4 安全側デフォルト | auto-detect 構造（env gate 無し / 既存挙動側に倒れる）＋ smoke Case (b)/(c) |
+| R3.1 失敗時 warn | コード（コピー失敗パスで `slot_warn`）。Case (c) で正常 NO-OP は warn を出さないことも確認 |
+| R3.2 失敗時継続 | 関数が常に return 0（smoke 全 Case で return 0 を assert）＋呼び出し側が `_slot_mark_failed` 非呼出 |
+| R3.3 失敗で claude-failed にしない | 呼び出し側で `_slot_mark_failed` を呼ばない（コードレビュー）＋関数 return 0 |
+| R4.1 冪等 | smoke Case (e) |
+| R4.2 `.claude/` 以外を巻き込まない | `cp -a "$src/.claude" "$wt/"` がディレクトリ単位（コードレビュー）＋ Case (b) で rules 非混入 |
+| R4.3 commit しない | 呼び出し側で git add / commit を行わない（コードレビュー）。`.claude/` は gitignore 対象のまま |
+| R4.4 idd-claude-labels.sh を含めない | コピー対象が `.claude/` のみ（`.github/scripts/` に触れない / コードレビュー） |
+| NFR1.1 env / ラベル / exit / ログ書式不変 | 後方互換根拠＋ shellcheck SC2317 件数不変 |
+| NFR1.2 reset 契約退行なし | `_worktree_reset` 未変更（dry-run 退行確認） |
+| NFR1.3 後方互換破壊時の migration | 該当なし（後方互換を破っていない。env 追加なし） |
+| NFR2.1 連続サイクル一貫性 | smoke Case (e)（冪等） |
+| NFR2.2 並列 slot 非干渉 | 各 slot の worktree path・REPO_DIR はサブシェル局所で独立。注入は per-worktree なので干渉しない（コードレビュー） |
+| NFR3.1 実行/スキップ/失敗をログ判別 | 注入時 `slot_log` / 失敗時 `slot_warn` / NO-OP は無ログ（Case a/b/c で確認）＋ README に grep 例 |
+
+## 確認事項
+
+なし
+
+STATUS: complete

--- a/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/requirements.md
+++ b/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/requirements.md
@@ -1,0 +1,81 @@
+# Requirements Document
+
+## Introduction
+
+idd-claude の watcher は slot worktree を毎サイクル `origin/<base>` へ強制リセット（`git reset --hard` ＋ `git clean -fdx`）してから agent を起動する。`.claude/` を gitignore して足場を public repo に出さない運用の consumer repo では、`.claude/` が commit されないため reset 後の worktree に `.claude/agents` `.claude/rules` が現れず、agent がルール・定義を読めない degraded 状態になる。
+
+本機能は、worktree reset 直後に REPO_DIR のローカル `.claude/`（`install.sh` が管理するコピー）を worktree へ注入する経路を追加し、gitignore 運用 repo でも agent runtime が必要な `.claude/` を参照できるようにする。同時に、tracked 運用 repo（idd-claude 自身 / feedman / altpocket 等）では一切挙動を変えないこと、注入失敗で reset サイクル自体を倒さないこと（fail-open）を最優先の制約とする。self-hosting 上で稼働するため後方互換性と冪等性が要件の中核となる。
+
+## Requirements
+
+### Requirement 1: gitignore 運用 repo への `.claude/` 注入
+
+**Objective:** As a watcher 運用者, I want gitignore 運用 repo の worktree reset 後に REPO_DIR の `.claude/` を worktree へ注入してほしい, so that agent が `.claude/agents` `.claude/rules` を読める健全な状態で起動できる
+
+#### Acceptance Criteria
+
+1. While worktree reset 直後に worktree に `.claude/` が存在しない状態であり, when REPO_DIR にローカル `.claude/` が存在するとき, the watcher shall REPO_DIR のローカル `.claude/` を当該 worktree へ注入する
+2. When `.claude/` 注入が成功したとき, the watcher shall agent runtime に必要な構成（少なくとも `.claude/agents` および `.claude/rules`）が worktree から参照可能な状態にする
+3. The watcher shall `.claude/` の注入を worktree reset 完了後かつ agent 起動前の時点で実施する
+4. When `.claude/` 注入が成功したとき, the watcher shall 注入を行った旨を観測可能なログとして出力する
+
+### Requirement 2: tracked 運用 repo での既存挙動非変更（NO-OP）
+
+**Objective:** As a tracked 運用 repo の運用者, I want `.claude/` を commit している repo の挙動を一切変えないでほしい, so that 既存稼働中の idd-claude 自身・consumer repo が本機能導入によって退行しない
+
+#### Acceptance Criteria
+
+1. While worktree reset 直後に worktree に既に `.claude/` が存在する状態であるとき, the watcher shall その worktree の `.claude/` を REPO_DIR のローカル版で上書きしない
+2. If REPO_DIR にローカル `.claude/` が存在しないとき, the watcher shall 注入を行わず何もしない（NO-OP）
+3. While 既定設定で稼働しているとき, the watcher shall tracked 運用 repo に対して本機能導入前と外形的に同一の振る舞い（reset → agent 起動）を保つ
+4. The watcher shall 注入の有無にかかわらず既定で安全側（既存挙動不変側）に倒れる振る舞いを採る
+
+### Requirement 3: 注入の fail-open（失敗時の継続）
+
+**Objective:** As a watcher 運用者, I want `.claude/` 注入が失敗しても reset サイクル自体を倒さないでほしい, so that 注入の問題が無実の Issue を claude-failed 化させない
+
+#### Acceptance Criteria
+
+1. If `.claude/` 注入が失敗したとき, the watcher shall warn レベルのログを出力する
+2. If `.claude/` 注入が失敗したとき, the watcher shall reset → agent 起動のサイクルを中断せず継続する
+3. If `.claude/` 注入が失敗したとき, the watcher shall 当該 Issue を注入失敗のみを理由に claude-failed へ遷移させない
+
+### Requirement 4: 注入の安全性・冪等性
+
+**Objective:** As a watcher 運用者, I want 注入が冪等で worktree のファイル属性を壊さないでほしい, so that 繰り返し実行・並列 slot 運用でも一貫した結果が得られ data-loss が起きない
+
+#### Acceptance Criteria
+
+1. When 同一条件で `.claude/` 注入が複数回実行されたとき, the watcher shall 1 回実行した場合と同じ worktree の `.claude/` 状態を生成する
+2. The watcher shall 注入対象に worktree の `.claude/` 以外の tracked / untracked ファイルを巻き込まない
+3. While worktree が gitignore 運用 repo であるとき, the watcher shall 注入した `.claude/` を worktree の untracked（commit 対象外）状態のまま保つ
+4. The watcher shall `.github/scripts/idd-claude-labels.sh` を注入対象に含めない
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While 本機能を有効化せず既定で稼働しているとき, the watcher shall 既存の env var 名・ラベル遷移契約・exit code 意味・ログ書式を変更しない
+2. The watcher shall worktree reset の既存契約（`git reset --hard origin/<base>` → `git clean -fdx` の順序・data-loss 防止方針、#180 / #198）を退行させない
+3. If 後方互換を破る変更が必要になった場合, the watcher shall 既定値を既存挙動側に置き、migration note を伴って導入する
+
+### NFR 2: 冪等性と self-hosting 安全性
+
+1. When watcher が連続サイクルで同一 slot worktree を処理したとき, the watcher shall 注入処理によって前サイクルの注入状態に依存しない一貫した結果を生成する
+2. While 並列 slot（PARALLEL_SLOTS > 1）で複数 worktree を処理しているとき, the watcher shall 各 worktree の `.claude/` 注入を互いに干渉させない
+
+### NFR 3: 可観測性
+
+1. The watcher shall 注入の実行・スキップ（NO-OP）・失敗を、運用者がログから判別できる形で記録する
+
+## Out of Scope
+
+- グローバル `~/.claude` フォールバック経路の追加（本 Issue のスコープは REPO_DIR からの注入に限定。グローバルフォールバック不在は degraded の根本原因の 1 つだが本機能では扱わない）
+- consumer repo が `.claude/` を gitignore すべきか tracked にすべきかの運用方針自体の決定（repo ごとの運用判断に委ねる）
+- `.github/scripts/idd-claude-labels.sh` など agent runtime に不要な足場ファイルの worktree への配布
+- 注入元 `.claude/` の内容生成・更新（`install.sh` の責務であり本機能では生成しない）
+- 注入手段（auto-detect 方式か新規 env var opt-in 方式か、コピーに用いるコマンドや実装上の関数構成）の確定（design / 実装の領分。要件は観測可能な振る舞いのみを規定する）
+
+## Open Questions
+
+なし

--- a/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/review-notes.md
+++ b/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/review-notes.md
@@ -1,0 +1,50 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-237-impl-feat-watcher-gitignore-repo-worktree-res
+- HEAD commit: e6b3532567d610575580251b55453cebd6c6a7c2
+- Compared to: main..HEAD
+- 備考: design-less impl（design.md / tasks.md 不在）。`_Boundary:_` アノテーションは存在しないため、boundary 判定は requirements.md の Out of Scope（特に Req 4.4 / labels.sh 非配布）と変更ファイル範囲の突き合わせで実施。CLAUDE.md に `## Feature Flag Protocol` 節が無いため opt-out として解釈し、flag 観点の確認は行わない。
+
+## Verified Requirements
+
+- 1.1 — `core_utils.sh:_worktree_inject_claude`（wt 不在 + src 有のとき `cp -a` で注入）/ smoke Case (a)
+- 1.2 — smoke Case (a) が `.claude/agents/developer.md` `.claude/rules/ears-format.md` の worktree 出現を assert
+- 1.3 — `issue-watcher.sh:6814-6820`：`worktree reset OK` ログ直後・`_hook_invoke`（hook / agent 起動）の前に呼び出し（コードレビュー）
+- 1.4 — 注入成功時 `slot_log ".claude を REPO_DIR から worktree へ注入 ..."` / smoke Case (a) がログ出力を assert
+- 2.1 — `[ -e "$wt/.claude" ]` で即 return 0（上書きしない）/ smoke Case (b)（TRACKED-ORIGINAL 不変・rules 非混入）
+- 2.2 — `[ ! -d "$src_repo_dir/.claude" ]` で即 return 0 / smoke Case (c)（.claude 未作成・warn 無し）
+- 2.3 — tracked 運用 repo は reset 後 `.claude/` 復元 → NO-OP（smoke Case (b) + impl-notes 後方互換根拠）
+- 2.4 — auto-detect 構造（env gate 無し / 既存挙動側へ倒れる）+ smoke Case (b)/(c)
+- 3.1 — コピー失敗パスで `slot_warn ".claude の注入に失敗しました ..."`（コードレビュー）
+- 3.2 — 関数が常に return 0（smoke 全 Case が rc=0 を assert）→ `set -euo pipefail` 下でも呼び出し側を倒さない
+- 3.3 — 呼び出し側（issue-watcher.sh:6820）は `_slot_mark_failed` を呼ばない（コードレビュー）+ return 0
+- 4.1 — 1 回目注入後は wt に `.claude/` が出来るため 2 回目は NO-OP（smoke Case (e)）
+- 4.2 — `cp -a "$src/.claude" "$wt/"` がディレクトリ単位 / smoke Case (b) が rules 非混入を assert
+- 4.3 — 呼び出し側で git add / commit を行わない（コードレビュー）。`.claude/` は gitignore 対象のまま untracked
+- 4.4 — コピー対象は `.claude/` のみで `.github/scripts/idd-claude-labels.sh` に触れない（コードレビュー / 変更ファイル一覧でも labels.sh 無変更）
+- NFR 1.1 — 新規 env var 追加なし・ラベル / exit code / ログ書式不変（shellcheck SC2317 件数 baseline 同一 / impl-notes）
+- NFR 1.2 — `_worktree_reset` 本体未変更（diff は注入呼び出し追加と SRC_REPO_DIR 捕捉のみ。reset → clean 順序不変）
+- NFR 1.3 — 後方互換を破っていない（migration 不要）
+- NFR 2.1 — smoke Case (e) の冪等性で連続サイクル一貫性を担保
+- NFR 2.2 — 注入は per-worktree（`$WT` / `$SRC_REPO_DIR` はサブシェル局所）で並列 slot 間非干渉（コードレビュー）
+- NFR 3.1 — 注入時 `slot_log` / 失敗時 `slot_warn` / NO-OP 無ログで判別可能 + README に grep 例
+
+## 独立再実行による裏取り
+
+- `bash docs/specs/237-feat-watcher-gitignore-repo-worktree-res/test-fixtures/test-inject-claude.sh` → 全 14 アサーション PASS（exit 0）を Reviewer 側で再実行確認
+- `shellcheck local-watcher/bin/modules/core_utils.sh` → 警告ゼロ（exit 0）
+- `shellcheck docs/.../test-inject-claude.sh` → 警告ゼロ（exit 0）
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（R1〜R4 / NFR 1〜3）に対応する実装またはテストが存在し、design-less impl のため boundary アノテーション逸脱もない（labels.sh / .github/scripts 無変更、Req 4.4 充足）。smoke テスト 14 件 PASS・shellcheck 警告ゼロを Reviewer 側で再実行確認した。
+
+RESULT: approve

--- a/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/test-fixtures/test-inject-claude.sh
+++ b/docs/specs/237-feat-watcher-gitignore-repo-worktree-res/test-fixtures/test-inject-claude.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# test-inject-claude.sh — _worktree_inject_claude のロジック隔離スモークテスト（Issue #237）
+#
+# 用途:
+#   core_utils.sh の _worktree_inject_claude を単体 source して、要件 R1〜R4 の
+#   観測可能な振る舞いを検証する。watcher 本体の起動は行わず、関数ロジックのみを
+#   隔離して回帰確認する。
+#
+# 配置先:
+#   docs/specs/237-feat-watcher-gitignore-repo-worktree-res/test-fixtures/
+#
+# 依存:
+#   - bash 4+ / cp / mktemp / git（core_utils.sh source 時の他関数定義ロード用）
+#   - core_utils.sh の前方参照 slot_log / slot_warn は本スクリプトで stub 定義する
+#
+# 実行:
+#   bash docs/specs/237-feat-watcher-gitignore-repo-worktree-res/test-fixtures/test-inject-claude.sh
+#   全ケース pass で exit 0 / いずれか失敗で非ゼロ exit。
+
+set -euo pipefail
+
+# ── テスト対象モジュールの解決 ──
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+MODULE="$REPO_ROOT/local-watcher/bin/modules/core_utils.sh"
+
+if [ ! -f "$MODULE" ]; then
+  echo "FATAL: モジュールが見つかりません: $MODULE" >&2
+  exit 1
+fi
+
+# ── 前方参照スタブ（core_utils.sh が呼び出し時に解決する関数群）──
+# 注入実行 / warn のログを変数に捕捉し、後段の検証で参照できるようにする。
+LAST_LOG=""
+LAST_WARN=""
+# これらの stub は core_utils.sh から間接的に呼ばれる（source 経由の前方参照解決）。
+# 静的解析は直接呼び出しを検出できず unreachable と誤判定するため SC2317 を抑制する。
+# shellcheck disable=SC2317
+slot_log() { LAST_LOG="$*"; }
+# shellcheck disable=SC2317
+slot_warn() { LAST_WARN="$*"; }
+# core_utils.sh は本体から source される前提のため、source 時に他関数の定義のみを
+# ロードする（即時実行コードは無いので副作用なし）。
+# shellcheck disable=SC1090
+source "$MODULE"
+
+# ── テストハーネス ──
+PASS=0
+FAIL=0
+fail() { echo "  FAIL: $*" >&2; FAIL=$((FAIL + 1)); }
+ok() { echo "  ok: $*"; PASS=$((PASS + 1)); }
+
+# 各ケースで使う一時領域を作る。SRC=注入元 REPO_DIR / WT=注入先 worktree。
+make_tmp() {
+  local base
+  base="$(mktemp -d -t inject-claude-XXXXXX)"
+  echo "$base"
+}
+
+# 注入元の `.claude/` を agents / rules 込みで作る。
+seed_src_claude() {
+  local src="$1"
+  mkdir -p "$src/.claude/agents" "$src/.claude/rules"
+  echo "developer agent def" >"$src/.claude/agents/developer.md"
+  echo "ears rule" >"$src/.claude/rules/ears-format.md"
+}
+
+# ── Case (a): worktree に `.claude/` 無し + REPO_DIR に `.claude/` 有り → 注入される（R1.1, R1.2, R1.4）──
+echo "Case (a): inject when worktree lacks .claude and REPO_DIR has it"
+{
+  TMP="$(make_tmp)"
+  SRC="$TMP/repo"
+  WT="$TMP/wt"
+  mkdir -p "$SRC" "$WT"
+  seed_src_claude "$SRC"
+  LAST_LOG=""; LAST_WARN=""
+  _worktree_inject_claude "$SRC" "$WT"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then fail "(a) 戻り値が 0 でない: $rc"; else ok "(a) 戻り値 0"; fi
+  if [ -f "$WT/.claude/agents/developer.md" ] && [ -f "$WT/.claude/rules/ears-format.md" ]; then
+    ok "(a) .claude/agents .claude/rules が worktree に現れた"
+  else
+    fail "(a) .claude/agents または .claude/rules が注入されていない"
+  fi
+  if [ -n "$LAST_LOG" ]; then ok "(a) 注入ログが出力された: $LAST_LOG"; else fail "(a) 注入ログが出力されていない"; fi
+  rm -rf "$TMP"
+}
+
+# ── Case (b): worktree に `.claude/` 既存（tracked 運用相当）→ 上書きされない（NO-OP / R2.1）──
+echo "Case (b): NO-OP when worktree already has .claude (tracked repo)"
+{
+  TMP="$(make_tmp)"
+  SRC="$TMP/repo"
+  WT="$TMP/wt"
+  mkdir -p "$SRC" "$WT/.claude/agents"
+  seed_src_claude "$SRC"
+  # worktree 側 .claude に「tracked 運用の既存内容」を置く（注入元と区別できる印）。
+  echo "TRACKED-ORIGINAL" >"$WT/.claude/agents/developer.md"
+  LAST_LOG=""; LAST_WARN=""
+  _worktree_inject_claude "$SRC" "$WT"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then fail "(b) 戻り値が 0 でない: $rc"; else ok "(b) 戻り値 0"; fi
+  content="$(cat "$WT/.claude/agents/developer.md")"
+  if [ "$content" = "TRACKED-ORIGINAL" ]; then
+    ok "(b) 既存 .claude が上書きされていない（NO-OP）"
+  else
+    fail "(b) 既存 .claude が上書きされた: $content"
+  fi
+  # rules は注入元にしか無い → NO-OP なので worktree に現れないはず
+  if [ ! -e "$WT/.claude/rules" ]; then
+    ok "(b) 注入元の rules が混入していない（完全 NO-OP）"
+  else
+    fail "(b) NO-OP のはずが rules が混入した"
+  fi
+  if [ -z "$LAST_LOG" ]; then ok "(b) 注入ログが出ていない（NO-OP）"; else fail "(b) NO-OP のはずがログが出た: $LAST_LOG"; fi
+  rm -rf "$TMP"
+}
+
+# ── Case (c): REPO_DIR に `.claude/` 無し → NO-OP（R2.2）──
+echo "Case (c): NO-OP when REPO_DIR has no .claude"
+{
+  TMP="$(make_tmp)"
+  SRC="$TMP/repo"
+  WT="$TMP/wt"
+  mkdir -p "$SRC" "$WT"
+  # SRC に .claude を作らない
+  LAST_LOG=""; LAST_WARN=""
+  _worktree_inject_claude "$SRC" "$WT"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then fail "(c) 戻り値が 0 でない: $rc"; else ok "(c) 戻り値 0（fail-open）"; fi
+  if [ ! -e "$WT/.claude" ]; then ok "(c) worktree に .claude が作られていない（NO-OP）"; else fail "(c) NO-OP のはずが .claude が作られた"; fi
+  if [ -z "$LAST_WARN" ]; then ok "(c) warn が出ていない（正常な NO-OP）"; else fail "(c) NO-OP のはずが warn が出た: $LAST_WARN"; fi
+  rm -rf "$TMP"
+}
+
+# ── Case (d): symlink / 実行権限が保持される（R4 / cp -a）──
+echo "Case (d): symlink and exec bit preserved (cp -a)"
+{
+  TMP="$(make_tmp)"
+  SRC="$TMP/repo"
+  WT="$TMP/wt"
+  mkdir -p "$SRC/.claude/agents" "$WT"
+  echo "exec script" >"$SRC/.claude/agents/hook.sh"
+  chmod +x "$SRC/.claude/agents/hook.sh"
+  # symlink を作る（相対リンク）
+  ln -s "agents/hook.sh" "$SRC/.claude/link-to-hook"
+  LAST_LOG=""; LAST_WARN=""
+  _worktree_inject_claude "$SRC" "$WT"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then fail "(d) 戻り値が 0 でない: $rc"; else ok "(d) 戻り値 0"; fi
+  if [ -x "$WT/.claude/agents/hook.sh" ]; then ok "(d) 実行権限が保持された"; else fail "(d) 実行権限が失われた"; fi
+  if [ -L "$WT/.claude/link-to-hook" ]; then ok "(d) symlink が symlink のまま保持された"; else fail "(d) symlink が実体化された / 失われた"; fi
+  rm -rf "$TMP"
+}
+
+# ── Case (e): 冪等性（R4.1）— 2 回実行しても結果が同じ ──
+echo "Case (e): idempotent across repeated runs"
+{
+  TMP="$(make_tmp)"
+  SRC="$TMP/repo"
+  WT="$TMP/wt"
+  mkdir -p "$SRC" "$WT"
+  seed_src_claude "$SRC"
+  _worktree_inject_claude "$SRC" "$WT"  # 1 回目: 注入
+  first="$(cat "$WT/.claude/agents/developer.md")"
+  # 1 回目で worktree に .claude が出来たので 2 回目は auto-detect で NO-OP のはず
+  echo "MUTATED-AFTER-FIRST" >"$WT/.claude/agents/developer.md"
+  LAST_LOG=""
+  _worktree_inject_claude "$SRC" "$WT"  # 2 回目: NO-OP（上書きしない）
+  second="$(cat "$WT/.claude/agents/developer.md")"
+  if [ "$first" = "developer agent def" ] && [ "$second" = "MUTATED-AFTER-FIRST" ]; then
+    ok "(e) 2 回目は NO-OP（worktree 既存 .claude を上書きしない = 冪等）"
+  else
+    fail "(e) 冪等性が崩れた first=$first second=$second"
+  fi
+  rm -rf "$TMP"
+}
+
+# ── 集計 ──
+echo ""
+echo "=== RESULT: PASS=$PASS FAIL=$FAIL ==="
+if [ "$FAIL" -ne 0 ]; then
+  echo "SMOKE TEST FAILED" >&2
+  exit 1
+fi
+echo "ALL CASES PASSED"
+exit 0

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -6792,6 +6792,11 @@ _slot_run_issue() {
     return 1
   fi
 
+  # Issue #237: REPO_DIR を worktree へ上書きする「前」に、注入元となる元の
+  # REPO_DIR（install.sh が `.claude/` を最新化したローカルクローン）を捕捉する。
+  # _worktree_inject_claude はこの元 REPO_DIR の `.claude/` を worktree へコピーする。
+  local SRC_REPO_DIR="$REPO_DIR"
+
   # Issue #76: slot worktree が REPO_DIR の意味を担う。サブシェル内で上書きするため
   # parent cron / launchd 側の REPO_DIR には伝播せず、後段の parse_review_result /
   # stage_checkpoint_* / `git -C "$REPO_DIR"` 系すべてが slot worktree を参照するようになる。
@@ -6805,6 +6810,14 @@ _slot_run_issue() {
     return 1
   fi
   slot_log "worktree reset OK (origin/${BASE_BRANCH} 最新化 + clean -fdx)"
+
+  # ── gitignore 運用 repo 向け `.claude/` 注入（reset 完了後・hook / agent 起動前）──
+  # Issue #237: worktree に `.claude/` が無い（= gitignore 運用 repo）場合のみ、
+  # 元 REPO_DIR の `.claude/` を worktree へ注入して agent runtime を健全化する。
+  # tracked 運用 repo は worktree に `.claude/` があるため NO-OP（既存挙動不変）。
+  # fail-open のため _worktree_inject_claude は常に 0 を返し、注入失敗で
+  # claude-failed へ遷移させない（Req 3.2, 3.3）。
+  _worktree_inject_claude "$SRC_REPO_DIR" "$WT"
 
   # ── SLOT_INIT_HOOK 起動（reset 後・claude 起動前に 1 度だけ）──
   if ! _hook_invoke "$IDD_SLOT_NUMBER" "$WT"; then

--- a/local-watcher/bin/modules/core_utils.sh
+++ b/local-watcher/bin/modules/core_utils.sh
@@ -6,7 +6,7 @@
 #   - processor 系の低レベルロガー（qa_log / mq_log / ar_log / pp_log / pi_log / drr_log 系）
 #   - 日付フォーマット取得（qa_format_iso8601）
 #   - per-slot git worktree 管理（_worktree_path / _worktree_is_registered /
-#     _worktree_ensure / _worktree_reset）
+#     _worktree_ensure / _worktree_reset / _worktree_inject_claude）
 #   - per-slot 非ブロッキング flock 管理（_slot_lock_path / _slot_acquire / _slot_release）
 #   - SLOT_INIT_HOOK 起動 wrapper（_hook_invoke）
 #
@@ -236,6 +236,63 @@ _worktree_reset() {
   if ! git -C "$wt" clean -fdx >/dev/null 2>&1; then
     return 1
   fi
+  return 0
+}
+
+# gitignore 運用 repo 向けに、worktree reset 直後の slot worktree へ
+# REPO_DIR のローカル `.claude/` を注入する（Issue #237）。
+#
+# 背景:
+#   `.claude/` を gitignore して足場を public repo に出さない運用 repo では、
+#   `.claude/` が commit されないため _worktree_reset の `git reset --hard` +
+#   `git clean -fdx` 後の worktree に `.claude/agents` `.claude/rules` が現れず、
+#   agent がルール・定義を読めない degraded 状態になる。本関数は reset 完了後・
+#   agent 起動前のタイミングで REPO_DIR（install.sh が `.claude/` を最新化した
+#   ローカルクローン）から worktree へ `.claude/` をコピーして健全化する。
+#
+# 採用方式: auto-detect（worktree に `.claude/` が無い場合のみ注入）。
+#   - tracked 運用 repo は `.claude/` が commit 済み → reset 後 worktree に必ず
+#     存在 → 注入は走らず NO-OP（Req 2.1 / 2.3）。env gate を持たないが、
+#     auto-detect により tracked 運用 repo の挙動は外形的に不変（Req 2.4）。
+#   - これはローカルファイルコピーであり外部サービス呼び出しではないため、
+#     opt-in gate は不要（CLAUDE.md「opt-in gate なしで新しい外部サービス
+#     呼び出しを有効化」禁止事項の対象外）。
+#
+# 引数:
+#   $1 = 注入元 REPO_DIR（_slot_run_issue で REPO_DIR が worktree へ上書きされる
+#        前に捕捉した元の REPO_DIR）
+#   $2 = 注入先 worktree 絶対パス
+# 戻り値: 常に 0（fail-open。注入失敗で _slot_run_issue を倒さない / Req 3.2, 3.3）
+# 副作用: 条件成立時に $2/.claude を $1/.claude の内容で作成する（commit はしない）
+#
+# Req 1.1, 1.2, 1.3, 1.4, 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 4.4, NFR 3.1
+_worktree_inject_claude() {
+  local src_repo_dir="$1"
+  local wt="$2"
+
+  # NO-OP 条件 1（Req 2.1）: worktree に既に `.claude/` がある = tracked 運用 repo。
+  # 上書きせず即 return（auto-detect による既存挙動非変更 / 冪等性 Req 4.1 も担保）。
+  if [ -e "$wt/.claude" ]; then
+    return 0
+  fi
+  # NO-OP 条件 2（Req 2.2）: 注入元 REPO_DIR に `.claude/` が無い → 何もしない。
+  if [ ! -d "$src_repo_dir/.claude" ]; then
+    return 0
+  fi
+
+  # `.claude/` のみをコピーする（Req 4.2 / 4.4: 他 tracked / untracked ファイルや
+  # `.github/scripts/idd-claude-labels.sh` を巻き込まない）。
+  # `cp -a` で mode / timestamps / symlink を保持（Req 4 / rsync は依存 CLI 保証外）。
+  if cp -a "$src_repo_dir/.claude" "$wt/" 2>/dev/null; then
+    slot_log ".claude を REPO_DIR から worktree へ注入 (src=$src_repo_dir/.claude)"
+    return 0
+  fi
+
+  # fail-open（Req 3.1, 3.2, 3.3）: コピー失敗時は warn のみ出して継続する。
+  # 中途半端にコピーされた `.claude/` が残ると次回 auto-detect が NO-OP 化して
+  # 不完全状態を温存しうるため、ベストエフォートで除去してから継続する。
+  rm -rf "$wt/.claude" 2>/dev/null || true
+  slot_warn ".claude の注入に失敗しました（継続します / src=$src_repo_dir/.claude）"
   return 0
 }
 


### PR DESCRIPTION
## 概要

idd-claude の watcher は slot worktree を毎サイクル `origin/<base>` へ強制リセットしてから agent を起動する。`.claude/` を gitignore している consumer repo では reset 後の worktree に `.claude/agents` / `.claude/rules` が現れず、agent がルール・定義を読めない degraded 状態になっていた。

本 PR は worktree reset 直後に `REPO_DIR` のローカル `.claude/`（`install.sh` が管理するコピー）を worktree へ注入する `_worktree_inject_claude` 関数を追加し、gitignore 運用 repo でも agent runtime が必要な `.claude/` を参照できるようにする。tracked 運用 repo（idd-claude 自身等、`.claude/` が commit 済み）は auto-detect により注入が走らず既存挙動を完全に保つ（NO-OP）。

## 対応 Issue

Closes #237

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

- (Req 1.1 / 1.3) `_worktree_inject_claude` 関数を `core_utils.sh` に追加し、`issue-watcher.sh` の `_worktree_reset` 成功直後・agent 起動前に呼び出し
- (Req 1.2 / 1.4) 注入成功時に `slot_log` でログ出力し、`.claude/agents` / `.claude/rules` が worktree から参照可能な状態にする
- (Req 2.1 / 2.3 / 2.4) auto-detect 方式を採用：worktree に `.claude/` が既存の場合は即 NO-OP（上書きしない）。tracked 運用 repo は reset 後に `.claude/` が必ず復元されるためこの分岐で確実に保護される
- (Req 2.2) 注入元 REPO_DIR に `.claude/` が無い場合も即 NO-OP（warn なし）
- (Req 3.1 / 3.2 / 3.3) fail-open 設計：`cp -a` 失敗時は `slot_warn` を出して return 0。呼び出し側で `_slot_mark_failed` を呼ばないため注入失敗のみで `claude-failed` にならない
- (Req 4.1) 冪等：2 回目の実行時は worktree に `.claude/` が存在するため NO-OP になる
- (NFR 1.2) `_worktree_reset` 本体（`reset --hard origin/<base>` → `clean -fdx`）は一切変更していない
- `README.md` に `### gitignore 運用 repo への .claude/ 注入` 節を新設

## 受入基準チェック

- [x] Req 1.1: While worktree reset 直後に `.claude/` が無く REPO_DIR に `.claude/` があるとき注入実行 ← smoke Case (a)
- [x] Req 1.2: 注入後に `.claude/agents` / `.claude/rules` が worktree から参照可能 ← smoke Case (a)
- [x] Req 1.3: reset 後・agent 起動前に注入を実施 ← issue-watcher.sh の呼び出し位置（`worktree reset OK` ログ直後・`_hook_invoke` 前）
- [x] Req 1.4: 注入成功時にログ出力 ← smoke Case (a)（`slot_log` 呼び出しを assert）
- [x] Req 2.1: 既存 `.claude/` を上書きしない ← smoke Case (b)（TRACKED-ORIGINAL 不変・rules 非混入）
- [x] Req 2.2: 注入元無しは NO-OP ← smoke Case (c)（`.claude` 未作成・warn 無し）
- [x] Req 2.3: tracked 運用 repo の外形不変 ← smoke Case (b) + impl-notes 後方互換根拠
- [x] Req 2.4: 安全側デフォルト ← auto-detect 構造（env gate 無し / 既存挙動側に倒れる）
- [x] Req 3.1 / 3.2 / 3.3: 失敗時 warn + 継続 + claude-failed 非遷移 ← 関数 return 0 + 呼び出し側 `_slot_mark_failed` 非呼出
- [x] Req 4.1: 冪等 ← smoke Case (e)
- [x] Req 4.2: `.claude/` 以外を巻き込まない ← `cp -a "$src/.claude" "$wt/"` がディレクトリ単位
- [x] Req 4.3: commit しない ← 呼び出し側で git add / commit 非実施
- [x] Req 4.4: `idd-claude-labels.sh` を含めない ← `.github/scripts/` 無変更
- [x] NFR 1.1: env / ラベル / exit / ログ書式不変 ← 新規 env var 追加なし・shellcheck SC2317 件数 baseline 同一
- [x] NFR 1.2: reset 契約退行なし ← `_worktree_reset` 本体未変更
- [x] NFR 2.1: 連続サイクル一貫性 ← smoke Case (e)（冪等）
- [x] NFR 2.2: 並列 slot 非干渉 ← 注入は per-worktree（`$WT` / `$SRC_REPO_DIR` はサブシェル局所）
- [x] NFR 3.1: 実行/スキップ/失敗をログ判別 ← `slot_log` / `slot_warn` / NO-OP 無ログ + README に grep 例

## テスト結果

```
スモークテスト（docs/specs/237-.../test-fixtures/test-inject-claude.sh）:
全 14 アサーション PASS（exit 0）
  Case (a): gitignore 運用 repo 向け注入 → .claude/agents / .claude/rules 出現 + ログ確認
  Case (b): tracked 運用 repo 向け NO-OP → 既存 .claude/ を上書きしない
  Case (c): REPO_DIR に .claude/ 無し → NO-OP・warn なし
  Case (d): cp -a による権限 / symlink 保持確認
  Case (e): 2 回実行で冪等動作確認

shellcheck local-watcher/bin/modules/core_utils.sh → 警告ゼロ（exit 0）
shellcheck local-watcher/bin/issue-watcher.sh → SC2317 info 11 件（変更前後で件数同一、本変更による新規警告なし）
shellcheck docs/.../test-inject-claude.sh → 警告ゼロ（exit 0）
```

## 実装上の判断

- auto-detect 方式（env gate なし）を採用。tracked 運用 repo は `.claude/` が commit 済みのため reset 後に必ず復元され、auto-detect により注入は走らず NO-OP になる。これにより zero-config で gitignore 運用 repo を救済しつつ tracked 運用 repo の後方互換を機械的に保証できる（impl-notes.md 参照）
- `_slot_run_issue` 内で `REPO_DIR="$WT"` の上書き直前に `local SRC_REPO_DIR="$REPO_DIR"` を捕捉し、注入元 REPO_DIR を保持する
- fail-open 実装：`_worktree_inject_claude` は常に return 0 を返す。コピー失敗時は中途半端な `.claude/` をベストエフォート除去（`rm -rf ... || true`）した上で warn・継続

## 確認事項 / レビュワーへの依頼

- Reviewer 判定: `docs/specs/237-feat-watcher-gitignore-repo-worktree-res/review-notes.md` 参照（RESULT: approve）
- base 検証: `--base main` 指定 / baseRefName: main / OK（一致）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #237 のコメントを参照してください。
