### PR TITLE
fix(watcher): .shellcheckrc で accepted info baseline を抑止し stage-a-verify ジャムを解消

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,15 @@
+# idd-claude shellcheck 設定
+#
+# CLAUDE.md「テスト・検証 / 静的解析」の基準は **warning ゼロ（info は許容）**。
+# 以下の info 級 false-positive / accepted baseline を抑止し、素の `shellcheck`
+# （stage-a-verify の構造化 verify ブロックや手動チェック）がプロジェクトの bar を
+# 反映するようにする。これにより、verify ブロックが素の `shellcheck` を使っていても
+# accepted な info ノイズで exit 1 にならず、stage-a-verify が正しく通る。
+#
+# - SC2317: Command appears to be unreachable — 間接呼び出し（dr_/po_/sc_ 系ロガー等）の
+#           false-positive。`issue-watcher.sh` に多数存在し、CLAUDE.md でも accepted と明記。
+# - SC2012: Use find instead of ls — 既存実装で許容している info 級スタイル指摘。
+#
+# 注: warning / error 級は引き続き検出される（severity を下げているわけではなく、
+#     accepted な info 2 種のみを個別 disable している）。
+disable=SC2317,SC2012

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Reviewer / PjM）は、以下の方針で **内部思考言語と出力言語を
 
 ### 静的解析
 
-- `shellcheck local-watcher/bin/*.sh install.sh setup.sh .github/scripts/*.sh` — 警告ゼロを目指す
+- `shellcheck local-watcher/bin/*.sh install.sh setup.sh .github/scripts/*.sh` — 警告ゼロを目指す（accepted な info 級 false-positive は root の `.shellcheckrc` で抑止＝`SC2317`/`SC2012`。これにより stage-a-verify の素 `shellcheck` verify ブロックも accepted baseline を反映して通る）
 - `actionlint .github/workflows/*.yml` — workflow YAML の検査
 - `diff -r .claude/agents repo-template/.claude/agents` — root↔repo-template の agents の byte 一致検証（差分が出たら二重管理規約違反。片系統だけ更新したドリフトを検出する）
 - `diff -r .claude/rules repo-template/.claude/rules` — root↔repo-template の rules の byte 一致検証（差分が出たら二重管理規約違反。片系統だけ更新したドリフトを検出する）


### PR DESCRIPTION
## 概要

idd-claude self-hosting で **#238 / #239 / #243 が stage-a-verify の無限 round=1 ループ**で停滞していた問題を、root に `.shellcheckrc` を追加して解消する。

## 根本原因（連鎖）

1. #224 の構造化 verify ブロックが各 Issue の tasks.md にあり、中身が **素の `shellcheck …`**。
2. stage-a-verify の resolve 優先順位は **構造化ブロック > `STAGE_A_VERIFY_COMMAND`（escape hatch）** なので、cron に設定した `--severity=warning` の escape hatch を**ブロックが上書き**。
3. 素の `shellcheck` は idd-claude の **info ベースライン（SC2317×10 / SC2012×1）で exit 1** → verify 失敗。
4. round counter は worktree 内（`clean -fdx` で毎サイクル消える）→ **round=1 を無限ループ**（claude-failed に escalate しない）→ サイクルを churn し、overlap する他 Issue を starve。

CLAUDE.md「静的解析」の基準は **warning ゼロ（info 許容）**。つまり本来この verify は通るべきで、**accepted な info ノイズで落ちている**のが本質。

## 変更内容

- root に **`.shellcheckrc`**（`disable=SC2317,SC2012`）を追加。
  - `SC2317`（Command appears to be unreachable）= 間接呼び出しロガー等の false-positive。CLAUDE.md で accepted と明記済み。
  - `SC2012`（Use find instead of ls）= 既存実装で許容している info 級スタイル指摘。
  - これにより素の `shellcheck local-watcher/bin/*.sh local-watcher/bin/modules/*.sh` が **exit 0**（warning/error 級は引き続き検出）。verify ブロックが素 shellcheck でも accepted baseline を反映して通る。
- `CLAUDE.md` 静的解析節に `.shellcheckrc` の趣旨を注記。

## スコープ外

- **round counter 非永続による無限ループ自体**は別 Issue で扱う（本 PR は verify が誤って落ちる原因を断つもの。真に失敗した場合の escalate 不全は別バグ）。
- **repo-template には追加しない**（consumer は固有言語のため、idd-claude の shell baseline は無関係）。

## Test plan

```
$ shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/*.sh ; echo $?
# .shellcheckrc 追加後 → 0（追加前は 1）
```

## 影響

- マージ後、次サイクルで #238/#239/#243 の impl-resume の stage-a-verify が通り、Stage B → 実装 PR に進める（ジャム解消）。`~/bin` 再デプロイ不要（`.shellcheckrc` は repo に同梱され worktree/REPO_DIR に展開される）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
