### PR TITLE
feat(#248): verify_pushed_or_retry の push 成功時 Issue コメントを抑止し info ログ化

### DIFF
--- a/docs/specs/248-bug-watcher-verify-pushed-or-retry-push/impl-notes.md
+++ b/docs/specs/248-bug-watcher-verify-pushed-or-retry-push/impl-notes.md
@@ -1,0 +1,78 @@
+# 実装ノート（Issue #248）
+
+## 変更概要
+
+`local-watcher/bin/issue-watcher.sh` の `verify_pushed_or_retry` の **push 成功パス**
+（`ahead>0`（または `unknown`）検出 → 自動 push リトライ成功時）を修正した。
+
+- **Issue コメント投稿を抑止**: 旧実装は push リトライ成功時に毎回 `⚠️ ... 自動 push
+  リトライで復旧しました` という Issue コメントを投稿していた。idd-claude は commit-only 設計
+  （Developer は push しない / push は watcher が集約）であり `ahead>0` はほぼ全 impl Issue で
+  発生する正常状態のため、このコメントは「サブエージェントの push 漏れ」という誤った原因
+  示唆を伴う誤検知ノイズだった。`comment_body` 構築 + `gh issue comment` 呼び出しを削除した。
+- **成功 info 行に監査トレーサビリティ用フィールドを追加**: 既存の `$LOG` 成功 info 行を
+  単一行のまま機械可読化し、Issue 番号 / stage 識別子 / branch / 復旧 commit 数（ahead 数）を
+  フィールド形式で追記した。新しい成功 info 行:
+
+  ```
+  [YYYY-MM-DD HH:MM:SS] <stage_label> 自動 push リトライ成功 → 継続 issue=#<N> stage_id=<stage_id> branch=<branch> recovered_commits=<ahead>
+  ```
+
+  - 「push 漏れ」「復旧 commit 数」等の誤原因示唆文言を info 行から排除（コメント削除に伴い
+    自然に解消するが、ログ文言にも残さない）。
+  - return 0 / temp ファイル cleanup / qa_warn の `auto-push retry SUCCESS` 行は維持。
+
+push 失敗パス（失敗通知コメント投稿・`mark_issue_failed` escalate・return 1・失敗通知書式・
+失敗時ログ行書式・リトライ 1 回）、`ahead==0` の無音 return 0、`ahead==unknown` の安全側経路は
+一切変更していない。
+
+## 各 AC への対応
+
+| AC | 対応 | 担保するテスト |
+|---|---|---|
+| Req 1.1（成功時コメント抑止） | `gh issue comment` 呼び出し + `comment_body` 構築を削除 | Case 2: `LAST_GH_ARGS` 空 / `LAST_GH_COMMENT_BODY` 空 / `$LOG` に「push 漏れ」文言なし |
+| Req 1.2（成功 info 行 1 件記録） | 成功 info 行を `$LOG` へ echo（維持） | Case 2: 成功 info 行 1 行のみ（`SUCCESS_LINE_COUNT==1`） |
+| Req 1.3（return 0） | `return 0` 維持 | Case 2: `rc=0` |
+| Req 1.4（escalate しない） | `mark_issue_failed` を呼ばない（成功パス） | Case 2: `LAST_MARK_FAILED_STAGE` 空 |
+| Req 2.1（Issue 番号） | info 行に `issue=#${NUMBER}` 追記 | Case 2: `issue=#106` を含む |
+| Req 2.2（stage 識別子） | info 行に `stage_id=${stage_id}` 追記 | Case 2: `stage_id=stageA-push-missing` を含む |
+| Req 2.3（対象 branch） | info 行に `branch=${branch}` 追記 | Case 2: `branch=work-branch` を含む |
+| Req 2.4（復旧 commit 数） | info 行に `recovered_commits=${ahead_count}` 追記 | Case 2: `recovered_commits=2` を含む |
+| Req 3.1〜3.5（失敗時挙動維持） | 失敗パス未変更 | Case 3 / Case 4: rc=1 / `mark_issue_failed` stage 識別子 / 失敗 body に branch・commit 数 / Stage B 識別子伝搬 |
+| Req 4.1, 4.2（ahead==0 無音 + return 0） | `ahead==0` 早期 return 未変更 | Case 1: rc=0 / `$LOG` 行数 0 |
+| Req 5.1, 5.2（unknown 安全側 + 成功時 Req 1 同一） | unknown→push 経路未変更。成功パスは共通のため Req 1 と同一挙動が適用される | Case 2 の成功パスが ahead 値に依存せず同経路を通ることで担保（unknown も同一の成功 info 行を出力） |
+| NFR 1.1〜1.4（後方互換） | env var 名 / 失敗通知書式 / 失敗時ログ書式 / stage 識別子伝搬契約 未変更 | Case 3 / Case 4 で失敗書式・stage 識別子伝搬を回帰確認 |
+| NFR 2.1, 2.2（冪等・無害） | 成功時コメント新規投稿なし / ahead==0 で副作用なし | Case 1 / Case 2 |
+| NFR 3.1（単一行 grep 可能） | 成功 info 行を 1 行に集約（複数行分割しない） | Case 2: `SUCCESS_LINE_COUNT==1` |
+
+> Req 5.2 の補足: 成功時挙動（コメント抑止 + info ログのみ）は push 成功パスに 1 経路で集約
+> されており、ahead が数値でも `unknown` でも同一の成功 info 行を出力する。Case 2 は数値 ahead
+> ケースで成功経路を直接検証しており、unknown ケースも同経路を通るため挙動は同一である。
+
+## 検証結果
+
+- `shellcheck local-watcher/bin/issue-watcher.sh` → exit 0（警告ゼロ。root `.shellcheckrc` の
+  accepted baseline 前提）
+- `bash local-watcher/test/verify_pushed_or_retry_test.sh` → **PASS: 21, FAIL: 0**（exit 0）
+  - Case 1（ahead==0 無音）/ Case 3・4（失敗パス）のアサーションは不変要件の回帰防止として
+    変更せず、全て PASS を維持。
+  - Case 2（push 成功）を新挙動（コメント未投稿 + 成功 info 行のトレーサビリティフィールド）に
+    更新し全 PASS。
+
+## 後方互換性の確認
+
+- 既存 env var 名（`REPO` / `REPO_DIR` / `LOG` / `NUMBER` 等）変更なし。
+- push 失敗パスの失敗通知コメント書式・失敗時ログ行書式・`mark_issue_failed` 呼び出し・
+  return 1・リトライ 1 回固定はすべて未変更（Case 3 / Case 4 で回帰確認）。
+- stage 識別子 `stageA-push-missing` / `stageA-prime-push-missing` / `stageB-push-missing` の
+  呼び出し側（全 call site）および伝搬契約は未変更（テスト冒頭の grep サニティ + Case 3/4 で確認）。
+- `ahead==0` の無音 return 0、`ahead==unknown` の安全側 push 経路は未変更。
+- README は `verify_pushed_or_retry` の役割（push 集約・完了済み commit の push リトライ）を
+  記述しているが、成功時 Issue コメント投稿の挙動には言及していないため修正不要（既存記述と
+  矛盾なし）。本変更は `.claude/agents` / `.claude/rules` の二重管理対象外。
+
+## 確認事項
+
+- なし（要件・後方互換要件が明確であり、Open Questions も「なし」。仕様の拡大解釈は行っていない）。
+
+STATUS: complete

--- a/docs/specs/248-bug-watcher-verify-pushed-or-retry-push/requirements.md
+++ b/docs/specs/248-bug-watcher-verify-pushed-or-retry-push/requirements.md
@@ -1,0 +1,97 @@
+# Requirements Document
+
+## Introduction
+
+watcher の `verify_pushed_or_retry`（#106 導入）は Stage A / A' / B 完了直後に「ローカル commit が
+origin に到達しているか」を verify し、`ahead>0`（未 push）を検出すると自動 push を 1 回リトライする。
+ところが現状は **push リトライが成功した場合にも毎回 Issue へ ⚠️ コメントを投稿**している。idd-claude
+の設計上 Developer は commit のみで push は行わず（push は watcher が集約する）、`ahead>0` は
+ほぼ全ての impl Issue で発生する正常状態である。このため成功時コメントは「サブエージェントの push
+漏れ」という誤った原因示唆を伴う誤検知ノイズとなり、Issue タイムラインを汚している（#219 / #238 /
+#239 / #243 / #246 で実害が観測されている）。本要件は、push 成功パスの Issue コメント投稿を抑止し
+cron ログへの info 記録のみに変更しつつ、push 失敗時の escalation 挙動を完全に温存することを定める。
+
+## Requirements
+
+### Requirement 1: push 成功時のコメント抑止と info ログ化
+
+**Objective:** As a idd-claude の運用者, I want push リトライ成功時に Issue コメントが投稿されない, so that Issue タイムラインが誤検知ノイズで汚れず本当に対応が必要な失敗だけが可視化される
+
+#### Acceptance Criteria
+
+1. When Stage 完了直後に `ahead>0` を検出し自動 push リトライが成功したとき, the watcher shall 当該 Issue へのコメント投稿を行わない
+2. When Stage 完了直後に `ahead>0` を検出し自動 push リトライが成功したとき, the watcher shall `$LOG`（cron ログ）に成功を示す info 行を 1 件記録する
+3. When 自動 push リトライが成功したとき, the watcher shall return code 0 を呼び出し側へ返す
+4. When 自動 push リトライが成功したとき, the watcher shall claude-failed への escalate を行わない
+
+### Requirement 2: 成功時 info ログの監査トレーサビリティ
+
+**Objective:** As a 運用者, I want 成功時 info ログに追跡に必要な識別情報が含まれる, so that Issue コメントを失っても cron ログから「いつ・どの Issue・どの stage で未 push が復旧したか」を後追いできる
+
+#### Acceptance Criteria
+
+1. When push リトライ成功時の info 行を記録するとき, the watcher shall 当該 Issue 番号を info 行に含める
+2. When push リトライ成功時の info 行を記録するとき, the watcher shall stage 識別子を info 行に含める
+3. When push リトライ成功時の info 行を記録するとき, the watcher shall 対象 branch を info 行に含める
+4. When push リトライ成功時の info 行を記録するとき, the watcher shall 復旧した commit 数（ahead 数）を info 行に含める
+
+### Requirement 3: push 失敗時の escalation 挙動の維持
+
+**Objective:** As a 運用者, I want push リトライ失敗時の Issue コメント投稿と claude-failed escalation が従来どおり維持される, so that 本当に対応が必要な未 push 失敗は引き続き Issue 上で気付ける
+
+#### Acceptance Criteria
+
+1. If 自動 push リトライが失敗したとき, the watcher shall 当該 Issue へ失敗通知コメントを投稿する
+2. If 自動 push リトライが失敗したとき, the watcher shall claude-failed への escalate を行う
+3. If 自動 push リトライが失敗したとき, the watcher shall return code 1 を呼び出し側へ返す
+4. If 自動 push リトライが失敗したとき, the watcher shall 失敗通知に stage 識別子 / 対象 branch / 未 push commit 数を含める
+5. While 自動 push リトライが 1 回に固定されている状態, when push が失敗したとき, the watcher shall リトライ回数を本変更前と同一（1 回）に保つ
+
+### Requirement 4: ahead==0（正常 push 済み）の無音挙動の維持
+
+**Objective:** As a 運用者, I want 既に origin へ push 済み（ahead==0）の場合に副作用が一切発生しない, so that 通常成功ケースの外形挙動が本変更前と完全に一致する
+
+#### Acceptance Criteria
+
+1. When Stage 完了直後に `ahead==0` を検出したとき, the watcher shall Issue コメント投稿・ログ追記・push リトライのいずれも行わない
+2. When Stage 完了直後に `ahead==0` を検出したとき, the watcher shall return code 0 を呼び出し側へ返す
+
+### Requirement 5: ahead が判定不能（unknown）の場合の安全側挙動の維持
+
+**Objective:** As a 運用者, I want ahead 数の取得に失敗した場合も本変更前と同じ安全側ロジックで動く, so that 未 push の可能性を取りこぼさず後方互換を保てる
+
+#### Acceptance Criteria
+
+1. If ahead 数の取得が失敗または timeout したとき, the watcher shall 未 push と同等扱いで自動 push リトライ経路へ進む
+2. When ahead が unknown の状態で自動 push リトライが成功したとき, the watcher shall Requirement 1 と同一の成功時挙動（コメント抑止 + info ログのみ）を適用する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The watcher shall push 失敗時の exit code・claude-failed escalation・リトライ回数（1 回）を本変更前と同一に保つ
+2. The watcher shall 既存 env var 名（`REPO` / `REPO_DIR` / `LOG` / `NUMBER` 等）・ラベル遷移契約を変更しない
+3. The watcher shall 既存の失敗通知コメント書式および失敗時ログ行書式を変更しない
+4. Where stage 識別子 `stageA-push-missing` / `stageA-prime-push-missing` / `stageB-push-missing` が呼び出し側から渡される構成, the watcher shall 当該識別子の伝搬契約を本変更前と同一に保つ
+
+### NFR 2: 冪等性・無害性
+
+1. The watcher shall 同一の未 push 状態に対して関数を再実行しても、push 成功時に Issue コメントを新規投稿しない
+2. While 通常成功ケース（ahead==0）を処理している状態, the watcher shall 副作用（コメント・ログ追記・push）を一切発生させない
+
+### NFR 3: 観測可能性
+
+1. The watcher shall push 成功時の info 行を機械的に grep 可能な単一行形式で `$LOG` に記録する（複数行に分割しない）
+
+## Out of Scope
+
+- Stage C 完了直後の PR 実在 verify ヘルパー（#108 / #110 の別関数）の挙動変更
+- Developer / Reviewer プロンプトへの「branch を push せよ」という指示追加（commit-only 設計は維持し、push 集約は watcher 側に残す）
+- `verify_pushed_or_retry` のリトライ回数を 1 回から増やす変更
+- 失敗時通知コメントの文言・構造の変更（成功時のみが対象）
+- 過去に投稿済みの成功時 ⚠️ コメントの遡及削除・クリーンアップ
+- ahead 数測定の timeout 値（30 秒）やロジックの変更
+
+## Open Questions
+
+- なし（Issue 本文の受入観点・後方互換要件が明確であり、人間コメントによる追加決定事項も存在しないため、推測による未確定事項はない）

--- a/docs/specs/248-bug-watcher-verify-pushed-or-retry-push/review-notes.md
+++ b/docs/specs/248-bug-watcher-verify-pushed-or-retry-push/review-notes.md
@@ -1,0 +1,44 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-248-impl-bug-watcher-verify-pushed-or-retry-push
+- HEAD commit: 6f20c8ef14e30c289686dea4cb3cd3231f96998f
+- Compared to: main..HEAD
+
+## Verified Requirements
+
+- 1.1 — `local-watcher/bin/issue-watcher.sh:4260-4271` push 成功パスから `comment_body` 構築 + `gh issue comment` 呼び出しを削除 / test Case 2 `LAST_GH_ARGS` 空・`LAST_GH_COMMENT_BODY` 空を検証
+- 1.2 — `issue-watcher.sh:4267` 成功 info 行を `$LOG` へ 1 行 echo（維持）/ test Case 2 `SUCCESS_LINE_COUNT==1`
+- 1.3 — `issue-watcher.sh:4270` `return 0` 維持 / test Case 2 `rc=0`
+- 1.4 — 成功パスで `mark_issue_failed` を呼ばない / test Case 2 `LAST_MARK_FAILED_STAGE` 空
+- 2.1 — info 行に `issue=#${NUMBER}` 追記 / test Case 2 `issue=#106` を含む
+- 2.2 — info 行に `stage_id=${stage_id}` 追記 / test Case 2 `stage_id=stageA-push-missing` を含む
+- 2.3 — info 行に `branch=${branch}` 追記 / test Case 2 `branch=work-branch` を含む
+- 2.4 — info 行に `recovered_commits=${ahead_count}` 追記 / test Case 2 `recovered_commits=2` を含む
+- 3.1 — 失敗パス（`issue-watcher.sh:4273` 以降）未変更。失敗通知コメント投稿経路温存 / test Case 3
+- 3.2 — 失敗パスの `mark_issue_failed` 呼び出し未変更 / test Case 3 `LAST_MARK_FAILED_STAGE`
+- 3.3 — 失敗パス `return 1` 未変更 / test Case 3 `rc=1`
+- 3.4 — 失敗 body に stage 識別子 / branch / 未 push commit 数を含む（未変更）/ test Case 3 `work-branch` / `未 push commit 数: 1`
+- 3.5 — リトライ 1 回固定（`auto-push retry 1/1`）未変更 / impl-notes 後方互換確認
+- 4.1 — `issue-watcher.sh:4243-4245` `ahead==0` 早期 return（副作用なし）未変更 / test Case 1 `$LOG` 0 行
+- 4.2 — 同上 `ahead==0` で `return 0` / test Case 1 `rc=0`
+- 5.1 — `issue-watcher.sh:4238-4240` unknown 判定 → push 経路（安全側）未変更
+- 5.2 — 成功パスは ahead 値非依存の共通経路のため unknown 成功時も Req 1 と同一挙動 / test Case 2 が成功経路を直接検証
+- NFR 1.1-1.4 — 失敗 exit code / escalation / リトライ回数 / env var 名 / 失敗書式 / stage 識別子伝搬 未変更 / test Case 3, 4（Stage B 識別子伝搬含む）
+- NFR 2.1, 2.2 — 成功時コメント新規投稿なし / `ahead==0` 無副作用 / test Case 1, 2
+- NFR 3.1 — 成功 info 行を単一行に集約 / test Case 2 `SUCCESS_LINE_COUNT==1`
+
+## Findings
+
+なし
+
+## Summary
+
+push 成功パスの Issue コメント投稿抑止と info 行への監査トレーサビリティフィールド追加を確認。
+失敗パス / ahead==0 / unknown 経路は未変更で後方互換を維持。テストスイート（21 件）は全 PASS、
+全 numeric ID をカバー。変更は `issue-watcher.sh` と対応テストに限定され境界逸脱なし。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -4258,20 +4258,13 @@ verify_pushed_or_retry() {
   fi
 
   if [ "$push_rc" -eq 0 ]; then
-    # ── リトライ成功（Req 4.2, 4.3）──
+    # ── リトライ成功（Req 1.1, 1.2, 1.3, 1.4）──
+    # #248: 成功時の Issue コメント投稿は誤検知ノイズ（ahead>0 は commit-only 設計の
+    # 正常状態）となるため抑止する。監査トレーサビリティは $LOG の単一 info 行に
+    # Issue 番号 / stage 識別子 / branch / 復旧 commit 数を機械可読フィールドとして
+    # 含めて担保する（Req 2.1〜2.4 / NFR 3.1）。「push 漏れ」原因示唆文言は出さない。
     qa_warn "${stage_label} auto-push retry SUCCESS: ahead=${ahead_count} issue=#${NUMBER:-?} branch=${branch} stage_id=${stage_id}"
-    echo "[$(date '+%F %T')] ${stage_label} 自動 push リトライ成功 ahead=${ahead_count} → 継続" >> "$LOG"
-
-    # Issue コメント投稿（NFR 2.2: Issue 番号 / stage 識別子 / branch / commit 数を含める）
-    local comment_body
-    comment_body="⚠️ Issue #${NUMBER:-?} の ${stage_label} 完了直後に未 push commit を検出し、自動 push リトライで復旧しました。
-
-- 対象 stage : \`${stage_id}\`
-- 対象 branch: \`${branch}\`
-- 復旧 commit 数: ${ahead_count}
-
-サブエージェント（Developer / Reviewer）の push 漏れ等が根本原因の可能性があります。詳細は watcher ログ \`${LOG}\` を確認してください。"
-    gh issue comment "${NUMBER}" --repo "$REPO" --body "$comment_body" >/dev/null 2>&1 || true
+    echo "[$(date '+%F %T')] ${stage_label} 自動 push リトライ成功 → 継続 issue=#${NUMBER:-?} stage_id=${stage_id} branch=${branch} recovered_commits=${ahead_count}" >> "$LOG"
 
     if [ -n "$push_stderr_tmp" ]; then rm -f "$push_stderr_tmp" 2>/dev/null || true; fi
     return 0

--- a/local-watcher/test/verify_pushed_or_retry_test.sh
+++ b/local-watcher/test/verify_pushed_or_retry_test.sh
@@ -7,9 +7,10 @@
 #       検証観点（Req と対応付け）:
 #         - ahead == 0 (通常成功) → return 0、副作用なし
 #           (Req 1.3, 2.3, 3.3, 5.1, NFR 1.1)
-#         - ahead > 0 + 自動 push リトライ成功 → return 0、qa_warn 発火、
-#           gh issue comment 投稿、mark_issue_failed 未呼出
-#           (Req 1.2, 4.1, 4.2, 4.3, NFR 2.1, 2.2)
+#         - ahead > 0 + 自動 push リトライ成功 → return 0、gh issue comment は
+#           投稿しない（#248 で抑止）、成功 info 行に Issue 番号 / stage 識別子 /
+#           branch / 復旧 commit 数を含める、mark_issue_failed 未呼出
+#           (Req 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 2.4, NFR 2.1, 2.2, 3.1)
 #         - ahead > 0 + 自動 push リトライ失敗 → return 1、mark_issue_failed 呼出、
 #           虚偽の成功メッセージなし、stage 識別子が正しく伝搬
 #           (Req 1.2, 4.1, 4.4, 4.5, 4.6, NFR 2.3)
@@ -222,7 +223,8 @@ LOG_SIZE_AHEAD0=$(wc -l < "$LOG" | tr -d ' ')
 assert_eq "Case 1 (ahead==0): \$LOG 行数 0（副作用なし / Req 5.1）" "0" "$LOG_SIZE_AHEAD0"
 
 # ─────────────────────────────────────────────────────────────────
-# Case 2: ahead > 0 + 自動 push 成功 (Req 4.1, 4.2, 4.3, NFR 2.1, 2.2)
+# Case 2: ahead > 0 + 自動 push 成功 (Req 1.1, 1.2, 1.3, 2.1〜2.4, NFR 2.1, 2.2, 3.1)
+# #248: 成功時の Issue コメント投稿は抑止され、info 行のみが記録される。
 # ─────────────────────────────────────────────────────────────────
 WORK=$(setup_work_with_upstream "case2")
 add_local_commit "$WORK" 2  # 2 commits 未 push
@@ -235,25 +237,38 @@ pushd "$WORK" >/dev/null
 verify_pushed_or_retry "stageA-push-missing" "work-branch" "Stage A" >/dev/null 2>&1 || rc=$?
 popd >/dev/null
 
-assert_eq "Case 2 (push 成功): rc=0 (Req 4.2)" "0" "$rc"
-assert_eq "Case 2 (push 成功): mark_issue_failed 未呼出 (Req 4.2)" "" "$LAST_MARK_FAILED_STAGE"
-assert_contains "Case 2 (push 成功): gh issue comment が #106 を含む (NFR 2.2)" \
-  "106" "$LAST_GH_ARGS"
-assert_contains "Case 2 (push 成功): gh comment body に stageA-push-missing (NFR 2.2)" \
-  "stageA-push-missing" "$LAST_GH_COMMENT_BODY"
-assert_contains "Case 2 (push 成功): gh comment body に commit 数 2 (NFR 2.2)" \
-  "復旧 commit 数: 2" "$LAST_GH_COMMENT_BODY"
+assert_eq "Case 2 (push 成功): rc=0 (Req 1.3)" "0" "$rc"
+assert_eq "Case 2 (push 成功): mark_issue_failed 未呼出 (Req 1.4)" "" "$LAST_MARK_FAILED_STAGE"
+# #248 Req 1.1: 成功時は Issue コメントを投稿しない（gh stub が一切呼ばれない）
+assert_eq "Case 2 (push 成功): gh issue comment 未投稿 / LAST_GH_ARGS 空 (Req 1.1)" \
+  "" "$LAST_GH_ARGS"
+assert_eq "Case 2 (push 成功): gh comment body 空 (Req 1.1)" \
+  "" "$LAST_GH_COMMENT_BODY"
 
-# WARN ログ ahead= が \$LOG に記録されているか (Req 1.2 / NFR 2.1) — stderr は捨てたので
-# qa_warn 出力は \$LOG に直接書き込まれないが、verify_pushed_or_retry の echo 行で
-# "auto-push retry" を含む log 行があることを確認する。
-if grep -q "auto-push retry" "$LOG"; then
-  echo "PASS: Case 2 (push 成功): \$LOG に auto-push retry 行 (Req 1.2 / NFR 2.1)"
-  PASS_COUNT=$((PASS_COUNT + 1))
-else
-  echo "FAIL: Case 2 (push 成功): \$LOG に auto-push retry 行が無い"
+# Req 1.2 / 2.1〜2.4 / NFR 3.1: 成功 info 行が \$LOG に 1 件記録され、その行に
+# Issue 番号 / stage 識別子 / branch / 復旧 commit 数（ahead 数）が含まれる。
+# 成功 info 行（"自動 push リトライ成功" を含む行）を 1 行だけ抽出して検査する
+# （NFR 3.1: 単一行形式で機械的に grep できること）。
+SUCCESS_LINE=$(grep "自動 push リトライ成功" "$LOG" || true)
+assert_contains "Case 2 (push 成功): 成功 info 行に Issue 番号 #106 (Req 2.1)" \
+  "issue=#106" "$SUCCESS_LINE"
+assert_contains "Case 2 (push 成功): 成功 info 行に stage 識別子 (Req 2.2)" \
+  "stage_id=stageA-push-missing" "$SUCCESS_LINE"
+assert_contains "Case 2 (push 成功): 成功 info 行に branch (Req 2.3)" \
+  "branch=work-branch" "$SUCCESS_LINE"
+assert_contains "Case 2 (push 成功): 成功 info 行に復旧 commit 数 2 (Req 2.4)" \
+  "recovered_commits=2" "$SUCCESS_LINE"
+# NFR 3.1: 成功 info 行は単一行（複数行に分割しない）
+SUCCESS_LINE_COUNT=$(grep -c "自動 push リトライ成功" "$LOG" || true)
+assert_eq "Case 2 (push 成功): 成功 info 行は 1 行のみ (NFR 3.1)" "1" "$SUCCESS_LINE_COUNT"
+# Req 1.1 補足: 成功 info 行に「push 漏れ」原因示唆文言を含めない
+if grep -q "push 漏れ" "$LOG"; then
+  echo "FAIL: Case 2 (push 成功): \$LOG に「push 漏れ」誤原因示唆文言が残存 (#248)"
   cat "$LOG" >&2
   FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+  echo "PASS: Case 2 (push 成功): \$LOG に「push 漏れ」文言なし (#248)"
+  PASS_COUNT=$((PASS_COUNT + 1))
 fi
 
 # bare 側に commit が伝播していることを git で確認


### PR DESCRIPTION
## 概要

watcher の `verify_pushed_or_retry` 関数は Stage 完了直後に `ahead>0`（ローカル commit が origin に未到達）を検出すると自動 push リトライを行う。
idd-claude では Developer が commit のみを行い push は watcher が集約する設計であるため、`ahead>0` はほぼ全ての impl Issue で発生する正常状態である。
しかし従来の実装は **push リトライが成功した場合にも毎回 Issue へ ⚠️ コメントを投稿** しており、Issue タイムラインに誤検知ノイズを蓄積していた（#219 / #238 / #239 / #243 / #246 で実害を確認）。

本 PR は push 成功パスの Issue コメント投稿を抑止し、cron ログへの info 記録（issue 番号 / stage_id / branch / 復旧 commit 数フィールド付き）のみに変更する。push 失敗時の escalation 挙動・ahead==0 の無音挙動・unknown 経路の安全側挙動はすべて従来どおり温存する。

## 対応 Issue

Closes #248

## 関連 PR

なし（Architect 非起動、設計 PR なし）

## 実装内容

- (Req 1.1 / Req 1.4) 成功パスから `gh issue comment` 呼び出しと `comment_body` 構築を削除し、Issue コメント投稿を抑止
- (Req 1.2) 成功時の info ログ行を `$LOG` へ 1 行 echo（維持）
- (Req 1.3) 成功パスで `return 0` を維持
- (Req 2.1-2.4) info 行に `issue=#${NUMBER}` / `stage_id=${stage_id}` / `branch=${branch}` / `recovered_commits=${ahead_count}` フィールドを追記
- (Req 3.1-3.5 / NFR 1.1-1.4) push 失敗パスの Issue コメント投稿 / `mark_issue_failed` escalation / `return 1` / リトライ 1 回固定 / stage 識別子伝搬を未変更で温存
- (Req 4.1-4.2) `ahead==0` の早期 return（副作用なし）を未変更で温存
- (Req 5.1-5.2) unknown 経路の push 経路（安全側）を未変更で温存

## 受入基準チェック

- [x] Req 1.1: When ahead>0 で push 成功 → Issue コメント投稿なし ← `test Case 2: LAST_GH_ARGS 空 / LAST_GH_COMMENT_BODY 空`
- [x] Req 1.2: When ahead>0 で push 成功 → `$LOG` に info 行 1 件 ← `test Case 2: SUCCESS_LINE_COUNT==1`
- [x] Req 1.3: push 成功 → return 0 ← `test Case 2: rc=0`
- [x] Req 1.4: push 成功 → `mark_issue_failed` 呼び出しなし ← `test Case 2: LAST_MARK_FAILED_STAGE 空`
- [x] Req 2.1: info 行に `issue=#${NUMBER}` を含む ← `test Case 2: issue=#106 を含む`
- [x] Req 2.2: info 行に `stage_id=${stage_id}` を含む ← `test Case 2: stage_id=stageA-push-missing を含む`
- [x] Req 2.3: info 行に `branch=${branch}` を含む ← `test Case 2: branch=work-branch を含む`
- [x] Req 2.4: info 行に `recovered_commits=${ahead_count}` を含む ← `test Case 2: recovered_commits=2 を含む`
- [x] Req 3.1: push 失敗 → Issue へ失敗通知コメント投稿 ← `test Case 3` （未変更の失敗パスで確認）
- [x] Req 3.2: push 失敗 → `mark_issue_failed` escalation ← `test Case 3: LAST_MARK_FAILED_STAGE`
- [x] Req 3.3: push 失敗 → return 1 ← `test Case 3: rc=1`
- [x] Req 3.4: 失敗通知に stage 識別子 / branch / 未 push commit 数を含む ← `test Case 3: work-branch / 未 push commit 数: 1`
- [x] Req 3.5: リトライ 1 回固定（未変更） ← impl-notes 後方互換確認 / `auto-push retry 1/1`
- [x] Req 4.1: `ahead==0` → コメント・ログ・push リトライいずれも発生しない ← `test Case 1: $LOG 0 行`
- [x] Req 4.2: `ahead==0` → return 0 ← `test Case 1: rc=0`
- [x] Req 5.1: unknown 判定 → push 経路（安全側） ← `issue-watcher.sh:4238-4240 未変更`
- [x] Req 5.2: unknown 成功時 → Req 1 と同一挙動 ← 成功パスは ahead 値非依存の共通経路のため `test Case 2` が直接カバー
- [x] NFR 1.1-1.4: 失敗 exit code / escalation / リトライ回数 / env var 名 / 失敗書式 / stage 識別子伝搬 未変更

## テスト結果

```
テストスイート: 21 件全 PASS（Reviewer: review-notes.md に記録）

Case 1 (ahead==0, 正常 push 済み): rc=0, $LOG 0 行追記, gh 呼び出しなし
Case 2 (ahead>0, push 成功):       rc=0, LAST_GH_ARGS 空, LAST_GH_COMMENT_BODY 空,
                                    SUCCESS_LINE_COUNT==1, info 行に issue/#stage_id/branch/recovered_commits を含む
Case 3 (ahead>0, push 失敗):       rc=1, LAST_MARK_FAILED_STAGE 非空, 失敗コメント投稿
Case 4 (stage_id=stageB):          NFR 1.4 stage 識別子伝搬を確認

shellcheck: 既存 `.shellcheckrc` ベースライン（SC2317/SC2012）込みで警告ゼロを確認済み（#245）
```

## 実装上の判断

- push 成功時に `comment_body` 構築・`gh issue comment` 呼び出しを削除。ログ行は維持してフィールドを拡充する形で実装した（ゼロ情報化ではなく cron ログへの可観測性を確保）
- 失敗パス・ahead==0・unknown 経路は `issue-watcher.sh` の当該行範囲を無変更で維持し、後方互換を確保した

## 確認事項

- base: main / baseRefName: main / OK
- Reviewer 判定（approve）の詳細: `docs/specs/248-bug-watcher-verify-pushed-or-retry-push/review-notes.md`
- 後方互換性: 既存 env var 名（`REPO` / `REPO_DIR` / `LOG` / `NUMBER` 等）・ラベル遷移契約・失敗時 exit code・`claude-failed` escalation・リトライ回数（1 回）・失敗通知コメント書式は本変更前と同一

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)