### PR TITLE
fix(watcher): Stage Checkpoint resume が per-task 残タスクありで Stage A を skip しないよう修正

### DIFF
--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -1182,9 +1182,29 @@ stage_checkpoint_resolve_resume_point() {
   # ここから has_impl=yes 系
   case "$rev_rc" in
     2)
-      # review-notes 不在 or 解釈不能 → Stage B から再実行 (Req 2.3, 4.3)
-      START_STAGE="B"
-      sc_log "decision: START_STAGE=B reason=impl-notes-only-or-review-unparsed" >> "$LOG"
+      # review-notes 不在 or 解釈不能。
+      # #251: per-task ループ未完（tasks.md に残必須タスクあり）の場合は、impl-notes.md が
+      # tracked でも Stage A を再開して残タスクを完了させる。per-task ループ (#21) は task 1
+      # 完了時点で impl-notes.md へ learning を commit するため、これを「Stage A 完了」と
+      # みなして Stage B へ skip すると、残タスク（後続）が永久に未完になり、後続タスクが
+      # 作る成果物（test fixture 等）に依存する stage-a-verify が無限に失敗する（#68 と
+      # #194 hold-resume の衝突）。残必須タスクが無い場合のみ従来どおり Stage B へ skip する。
+      local _sc_tasks_md="$REPO_DIR/$SPEC_DIR_REL/tasks.md"
+      local _sc_pending=""
+      if [ -f "$_sc_tasks_md" ]; then
+        _sc_pending=$(pt_extract_pending_tasks "$_sc_tasks_md" 2>/dev/null || true)
+      fi
+      if [ -n "$_sc_pending" ]; then
+        local _sc_pending_count
+        _sc_pending_count=$(printf '%s\n' "$_sc_pending" | grep -c . 2>/dev/null || echo 0)
+        # shellcheck disable=SC2034
+        START_STAGE="A"
+        sc_log "decision: START_STAGE=A reason=per-task-incomplete (#251: impl-notes.md ありだが tasks.md に残必須タスク ${_sc_pending_count} 件 → Stage A 再開)" >> "$LOG"
+      else
+        # tasks.md 不在（design-less impl）/ 残必須タスク 0 件（完走済み）→ 従来どおり Stage B
+        START_STAGE="B"
+        sc_log "decision: START_STAGE=B reason=impl-notes-only-or-review-unparsed" >> "$LOG"
+      fi
       ;;
     0)
       # approve → Stage C (Req 2.4)

--- a/local-watcher/test/stage_checkpoint_pending_tasks_test.sh
+++ b/local-watcher/test/stage_checkpoint_pending_tasks_test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# 本テストの対象は issue-watcher.sh の pt_extract_pending_tasks（#194 で導入、#251 で
+# stage_checkpoint_resolve_resume_point の Stage A skip 判定にも再利用）。
+# #251 の修正は「resolve が Stage B へ skip する前に pt_extract_pending_tasks で残必須
+# タスクを確認し、残っていれば Stage A を再開する」ものなので、その判定入力である
+# pt_extract_pending_tasks が次を満たすことを fixture で固定する:
+#   - 親タスク完了 + 子/後続タスク未完（#239 の 1/8 状態）→ 残タスクを非空で返す（= Stage A 再開側）
+#   - 全タスク完了 → 空（= 従来どおり Stage B skip 側）
+#   - deferrable（`- [ ]*`）のみ残存 → 空（必須ではないので Stage A 再開しない）
+#
+# 配置先: local-watcher/test/stage_checkpoint_pending_tasks_test.sh
+# 依存:   bash 4+, awk/grep/sed/sort
+# 実行:   bash local-watcher/test/stage_checkpoint_pending_tasks_test.sh
+# shellcheck disable=SC2317
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+extract_function() {
+  local script="$1" fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "pt_extract_pending_tasks")"
+
+if ! declare -F pt_extract_pending_tasks >/dev/null; then
+  echo "ERROR: pt_extract_pending_tasks not loaded" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+assert_nonempty() {
+  local out="$1" label="$2"
+  if [ -n "$out" ]; then echo "  ok: $label（残=$(printf '%s' "$out" | tr '\n' ' ')）"; PASS=$((PASS+1));
+  else echo "  NG: $label（空でない想定だが空）" >&2; FAIL=$((FAIL+1)); fi
+}
+assert_empty() {
+  local out="$1" label="$2"
+  if [ -z "$out" ]; then echo "  ok: $label（残なし）"; PASS=$((PASS+1));
+  else echo "  NG: $label（空想定だが残=$(printf '%s' "$out" | tr '\n' ' ')）" >&2; FAIL=$((FAIL+1)); fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ── ケース 1: task 1 完了 + 後続未完（#239 の 1/8 状態）→ 残あり（Stage A 再開側）──
+cat > "$TMP/partial.md" <<'EOF'
+- [x] 1. run-summary.sh モジュールの新規作成
+- [x] 1.1 骨格
+- [ ] 2. 本体への source 追加
+- [ ] 3. mode 記録差し込み
+- [ ]* 8.1 追加の deferrable テスト
+EOF
+echo "[case1] 親完了 + 後続必須未完（#239 相当）→ 残必須タスクあり"
+assert_nonempty "$(pt_extract_pending_tasks "$TMP/partial.md")" "残必須タスクを検出（Stage A 再開）"
+
+# ── ケース 2: 全タスク完了 → 空（従来どおり Stage B skip 側）──
+cat > "$TMP/done.md" <<'EOF'
+- [x] 1. モジュール作成
+- [x] 1.1 骨格
+- [x] 2. 配線
+- [ ]* 3.1 deferrable テスト
+EOF
+echo "[case2] 全必須完了（deferrable のみ残）→ 残必須なし（Stage B skip 維持）"
+assert_empty "$(pt_extract_pending_tasks "$TMP/done.md")" "全必須完了で空"
+
+# ── ケース 3: deferrable（- [ ]*）のみ残存 → 空（必須扱いしない）──
+cat > "$TMP/deferrable.md" <<'EOF'
+- [x] 1. 実装
+- [ ]* 2. 統合テスト追加（deferrable）
+- [ ]* 3. 追加の fixture（deferrable）
+EOF
+echo "[case3] deferrable のみ残存 → 残必須なし"
+assert_empty "$(pt_extract_pending_tasks "$TMP/deferrable.md")" "deferrable は pending に数えない"
+
+echo ""
+echo "PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -ne 0 ]; then echo "RESULT: FAIL" >&2; exit 1; fi
+echo "RESULT: PASS"


### PR DESCRIPTION
## 概要

Stage Checkpoint resume (#68) が **`impl-notes.md` の tracked 有無だけで「Stage A 完了」と判定**し、tasks.md に残必須タスクがあっても Stage A（per-task ループ）を skip していた問題を修正する。

## 根本原因

- `stage_checkpoint_resolve_resume_point()` は `impl-notes.md` が tracked かつ review-notes 不在のとき `START_STAGE=B`（Stage A skip）を選ぶ。
- per-task ループ (#21) は **task 1 完了時点で impl-notes.md へ learning を commit** する設計。→ partial impl（残タスクあり）でも impl-notes.md が tracked になる。
- 結果、次サイクル以降の impl-resume で Stage A が常に skip され、**per-task ループが残タスク（後続）を完了できない**。後続タスクが作る成果物（test fixture 等）に依存する stage-a-verify が永久に失敗し round=1 ループ（#246）と相まって churn する。
- **#194（per-task hold-resume）と衝突**: per-task ループは「残タスクありなら hold して次サイクルで Stage A 再開」する前提だが、Stage Checkpoint が Stage A を skip するため再開されない。

実例: **#239（8 タスク中 task 1 のみ完了）/ #243（5 タスク中 1 完了）** が task 1 で固着し、毎サイクル `⏭️ Stage A スキップ（Stage Checkpoint resume）` → verify が後続タスクの fixture 不在で失敗（exit 127）→ round=1 ループ。

## 変更内容

- `resolve_resume_point` の `rev_rc=2`（impl-notes-only / review 不在）分岐に **残必須タスク確認 gate** を追加:
  - `pt_extract_pending_tasks`（#194 で既存・deferrable `- [ ]*` を除外）で tasks.md の残必須タスクを抽出。
  - **1 件でも残っていれば `START_STAGE=A`**（per-task ループ再開）。
  - 0 件（全必須完了）/ tasks.md 不在（design-less impl）→ 従来どおり `START_STAGE=B`。
- 回帰テスト `local-watcher/test/stage_checkpoint_pending_tasks_test.sh` を追加（partial→残あり / 全完了→空 / deferrable のみ→空）。

## 後方互換 / 非機能

- **design-less impl（tasks.md 不在）/ 全必須完了の per-task impl は挙動不変**（残必須 0 件 → 従来どおり Stage B）。
- approve（C）/ reject（A）/ TERMINAL_OK / TERMINAL_FAILED の各分岐は不変。本修正は `rev_rc=2`（B）分岐のみに限定。
- `STAGE_CHECKPOINT_ENABLED=false` 明示時の挙動は不変。
- env var 名 / ラベル遷移契約 / exit code / ログ書式の後方互換を維持。

## Test plan

```
$ bash local-watcher/test/stage_checkpoint_pending_tasks_test.sh   # PASS=3 FAIL=0
$ bash -n local-watcher/bin/issue-watcher.sh                       # syntax OK
$ shellcheck local-watcher/bin/issue-watcher.sh                    # 新規警告ゼロ（SC2317 info は main と同数）
```

## 補足（手動 PR の理由）

本 Issue は watcher 本体（resolve_resume_point）の修正であり、auto-dev で watcher に処理させると **修正対象のバグ自身が trap となり完走しない**（chicken-and-egg）懸念があるため、直接 PR とした（#251 の auto-dev ラベルは除去済み）。

## マージ後

`install.sh --local` で `~/bin` 反映後、停止中の **#239 / #243 の `needs-decisions` を外す**と、Stage A（per-task ループ）が再開され残タスクを完了 → fixture 作成 → stage-a-verify 通過 → PR、と進む。

Closes #251

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
