### PR TITLE
feat(#251): Stage Checkpoint resume が残必須タスクありなら START_STAGE=A を選び per-task ループを再開

### DIFF
--- a/README.md
+++ b/README.md
@@ -3229,15 +3229,31 @@ working tree のみに存在する未 commit ファイル / main にしか存在
 |---|---|---|---|---|---|
 | × | × | - | × | A | 通常通り Stage A から実行 |
 | × | ○ | (any) | × | A | INCONSISTENT 検出 → 安全側で Stage A 再実行 |
-| ○ | × | - | × | B | Stage A スキップ → Reviewer から再実行（NFR 3.1） |
-| ○ | ○ | (RESULT 行欠落) | × | B | parse 失敗 → Stage B から再実行 |
+| ○ | × | - | × | A | **tasks.md に残必須タスクあり** → per-task ループ再開（#251） |
+| ○ | × | - | × | B | tasks.md 全タスク完了 / tasks.md 不在 → Reviewer から再実行（NFR 3.1） |
+| ○ | ○ | (RESULT 行欠落) | × | A | **tasks.md に残必須タスクあり** → per-task ループ再開（#251） |
+| ○ | ○ | (RESULT 行欠落) | × | B | tasks.md 全タスク完了 / tasks.md 不在 → Stage B から再実行 |
 | ○ | ○ | `approve` | × | C | Stage A / B スキップ → PjM のみ実行（NFR 3.2） |
 | ○ | ○ | `reject` (round=1) | × | A | 中断と判断、Stage A から再実行（D-3 fallback） |
 | ○ | ○ | `reject` (round=2) | × | TERMINAL_FAILED | `claude-failed` 化して人間に委ねる |
 | (any) | (any) | (any) | ○ | TERMINAL_OK | 自動進行を停止（ラベル不変） |
 
+> **per-task ループ残タスク再開（#251）**: per-task ループ (#21) は task 完了ごとに
+> `impl-notes.md` を commit するため、task 1 完了時点で `impl-notes.md` が tracked になります。
+> 従来は「impl-notes 有 / review-notes 無（または RESULT 行欠落）」を一律 `START_STAGE=B`
+> （Stage A skip）と判定していたため、残タスクがあっても per-task ループが二度と起動せず
+> 残タスクが永久に消化されない不具合がありました。#251 以降は、この **impl-notes 有 /
+> review-notes 無の B 分岐に限って** `tasks.md` の残必須タスク（deferrable `- [ ]*` を除く
+> `- [ ]`）を read-only で確認し、1 件以上残っていれば `START_STAGE=A` を選んで per-task
+> ループを再開します（ログ `reason=pending-tasks-remain count=N`）。全タスク完了済み /
+> `tasks.md` 不在（design-less impl）の場合は従来どおり `START_STAGE=B` のままで、`approve`
+> （C）/ `reject`（round 分岐）系の判定には一切介入しません。`tasks.md` の編集・commit・push
+> は行わない read-only 判定です。
+
 判定根拠は `stage-checkpoint:` prefix のログに 1 ブロックで出力され、
-`grep stage-checkpoint $HOME/.issue-watcher/logs/...` で機械抽出できます。
+`grep stage-checkpoint $HOME/.issue-watcher/logs/...` で機械抽出できます。残必須タスクによる
+Stage A 再開時は `decision: START_STAGE=A reason=pending-tasks-remain count=N` の行で件数まで
+追跡できます。
 
 > **Stage C PR 作成直前の再確認ガード（#212）**: サイクル開始時の上記判定に加え、Stage C が
 > PR 作成へ進む直前にも同一 head ブランチの既存 impl PR を再確認します（`STAGE_CHECKPOINT_ENABLED=true`

--- a/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/impl-notes.md
+++ b/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/impl-notes.md
@@ -1,0 +1,127 @@
+# 実装ノート（Issue #251）
+
+## 概要
+
+Stage Checkpoint resume (#68) の `stage_checkpoint_resolve_resume_point()` が、per-task
+ループ (#21) の途中で `impl-notes.md` が tracked になると、残必須タスクがあっても
+`START_STAGE=B`（Stage A skip）を選び per-task ループが二度と起動しないバグを修正した。
+
+修正は **impl-notes 有 / review-notes 無（`rev_rc=2`）の B 分岐に限定**し、`tasks.md` の
+残必須タスク（deferrable `- [ ]*` を除く `- [ ]`）を read-only で確認して、残っていれば
+`START_STAGE=A`（per-task ループ再開）を選ぶ。`approve`（C）/ `reject`（round 分岐）系の
+判定には一切介入しない（Req 3）。
+
+## 修正内容
+
+### `local-watcher/bin/issue-watcher.sh`
+
+- 関数冒頭の Decision Table コメント（1105-1117 行付近）を tasks.md 残必須タスク有無で
+  分岐する記述へ更新。
+- `case "$rev_rc" in 2)` 分岐（従来 `START_STAGE=B` 固定）を以下のロジックに置換:
+  1. `$REPO_DIR/$SPEC_DIR_REL/tasks.md` が **存在しない**（design-less impl）→ 残タスク判定を
+     スキップし従来どおり `START_STAGE=B`（reason 据え置き `impl-notes-only-or-review-unparsed`）。
+  2. tasks.md が存在する → 既存 `pt_extract_pending_tasks "$sc_tasks_md"` を再利用して残必須
+     タスクを抽出。
+     - 抽出が **内部エラー（rc≠0）** → 安全側で `START_STAGE=A`（reason `pending-extract-error`、
+       `sc_warn` で警告）。`[ -f ]` チェックを先行させているため tasks.md 不在の return 1 とは
+       自然に分離される（NFR 3.1）。
+     - 残必須タスク **1 件以上** → `START_STAGE=A`、`sc_log` で
+       `reason=pending-tasks-remain count=N` を出力（Req 1, Req 5）。
+     - 残必須タスク **0 件** → 従来どおり `START_STAGE=B`（reason 据え置き、Req 2）。
+- 新規 env var は追加していない（既存 `REPO_DIR` / `SPEC_DIR_REL` のみ使用 / NFR 1.2）。
+- read-only 判定のみで tasks.md / impl-notes.md / branch を編集・commit・push しない（NFR 2.2）。
+
+### `README.md`
+
+- 「Stage Checkpoint (#68)」節の Decision Table（impl-notes 有 / review-notes 無の行）を
+  tasks.md 残必須タスク有無で 2 行に分割し、`#251` の残タスク再開挙動を 1 段落で追記。
+- 残必須タスクによる Stage A 再開時のログ書式 `reason=pending-tasks-remain count=N` を明記。
+
+## Migration note の要否判断
+
+本修正は **既定挙動のバグ修正**であり、新規 opt-in / 新規外部サービス呼び出しの追加では
+ない。判定が変わるのは「impl-notes 有 / review-notes 無 / tasks.md に残必須タスクあり」の
+ケースに限定され、従来 `B`（Stage A skip → 残タスク永久未消化）だったものが `A`（per-task
+ループ再開）に正される方向のみ。全タスク完了済み per-task impl / design-less impl（tasks.md
+不在）/ `STAGE_CHECKPOINT_ENABLED=false` 経路は従来と完全に同一の `START_STAGE` を返す
+（NFR 1.1, 1.4）。したがって独立した migration note セクションは不要と判断し、README の
+Decision Table と説明段落で「判定が変わる旨」を明記する形にとどめた（CLAUDE.md「README との
+二重管理」規約に従い同一 PR で README を更新）。
+
+## Test plan
+
+本リポジトリに unit test フレームワークは無いため、静的解析 + スモークテストで検証した。
+
+### 静的解析
+
+- `shellcheck local-watcher/bin/issue-watcher.sh` → 警告ゼロ（SHELLCHECK_CLEAN）
+- `shellcheck docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh`
+  → 警告ゼロ（subshell env 隔離の SC2030/SC2031 は意図的なため局所 disable）
+
+### スモークテスト
+
+`docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh` を
+新規作成。再実装ドリフトを避けるため、`issue-watcher.sh` から実関数定義
+（`stage_checkpoint_*` / `pt_extract_pending_tasks` / `parse_review_result` /
+`extract_review_result_token` / `sc_log` 等）を `sed` で抽出して `source` し、**実関数を直接
+実行**する。git tracked 判定は一時 git repo で実体を作り、`gh pr list` は PATH スタブで
+「PR なし（rc=1）」に固定する。実 repo・branch には一切触れない。
+
+実行結果（全 11 アサーション pass / `SMOKE_RESULT: pass`）:
+
+| ケース | 入力 | 期待 START_STAGE | 結果 |
+|---|---|---|---|
+| 本バグ修正 | impl有 / review無 / 残必須2件 | A | OK |
+| Req5 可観測性 | 同上のログに `reason=pending-tasks-remain count=2` | （ログ一致） | OK |
+| Req2 従来維持 | impl有 / review無 / 全タスク完了 | B | OK |
+| Req2 reason維持 | 全完了時 `reason=impl-notes-only-or-review-unparsed` | （ログ一致） | OK |
+| Req4 design-less | impl有 / review無 / tasks.md不在 | B | OK |
+| NFR3.2 deferrable | `- [ ]*` のみ残（必須0件） | B | OK |
+| Req3.1 approve | approve + 残必須あり | C（介入しない） | OK |
+| Req3.2 reject r2 | reject round=2 + 残必須あり | TERMINAL_FAILED（介入しない） | OK |
+| Req3.3 reject r1 | reject round=1 + 残必須あり | A（既存どおり） | OK |
+| NFR2.1 冪等性 | 同一 HEAD で 3 回呼ぶ | A（毎回同一） | OK |
+| NFR2.2 副作用ゼロ | resolve 前後で HEAD / ファイル / status 不変 | （不変） | OK |
+
+実行コマンド: `./docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh`
+
+### 動作確認（定義順）
+
+`pt_extract_pending_tasks`（2192 行付近）は `stage_checkpoint_resolve_resume_point`（1129 行付近）
+より後方で定義されているが、bash は関数呼び出しを実行時に解決するため定義順は問題ない。
+スモークテストでも実際に呼び出して pass することを確認済み。
+
+## 受入基準とテストの対応
+
+| Req ID | 担保テスト |
+|---|---|
+| Req 1.1 / 1.2 / 1.3 | Case1（impl有/review無/残必須あり → START_STAGE=A）+ run_impl_pipeline の START_STAGE=A 経路で per-task ループ再開（既存 4759-4778 行の分岐に制御を渡す） |
+| Req 2.1 | Case2（全タスク完了 → B）+ reason 維持ログ確認 |
+| Req 2.2 | Case5（approve → C、既存ロジック不変） |
+| Req 3.1 | Case5（approve は残必須あっても C） |
+| Req 3.2 | Case6（reject round=2 は残必須あっても TERMINAL_FAILED） |
+| Req 3.3 | Case7（reject round=1 は既存どおり A） |
+| Req 3.4 | rev_rc=2 分岐のみに介入を限定（実装上、他分岐のコードは未変更）。Case5/6/7 で他分岐不変を確認 |
+| Req 4.1 / 4.2 | Case3（tasks.md 不在 → B） |
+| Req 5.1 / 5.2 | Case1 のログアサート（`stage-checkpoint:` prefix + `count=2` 抽出） |
+| NFR 1.1 | run_impl_pipeline 4730 行の `STAGE_CHECKPOINT_ENABLED=false` gate を確認（本関数を呼ばない経路は不変） |
+| NFR 1.2 | 新規 env var を追加せず実装（コードレビューで担保） |
+| NFR 1.4 | Case2 / Case3（全完了 per-task impl / design-less impl で従来同一 START_STAGE） |
+| NFR 2.1 | Case8（複数回呼び出しで同一 START_STAGE） |
+| NFR 2.2 | Case9（HEAD / ファイル / git status 不変） |
+| NFR 3.1 | 実装の `pending-extract-error → START_STAGE=A` フォールバック（コードレビューで担保）。`[ -f ]` 先行分離により tasks.md 不在の return 1 は Case3 で別途 B に分岐 |
+| NFR 3.2 | Case4（deferrable `- [ ]*` を必須として数えない → 必須0件 → B） |
+
+## 確認事項
+
+- 本 Issue は design-less impl（design.md / tasks.md は本 spec dir に存在しない）。要件の
+  scope（rev_rc=2 分岐限定、Req 3）を厳守した。曖昧点・矛盾は発見していない。
+- `NFR 3.1` の内部エラーフォールバックは、実装上 `pt_extract_pending_tasks` が tasks.md
+  存在時に通常 rc=0 を返すため、スモークテストで自然発火させるのは難しい。`[ -f ]` 先行
+  チェックで tasks.md 不在の return 1 は別経路（Case3=B）に分離済みであり、残る「想定外の
+  内部エラー」は防御的フォールバックとしてコードに明示（`sc_extract_rc != 0 → START_STAGE=A`）。
+  実害のある false negative を避ける安全側設計として、専用 fixture でのエラー注入テストは
+  追加していない（実関数を改変せず注入する手段が無いため）。これは仕様逸脱ではなく
+  防御コードの位置付け。
+
+STATUS: complete

--- a/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/requirements.md
+++ b/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/requirements.md
@@ -1,0 +1,98 @@
+# Requirements Document
+
+## Introduction
+
+Stage Checkpoint resume (#68) は impl 系パイプラインの再開時に、各 Stage の checkpoint 成果物
+（`impl-notes.md` / `review-notes.md` / 既存 impl PR）を観測して `START_STAGE` を 1 つに決定し、
+完了済み Stage の再実行を避ける機能である。現在 `impl-notes.md` が当該 branch HEAD で tracked
+であれば「Stage A 完了」とみなし、`tasks.md` に必須タスクが残っていても Stage A（per-task ループ）
+を skip して `START_STAGE=B`（Reviewer から再実行）を選んでしまう。
+
+per-task ループ (#21) は task 完了ごとに `impl-notes.md` を commit するため、task 1 完了時点で
+`impl-notes.md` が tracked になる。その結果、残タスクがあるのに次サイクル以降は Stage A が常に
+skip され、per-task ループが二度と起動せず残タスクが永久に消化されない。後続タスクが生成する
+成果物（test fixture 等）に依存する stage-a-verify ブロックは永遠に失敗し、round=1 ループ (#246)
+と相まって churn する。本要件は、Stage A を skip する前に `tasks.md` の残必須タスクを確認し、
+残っていれば per-task ループを再開させることで partial impl を完走可能にする。
+
+## Requirements
+
+### Requirement 1: 残必須タスクがある場合の Stage A 再開
+
+**Objective:** As an idd-claude 運用者, I want per-task impl が中断後も残必須タスクを確実に消化できること, so that partial impl が後続サイクルで完走でき churn が止まる
+
+#### Acceptance Criteria
+
+1. While `tasks.md` に必須タスク（deferrable `- [ ]*` を除く `- [ ]`）が 1 件以上残っている場合, the Stage Checkpoint resume shall `impl-notes.md` が tracked であっても `START_STAGE=A` を選ぶ
+2. When 必須タスクが残存し `START_STAGE=A` が選ばれた場合, the Stage Checkpoint resume shall per-task ループを再開させる経路（Stage A 実行）へ制御を渡す
+3. While 必須タスクが残存し `START_STAGE=A` が選ばれた場合, the Stage Checkpoint resume shall `impl-notes.md` の tracked 有無に関わらず残タスク判定を優先する
+
+### Requirement 2: 全タスク完了時の従来 Stage A skip 維持
+
+**Objective:** As an idd-claude 運用者, I want 全タスク完了済みの impl は従来どおり Reviewer から再開されること, so that 完了済み Stage A を不要に再実行しない既存の効率が保たれる
+
+#### Acceptance Criteria
+
+1. When `tasks.md` の必須タスク（deferrable `- [ ]*` を除く `- [ ]`）が 0 件かつ `impl-notes.md` が tracked かつ `review-notes.md` が不在または解釈不能の場合, the Stage Checkpoint resume shall 従来どおり `START_STAGE=B` を選ぶ
+2. When `tasks.md` の必須タスクが 0 件かつ `review-notes.md` の RESULT が `approve` の場合, the Stage Checkpoint resume shall 従来どおり `START_STAGE=C` を選ぶ
+
+### Requirement 3: 介入対象分岐の限定
+
+**Objective:** As an idd-claude 運用者, I want 残タスク確認の介入を impl-notes 有 / review-notes 無（rev_rc=2）の B 分岐に限定すること, so that approve / reject 系の既存判定や TERMINAL_FAILED 契約と衝突しない
+
+#### Acceptance Criteria
+
+1. Where `review-notes.md` の RESULT が `approve` の場合, the Stage Checkpoint resume shall 残必須タスクの有無に関わらず `START_STAGE=C` 判定を変更しない
+2. Where `review-notes.md` の RESULT が `reject` かつ round=2 と判定される場合, the Stage Checkpoint resume shall 残必須タスクの有無に関わらず `START_STAGE=TERMINAL_FAILED` 判定を変更しない
+3. Where `review-notes.md` の RESULT が `reject` かつ round=1 または round 不明と判定される場合, the Stage Checkpoint resume shall 既存どおり `START_STAGE=A` を選ぶ（残タスク確認の追加介入なしで結果が一致する）
+4. The Stage Checkpoint resume shall 残必須タスク確認を impl-notes 有かつ review-notes 不在または解釈不能（従来 `START_STAGE=B` となる）分岐に限って適用し、それ以外の分岐の判定ロジックを変更しない
+
+### Requirement 4: tasks.md 不在（design-less impl）の後方互換
+
+**Objective:** As an idd-claude 運用者, I want tasks.md を持たない design-less impl の挙動が変わらないこと, so that per-task ループを使わない既存ワークフローが影響を受けない
+
+#### Acceptance Criteria
+
+1. Where `tasks.md` が存在しない（design-less impl）場合, the Stage Checkpoint resume shall 残必須タスク判定を行わず従来の `impl-notes.md` ベース判定を維持する
+2. When `tasks.md` が存在せず `impl-notes.md` が tracked かつ `review-notes.md` が不在または解釈不能の場合, the Stage Checkpoint resume shall 従来どおり `START_STAGE=B` を選ぶ
+
+### Requirement 5: 判定根拠の可観測性
+
+**Objective:** As an idd-claude 運用者, I want 残タスク確認による判定分岐がログから追跡できること, so that resume が想定どおり Stage A を選んだか機械抽出で検証できる
+
+#### Acceptance Criteria
+
+1. When 残必須タスクが残存し `START_STAGE=A` を選んだ場合, the Stage Checkpoint resume shall `stage-checkpoint:` prefix で残必須タスクを理由とする判定根拠を 1 行以上ログに出力する
+2. The Stage Checkpoint resume shall 残必須タスク件数を含む判定根拠を `grep stage-checkpoint` で機械抽出できる形式で出力する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While `STAGE_CHECKPOINT_ENABLED=false` が明示指定された場合, the Stage Checkpoint resume shall 本要件導入前と完全に同一の挙動を維持する（残タスク判定を一切行わない）
+2. The Stage Checkpoint resume shall 既存の env var 名（`STAGE_CHECKPOINT_ENABLED` / `SPEC_DIR_REL` / `REPO_DIR` 等）を変更せず新規 env var を追加せずに本判定を実現する
+3. The Stage Checkpoint resume shall 既存のラベル遷移契約・exit code の意味・`stage-checkpoint:` ログ書式を変更しない
+4. When 必須タスクが 0 件の per-task impl または design-less impl を再開した場合, the Stage Checkpoint resume shall 本要件導入前と同一の `START_STAGE` を返す
+
+### NFR 2: 冪等性
+
+1. When 同一 branch HEAD・同一 `tasks.md` 状態に対して resume 判定を複数回実行した場合, the Stage Checkpoint resume shall 毎回同一の `START_STAGE` を返す
+2. The Stage Checkpoint resume shall 残必須タスク判定の過程で `tasks.md` / `impl-notes.md` / 当該 branch に対する破壊的副作用（編集・commit・push・ラベル変更）を行わない
+
+### NFR 3: 堅牢性
+
+1. If 残必須タスク抽出処理が内部エラーで失敗した場合, the Stage Checkpoint resume shall 安全側として `START_STAGE=A`（Stage A 再実行）へフォールバックする
+2. The Stage Checkpoint resume shall 残必須タスク抽出に既存の deferrable 除外規約（`- [ ]*` を必須タスクとして数えない）を適用する
+
+## Out of Scope
+
+- per-task 全 task 完了ゲート (#194) 自体の挙動変更（本要件は resume 時の Stage A 選択のみを対象とし、ループ内の完了判定や ready-for-review 遷移ロジックは変更しない）
+- stage-a-verify gate (#125) / round=1 ループ (#246) のロジック修正（残タスク完走により stage-a-verify の churn は副次的に解消するが、これらの gate 自体は本要件の修正対象ではない）
+- `tasks.md` のタスク抽出規約（deferrable 印 `- [ ]*` の扱い、numeric 階層 ID 認識）の変更
+- design-less impl（tasks.md 不在）に対する新たな verify / 完了判定の導入
+- review-notes が approve / reject を持つ Stage B/C 完了側分岐への残タスク確認の適用（Req 3 で明示的に対象外とする）
+- 既存 impl PR が存在する TERMINAL_OK 分岐の挙動変更
+
+## Open Questions
+
+- なし（Issue 本文および提案修正方針により、介入対象を「impl-notes 有 / review-notes 無（rev_rc=2）の B 分岐」に限定する scope が確定しているため、要件として Req 3 で明示した。review-notes が approve/reject を持つケースへの適用は Out of Scope として除外済み）

--- a/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/review-notes.md
+++ b/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/review-notes.md
@@ -1,0 +1,50 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-26T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-251-impl-bug-watcher-stage-checkpoint-resume-impl
+- HEAD commit: 14d20def52d6ac1a4ac2ca2f7e9b20711e576ecb
+- Compared to: main..HEAD
+
+本 Issue は design-less impl（`design.md` / `tasks.md` は本 spec dir に不在）。CLAUDE.md に
+`## Feature Flag Protocol` 節が存在しないため opt-out 扱いとし、通常の 3 カテゴリ判定のみを実施。
+
+## Verified Requirements
+
+- 1.1 — issue-watcher.sh:1241-1246（rev_rc=2 分岐で残必須タスク 1 件以上 → `START_STAGE=A`）。テスト Case1（impl有/review無/残必須2件 → A）
+- 1.2 — issue-watcher.sh:4796-4815（`case "$START_STAGE" in A)` → `run_per_task_loop` へ制御を渡す既存経路）。START_STAGE=A 解決で per-task ループ再開
+- 1.3 — issue-watcher.sh:1224-1246（rev_rc=2 内で tracked 有無に依らず `[ -f tasks.md ]` → 残タスク抽出を先に評価し優先）。Case1
+- 2.1 — issue-watcher.sh:1249-1250（残必須 0 件 → `START_STAGE=B` + reason 据え置き）。テスト Case2 + reason 維持ログアサート
+- 2.2 — issue-watcher.sh:1254-1257（approve → `START_STAGE=C`、既存ロジック不変）。テスト Case5
+- 3.1 — issue-watcher.sh:1254-1257（rev_rc=0 分岐未変更）。テスト Case5（approve は残必須あっても C）
+- 3.2 — issue-watcher.sh:1259-1265（reject round=2 → TERMINAL_FAILED、未変更）。テスト Case6
+- 3.3 — issue-watcher.sh:1266-1270（reject round=1 → A、未変更）。テスト Case7
+- 3.4 — 介入は rev_rc=2 分岐に限定（diff 上 rev_rc=0 / rev_rc=1 分岐は無変更）。Case5/6/7 で他分岐不変を確認
+- 4.1 — issue-watcher.sh:1223-1227（`[ ! -f tasks.md ]` → 残タスク判定スキップし従来 B）。テスト Case3
+- 4.2 — 同上（design-less impl で従来どおり `START_STAGE=B`）。テスト Case3
+- 5.1 — issue-watcher.sh:1246（`sc_log "decision: START_STAGE=A reason=pending-tasks-remain count=$sc_pending_count"`、`stage-checkpoint:` prefix）。テスト Case1 ログアサート
+- 5.2 — 同上（`count=N` を含み `grep stage-checkpoint` で機械抽出可能）。テスト Case1 ログアサート（`count=2` 一致）
+- NFR1.1 — issue-watcher.sh:4767（`STAGE_CHECKPOINT_ENABLED != true` 時は resolve をスキップ、START_STAGE=A 維持）
+- NFR1.2 — diff 上で新規 env var 追加なし（既存 `REPO_DIR` / `SPEC_DIR_REL` のみ使用）
+- NFR1.3 — `stage-checkpoint:` ログ書式 / exit code / ラベル遷移契約を変更せず（既存 reason 文字列を据え置き）
+- NFR1.4 — 全完了 per-task impl（Case2）/ design-less impl（Case3）で従来同一 START_STAGE
+- NFR2.1 — テスト Case8（同一 HEAD で 3 回呼び同一 START_STAGE=A）
+- NFR2.2 — テスト Case9（resolve 前後で HEAD / ファイル sha1 / git status 不変。read-only 判定）
+- NFR3.1 — issue-watcher.sh:1233-1239（抽出 rc≠0 で安全側 `START_STAGE=A` フォールバック）。`[ -f ]` 先行分離で tasks.md 不在の return 1 は Case3 の B に分離
+- NFR3.2 — `pt_extract_pending_tasks`（issue-watcher.sh:2192-2204）が deferrable `- [ ]*` を除外。テスト Case4
+
+## Findings
+
+なし
+
+## Summary
+
+design-less impl の rev_rc=2（impl-notes 有 / review-notes 無）分岐に限定して残必須タスク
+確認を追加し、残っていれば `START_STAGE=A` で per-task ループを再開する修正。全 numeric ID
+（Req 1-5 / NFR 1-3）が実装とスモークテスト（全 11 アサーション pass）でカバーされ、approve/reject
+系の既存判定・design-less 後方互換・冪等性・副作用ゼロも担保。shellcheck クリーン、README の
+二重管理も同一 PR で更新済み。boundary 逸脱・AC 未カバー・missing test いずれも無し。
+
+RESULT: approve

--- a/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh
+++ b/docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #251 で修正した「Stage Checkpoint resume の rev_rc=2 (impl-notes 有 /
+#       review-notes 無) 分岐における残必須タスク確認」の判定挙動を fixture 付きで
+#       検証するスモークスクリプト。per-task ループ (#21) が task 完了ごとに
+#       impl-notes.md を commit する結果、残タスクがあるのに Stage A が永久 skip される
+#       バグ (#251) の修正を回帰確認する。
+# 配置: docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh
+# 依存: bash 4+, git, grep, sed, sort, wc, sed (関数抽出)
+# セットアップ参照先: docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/impl-notes.md
+#
+# 検証手法:
+#   再実装ドリフトを避けるため、本テストは local-watcher/bin/issue-watcher.sh の
+#   実関数定義（stage_checkpoint_* / pt_extract_pending_tasks / sc_log 等）を sed で
+#   抽出して source し、実関数を直接実行する。git tracked 判定は一時 git repo で実体を
+#   作り、gh CLI 呼び出しは PATH スタブで「PR なし (rc=1)」に固定する。
+#
+# 実行:
+#   ./docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh
+# 出力:
+#   各ケース: `[OK]` / `[NG]` の prefix で 1 行レポート
+#   末尾: `SMOKE_RESULT: pass` / `SMOKE_RESULT: fail`
+# 副作用:
+#   /tmp/sc-resume-XXXX/ に一時 git repo / gh スタブ / 抽出関数ファイルを作成し、
+#   終了時に削除する（実 repo・branch には一切触れない / NFR 2.2）。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER="$SCRIPT_DIR/../../../local-watcher/bin/issue-watcher.sh"
+if [ ! -f "$WATCHER" ]; then
+  echo "ERROR: watcher script not found: $WATCHER" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d /tmp/sc-resume-XXXX)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+# ─── 実関数を issue-watcher.sh から抽出して source する ───
+# `<func>() {` から、列 0 で `}` が現れる行までを 1 ブロックとして抽出する。
+# 抽出対象は本テストが必要とする関数群のみ（自動実行される _dispatcher_run 等は除外）。
+FUNCS_FILE="$WORKDIR/extracted-funcs.sh"
+extract_func() {
+  local fname="$1"
+  # 関数定義開始行から、列 0 の閉じ波括弧までを抽出
+  sed -n "/^${fname}() {/,/^}/p" "$WATCHER"
+}
+{
+  echo '#!/usr/bin/env bash'
+  extract_func "sc_log"
+  extract_func "sc_warn"
+  extract_func "sc_error"
+  extract_func "extract_review_result_token"
+  extract_func "parse_review_result"
+  extract_func "stage_checkpoint_has_impl_notes"
+  extract_func "stage_checkpoint_read_review_result"
+  extract_func "stage_checkpoint_find_impl_pr"
+  extract_func "pt_extract_pending_tasks"
+  extract_func "stage_checkpoint_resolve_resume_point"
+} > "$FUNCS_FILE"
+
+# 抽出健全性チェック: 必須関数が抽出できているか
+for f in sc_log extract_review_result_token parse_review_result stage_checkpoint_has_impl_notes \
+         stage_checkpoint_read_review_result stage_checkpoint_find_impl_pr \
+         pt_extract_pending_tasks stage_checkpoint_resolve_resume_point; do
+  if ! grep -q "^${f}() {" "$FUNCS_FILE"; then
+    echo "ERROR: 関数 $f を issue-watcher.sh から抽出できませんでした" >&2
+    exit 1
+  fi
+done
+
+# shellcheck disable=SC1090
+source "$FUNCS_FILE"
+
+# ─── gh CLI スタブ（既存 impl PR なし = rc=1 に固定） ───
+# stage_checkpoint_find_impl_pr は `gh pr list ...` を呼ぶ。PR なし状態を再現するため
+# 空 JSON 配列を返す（found が空 → return 1）。jq は実体を使う。
+STUB_BIN="$WORKDIR/stub-bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+# テスト用 gh スタブ: pr list は常に空配列（PR なし）を返す
+echo '[]'
+exit 0
+EOF
+chmod +x "$STUB_BIN/gh"
+export PATH="$STUB_BIN:$PATH"
+
+# ─── 一時 git repo セットアップヘルパ ───
+# 各ケースごとに新しい git repo を作り、spec dir に impl-notes.md / review-notes.md /
+# tasks.md を配置して HEAD に commit（= tracked 化）する。引数で各ファイル内容を制御。
+SPEC_REL="docs/specs/251-test/spec"
+
+setup_repo() {
+  # $1=repo dir, $2=impl(yes/no), $3=review内容(空=無), $4=tasks内容(NONE=不在)
+  local repo="$1" impl="$2" review="$3" tasks="$4"
+  rm -rf "$repo"
+  mkdir -p "$repo/$SPEC_REL"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "test"
+  if [ "$impl" = "yes" ]; then
+    printf 'impl notes\nSTATUS: complete\n' > "$repo/$SPEC_REL/impl-notes.md"
+    git -C "$repo" add "$SPEC_REL/impl-notes.md"
+  fi
+  if [ -n "$review" ]; then
+    printf '%s\n' "$review" > "$repo/$SPEC_REL/review-notes.md"
+    git -C "$repo" add "$SPEC_REL/review-notes.md"
+  fi
+  if [ "$tasks" != "NONE" ]; then
+    printf '%s\n' "$tasks" > "$repo/$SPEC_REL/tasks.md"
+    git -C "$repo" add "$SPEC_REL/tasks.md"
+  fi
+  # 何か 1 つは commit する（空 commit でも HEAD を作る）
+  git -C "$repo" commit -q --allow-empty -m "setup" >/dev/null 2>&1
+}
+
+# ─── resolve 実行ヘルパ ───
+# 実関数 stage_checkpoint_resolve_resume_point を呼び、START_STAGE と LOG を返す。
+run_resolve() {
+  local repo="$1"
+  # サブシェルで env を隔離し、START_STAGE を stdout の最終行へ吐く。
+  # env 変更がサブシェル内に閉じるのは意図的（テストケース間の汚染回避）なので
+  # SC2030/SC2031（subshell modification）を抑制する。
+  # shellcheck disable=SC2030,SC2031
+  (
+    export REPO_DIR="$repo"
+    export SPEC_DIR_REL="$SPEC_REL"
+    export REPO="owner/test"
+    export BRANCH="claude/issue-251-test"
+    export NUMBER="251"
+    export LOG="$WORKDIR/run.log"
+    : > "$LOG"
+    START_STAGE="A"
+    stage_checkpoint_resolve_resume_point >/dev/null 2>&1 || true
+    echo "$START_STAGE"
+  )
+}
+
+FAIL=0
+assert_stage() {
+  local desc="$1" repo="$2" expected="$3"
+  local got
+  got=$(run_resolve "$repo")
+  if [ "$got" = "$expected" ]; then
+    echo "[OK] $desc (START_STAGE=$got)"
+  else
+    echo "[NG] $desc (expected=$expected got=$got)"
+    FAIL=1
+  fi
+}
+
+# ログに残タスク理由が出ているか（Req 5: 可観測性）を確認
+assert_log_contains() {
+  local desc="$1" repo="$2" pattern="$3"
+  local log="$WORKDIR/check.log"
+  # shellcheck disable=SC2030,SC2031
+  (
+    export REPO_DIR="$repo" SPEC_DIR_REL="$SPEC_REL" REPO="owner/test"
+    export BRANCH="claude/issue-251-test" NUMBER="251" LOG="$log"
+    : > "$log"
+    START_STAGE="A"
+    stage_checkpoint_resolve_resume_point >/dev/null 2>&1 || true
+  )
+  if grep -qE "$pattern" "$log"; then
+    echo "[OK] $desc (log matched: $pattern)"
+  else
+    echo "[NG] $desc (log missing pattern: $pattern)"
+    echo "----- log -----"; cat "$log"; echo "---------------"
+    FAIL=1
+  fi
+}
+
+echo "=== Issue #251 Stage Checkpoint resume 残必須タスク確認スモーク ==="
+
+# ── fixture 内容 ──
+TASKS_PENDING='- [x] 1. task1 完了
+  - _Requirements: 1.1_
+- [ ] 2. task2 未完了
+  - _Requirements: 1.2_
+- [ ] 2.1 子タスク未完了
+  - _Requirements: 1.3_'
+
+TASKS_ALL_DONE='- [x] 1. task1 完了
+  - _Requirements: 1.1_
+- [x] 2. task2 完了
+  - _Requirements: 1.2_
+- [x] 2.1 子タスク完了
+  - _Requirements: 1.3_'
+
+TASKS_DEFERRABLE_ONLY='- [x] 1. 実装完了
+  - _Requirements: 1.1_
+- [ ]* 1.1 deferrable テスト追加
+  - _Requirements: 1.1_'
+
+REVIEW_APPROVE='# review notes
+RESULT: approve'
+
+REVIEW_REJECT_R2='<!-- idd-claude:review round=2 -->
+# review notes
+RESULT: reject'
+
+REVIEW_REJECT_R1='<!-- idd-claude:review round=1 -->
+# review notes
+RESULT: reject'
+
+# ── Case 1 (本バグ修正): impl有 + review無 + tasks残必須あり → A (Req 1) ──
+R1="$WORKDIR/case1"
+setup_repo "$R1" yes "" "$TASKS_PENDING"
+assert_stage "Req1: impl有/review無/残必須あり → START_STAGE=A" "$R1" "A"
+assert_log_contains "Req5: 残タスク件数を含む判定根拠ログ (count=2)" "$R1" \
+  'stage-checkpoint:.*reason=pending-tasks-remain count=2'
+
+# ── Case 2: impl有 + review無 + tasks全完了 → B (Req 2 従来維持) ──
+R2="$WORKDIR/case2"
+setup_repo "$R2" yes "" "$TASKS_ALL_DONE"
+assert_stage "Req2: impl有/review無/全タスク完了 → START_STAGE=B" "$R2" "B"
+assert_log_contains "Req2: 全完了は従来 reason を維持" "$R2" \
+  'stage-checkpoint:.*reason=impl-notes-only-or-review-unparsed'
+
+# ── Case 3: impl有 + review無 + tasks不在(design-less) → B (Req 4 後方互換) ──
+R3="$WORKDIR/case3"
+setup_repo "$R3" yes "" "NONE"
+assert_stage "Req4: impl有/review無/tasks.md不在 → START_STAGE=B" "$R3" "B"
+
+# ── Case 4: deferrable `- [ ]*` のみ残存 → 必須0件 → B (NFR 3.2) ──
+R4="$WORKDIR/case4"
+setup_repo "$R4" yes "" "$TASKS_DEFERRABLE_ONLY"
+assert_stage "NFR3.2: deferrable のみ残 → 必須0件 → START_STAGE=B" "$R4" "B"
+
+# ── Case 5: approve → C (Req 3.1 介入しない / 残必須あっても C) ──
+R5="$WORKDIR/case5"
+setup_repo "$R5" yes "$REVIEW_APPROVE" "$TASKS_PENDING"
+assert_stage "Req3.1: approve は残必須あっても START_STAGE=C 維持" "$R5" "C"
+
+# ── Case 6: reject round=2 → TERMINAL_FAILED (Req 3.2 介入しない) ──
+R6="$WORKDIR/case6"
+setup_repo "$R6" yes "$REVIEW_REJECT_R2" "$TASKS_PENDING"
+assert_stage "Req3.2: reject round=2 は残必須あっても TERMINAL_FAILED 維持" "$R6" "TERMINAL_FAILED"
+
+# ── Case 7: reject round=1 → A (Req 3.3 既存どおり / 残タスク確認の追加介入なしで一致) ──
+R7="$WORKDIR/case7"
+setup_repo "$R7" yes "$REVIEW_REJECT_R1" "$TASKS_PENDING"
+assert_stage "Req3.3: reject round=1 は既存どおり START_STAGE=A" "$R7" "A"
+
+# ── Case 8 (冪等性 NFR 2.1): 同一 repo HEAD で複数回呼んでも同一 START_STAGE ──
+R8="$WORKDIR/case8"
+setup_repo "$R8" yes "" "$TASKS_PENDING"
+G1=$(run_resolve "$R8"); G2=$(run_resolve "$R8"); G3=$(run_resolve "$R8")
+if [ "$G1" = "A" ] && [ "$G1" = "$G2" ] && [ "$G2" = "$G3" ]; then
+  echo "[OK] NFR2.1: 複数回呼び出しで同一 START_STAGE ($G1=$G2=$G3)"
+else
+  echo "[NG] NFR2.1: 冪等性違反 ($G1 / $G2 / $G3)"
+  FAIL=1
+fi
+
+# ── Case 9 (NFR 2.2 破壊的副作用ゼロ): resolve 前後で tasks.md / impl-notes.md / HEAD 不変 ──
+R9="$WORKDIR/case9"
+setup_repo "$R9" yes "" "$TASKS_PENDING"
+HEAD_BEFORE=$(git -C "$R9" rev-parse HEAD)
+SUM_BEFORE=$(cat "$R9/$SPEC_REL/tasks.md" "$R9/$SPEC_REL/impl-notes.md" | sha1sum)
+STATUS_BEFORE=$(git -C "$R9" status --porcelain)
+run_resolve "$R9" >/dev/null
+HEAD_AFTER=$(git -C "$R9" rev-parse HEAD)
+SUM_AFTER=$(cat "$R9/$SPEC_REL/tasks.md" "$R9/$SPEC_REL/impl-notes.md" | sha1sum)
+STATUS_AFTER=$(git -C "$R9" status --porcelain)
+if [ "$HEAD_BEFORE" = "$HEAD_AFTER" ] && [ "$SUM_BEFORE" = "$SUM_AFTER" ] && [ "$STATUS_BEFORE" = "$STATUS_AFTER" ]; then
+  echo "[OK] NFR2.2: resolve は破壊的副作用なし (HEAD / ファイル / status 不変)"
+else
+  echo "[NG] NFR2.2: 破壊的副作用検出 (HEAD: $HEAD_BEFORE→$HEAD_AFTER)"
+  FAIL=1
+fi
+
+echo "---"
+if [ "$FAIL" -eq 0 ]; then
+  echo "SMOKE_RESULT: pass"
+  exit 0
+else
+  echo "SMOKE_RESULT: fail"
+  exit 1
+fi

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -1106,8 +1106,11 @@ stage_checkpoint_find_impl_pr() {
 #   既存 PR あり                                      → TERMINAL_OK
 #   impl-notes 無 / review-notes 有 (任意)            → A (INCONSISTENT, Req 5.1)
 #   impl-notes 無 / review-notes 無                   → A (Req 2.2)
-#   impl-notes 有 / review-notes 無                   → B (Req 2.3)
-#   impl-notes 有 / review-notes parse 失敗            → B (Req 4.3)
+#   impl-notes 有 / review-notes 無 / tasks.md 残必須あり → A (#251, per-task ループ再開)
+#   impl-notes 有 / review-notes 無 / tasks.md 残必須なし → B (Req 2.3)
+#   impl-notes 有 / review-notes 無 / tasks.md 不在    → B (Req 2.3, design-less impl)
+#   impl-notes 有 / review-notes parse 失敗 / tasks.md 残必須あり → A (#251)
+#   impl-notes 有 / review-notes parse 失敗 / tasks.md 残必須なし → B (Req 4.3)
 #   impl-notes 有 / RESULT=approve                     → C (Req 2.4)
 #   impl-notes 有 / RESULT=reject (round=2 と推定)     → TERMINAL_FAILED (Req 2.5)
 #   impl-notes 有 / RESULT=reject (round=1 と推定)     → A (D-3, INCONSISTENT 扱い)
@@ -1210,9 +1213,43 @@ stage_checkpoint_resolve_resume_point() {
   # ここから has_impl=yes 系
   case "$rev_rc" in
     2)
-      # review-notes 不在 or 解釈不能 → Stage B から再実行 (Req 2.3, 4.3)
-      START_STAGE="B"
-      sc_log "decision: START_STAGE=B reason=impl-notes-only-or-review-unparsed" >> "$LOG"
+      # review-notes 不在 or 解釈不能（従来 Stage B から再実行 / Req 2.3, 4.3）。
+      # ただし per-task ループ (#21) は task 完了ごとに impl-notes.md を commit するため、
+      # task 1 完了時点で impl-notes.md が tracked になる。残必須タスクがあるのに従来
+      # ロジックで Stage B を選ぶと per-task ループが二度と起動せず残タスクが永久に消化
+      # されない（#251）。そこで本 B 分岐に限り tasks.md の残必須タスクを確認し、残って
+      # いれば Stage A（per-task ループ）を再開させる（Req 1, Req 5）。
+      # 介入は本 rev_rc=2 分岐に限定し、approve(C) / reject(round で分岐) には介入しない（Req 3）。
+      local sc_tasks_md="$REPO_DIR/$SPEC_DIR_REL/tasks.md"
+      if [ ! -f "$sc_tasks_md" ]; then
+        # tasks.md 不在（design-less impl）→ 残タスク判定をスキップし従来どおり B（Req 4）。
+        START_STAGE="B"
+        sc_log "decision: START_STAGE=B reason=impl-notes-only-or-review-unparsed" >> "$LOG"
+      else
+        # tasks.md あり → 残必須タスク（deferrable `- [ ]*` を除く `- [ ]`）を抽出（NFR 3.2）。
+        # 内部エラー時は安全側として Stage A へフォールバックさせるため、抽出失敗を捕捉する（NFR 3.1）。
+        local sc_pending sc_extract_rc=0
+        sc_pending=$(pt_extract_pending_tasks "$sc_tasks_md") || sc_extract_rc=$?
+        if [ "$sc_extract_rc" -ne 0 ]; then
+          # pt_extract_pending_tasks は tasks.md 不在で return 1 を返すが、上の [ -f ] で
+          # 分離済みのため、ここに来るのは想定外の内部エラー。安全側で Stage A 再実行（NFR 3.1）。
+          # shellcheck disable=SC2034
+          START_STAGE="A"
+          sc_warn "pending task 抽出失敗 (rc=$sc_extract_rc) → safe fallback: START_STAGE=A" >> "$LOG"
+          sc_log "decision: START_STAGE=A reason=pending-extract-error" >> "$LOG"
+        elif [ -n "$sc_pending" ]; then
+          # 残必須タスクが 1 件以上 → per-task ループ再開のため Stage A を選ぶ（Req 1）。
+          local sc_pending_count
+          sc_pending_count=$(printf '%s\n' "$sc_pending" | wc -l | tr -d '[:space:]')
+          # shellcheck disable=SC2034
+          START_STAGE="A"
+          sc_log "decision: START_STAGE=A reason=pending-tasks-remain count=$sc_pending_count" >> "$LOG"
+        else
+          # 残必須タスク 0 件 → 全タスク完了済み per-task impl は従来どおり Stage B（Req 2）。
+          START_STAGE="B"
+          sc_log "decision: START_STAGE=B reason=impl-notes-only-or-review-unparsed" >> "$LOG"
+        fi
+      fi
       ;;
     0)
       # approve → Stage C (Req 2.4)


### PR DESCRIPTION
## 概要

Stage Checkpoint resume (#68) の `stage_checkpoint_resolve_resume_point()` が、per-task ループ (#21) の途中で `impl-notes.md` が tracked になると、残必須タスクがあっても `START_STAGE=B`（Stage A skip）を選び per-task ループが二度と起動しないバグを修正する。

修正は **impl-notes 有 / review-notes 無（`rev_rc=2`）の B 分岐に限定**し、`tasks.md` の残必須タスク（deferrable `- [ ]*` を除く `- [ ]`）を read-only で確認して、残っていれば `START_STAGE=A`（per-task ループ再開）を選ぶ。`approve`（C）/ `reject`（round 分岐）系の判定および design-less impl（tasks.md 不在）の挙動には一切介入しない。

## 対応 Issue

Closes #251

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

- (Req 1) `rev_rc=2` 分岐に残必須タスク確認を追加し、残っていれば `START_STAGE=A` を選び per-task ループを再開
- (Req 2) 全タスク完了時（必須0件）は従来どおり `START_STAGE=B` を維持（挙動変更なし）
- (Req 3) 介入を `rev_rc=2` 分岐のみに限定し、approve/reject 系の既存判定を変更しない
- (Req 4) `tasks.md` が存在しない design-less impl は残タスク判定をスキップし従来動作を維持
- (Req 5) 残必須タスクを理由とする判定根拠を `stage-checkpoint:` prefix でログ出力し `grep` 抽出可能にする
- (NFR 1-3) 後方互換性・冪等性・堅牢性（抽出エラー時に安全側で `START_STAGE=A` フォールバック）を確保
- `README.md` の「Stage Checkpoint (#68)」節 Decision Table を同一 PR で更新（CLAUDE.md「README との二重管理」規約遵守）

## 受入基準チェック

- [x] Req 1.1: While tasks.md に必須タスクが 1 件以上残っている場合、START_STAGE=A を選ぶ ← Case1（impl有/review無/残必須2件 → A）
- [x] Req 1.2: START_STAGE=A が選ばれた場合、per-task ループ再開経路へ制御を渡す ← issue-watcher.sh:4796-4815（START_STAGE=A → run_per_task_loop）
- [x] Req 1.3: 残タスク判定が impl-notes.md tracked 有無に関わらず優先される ← issue-watcher.sh:1224-1246（[ -f tasks.md ] → 残タスク抽出を先に評価）
- [x] Req 2.1: 必須タスク 0 件かつ impl-notes 有 / review-notes 無なら従来どおり START_STAGE=B ← Case2 + reason 維持ログアサート
- [x] Req 2.2: approve の場合は従来どおり START_STAGE=C ← Case5（approve は残必須あっても C）
- [x] Req 3.1: approve は残必須あっても C（介入しない） ← Case5
- [x] Req 3.2: reject round=2 は残必須あっても TERMINAL_FAILED（介入しない） ← Case6
- [x] Req 3.3: reject round=1 は既存どおり A ← Case7
- [x] Req 3.4: 残必須タスク確認を rev_rc=2 分岐に限定 ← diff で rev_rc=0/1 分岐は無変更
- [x] Req 4.1 / 4.2: tasks.md 不在（design-less impl）は残タスク判定スキップし従来 B ← Case3
- [x] Req 5.1 / 5.2: `stage-checkpoint:` prefix + `count=N` でログ出力、grep 機械抽出可能 ← Case1 ログアサート
- [x] NFR 1.1: `STAGE_CHECKPOINT_ENABLED=false` 時は本判定を一切行わない（既存 gate が先行）
- [x] NFR 2.1 / 2.2: 冪等性（Case8）・副作用ゼロ（Case9）確認済み
- [x] NFR 3.1 / 3.2: 抽出エラー安全側フォールバック・deferrable 除外（Case4）

## テスト結果

```
スモークテスト: docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh
全 11 アサーション pass / SMOKE_RESULT: pass

Case1  impl有/review無/残必須2件 → START_STAGE=A               OK
Case1L reason=pending-tasks-remain count=2 ログ確認             OK
Case2  全タスク完了 → START_STAGE=B                             OK
Case2L reason=impl-notes-only-or-review-unparsed ログ確認       OK
Case3  tasks.md不在（design-less）→ START_STAGE=B               OK
Case4  deferrable-only（必須0件）→ START_STAGE=B                OK
Case5  approve + 残必須あり → START_STAGE=C（介入しない）        OK
Case6  reject round=2 + 残必須あり → TERMINAL_FAILED（介入しない）OK
Case7  reject round=1 + 残必須あり → START_STAGE=A（既存どおり） OK
Case8  冪等性（3回呼んで毎回 START_STAGE=A）                     OK
Case9  副作用ゼロ（HEAD / ファイル / git status 不変）            OK

静的解析:
shellcheck local-watcher/bin/issue-watcher.sh → 警告ゼロ
shellcheck docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/test-stage-checkpoint-resume.sh → 警告ゼロ
```

## 実装上の判断

- 修正を `rev_rc=2` 分岐に限定することで、approve/reject/TERMINAL_FAILED 系の既存判定と完全に分離
- tasks.md 存在確認（`[ -f ]`）を先行させ、不在時は return 1 ではなく自然に `tasks.md 不在` 経路へ分岐させることで NFR 3.1 の安全側フォールバックと design-less 後方互換を両立
- `pt_extract_pending_tasks` は per-task ループ (#21) の既存関数を再利用（deferrable 除外規約 `- [ ]*` を自動適用）
- 新規 env var の追加なし（既存 `REPO_DIR` / `SPEC_DIR_REL` のみ使用、NFR 1.2 準拠）
- README の Decision Table を同一 PR で更新（CLAUDE.md 規約「挙動を変えたら必ず README の該当箇所も同じ PR で更新」）

## 確認事項 / レビュワーへの依頼

- base ブランチ検証: `--base main` 指定 / baseRefName: main / OK（一致）
- Reviewer 判定の詳細: `docs/specs/251-bug-watcher-stage-checkpoint-resume-impl/review-notes.md` を参照
- NFR 3.1 の内部エラーフォールバックは実害のある false negative を避ける安全側設計として専用 fixture なし（impl-notes.md に詳細説明あり）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #251 のコメントを参照してください。