### PR TITLE
fix(#263): per-task Implementer の進捗ゼロ無限ループを検出して claude-failed 化する

### DIFF
--- a/docs/specs/263--bug-per-task-implementer-tasks-md/impl-notes.md
+++ b/docs/specs/263--bug-per-task-implementer-tasks-md/impl-notes.md
@@ -1,0 +1,182 @@
+# Implementation Notes
+
+## 実装サマリ
+
+Issue #263（per-task Implementer が rc=0 で進捗ゼロのまま終了し、次 tick 以降で同じ task を
+無限再 pickup する無限リトライループ）の修正を以下の通り実装した。すべて
+`local-watcher/bin/issue-watcher.sh` 単一ファイルへの変更で完結する。
+
+### 追加した関数
+
+1. **`pt_check_task_completed <tasks_md_path> <task_id>`** (新規 / `issue-watcher.sh` 内)
+   - tasks.md 上で指定 task_id の checkbox 状態を判定し、戻り値で表現する
+   - 戻り値: `0` = `- [x]` 完了 / `1` = `- [ ]` 未完了 / `2` = tasks.md 不在 or 該当行不在
+   - `pt_extract_pending_tasks` の正規表現 `^- \[ \] [0-9]+(\.[0-9]+)*\.? ` と整合し、親
+     （`- [ ] 1. <title>`）/ 子（`- [ ] 1.1 <title>`）両慣習をカバー
+   - `set -euo pipefail` 配下で grep no-match を `2>/dev/null` で吸収し、関数全体を止めない
+   - task_id を sed で正規表現リテラル化し、`1` が `1.1` / `1.10` の prefix に誤マッチしないことを保証
+   - 配置場所: `pt_extract_pending_tasks` の直後（`issue-watcher.sh:2202` 付近）
+
+2. **`pt_mark_no_progress_failed <task_id> <stage_phase> <check_rc>`** (新規 / `issue-watcher.sh` 内)
+   - 進捗ゼロ検出時に `mark_issue_failed "per-task-implementer-no-progress" "<body>"` を流用して
+     `claude-failed` 化する専用ヘルパー（Req 2.1, 2.2 / NFR 1.2 既存ハンドラ流用）
+   - Issue コメント本文に task_id・検出フェーズ（`initial` / `blocked-redo` / `round2-redo` /
+     `round3-redo`）・判定根拠（`pt_check_task_completed` rc）・watcher ログパス・人間向け
+     復旧手順を含める（Req 4.1〜4.5）
+   - watcher ログに grep 可能な 1 行 `pt_log "task=<id> implementer end rc=0 progress=zero
+     phase=<phase> check_rc=<rc> → claude-failed (per-task-implementer-no-progress)"` を出力
+     （Req 4.4, NFR 2.1, 2.2）
+   - 配置場所: `run_per_task_loop` の直前（`issue-watcher.sh:2880` 付近）
+
+### 修正箇所（`run_per_task_loop` 関数内 4 箇所の rc=0 分岐）
+
+`run_per_task_loop()` 関数内の 4 つの `run_per_task_implementer "$task_id"` 呼出直後の
+`impl_rc=0` ケースに、`pt_check_task_completed` を呼んで進捗を機械検証し、未完了なら
+`pt_mark_no_progress_failed` を呼んで `return 1` する分岐を追加（Req 1.3 / 全 4 箇所適用）:
+
+| 呼出位置 | 変数名 | 検出フェーズ識別子 | 旧挙動 | 新挙動 |
+|---|---|---|---|---|
+| round=1 初回実行 | `impl_rc` | `initial` | `0) ;;` で即続行 | rc=0 でも進捗ゼロなら停止 |
+| BLOCKED 経路再実行 | `impl_bl_rc` | `blocked-redo` | `0) ;;` で即続行 | rc=0 でも進捗ゼロなら停止 |
+| Reviewer reject 後再実行 | `impl2_rc` | `round2-redo` | `0) ;;` で即続行 | rc=0 でも進捗ゼロなら停止 |
+| Debugger 経由 3 回目再実行 | `impl3_rc` | `round3-redo` | `0) ;;` で即続行 | rc=0 でも進捗ゼロなら停止 |
+
+#### 後方互換性（NFR 1.1, 1.3 / Req 1.2）
+
+- `PER_TASK_LOOP_ENABLED=true` の場合のみ `run_per_task_loop()` が起動する既存の dispatcher
+  経路に変更はない（`run_impl_pipeline` 側の分岐は無修正）
+- `PER_TASK_LOOP_ENABLED` 未設定 / `true` 以外 / `false` のケースでは、本機能の追加コードは
+  1 行も実行されない（構造的 skip / Req 1.2）
+- 既存 `mark_issue_failed` を流用しており、`claude-claimed` / `claude-picked-up` の除去順序・
+  `claude-failed` 付与・末尾の `build_recovery_hint` 流用も既存挙動と完全一致（NFR 1.2）
+- `rc=99`（quota）/ `rc=非 0`（claude 非 0 exit）の既存経路は変更せず、本検証は rc=0 分岐
+  のみに挿入（Req 1.4）
+
+### 既存 `pt_extract_pending_tasks` 正規表現との整合（Req 3.3）
+
+`pt_check_task_completed` は `pt_extract_pending_tasks` と同じ判定パターン
+（`^- \[[ x]\] <id>\.? `）に依拠する。`- [ ]*` deferrable は両者の判定パターンの「`\[ \]` 直後に
+空白を要求」する仕様により自然に除外されるため、deferrable は per-task ループの dispatch 対象に
+入らず、`pt_check_task_completed` の検証経路にも乗らない（Req 3.3 / Req 5.3 と整合）。
+
+## 検証結果
+
+### Mechanical check
+
+- **`shellcheck local-watcher/bin/issue-watcher.sh`**: 警告ゼロ（exit code 0）。1 箇所
+  `SC2016`（sed 単引用符内のリテラル `\\&`）は意図的な無展開のため `# shellcheck disable=SC2016`
+  ディレクティブで個別抑止
+- **`bash -n local-watcher/bin/issue-watcher.sh`**: syntax error なし（exit code 0）
+
+### 手動スモークテスト
+
+新規 fixture `docs/specs/263--bug-per-task-implementer-tasks-md/test-fixtures/test-pt-check-task-completed.sh`
+を作成し、17 ケース全 pass を確認:
+
+| ケース | 入力 | 期待 rc | 実 rc | 判定 |
+|---|---|---|---|---|
+| 親タスク `- [x] 1.` | task_id=1 | 0 | 0 | PASS |
+| 親タスク `- [ ] 2.` | task_id=2 | 1 | 1 | PASS |
+| 不在 task_id=9 | (該当行なし) | 2 | 2 | PASS |
+| 子タスク `- [x] 1.1` | task_id=1.1 | 0 | 0 | PASS |
+| 子タスク `- [ ] 1.2` | task_id=1.2 | 1 | 1 | PASS |
+| 子タスク `- [ ] 1.10` | task_id=1.10 (2 桁) | 1 | 1 | PASS |
+| 1.1 prefix の誤マッチ防止 | task_id=1.1, 1.10 が `- [x]` | 1 | 1 | PASS |
+| tasks.md 不在 | (ファイルなし) | 2 | 2 | PASS |
+| deferrable `- [ ]* 3.1` | task_id=3.1 | 2 | 2 | PASS |
+| 空 tasks.md | (空ファイル) | 2 | 2 | PASS |
+| 実際的な親 + 子 + deferrable mix | 6 task | 各期待値 | 一致 | 6/6 PASS |
+
+実行: `bash docs/specs/263--bug-per-task-implementer-tasks-md/test-fixtures/test-pt-check-task-completed.sh`
+→ `PASS=17 FAIL=0`
+
+### 既存テストとの整合性
+
+`pt_extract_pending_tasks` の regex 動作（`1`, `1.1`, `1.10` を抽出、`- [x]` 完了行 / `- [ ]*`
+deferrable 行を除外）が変更されていないことを `/tmp/regex-cross-check.sh` で確認。本機能は
+`pt_extract_pending_tasks` の出力を変更しないため、既存 per-task ループの dispatch 対象は
+不変（Req 3.4 / NFR 1.1）。
+
+## 受入基準のテスト割当
+
+| Req ID | 内容 | テスト割当 |
+|---|---|---|
+| 1.1 | rc=0 直後の `- [ ] → - [x]` 機械検証 | `test-pt-check-task-completed.sh` 全 17 ケース |
+| 1.2 | `PER_TASK_LOOP_ENABLED` 未設定 / false 時 1 行も実行しない | 構造的 skip。`run_per_task_loop()` が呼ばれない経路で本機能のコードは到達不能（コードレビューで担保） |
+| 1.3 | 全 4 箇所（initial / blocked-redo / round2-redo / round3-redo）に適用 | コードレビューで担保（4 箇所の `case "$impl*_rc"` 0) 分岐に `pt_check_task_completed` 呼出を挿入したことを diff で確認可能） |
+| 1.4 | rc=99 / 非 0 終了時は本検証を skip | コードレビューで担保（既存 `99)` / `*)` 分岐は無修正） |
+| 2.1 | 進捗ゼロ検出時に `claude-failed` 化 | `pt_mark_no_progress_failed` が `mark_issue_failed` を流用（実装ロジック） |
+| 2.2 | ラベル付け替え（picked-up / claimed 除去 + failed 付与） | `mark_issue_failed` 流用で既存挙動と等価（NFR 1.2） |
+| 2.3 | 進捗ゼロ検出時に per-task ループ即時打ち切り | 4 箇所すべてで `return 1` |
+| 2.4 | Reviewer / PR / ready-for-review / Stage A 完了ゲートを起動しない | `return 1` により後続経路に到達しない（構造的） |
+| 2.5 | 同一実行に対し二重発火しない | 1 回の `case` 0) 分岐内で 1 度だけ判定 + 1 度だけ `mark_issue_failed`、`return 1` で即離脱 |
+| 3.1 | 進捗ありの正常系（`- [x]` 遷移済み）は本機能導入前と同一経路 | `pt_check_task_completed` rc=0 時の処理: 旧来通り続行（diff 範囲外） |
+| 3.2 | 後段 Reviewer / Debugger Gate / Stage A 完了ゲートの起動タイミングを変更しない | コードレビューで担保（rc=0 分岐に検証を追加したのみで rc=99 / 非 0 / Reviewer 経路に変更なし） |
+| 3.3 | `- [ ]*` deferrable は検証対象外 | `pt_extract_pending_tasks` regex で除外されているため per-task ループの dispatch 対象に入らない（fixture でも検証） |
+| 3.4 | 判定単位は当該 round の task_id 1 件 | `pt_check_task_completed` は単一 task_id を引数に取り他 task に依存しない |
+| 4.1 | Issue コメント本文に task_id 識別文字列 | `pt_mark_no_progress_failed` 本文に `対象 task ID: \`${task_id}\`` |
+| 4.2 | Issue コメント本文に進捗ゼロ説明文 | `pt_mark_no_progress_failed` 本文に「rc=0 で終了したが `- [ ] → - [x]` 遷移が確認できなかった」旨を記載 |
+| 4.3 | Issue コメント本文に自動再開停止旨 + watcher ログパス参照 | `pt_mark_no_progress_failed` 本文に `ログ: \`$LOG\`` および無限ループ防止旨を記載 |
+| 4.4 | watcher ログに grep 可能な 1 行 | `pt_log "task=<id> implementer end rc=0 progress=zero phase=<phase> check_rc=<rc>"` を出力 |
+| 4.5 | Issue コメントに人間向け復旧手順 | `pt_mark_no_progress_failed` 本文に「次の手順」セクション + 既存 `build_recovery_hint` 流用 |
+| 4.6 | 新規 stage 識別子 `per-task-implementer-no-progress` | `mark_issue_failed "per-task-implementer-no-progress" ...` で既存 stage 識別子と区別可能 |
+| 5.1 | 1 回の Implementer 呼出に対し 1 回判定 | `case "$impl*_rc"` 0) 分岐内で 1 回だけ呼出（4 箇所すべて） |
+| 5.2 | `claude-failed` 既付与 Issue は再 pickup しない | 既存ラベル除外条件（変更なし） |
+| 5.3 | tasks.md 読取失敗時は claude-failed で停止 | `pt_check_task_completed` rc=2 (tasks.md 不在 / 該当行不在) → `pt_mark_no_progress_failed` 呼出 |
+| NFR 1.1 | `PER_TASK_LOOP_ENABLED` 無効時に既存挙動を維持 | 構造的 skip（`run_per_task_loop` が呼ばれない） |
+| NFR 1.2 | 既存失敗ハンドラを流用 | `mark_issue_failed` を引数違いで呼ぶのみ |
+| NFR 1.3 | 既存 Reviewer reject / Debugger Gate / Stage A 完了ゲートの判定ロジックを変更しない | 変更なし（rc=0 分岐に新検証を追加したのみ） |
+| NFR 2.1 | 新規 stage 識別子 `per-task-implementer-no-progress` で区別可能 | 既存識別子 (`per-task-implementer-failed` 等) と異なる文字列 |
+| NFR 2.2 | per-task ロガー既存書式 (`task=<id> implementer end ...`) と整合 | `pt_log "task=${task_id} implementer end rc=0 progress=zero phase=..."` で整合 |
+| NFR 3.1 | grep / read 高々 2 回 | 実際は 1 回の Implementer 呼出に対し `pt_check_task_completed` 内 grep 高々 2 回（完了 → 未完了の順序）+ 実行前 grep は呼ばない設計（実行後のみで判定可能） |
+
+> 注: 実装では「実行前 / 実行後」の 2 回 grep ではなく **実行後 1 回のみ** の grep で
+> 判定している。これは「実行前に `- [ ]` 行が存在し、実行後に `- [x]` で同じ行が出ていれば
+> 完了」という素朴な diff 比較ではなく、「実行後の最終状態が `- [x]` か `- [ ]` か」を
+> 直接判定するアプローチに簡素化したため。Implementer 実行前後で tasks.md 上の当該行が
+> 完全に消える / 別 ID に置換されるケースは spec 外であり、本実装の判定で十分（NFR 3.1
+> の「高々 2 回」要件を 1 回に圧縮）。
+
+## 後方互換性の確認
+
+- **`PER_TASK_LOOP_ENABLED=false` / 未設定**: `run_per_task_loop()` 自体が呼ばれず、Stage A は
+  既存の単一 Developer 経路で動作する。本機能のコードは 1 行も実行されない（Req 1.2 / NFR 1.1）
+- **既存 `mark_issue_failed` の挙動**: 変更なし。本機能は同関数を新しい stage 識別子で呼ぶだけ
+- **既存 `pt_log` の書式**: 変更なし。本機能は同関数を `task=<id> implementer end ...` 書式で呼ぶ
+- **`pt_extract_pending_tasks` の出力**: 変更なし。同関数は本機能で参照しない
+- **ラベル遷移契約**: `claude-claimed` / `claude-picked-up` 除去 + `claude-failed` 付与の順序は
+  既存 `mark_issue_failed` の挙動そのまま
+- **env var 名 / cron 登録文字列 / exit code 意味**: 一切変更なし
+
+## 確認事項（PR レビュワーへ）
+
+- 進捗検証の判定タイミングを「実行後 1 回のみ」に簡素化した（NFR 3.1 の「高々 2 回」を満たす）。
+  仕様上は「実行前 + 実行後」の 2 回判定でも構わないが、実行後の最終状態だけで未完了 / 完了
+  が判定できるため、実行前の grep は冗長と判断した。問題があれば指摘されたい
+- `pt_check_task_completed` の戻り値 `2`（該当行不在）は要件 5.3「tasks.md 読取失敗時の fail-safe」
+  と「該当 task_id 行不在の防御」を両方含む。tasks.md 自体が存在しないケースは
+  `run_per_task_loop()` 冒頭で防御済みのため、戻り値 2 が実発火するのは spec 不整合（tasks.md
+  に該当 task_id 行が無いのに per-task ループに dispatch されたケース）に限られる。この場合も
+  「fail-safe で claude-failed 化」する方針で実装した（Req 5.3）
+- Issue コメント本文に含めた「検出フェーズ」（`initial` / `blocked-redo` / `round2-redo` /
+  `round3-redo`）は要件で明示されていないが、運用者がどの round で進捗ゼロが発生したかを
+  把握しやすくする観測性向上のため追加した（NFR 2.1 / 2.2 の趣旨に沿うと判断）
+
+## Reviewer への引き継ぎメモ
+
+- 変更箇所の意図: per-task ループの **rc=0 分岐に限定** して進捗検証フックを挿入したため、
+  既存の rc=99（quota）/ rc=非 0（claude 非 0 exit）経路には一切手を加えていない。Reviewer は
+  diff の 4 箇所 (`case "$impl_rc"` / `case "$impl_bl_rc"` / `case "$impl2_rc"` / `case "$impl3_rc"`)
+  すべてで `0)` ブロック内に `pt_check_task_completed` + `pt_mark_no_progress_failed` 呼出が
+  挿入されていることを確認してほしい
+- 新規ヘルパー 2 関数 (`pt_check_task_completed` / `pt_mark_no_progress_failed`) は既存の
+  `pt_log` / `mark_issue_failed` を流用しており、独自に副作用を持たない
+- 既存の `pt_mark_diff_range_resolve_failed`（Issue #164 由来）は重複コメント抑制機能を持つが、
+  本機能の `pt_mark_no_progress_failed` は「進捗ゼロ検出は 1 回の rc=0 分岐に対し 1 回しか
+  発火しない」（Req 2.5 / 5.1）ため重複コメント抑制ロジックを持たない。同一 Issue が複数 tick に
+  またがって持ち越されるケースは `claude-failed` ラベル除外条件で既存仕組みが捕捉する（Req 5.2）
+- fixture テスト `test-pt-check-task-completed.sh` は `awk` で関数本体だけを抽出して `eval` で
+  局所評価する方式。`source` で `issue-watcher.sh` 全体を読み込むと main 実行ロジックが走って
+  しまうため避けた。本 fixture は POSIX-bash 4+ 環境で完全動作する
+
+STATUS: complete

--- a/docs/specs/263--bug-per-task-implementer-tasks-md/requirements.md
+++ b/docs/specs/263--bug-per-task-implementer-tasks-md/requirements.md
@@ -1,0 +1,177 @@
+# Requirements Document
+
+## Introduction
+
+`PER_TASK_LOOP_ENABLED=true` のとき、per-task Implementer が編集失敗（置換競合・コンパイル
+エラー等）を解消できないまま **rc=0（正常終了扱い）で終了**することがある。現状の per-task
+ループは `impl_rc=0` を「続行 OK」として無条件に Reviewer フェーズへ流す設計のため、対象 task
+の checkbox（`tasks.md` 上の `- [ ] <task_id>`）が `- [x]` に更新されたかを **実行直後に検証
+していない**。
+
+進捗ゼロのまま rc=0 で抜けた場合、後段の Stage A 完了ゲート（必須未完了 task が残ったら
+resumable return 0 で抜ける経路）が「中断扱い」で `claude-picked-up` を除去して Issue を
+再 pickup 可能状態に戻すため、次 tick の dispatcher が同じ Issue を再選択 → impl-resume が
+同じ task を再開 → 同じ失敗を rc=0 で返す、という **無限リトライループ** が成立する。本ループは
+API quota とログ容量を浪費し続けるため、運用上 high severity の不具合である（Issue #263）。
+
+本要件は、per-task Implementer が rc=0 を返した直後に「今回の task_id 実行で当該 task が
+`- [ ] → - [x]` に遷移したか」を検証し、進捗ゼロを検出したら無限ループに入る前に
+`claude-failed` で停止させることをスコープとする。影響範囲は per-task ループ内の Implementer
+rc=0 分岐のみで、Implementer 自身の編集失敗対策・Debugger Gate の挙動変更・通常 Stage A 経路
+（PER_TASK_LOOP_ENABLED 無効時）の変更は本要件のスコープ外とする。
+
+## Requirements
+
+### Requirement 1: 進捗検証の発火条件
+
+**Objective:** As an idd-claude harness operator, I want per-task Implementer が rc=0 を返した
+直後に対象 task の進捗を機械検証する仕組みを導入したい, so that 編集失敗のまま正常終了した
+Implementer によって無限リトライループに陥ることを防げる。
+
+#### Acceptance Criteria
+
+1. When `PER_TASK_LOOP_ENABLED=true` かつ per-task Implementer が rc=0 で終了したとき, the Issue
+   Watcher shall 当該 task_id について `tasks.md` 上の checkbox が実行前に `- [ ]` であった行を
+   実行後に `- [x]` へ遷移させたかを検証する。
+2. While `PER_TASK_LOOP_ENABLED` が未設定または `true` 以外であるとき, the Issue Watcher shall
+   本検証ロジックを 1 行も実行せず、本機能導入前と完全に同一の挙動を維持する。
+3. The Issue Watcher shall 本検証を per-task ループ内のすべての Implementer 呼出（round=1 初回
+   実行・Reviewer reject 後の round=2 用再実行・Debugger 経由 round=3 用再実行・BLOCKED 経路
+   再実行）の rc=0 分岐に適用する。
+4. If per-task Implementer が rc=99（quota 超過）または rc=非 0（claude 非 0 exit）で終了した
+   とき, the Issue Watcher shall 本検証ロジックをスキップし、既存の quota 早期 return 経路 /
+   既存の Implementer 失敗経路をそのまま実行する。
+
+### Requirement 2: 進捗ゼロ検出時の処理
+
+**Objective:** As an idd-claude harness operator, I want 進捗ゼロが検出された Issue を即座に
+`claude-failed` 状態にして自動リトライを停止させたい, so that 同じ task で同じ失敗を繰り返す
+無限ループによる API 浪費・ログ汚染を未然に止められる。
+
+#### Acceptance Criteria
+
+1. If per-task Implementer rc=0 終了後に対象 task_id の checkbox が `- [ ]` のまま遷移していな
+   いことを検出したとき, the Issue Watcher shall 当該 Issue を `claude-failed` 化する失敗
+   ハンドラを起動する。
+2. When 進捗ゼロが検出されたとき, the Issue Watcher shall 当該 Issue から `claude-picked-up` /
+   `claude-claimed` ラベルを除去し `claude-failed` ラベルを付与する（既存失敗ハンドラの挙動と
+   等価）。
+3. When 進捗ゼロが検出されたとき, the Issue Watcher shall per-task ループを直ちに打ち切り、
+   残りの未完了 task を処理しない。
+4. When 進捗ゼロが検出されたとき, the Issue Watcher shall 後続の Reviewer 起動・PR 作成・
+   ready-for-review 遷移・Stage A 完了ゲートをいずれも実行しない。
+5. The Issue Watcher shall 進捗ゼロ検出 1 回ごとに `claude-failed` 化処理を高々 1 回だけ実行し
+   （同一 task の同一実行に対して二重発火しない）、Issue コメントを高々 1 件投稿する。
+
+### Requirement 3: 正常系（進捗ありの場合）の非干渉
+
+**Objective:** As an idd-claude harness operator, I want 進捗ありの正常系では本機能導入前と
+完全に同一の挙動を維持したい, so that 既存 per-task ループの安定動作と後段（Reviewer / Debugger
+Gate / Stage A 完了ゲート）に対する副作用を一切持ち込まない。
+
+#### Acceptance Criteria
+
+1. When per-task Implementer rc=0 終了後に対象 task_id の checkbox が `- [x]` に遷移している
+   ことが確認できたとき, the Issue Watcher shall 本機能導入前と同一の続行経路（Debugger Gate
+   判定 → Reviewer round=1 起動）へ流れる。
+2. The Issue Watcher shall 本検証によって既存の Reviewer 起動条件・Debugger Gate 起動条件・
+   Stage A 完了ゲート（必須未完了 task 残存時の resumable return 0 経路）の発火タイミングを
+   変更しない。
+3. While 対象 task が `- [ ]*`（deferrable テストタスク）として記述されているとき, the Issue
+   Watcher shall 本検証の対象外として扱い、既存挙動と同一に動作する（既存 pending 判定パターン
+   が `- [ ]*` を除外していることと整合する）。
+4. The Issue Watcher shall 進捗検証の判定単位を「当該 round で実行した task_id 1 件」に限定し、
+   同一 Issue 内の他 task の checkbox 状態に依存しない判定を行う。
+
+### Requirement 4: Issue コメントとログ出力
+
+**Objective:** As an idd-claude operator, I want 進捗ゼロで停止した Issue を確認したときに、
+どの task で何が起きて自動再開が停止されたのかをコメントとログから即座に把握したい, so that
+人間が手動で原因を調査し復旧操作（編集失敗の修正 → `claude-failed` 除去）を判断できる。
+
+#### Acceptance Criteria
+
+1. When 進捗ゼロ検出により `claude-failed` 化されるとき, the Issue Watcher shall Issue コメント
+   本文に対象 task_id を識別可能な固定文字列として含める。
+2. When 進捗ゼロ検出により `claude-failed` 化されるとき, the Issue Watcher shall Issue コメント
+   本文に「per-task Implementer が rc=0 で終了したが対象 task の `- [ ]` → `- [x]` 遷移が確認
+   できなかった」旨の説明文を含める。
+3. When 進捗ゼロ検出により `claude-failed` 化されるとき, the Issue Watcher shall Issue コメント
+   本文に無限リトライループ防止のため自動再開を停止した旨と、人間が確認すべき watcher
+   ログファイルパスへの参照を含める。
+4. When 進捗ゼロ検出により `claude-failed` 化されるとき, the Issue Watcher shall watcher ログ
+   に対象 task_id・検出時刻・判定根拠（実行前後の checkbox 状態または進捗ゼロ判定）が grep
+   可能な形で記録される 1 行以上のログ行を出力する。
+5. The Issue Watcher shall Issue コメントに人間向け復旧手順（修正 commit を積んで `claude-failed`
+   を外す）を含める（既存失敗ハンドラの末尾セクション流用で満たしてよい）。
+6. The Issue Watcher shall 進捗ゼロ検出による `claude-failed` 化を、watcher ログ・Issue コメント
+   上で `per-task-implementer-no-progress` という新規 stage 識別子により、既存の per-task
+   失敗種別（claude 非 0 exit / Reviewer reject 由来）と区別可能にする。
+
+### Requirement 5: 冪等性と再起動耐性
+
+**Objective:** As an idd-claude harness operator, I want 同じ Issue が複数 tick にまたがって
+評価される場合でも進捗検証が冪等に動作することを保証したい, so that 部分的なネットワーク
+断・watcher 再起動・slot 切り替えによって不整合（二重 `claude-failed` 化、コメント重複等）が
+発生しない。
+
+#### Acceptance Criteria
+
+1. The Issue Watcher shall 進捗検証を「1 回の per-task Implementer 呼出に対して 1 回」実行し、
+   同一呼出に対する再評価を行わない。
+2. When 進捗ゼロが検出された Issue が `claude-failed` ラベル付与済の状態で次 tick に持ち越された
+   とき, the Issue Watcher shall 既存の `claude-failed` 除外条件により当該 Issue を再 pickup
+   しない。
+3. If 進捗検証の実行中に `tasks.md` の読み取りに失敗したとき, the Issue Watcher shall 無限
+   ループ防止を優先し、`claude-failed` 化して停止する（silent fail で resumable return 0 に
+   倒してはならない）。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While `PER_TASK_LOOP_ENABLED` 環境変数が未設定または `true` 以外であるとき, the Issue
+   Watcher shall 本機能を構造的に skip し、既存の単一 Developer 経路（Stage A 通常パス）の
+   外形挙動を 1 行も変更しない。
+2. The Issue Watcher shall 既存の失敗ハンドラ（ラベル付け替え順序・Issue コメント本文の末尾
+   復旧手順セクション）の振る舞いを変更せず、流用のみで本機能を実装できる形を保つ。
+3. The Issue Watcher shall 既存の per-task Reviewer reject 経路・Debugger Gate 起動経路・
+   Stage A 完了ゲート（必須未完了 task 残存時 resumable return 0）の判定ロジックを変更しない。
+
+### NFR 2: 観測性
+
+1. The Issue Watcher shall 本機能による `claude-failed` 化を `per-task-implementer-no-progress`
+   という新規 stage 識別子で記録し、既存の `per-task-implementer-failed` /
+   `per-task-implementer-redo-failed` / `per-task-implementer-blocked-redo-failed` /
+   `per-task-implementer-pp-failed` とログ・コメント上で区別可能にする。
+2. The Issue Watcher shall watcher ログに per-task ロガーの既存書式（`task=<id> implementer
+   end ...` と整合する形式）で進捗ゼロ判定結果を記録する。
+
+### NFR 3: 性能
+
+1. The Issue Watcher shall 進捗検証の実行コストを「1 回の per-task Implementer 呼出に対して
+   `tasks.md` の grep / read を高々 2 回（実行前 + 実行後）」に抑える。
+
+## Out of Scope
+
+- Implementer 自身が編集失敗（置換競合・コンパイルエラー等）を起こさないようにする改善
+  （Implementer prompt の改修・編集リトライ機構の導入等）は本要件のスコープ外。本要件は
+  「Implementer が編集失敗から復旧できなかった事実を検知して自動停止する」ことに限定する。
+- Debugger Gate の動作変更（BLOCKED 経路・round=3 経路の流れの変更）は対象外。本要件は
+  Debugger Gate の前後に位置する Implementer rc=0 分岐に検証を挿入することのみを範囲とする。
+- 通常 Stage A 経路（`PER_TASK_LOOP_ENABLED` 未設定・`false` 時の単一 Developer 経路）の進捗
+  検証は対象外。当該経路は task ごとの粒度を持たないため別設計が必要。
+- Reviewer の reject 判定ロジック・Stage B（PR 作成）・Stage C（PR 確認）の挙動変更は対象外。
+- 既存 `partial_blocked` / `partial_overrun` 経路（#148）との統合は対象外。本要件は Developer
+  が status 出力をしない「進捗ゼロのまま rc=0」ケースを扱う。
+- 進捗ゼロ検出後の自動リトライ・自動 fallback・自動 Architect 差し戻しは対象外
+  （`claude-failed` で人間判断に委ねる）。
+
+## Open Questions
+
+- なし（Issue #263 本文と既存実装（per-task ループ / pending task 抽出 / 失敗ハンドラ /
+  Stage A 完了ゲート）から要件を確定可能と判断した）。
+
+## 関連
+
+- Related: #263

--- a/docs/specs/263--bug-per-task-implementer-tasks-md/review-notes.md
+++ b/docs/specs/263--bug-per-task-implementer-tasks-md/review-notes.md
@@ -1,0 +1,75 @@
+# Review Notes (Round 1)
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-28T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-263-impl--bug-per-task-implementer-tasks-md
+- HEAD commit: 93a6ecc109471b0971595a9a6dd8e051d8d95342
+- Compared to: main..HEAD
+- 差分規模: 4 files changed, +667/-4
+  - `local-watcher/bin/issue-watcher.sh`: +175/-4（`pt_check_task_completed` 新規 / `pt_mark_no_progress_failed` 新規 / 4 箇所の `case "$impl*_rc" 0)` 分岐に進捗検証フック挿入）
+  - `docs/specs/263--.../{requirements.md,impl-notes.md}`: spec ドキュメント
+  - `docs/specs/263--.../test-fixtures/test-pt-check-task-completed.sh`: 17 ケースの fixture テスト
+- Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節は **不在** のため opt-out（flag 観点判定は適用しない）
+
+## Summary
+
+`PER_TASK_LOOP_ENABLED=true` 配下で per-task Implementer が rc=0 を返したにもかかわらず対象 task の checkbox を `- [ ] → - [x]` に遷移させていないケースを検出して `claude-failed` 化する修正。`local-watcher/bin/issue-watcher.sh` 単一ファイルへの変更で完結し、4 箇所すべての rc=0 分岐（initial / blocked-redo / round2-redo / round3-redo）に検証フックが対称に挿入されている。fixture テスト 17 ケース全 pass、`shellcheck` exit 0 を再現確認した。requirements.md の全 numeric AC (1.1〜1.4, 2.1〜2.5, 3.1〜3.4, 4.1〜4.6, 5.1〜5.3, NFR 1.1〜3.1) は実装または既存ハンドラ流用で裏打ちされている。
+
+## Verified Requirements
+
+- **1.1** — `pt_check_task_completed` (issue-watcher.sh:2227-2252) が `- [x]` / `- [ ]` を grep で判定。fixture 17 ケースで遷移検証
+- **1.2** — `PER_TASK_LOOP_ENABLED` 未設定 / `true` 以外時に `run_per_task_loop` 自体が呼ばれない既存 dispatcher 経路は無修正（構造的 skip）
+- **1.3** — 4 箇所の rc=0 分岐すべてに検証フック挿入を diff で確認: initial (3040-3056), blocked-redo (3112-3125), round2-redo (3154-3167), round3-redo (3213-3228)
+- **1.4** — rc=99 / 非 0 分岐は diff で変更なし。検証フックは `0)` 分岐内に閉じている
+- **2.1, 2.2** — `pt_mark_no_progress_failed` が `mark_issue_failed "per-task-implementer-no-progress" ...` を呼出。`mark_issue_failed` (issue-watcher.sh:4713-4714) で claude-claimed / claude-picked-up 除去 + claude-failed 付与
+- **2.3, 2.4** — 4 箇所すべてで helper 呼出後 `return 1` により per-task ループ即時打ち切り。後続 Reviewer / PR / ready-for-review に到達しない
+- **2.5** — 1 つの rc=0 case 分岐内で `pt_mark_no_progress_failed` を高々 1 回呼出 + 即 `return 1`
+- **3.1** — `_pt_check_rc=0`（完了）ケースは検証フック内で何もせず既存続行経路に流れる
+- **3.2** — 検証フックは rc=0 分岐内に閉じており、Reviewer / Debugger Gate / Stage A 完了ゲートの判定ロジックに変更なし
+- **3.3** — `pt_check_task_completed` の判定パターン `^- \[[ x]\] <id>\.? ` は `- [ ]*` deferrable を「`\[ \]` 直後の空白要求」で除外。fixture でも rc=2 と確認
+- **3.4** — 判定単位は単一 task_id 引数のみで他 task に依存しない
+- **4.1** — Issue コメント本文に `対象 task ID: \`${task_id}\`` を含む (issue-watcher.sh:2972)
+- **4.2** — 「rc=0 で終了したが `- [ ]` → `- [x]` 遷移が確認できなかった」旨を本文に記載 (2979-2980)
+- **4.3** — 「自動再開を停止しました」+ `ログ: \`$LOG\`` の参照を含む (2974, 2982-2983)
+- **4.4** — `pt_log "task=${task_id} implementer end rc=0 progress=zero phase=${stage_phase} check_rc=${check_rc} → claude-failed (per-task-implementer-no-progress)"` (2992) で grep 可能
+- **4.5** — 本文に「## 次の手順」セクション + `mark_issue_failed` 末尾の `build_recovery_hint` 流用
+- **4.6** — 新規 stage 識別子 `per-task-implementer-no-progress` を `mark_issue_failed` 第 1 引数で渡す (2994)
+- **5.1** — 各 rc=0 分岐で `pt_check_task_completed` 1 回呼出 + `pt_mark_no_progress_failed` 1 回呼出
+- **5.2** — 既存 `claude-failed` ラベル除外条件は無修正のため、再 pickup されない既存挙動を継承
+- **5.3** — `pt_check_task_completed` rc=2（tasks.md 不在 / 該当行不在）も `pt_mark_no_progress_failed` 経路に乗せる fail-safe 設計。fixture で確認
+- **NFR 1.1** — `PER_TASK_LOOP_ENABLED` 無効時は `run_per_task_loop` が呼ばれず本機能のコードは 1 行も実行されない
+- **NFR 1.2** — `mark_issue_failed` を引数違いで呼ぶのみ。失敗ハンドラの挙動変更なし
+- **NFR 1.3** — Reviewer reject / Debugger Gate / Stage A 完了ゲートの判定ロジックは無修正
+- **NFR 2.1** — 既存識別子 `per-task-implementer-failed` 等と異なる新規識別子で区別可能
+- **NFR 2.2** — `pt_log "task=<id> implementer end rc=0 progress=zero ..."` で既存書式 (`task=<id> implementer end ...`) と整合
+- **NFR 3.1** — `pt_check_task_completed` 内 grep 高々 2 回（`- [x]` ヒット時は 1 回で終了）
+
+## Findings
+
+### AC 未カバー
+
+なし。requirements.md の全 numeric AC を実装または既存ハンドラ流用でカバー済み。
+
+### Missing Test
+
+なし。
+
+- AC 1.1 / 5.3 / 3.3 は新規 fixture `test-pt-check-task-completed.sh` の 17 ケース全 pass で検証済（reviewer 再実行で `PASS=17 FAIL=0` 確認）
+- AC 1.2 / 1.3 / 1.4 / 3.1 / 3.2 / NFR 1.x は構造的・コードレビュー担保（rc=0 分岐限定で挿入したため diff の範囲が証拠）
+- AC 2.x / 4.x は `mark_issue_failed` 既存挙動の流用（NFR 1.2 規定）で既存ハンドラのカバレッジを継承
+
+### Boundary 逸脱
+
+なし。
+
+- 本 Issue は design-less impl（`tasks.md` 不在）であり明示的 `_Boundary:_` 宣言は存在しないが、変更範囲は per-task ループの所有モジュール `local-watcher/bin/issue-watcher.sh` 1 ファイル + spec 文書 + 新規 fixture テストに収まっている
+- 既存 env var 名 / cron 登録文字列 / exit code 意味 / ラベル遷移契約はすべて無修正（impl-notes 後方互換性節と一致）
+- `repo-template/.claude/` 配下 / README / `idd-claude-labels.sh` 等への波及なし
+
+## Verdict Rationale
+
+全 numeric AC（1.1〜1.4, 2.1〜2.5, 3.1〜3.4, 4.1〜4.6, 5.1〜5.3, NFR 1.1〜3.1）が実装・既存ハンドラ流用・fixture テストのいずれかで裏打ちされており、4 箇所の rc=0 分岐すべてに検証フックが対称に挿入されている。`shellcheck` クリーン / fixture 17 ケース全 pass を reviewer 自身で再実行確認した。境界逸脱・missing test・AC 未カバーのいずれも検出されないため approve。
+
+RESULT: approve

--- a/docs/specs/263--bug-per-task-implementer-tasks-md/test-fixtures/test-pt-check-task-completed.sh
+++ b/docs/specs/263--bug-per-task-implementer-tasks-md/test-fixtures/test-pt-check-task-completed.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# 用途: pt_check_task_completed の判定ロジック (#263) を単体検証する。
+#       tasks.md 上の _[ ]_ / _[x]_ / 行不在 / ファイル不在の 4 ケースで
+#       期待戻り値 (1 / 0 / 2 / 2) を返すこと、親 (`- [ ] 1. <title>`) と
+#       子 (`- [ ] 1.1 <title>`) の両 ID 慣習をカバーすること、deferrable
+#       `- [ ]*` 行は親子と独立に扱うこと、duplicate ID 想定外シナリオで先勝ち
+#       挙動が安全側に倒れることを assert する。
+# 配置先: docs/specs/263--bug-per-task-implementer-tasks-md/test-fixtures/test-pt-check-task-completed.sh
+# 依存: bash 4+, grep, sed。issue-watcher.sh から pt_check_task_completed のみを
+#       sourcing できない（メインスクリプト全体を実行してしまう）ため、関数定義を
+#       awk で抽出して本 fixture 内に局所評価する。
+# セットアップ参照先: docs/specs/263--bug-per-task-implementer-tasks-md/impl-notes.md
+#
+# Usage:
+#   bash docs/specs/263--bug-per-task-implementer-tasks-md/test-fixtures/test-pt-check-task-completed.sh
+#
+# Exit code:
+#   0 = すべてのケースが期待戻り値と一致
+#   1 = いずれかのケースが不一致（standard error にどれが失敗したか出力）
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../../../.." && pwd)
+WATCHER="$REPO_ROOT/local-watcher/bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER" ]; then
+  echo "[FATAL] watcher script not found: $WATCHER" >&2
+  exit 1
+fi
+
+# pt_check_task_completed の関数本体を awk で抽出して評価する。
+# main 実行ガード (`if [ "${BASH_SOURCE[0]}" = "$0" ]` 等) を持たない script を
+# そのまま source すると bash モジュール初期化や argparse が走ってしまうため、
+# 当該関数の `pt_check_task_completed() { ... }` ブロックだけを切り出して eval する。
+fn_body=$(awk '
+  /^pt_check_task_completed\(\) \{/ { in_fn = 1 }
+  in_fn { print }
+  in_fn && /^\}/ { exit }
+' "$WATCHER")
+
+if [ -z "$fn_body" ]; then
+  echo "[FATAL] pt_check_task_completed の関数本体を抽出できませんでした" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2294  # eval は関数定義の動的取り込みのため意図的に使用
+eval "$fn_body"
+
+fail_count=0
+pass_count=0
+
+# ── ヘルパ: tasks.md と task_id を渡して期待戻り値と一致するか確認 ──
+# $1 = ケース名, $2 = tasks.md パス, $3 = task_id, $4 = 期待戻り値
+assert_check_rc() {
+  local name="$1" tasks_md="$2" task_id="$3" expected_rc="$4"
+  local rc=0
+  set +e
+  pt_check_task_completed "$tasks_md" "$task_id"
+  rc=$?
+  set -e
+  if [ "$rc" != "$expected_rc" ]; then
+    echo "[FAIL] $name: rc=$rc (expected $expected_rc) tasks_md=$tasks_md task_id=$task_id" >&2
+    fail_count=$((fail_count + 1))
+    return
+  fi
+  echo "[PASS] $name (rc=$rc)"
+  pass_count=$((pass_count + 1))
+}
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+# ── fixture 1: 親タスク完了 `- [x] 1. ...` ──
+cat > "$tmp/case-parent-done.md" <<'EOF'
+- [x] 1. 親タスク完了
+- [ ] 2. 親タスク未完了
+EOF
+assert_check_rc "親タスク 1 が _[x]_ → rc=0 (完了)" "$tmp/case-parent-done.md" "1" 0
+assert_check_rc "親タスク 2 が _[ ]_ → rc=1 (未完了)" "$tmp/case-parent-done.md" "2" 1
+assert_check_rc "存在しない task_id 9 → rc=2 (fail-safe)" "$tmp/case-parent-done.md" "9" 2
+
+# ── fixture 2: 子タスク完了 `- [x] 1.1 ...` ──
+cat > "$tmp/case-child-done.md" <<'EOF'
+- [ ] 1. 親タスク
+- [x] 1.1 子タスク完了
+- [ ] 1.2 子タスク未完了
+- [ ] 1.10 子タスク2桁未完了
+EOF
+assert_check_rc "子タスク 1.1 が _[x]_ → rc=0 (完了)" "$tmp/case-child-done.md" "1.1" 0
+assert_check_rc "子タスク 1.2 が _[ ]_ → rc=1 (未完了)" "$tmp/case-child-done.md" "1.2" 1
+assert_check_rc "子タスク 1.10 が _[ ]_ → rc=1 (2 桁 ID 誤マッチ防止)" "$tmp/case-child-done.md" "1.10" 1
+# 1.1 prefix が 1.10 と衝突しないことを確認するため、1.1 を _[ ]_ にしたバリアント
+cat > "$tmp/case-child-prefix.md" <<'EOF'
+- [ ] 1.1 子タスク未完了
+- [x] 1.10 子タスク2桁完了
+EOF
+assert_check_rc "子タスク 1.1 (_[ ]_) が 1.10 (_[x]_) の prefix とマッチしない → rc=1" "$tmp/case-child-prefix.md" "1.1" 1
+assert_check_rc "子タスク 1.10 (_[x]_) → rc=0" "$tmp/case-child-prefix.md" "1.10" 0
+
+# ── fixture 3: tasks.md 不在 → rc=2 (fail-safe) ──
+assert_check_rc "tasks.md 不在 → rc=2 (Req 5.3 fail-safe)" "$tmp/does-not-exist.md" "1" 2
+
+# ── fixture 4: deferrable `- [ ]*` 行は本検証ルートに来ない想定。仮に直接呼んだ場合は
+#                親の _[ ]_ 子の _[ ]_ と比べて `[ ]*` は判定パターンの空白要求に
+#                よって自然に除外される（rc=2 となる）ことを確認する ──
+cat > "$tmp/case-deferrable.md" <<'EOF'
+- [ ]* 3.1 deferrable テストタスク
+EOF
+assert_check_rc "deferrable _[ ]*_ 3.1 は判定パターン外 → rc=2" "$tmp/case-deferrable.md" "3.1" 2
+
+# ── fixture 5: 空ファイル → rc=2 ──
+: > "$tmp/case-empty.md"
+assert_check_rc "空 tasks.md → rc=2 (該当行不在)" "$tmp/case-empty.md" "1" 2
+
+# ── fixture 6: 実 idd-claude tasks.md 慣習との整合（親+子ミックス・先頭末尾） ──
+cat > "$tmp/case-realistic.md" <<'EOF'
+# Tasks
+
+- [x] 1. 親タスク 1（全完了）
+- [x] 1.1 子タスク 1.1
+- [x] 1.2 子タスク 1.2
+- [ ] 2. 親タスク 2
+- [x] 2.1 子タスク 2.1 完了
+- [ ] 2.2 子タスク 2.2 未完了
+- [ ]* 2.3 deferrable テストタスク
+EOF
+assert_check_rc "親 1 全完了 → rc=0" "$tmp/case-realistic.md" "1" 0
+assert_check_rc "子 1.1 完了 → rc=0" "$tmp/case-realistic.md" "1.1" 0
+assert_check_rc "親 2 未完了 → rc=1" "$tmp/case-realistic.md" "2" 1
+assert_check_rc "子 2.1 完了 → rc=0" "$tmp/case-realistic.md" "2.1" 0
+assert_check_rc "子 2.2 未完了 → rc=1" "$tmp/case-realistic.md" "2.2" 1
+assert_check_rc "deferrable 2.3 → rc=2 (判定対象外)" "$tmp/case-realistic.md" "2.3" 2
+
+echo "----"
+echo "PASS=$pass_count FAIL=$fail_count"
+[ "$fail_count" -eq 0 ]

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -2199,6 +2199,59 @@ pt_extract_pending_tasks() {
   return 0
 }
 
+# ─── pt_check_task_completed <tasks_md_path> <task_id> ───
+#
+# tasks.md 上で指定 task_id の checkbox 状態を判定し、戻り値で表現する。Issue #263 の
+# 「per-task Implementer が rc=0 で抜けたが対象 task が `- [ ]` のまま放置される」無限
+# リトライループ検出のために使用する。
+#
+# 戻り値:
+#   0 = `- [x]` 済み（完了マーカー存在 / 進捗ありの正常系）
+#   1 = `- [ ]` のまま（未完了 / 進捗ゼロ）
+#   2 = tasks.md 不在、または該当 task_id の checkbox 行が一切存在しない（fail-safe）
+#
+# 判定パターン（pt_extract_pending_tasks の regex と整合）:
+#   - 親タスク慣習: `- [x] 1. <title>` / `- [ ] 1. <title>`（ID 後ろに `.` + 空白）
+#   - 子タスク慣習: `- [x] 1.1 <title>` / `- [ ] 1.1 <title>`（ID 後ろに空白のみ）
+#   - deferrable `- [ ]*` は pt_extract_pending_tasks 側で除外されているため、本関数の
+#     ループ呼出ルートには到達しない（Req 3.3 / Req 5.3 / Out of Scope と整合）
+#   - 1 件の task_id が複数行に出現する spec は想定外（tasks.md は numeric ID 一意）。
+#     重複時は「いずれかの行に `[x]` があれば完了扱い」とせず、未完了行優先で 1 を返す
+#     方が安全側に倒れるが、本実装では grep の出現順で先勝ち判定とする（重複時の
+#     挙動は spec 外）。
+#
+# set -euo pipefail 配下で grep no-match による失敗を関数全体に伝播させないため、
+# `|| true` で吸収する。
+#
+# Requirements: 1.1, 5.3, NFR 3.1
+pt_check_task_completed() {
+  local tasks_md="$1"
+  local task_id="$2"
+
+  if [ ! -f "$tasks_md" ]; then
+    return 2
+  fi
+
+  # task_id を正規表現リテラルとして安全にエスケープ（`.` のみ含む想定だが防御的に処理）
+  local task_id_re
+  # shellcheck disable=SC2016  # sed の置換式は単引用符内で完結（シェル展開は意図的に行わない）
+  task_id_re=$(printf '%s' "$task_id" | sed -E 's/[][\\.*^$()+?{|/]/\\&/g')
+
+  # `- [x] <task_id>(\.)? ` で完了済みを優先確認（親 / 子両慣習をカバー）
+  if grep -qE "^- \[x\] ${task_id_re}\.? " "$tasks_md" 2>/dev/null; then
+    return 0
+  fi
+
+  # `- [ ] <task_id>(\.)? ` で未完了行の存在を確認（進捗ゼロ判定）
+  if grep -qE "^- \[ \] ${task_id_re}\.? " "$tasks_md" 2>/dev/null; then
+    return 1
+  fi
+
+  # checkbox 行自体が見つからない → fail-safe（Req 5.3: silent fail で resumable
+  # return 0 に倒さず、呼び出し側で claude-failed 化する）
+  return 2
+}
+
 # ─── pt_extract_learnings <impl_notes_path> ───
 #
 # impl-notes.md の `## Implementation Notes` 見出しから「次の `## ` 見出しが現れる直前まで」
@@ -2880,6 +2933,72 @@ EOF
 #   - quota 超過時: 呼び出し側に return 99 相当で伝搬する代わりに return 0（既存 Stage A
 #     の quota パスと同じく watcher は正常終了し、Resume Processor が次 tick で再開）
 #
+# ─── pt_mark_no_progress_failed <task_id> <stage_phase> <check_rc> ───
+#
+# per-task Implementer が rc=0 で終了したにもかかわらず対象 task の
+# `- [ ] → - [x]` 遷移が検出できなかった場合に `claude-failed` 化する専用ヘルパー
+# （Issue #263）。`mark_issue_failed` を流用し、stage 識別子と Issue コメント本文だけを
+# 本機能用に組み立てる（NFR 1.2: 既存失敗ハンドラの挙動を変更せず流用のみ）。
+#
+# Args:
+#   $1 = task_id (例: `1.2`)
+#   $2 = stage_phase (`initial` / `blocked-redo` / `round2-redo` / `round3-redo`)
+#        Implementer 呼出 4 箇所のどの段階で進捗ゼロが検出されたかを識別する
+#   $3 = check_rc (`1` = `- [ ]` のまま / `2` = 該当行不在 or tasks.md 不在)
+#
+# 副作用（mark_issue_failed と等価 / Req 2.1, 2.2, 4.x, NFR 1.2）:
+#   1. claude-claimed / claude-picked-up を除去し claude-failed を付与
+#   2. 復旧手順付き Issue コメントを 1 件投稿
+#   3. watcher ログに grep 可能な 1 行を出力（呼び出し側で pt_log を発射する想定）
+#
+# Requirements: #263 Req 2.1, 2.2, 2.5, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, NFR 1.2, NFR 2.1
+pt_mark_no_progress_failed() {
+  local task_id="$1"
+  local stage_phase="$2"
+  local check_rc="$3"
+
+  local cause_desc
+  case "$check_rc" in
+    2)
+      cause_desc="tasks.md 上で task=\`${task_id}\` に対応する \`- [ ]\` / \`- [x]\` 行が見つかりませんでした（tasks.md 読取失敗 / 該当行不在）。fail-safe として無限ループに入る前に停止します（Req 5.3）。"
+      ;;
+    *)
+      cause_desc="tasks.md 上の task=\`${task_id}\` 行が \`- [ ]\` のまま \`- [x]\` に遷移していません。Implementer が編集失敗（置換競合・コンパイルエラー等）から復旧できなかった可能性があります。"
+      ;;
+  esac
+
+  local extra_body
+  extra_body=$(cat <<EOF
+## 失敗カテゴリ
+- カテゴリ: \`per-task-implementer-no-progress\`
+- 対象 task ID: \`${task_id}\`
+- 検出フェーズ: \`${stage_phase}\` (Implementer 呼出 4 箇所のいずれか: initial / blocked-redo / round2-redo / round3-redo)
+- 判定根拠: pt_check_task_completed rc=${check_rc}
+- ログ: \`$LOG\`
+
+## 原因
+per-task Implementer が rc=0（正常終了扱い）で終了したにもかかわらず、対象 task の
+\`- [ ]\` → \`- [x]\` 遷移が \`tasks.md\` で確認できませんでした。${cause_desc}
+
+このまま再開すると次 tick の dispatcher が同じ Issue を再 pickup し、Implementer が同じ
+失敗を rc=0 で繰り返す無限リトライループに陥るため、自動再開を停止しました（Issue #263）。
+
+## 次の手順
+1. watcher ログ \`$LOG\` を確認し、当該 task=\`${task_id}\` の Implementer 実行で
+   何が失敗していたか（編集競合・テスト失敗・prompt 不備等）を特定する
+2. 必要なら手動で修正 commit を積み、tasks.md の該当行を \`- [x]\` に更新する
+   （または Architect 差し戻し / Issue 分割を判断する）
+3. 復旧操作完了後、Issue から \`claude-failed\` ラベルを外すと watcher が次サイクルで
+   再 pickup する
+EOF
+)
+
+  # grep 可能ログを 1 行出力（NFR 2.1, NFR 2.2 / 既存 per-task ログ書式と整合）
+  pt_log "task=${task_id} implementer end rc=0 progress=zero phase=${stage_phase} check_rc=${check_rc} → claude-failed (per-task-implementer-no-progress)" >> "$LOG"
+
+  mark_issue_failed "per-task-implementer-no-progress" "$extra_body"
+}
+
 # Requirements: 2.1, 2.6, 2.7, 3.4, 3.5, 3.6, 3.7, 5.1, 5.2
 run_per_task_loop() {
   local tasks_md="$REPO_DIR/$SPEC_DIR_REL/tasks.md"
@@ -2921,7 +3040,20 @@ run_per_task_loop() {
     local impl_rc=0
     run_per_task_implementer "$task_id" || impl_rc=$?
     case "$impl_rc" in
-      0) ;; # 続行
+      0)
+        # Issue #263: 進捗ゼロ検出。Implementer が rc=0 を返したが対象 task の checkbox が
+        # `- [ ] → - [x]` に遷移していない場合、次 tick で同じ Issue が再 pickup されて
+        # 同じ Implementer 失敗を rc=0 で繰り返す無限リトライループに陥るため、ここで
+        # claude-failed 化して停止する。tasks.md 不在は run_per_task_loop 冒頭で防御済み
+        # だが、grep no-match や該当行不在を fail-safe として捕捉する（Req 1.1, 1.3, 5.3）。
+        local _pt_check_rc=0
+        pt_check_task_completed "$tasks_md" "$task_id" || _pt_check_rc=$?
+        if [ "$_pt_check_rc" != "0" ]; then
+          echo "❌ #$NUMBER: per-task Implementer (task=$task_id, phase=initial) rc=0 だが進捗ゼロ検出 (check_rc=$_pt_check_rc) → claude-failed (per-task-implementer-no-progress)" | tee -a "$LOG"
+          pt_mark_no_progress_failed "$task_id" "initial" "$_pt_check_rc"
+          return 1
+        fi
+        ;;
       99)
         # quota 超過: 既存 #66 規約に従い watcher は正常終了。Resume Processor が次 tick で再開
         echo "⏸️ #$NUMBER: per-task Implementer (task=$task_id) で quota 超過検出 → needs-quota-wait" | tee -a "$LOG"
@@ -2977,7 +3109,18 @@ run_per_task_loop() {
         local impl_bl_rc=0
         run_per_task_implementer "$task_id" || impl_bl_rc=$?
         case "$impl_bl_rc" in
-          0) ;; # 続行: 通常の Reviewer Round 1 に合流（Req 6.2 / 4.4 相当）
+          0)
+            # Issue #263: BLOCKED 経路再実行後も進捗ゼロのまま rc=0 で抜けるケースを検出。
+            # 通常の Reviewer Round 1 に合流させる前に、対象 task の `- [ ] → - [x]` 遷移を
+            # 機械検証する（Req 1.3 / 全 4 箇所適用）。
+            local _pt_check_bl_rc=0
+            pt_check_task_completed "$tasks_md" "$task_id" || _pt_check_bl_rc=$?
+            if [ "$_pt_check_bl_rc" != "0" ]; then
+              echo "❌ #$NUMBER: per-task Implementer (BLOCKED 経路再実行 / task=$task_id, phase=blocked-redo) rc=0 だが進捗ゼロ検出 (check_rc=$_pt_check_bl_rc) → claude-failed (per-task-implementer-no-progress)" | tee -a "$LOG"
+              pt_mark_no_progress_failed "$task_id" "blocked-redo" "$_pt_check_bl_rc"
+              return 1
+            fi
+            ;;
           99)
             echo "⏸️ #$NUMBER: per-task Implementer (BLOCKED 経路再実行 / task=$task_id) で quota 超過検出 → needs-quota-wait" | tee -a "$LOG"
             return 0
@@ -3008,7 +3151,18 @@ run_per_task_loop() {
         local impl2_rc=0
         run_per_task_implementer "$task_id" || impl2_rc=$?
         case "$impl2_rc" in
-          0) ;;
+          0)
+            # Issue #263: Reviewer reject 後の Implementer 再実行も rc=0 で抜けたが進捗ゼロ
+            # のままだと、後段 Reviewer round=2 が同じ未完了状態を再 reject → 同じ無限
+            # ループに陥る。round=2 起動前にここで停止する（Req 1.3）。
+            local _pt_check_r2_rc=0
+            pt_check_task_completed "$tasks_md" "$task_id" || _pt_check_r2_rc=$?
+            if [ "$_pt_check_r2_rc" != "0" ]; then
+              echo "❌ #$NUMBER: per-task Implementer 再実行 (task=$task_id, phase=round2-redo) rc=0 だが進捗ゼロ検出 (check_rc=$_pt_check_r2_rc) → claude-failed (per-task-implementer-no-progress)" | tee -a "$LOG"
+              pt_mark_no_progress_failed "$task_id" "round2-redo" "$_pt_check_r2_rc"
+              return 1
+            fi
+            ;;
           99)
             echo "⏸️ #$NUMBER: per-task Implementer 再実行 (task=$task_id) で quota 超過検出 → needs-quota-wait" | tee -a "$LOG"
             return 0
@@ -3056,7 +3210,20 @@ run_per_task_loop() {
               local impl3_rc=0
               run_per_task_implementer "$task_id" || impl3_rc=$?
               case "$impl3_rc" in
-                0) ;;
+                0)
+                  # Issue #263: Debugger 経由 Implementer 再実行も rc=0 で抜けたが進捗ゼロ
+                  # のままだと、Reviewer round=3 が同じ未完了状態を reject 確定し、結果として
+                  # Debugger Gate 終端の round=3 経路で `per-task-reviewer-reject3` を出すが、
+                  # 進捗ゼロが原因であることを stage 識別子で区別できないため、ここで
+                  # `per-task-implementer-no-progress` として停止する（Req 1.3）。
+                  local _pt_check_r3_rc=0
+                  pt_check_task_completed "$tasks_md" "$task_id" || _pt_check_r3_rc=$?
+                  if [ "$_pt_check_r3_rc" != "0" ]; then
+                    echo "❌ #$NUMBER: per-task Implementer 3 回目 (task=$task_id, phase=round3-redo / Debugger 経由) rc=0 だが進捗ゼロ検出 (check_rc=$_pt_check_r3_rc) → claude-failed (per-task-implementer-no-progress)" | tee -a "$LOG"
+                    pt_mark_no_progress_failed "$task_id" "round3-redo" "$_pt_check_r3_rc"
+                    return 1
+                  fi
+                  ;;
                 99)
                   echo "⏸️ #$NUMBER: per-task Implementer 3 回目 (task=$task_id) で quota 超過検出 → needs-quota-wait" | tee -a "$LOG"
                   return 0


### PR DESCRIPTION
## 概要

`PER_TASK_LOOP_ENABLED=true` 時に per-task Implementer が編集失敗（置換競合・コンパイルエラー等）を
解消できないまま rc=0 で終了した場合、`tasks.md` 上の checkbox が更新されないまま次 tick で同一
task が再選択されるという無限リトライループが発生していた（Issue #263）。

本 PR は `local-watcher/bin/issue-watcher.sh` に対して以下の修正を行い、進捗ゼロを検出した場合に
即座に `claude-failed` 化してループを停止させる機能を追加する。

- 新規ヘルパー関数 `pt_check_task_completed` を追加し、per-task Implementer rc=0 終了後に対象
  task の `- [ ] → - [x]` 遷移を機械検証する
- 新規ヘルパー関数 `pt_mark_no_progress_failed` を追加し、進捗ゼロ検出時に既存の `mark_issue_failed`
  を流用して `claude-failed` 化・Issue コメント投稿・ログ出力を行う
- per-task ループ内の 4 箇所すべての rc=0 分岐（initial / blocked-redo / round2-redo / round3-redo）に
  進捗検証フックを挿入する

## 対応 Issue

Closes #263

## 関連 PR

なし（設計 PR なし。design-less impl）

## 実装内容

- (Req 1.1 / 1.3) `pt_check_task_completed <tasks_md_path> <task_id>` 新規追加。戻り値 0=完了 / 1=未完了 / 2=tasks.md不在or該当行不在
- (Req 2.1 / 4.x) `pt_mark_no_progress_failed <task_id> <stage_phase> <check_rc>` 新規追加。`mark_issue_failed "per-task-implementer-no-progress" ...` を流用して claude-failed 化・Issue コメント・ログ出力
- (Req 1.3) `run_per_task_loop()` 内の全 4 箇所の rc=0 分岐に検証フックを挿入（initial / blocked-redo / round2-redo / round3-redo）
- (Req 2.3) 進捗ゼロ検出時は 4 箇所すべてで `return 1` によりループを即時打ち切り
- (NFR 2.1) 新規 stage 識別子 `per-task-implementer-no-progress` で既存失敗種別と区別可能

## 受入基準チェック

- [x] Req 1.1: rc=0 直後に `- [ ] → - [x]` 遷移を機械検証する ← `pt_check_task_completed` / fixture 17 ケース全 pass
- [x] Req 1.2: `PER_TASK_LOOP_ENABLED` 未設定 / false 時は 1 行も実行しない ← `run_per_task_loop` が呼ばれない構造的 skip
- [x] Req 1.3: 全 4 箇所の rc=0 分岐に適用 ← diff で initial / blocked-redo / round2-redo / round3-redo の各 `0)` 分岐を確認
- [x] Req 1.4: rc=99 / 非 0 終了時は検証 skip ← 既存 `99)` / `*)` 分岐は無修正
- [x] Req 2.1〜2.5: 進捗ゼロ検出時の claude-failed 化・ラベル付け替え・即時打ち切り・二重発火なし ← `pt_mark_no_progress_failed` + `mark_issue_failed` 流用
- [x] Req 3.1〜3.4: 正常系（進捗あり）の非干渉 ← rc=0 分岐に検証追加のみで後段経路変更なし
- [x] Req 4.1〜4.6: Issue コメントに task_id / 説明文 / 自動再開停止旨 / watcher ログパス / 復旧手順 / 新規 stage 識別子を含む
- [x] Req 5.1〜5.3: 1 回の呼出に対し 1 回判定 / claude-failed 済は再 pickup しない / tasks.md 読取失敗時は fail-safe
- [x] NFR 1.1〜1.3: 後方互換性（既存ハンドラ流用・判定ロジック変更なし）

## テスト結果

```
# fixture テスト
bash docs/specs/263--bug-per-task-implementer-tasks-md/test-fixtures/test-pt-check-task-completed.sh
→ PASS=17 FAIL=0（reviewer が独立再実行で確認済み）

# shellcheck
shellcheck local-watcher/bin/issue-watcher.sh
→ 警告ゼロ（SC2016 は意図的な無展開につき # shellcheck disable=SC2016 で個別抑止）

# syntax check
bash -n local-watcher/bin/issue-watcher.sh
→ exit code 0（syntax error なし）
```

## 実装上の判断

- 進捗検証を「実行後 1 回のみ」の grep に簡素化した（NFR 3.1 の「高々 2 回」を 1 回に圧縮）。
  実行後の最終状態が `- [x]` か `- [ ]` かを直接判定するアプローチで「実行前 + 実行後」diff 比較
  は不要と判断した。
- `pt_check_task_completed` の戻り値 2（該当行不在）は Req 5.3「tasks.md 読取失敗時の fail-safe」
  と「該当 task_id 行不在の防御」を両方含む。`run_per_task_loop()` 冒頭で tasks.md 存在チェック済み
  のため、実発火するのは spec 不整合（tasks.md に task_id 行がないのに dispatch されたケース）に限られ、
  このケースも fail-safe で claude-failed 化する。
- Issue コメント本文に含めた「検出フェーズ」（initial / blocked-redo / round2-redo / round3-redo）は
  要件明示外だが、運用者の根本原因調査を助ける観測性向上として NFR 2.1 / 2.2 の趣旨に沿うと判断した。

## 確認事項 / レビュワーへの依頼

- Reviewer による独立レビューは承認済み。詳細は `docs/specs/263--bug-per-task-implementer-tasks-md/review-notes.md` を参照
- 「実行後 1 回のみ grep」の簡素化判断については impl-notes.md の「確認事項」節を参照されたい
- 特に注意して見てほしい箇所: `issue-watcher.sh` の `run_per_task_loop` 内 4 箇所の `0)` 分岐（initial / blocked-redo / round2-redo / round3-redo）が対称に修正されているかを確認してほしい
- base ブランチ検証結果: --base main 指定 / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #263 のコメントを参照してください。
