### PR TITLE
fix(watcher): #270 親タスク checkbox flip コミット時の per-task Reviewer 起動をスキップ

### DIFF
--- a/docs/specs/270--bug-checkbox-flip-per-task-reviewer/impl-notes.md
+++ b/docs/specs/270--bug-checkbox-flip-per-task-reviewer/impl-notes.md
@@ -1,0 +1,152 @@
+# Implementation Notes — Issue #270
+
+## 概要
+
+per-task ループ内の「親タスク完了マーク commit のみ（`tasks.md` 1 行 checkbox flip）」に対する
+Reviewer 起動を `pt_should_skip_reviewer` 判定で抑止し、`parse-failed` → `claude-failed` を
+回避する。LLM 呼び出し削減によるトークン節約と実行時間短縮も得られる。
+
+## 変更ファイル
+
+- `local-watcher/bin/issue-watcher.sh`
+  - 追加関数:
+    - `pt_has_subtasks <tasks_md> <task_id>` — 子タスク存在判定（Req 2.1, 2.4, 2.5）
+    - `pt_is_parent_checkbox_only_diff <task_id> <range_start> <range_end>` — diff range 内容判定（Req 3.1, 3.2, 3.4, 3.5）
+    - `pt_should_skip_reviewer <task_id>` — dispatcher（Req 1.1〜1.4）
+  - 修正箇所:
+    - `run_per_task_loop` 内の round=1 Reviewer 起動直前で `pt_should_skip_reviewer` を呼び、
+      スキップ成立時は `rev_rc=0` 設定で即時 approve 扱いとし `run_per_task_reviewer` を起動しない
+- `docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/`
+  - `tasks-parent-with-children.md` — 固定 fixture
+  - `test-skip-logic.sh` — 判定ヘルパー 3 関数を bash subshell で直接呼ぶスモークテスト（23 ケース全 PASS）
+
+## 設計判断
+
+### スキップ適用範囲は round=1 のみ
+
+要件本文の AC 1.1 が「per-task ループが次に処理する task が...」と表現していることから、
+スキップの対象は初回 Reviewer 起動（round=1）のみと解釈した。round=2 / round=3 は
+Reviewer による reject が発生した後の reviewer 再起動であり、本来「親タスクの checkbox flip
+のみ」のシチュエーションには到達しない（一度 approve 扱いされた task は次 task へ進む）。
+よって round=2 / round=3 経路は変更不要。
+
+### dispatcher のシグナル化（return 0 = skip, return 1 = run）
+
+`pt_should_skip_reviewer` は判定 dispatcher としてシンプルに「スキップしてよいか」だけを
+return 値で表現する。これにより呼び出し側の `if pt_should_skip_reviewer ...; then rev_rc=0;
+else run_per_task_reviewer ... || rev_rc=$?; fi` という 4 行で意図を明示できる。
+
+### tasks.md only diff の判定アルゴリズム
+
+`git diff --name-only <range>` で変更ファイル集合を取り、ちょうど 1 件 + 一致が
+`SPEC_DIR_REL/tasks.md` であることを必要条件とした。続けて `git diff <range> -- <tasks_md>`
+の hunk 内 `-`/`+` 行数をそれぞれ厳密に 1 件に限定した上で、当該 task_id の checkbox flip
+パターン (`^-- \[ \] <id>(\.)? ` / `^\+- \[x\] <id>(\.)? `) との完全一致を求めることで、
+他編集が混入する場合を全て不成立に倒せる（Req 3.4, 3.5）。
+
+### diff header の除外
+
+git diff の出力では、削除行の中身が markdown list `- [ ]` で始まる場合、行頭が `--` 2 文字に
+なる（diff marker `-` + 内容 `-`）。当初は `^-[^-]` で diff file header `--- a/path` を除外
+しようとしたが、これだと markdown 削除行も誤って除外されることが smoke test (B-1 / C-1) で
+判明したため、`grep -E '^-' | grep -cvE '^--- '` のように 2 段階で file header のみを
+明示除外する形に修正した。
+
+### fail-safe 経路（NFR 1.3）
+
+以下のいずれかで `pt_should_skip_reviewer` は 1（= skip しない）を返し、従来 Reviewer 起動
+経路へ倒す:
+
+- `pt_has_subtasks` が rc=1（子なし）または rc=2（tasks.md 不在 / 空 task_id）
+- `pt_resolve_diff_range` が失敗（marker commit 不在）
+- `pt_is_parent_checkbox_only_diff` が rc=1（任意の不一致条件）
+
+これにより異常系では既存挙動（claude-failed まで含む）が温存される。
+
+### ログ書式（NFR 2.1, NFR 2.3）
+
+スキップ成立時のみ `pt_log "task=<id> reviewer skipped reason=parent-task-checkbox-only-diff
+range=<short_sha>..<short_sha>"` を出力。`grep "reviewer skipped"` で件数把握可能。
+スキップ不成立時は新規ログを増やさない（既存ログ量を増やさない後方互換）。
+
+## テスト結果
+
+### スモークテスト（自作）
+
+```
+$ bash docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh
+Results: PASS=23 FAIL=0
+```
+
+検証ケース内訳:
+
+- **A. pt_has_subtasks**（9 ケース）: 親 / 子 / 末端 / deferrable 子 / 完了済み親 /
+  不在 task_id / file 不在 / 空 task_id / false positive（task_id `1` が `11.` を誤検出しない）
+- **B. pt_is_parent_checkbox_only_diff**（7 ケース）: checkbox flip のみ成立 / 範囲不正 /
+  別 task_id 誤マッチしない / 他ファイル混入 / tasks.md 内別 task の flip 混入 / 空 diff
+- **C. pt_should_skip_reviewer (E2E)**（7 ケース）: 親 task の checkbox-only / 子 task /
+  単独 task / 存在しない task_id / ログ出力検証（成立時に grep 可能）/ ログ抑止検証（不成立時に新規ログなし）
+
+### shellcheck
+
+```
+$ shellcheck local-watcher/bin/*.sh install.sh setup.sh .github/scripts/*.sh
+（出力なし = 警告ゼロ）
+$ shellcheck docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh
+（出力なし = 警告ゼロ）
+```
+
+### 構文チェック
+
+```
+$ bash -n local-watcher/bin/issue-watcher.sh
+syntax OK
+```
+
+## 受入基準とテストの紐付け
+
+| Req ID | 担保テスト |
+|---|---|
+| 1.1 | C-1, C-2, C-3, C-4（親かつ checkbox-only のみ skip 成立） |
+| 1.2 | C-1（dispatcher が rc=0 を返す = approve 扱い） |
+| 1.3 | C-5（fail-safe 経路で skip しない / claude-failed 化を防ぐため通常経路へ） |
+| 1.4 | C-6（スキップ成立時の単一行 grep 可能ログ） |
+| 1.5 | dispatcher の戻り値 contract により後続 task 処理は通常通り継続（コード上明らか） |
+| 1.6 | Stage A 完了後の遷移は本変更で触っていない（rev_rc=0 経路は既存の approve 経路と同一） |
+| 2.1 | A-1, A-2, A-3, A-4（子タスク存在判定の挙動検証） |
+| 2.2 | A-3, A-5（子なし / 存在しない task_id では rc=1） |
+| 2.3 | A-4（子タスク自体は子を持たないので rc=1） |
+| 2.4 | A-9（完了済み子タスクでも親判定成立） |
+| 2.5 | A-2（deferrable `- [ ]*` 子タスクも判定成立） |
+| 3.1 | B-1（成立条件のうち変更ファイル集合判定） |
+| 3.2 | B-5（tasks.md 以外混入で不成立） |
+| 3.3 | C-5（diff range 解決失敗時は skip 判定せず従来経路） |
+| 3.4 | B-1（checkbox flip ペアで成立） |
+| 3.5 | B-6（tasks.md 内に他 task の flip 混入で不成立） |
+| 4.1 | C-2, C-3（子タスクは従来通り Reviewer 起動） |
+| 4.2 | C-4（単独タスクは従来通り Reviewer 起動） |
+| 4.3 | B-5（親タスクだが他ファイル変更ありで従来通り Reviewer 起動） |
+| 4.4 | round=2 / round=3 経路を一切変更していないため等価性は構造的に保証 |
+| 4.5 | 既存テスト範囲外（ベースライン挙動と等価。retrofit は本 spec のスコープ外） |
+| NFR 1.1 | 既定で有効（追加 env var なし）= dispatcher 直接呼び出しで動作 |
+| NFR 1.2 | 既存進捗（`- [x]` / 既存 marker commit）と互換（既存 marker commit を読み取るのみ） |
+| NFR 1.3 | A-6, A-7, C-5（fail-safe 経路の検証） |
+| NFR 2.1 | C-6（grep 可能ログ） |
+| NFR 2.2 | C-6（task ID と判定経路識別子を含む） |
+| NFR 2.3 | C-7（スキップ不成立時に新規ログ増えない） |
+| NFR 3.1 | git diff / grep のみで構成された軽量判定。Reviewer 1 回（数十秒〜数分）と比べ無視可能 |
+| NFR 3.2 | スキップ成立時は `claude --print` 起動を完全に bypass（コード上明らか） |
+
+## 確認事項
+
+- 本機能はランタイム判定のみで、tasks.md / requirements.md / design.md / 既存 spec の
+  retrofit は行っていない（Out of Scope 規定どおり）
+- round=2 / round=3 Reviewer 起動経路は本変更の対象外（要件 1.1 が「次に処理する task」と
+  規定しているため round=1 のみが該当する）
+- `pt_should_skip_reviewer` の戻り値 1（= skip しない）は「fail-safe / 通常タスク」両方を
+  包含する。呼び出し側はこれを区別する必要がないため統合した
+- スモークテストは bash subshell で関数定義のみを抽出して実行する方式を採った（issue-watcher.sh
+  全体を source すると watcher の main 処理が走り副作用が大きいため）。CI 統合は本 PR の
+  スコープ外（local-watcher 配下のテスト戦略は手動スモーク中心 / CLAUDE.md「テスト・検証」節）
+
+STATUS: complete

--- a/docs/specs/270--bug-checkbox-flip-per-task-reviewer/requirements.md
+++ b/docs/specs/270--bug-checkbox-flip-per-task-reviewer/requirements.md
@@ -1,0 +1,101 @@
+# Requirements Document
+
+## Introduction
+
+per-task ループ実行中、ある親タスク（子タスクを内包するタスク）配下の全子タスクの実装と
+Reviewer 通過が完了したあと、watcher は親タスクの完了マーク（`tasks.md` 上で
+`- [ ] 4.` → `- [x] 4.` の checkbox flip のみ）を独立コミット（`docs(tasks): mark <id> as done`）
+として積む。続けて per-task ループはこの親タスクに対しても `run_per_task_reviewer` を起動する
+が、対象 diff range には `tasks.md` の 1 行 checkbox flip しか含まれず、Reviewer エージェントは
+レビュー観点上の指摘事項が無いと判断して `review-notes.md` をディスクに書き出さない
+（chat に `RESULT: approve` を出すのみで `editFileCount=0`）。結果として `parse_review_result`
+が `review-notes.md` 不在で失敗（rc=2 / `parse-failed`）し、watcher は本来 approve 相当であった
+このサイクルを `per-task-reviewer-error` カテゴリで `claude-failed` 化してしまう。
+
+親タスクの完了マーク commit には対応する `_Requirements:_` 由来の実装差分がそもそも存在せず
+（実装も Reviewer 判定も子タスク側で完了済み）、Reviewer 起動自体が無意味であるため、
+watcher 側でこの状況を検出して Reviewer 起動をスキップし、approve 扱いで per-task ループを
+継続させる。LLM 呼び出し削減によるトークン節約と実行時間短縮も副次的に得られる。
+
+## Requirements
+
+### Requirement 1: 親タスク + checkbox-only diff の Reviewer 起動スキップ
+
+**Objective:** As an idd-claude 運用者, I want per-task ループが親タスク完了マーク commit に対して Reviewer 起動を自動でスキップする, so that 子タスクで既にレビュー済みの内容に対する無意味な Reviewer 起動と、それに伴う `parse-failed` 由来の `claude-failed` 化を防げる
+
+#### Acceptance Criteria
+
+1. When per-task ループが次に処理する task が「子タスクを 1 件以上持つ親タスク」であり、かつ当該 task の diff range に含まれる変更ファイルが `tasks.md` のみである, the per-task Loop shall `run_per_task_reviewer` を起動せずに当該 task の Reviewer フェーズをスキップする
+2. When 上記スキップ条件が成立, the per-task Loop shall 当該 task の Reviewer 結果を approve 扱い（後続のディスパッチャ分岐で `rev_rc=0` 相当）として後続処理を継続する
+3. When 上記スキップ条件が成立, the per-task Loop shall `review-notes.md` の不在 / 空の状態を理由に `claude-failed` を付与しない
+4. When 上記スキップが発生, the per-task Loop shall 当該 task のスキップ発生を識別可能な単一行ログを `$LOG` に出力し、ログ行には task ID とスキップ理由（親タスクかつ checkbox-only diff である旨）が含まれる
+5. When スキップ後に後続 task（兄弟タスク / 後続親タスク）が pending として残っている, the per-task Loop shall 通常の pending 順序に従って後続 task の処理を継続する
+6. When スキップ後に後続 task が存在せず per-task ループが完走した, the watcher shall 既存の Stage B Reviewer / PR 作成等の後続フェーズに通常通り遷移する
+
+### Requirement 2: 「親タスク」の判定方法
+
+**Objective:** As an idd-claude 運用者, I want スキップ対象を機械的・決定論的に判定する, so that 通常タスクや子タスクへの誤適用を起こさず、既存の per-task Reviewer 動作との互換性を保てる
+
+#### Acceptance Criteria
+
+1. The per-task Loop shall 「親タスク」を「`tasks.md` 上で当該 task ID を prefix とする子タスク（例: 親 `4` に対する `4.1`, `4.2`, `4.1.1` 等）が `tasks.md` の checkbox 行として 1 件以上存在する task」と定義する
+2. When 判定対象 task ID に対応する子タスクが `tasks.md` 上に 1 件も存在しない, the per-task Loop shall 当該 task を「子を持たない通常タスク」として扱い、Requirement 1 のスキップ対象外とする
+3. When 判定対象 task ID 自体が numeric 階層の最下層（例: `1.2`, `2.3.1` のように更に下位を持たない ID）, the per-task Loop shall 当該 task を Requirement 1 のスキップ対象外とする
+4. The per-task Loop shall 子タスクの完了 / 未完了状態（`- [x]` か `- [ ]` か）に関わらず、子タスクの存在のみで親タスク判定を成立させる
+5. The per-task Loop shall deferrable 印（`- [ ]*`）の子タスクも子タスク存在判定の対象に含める
+
+### Requirement 3: 「tasks.md only diff」の判定方法
+
+**Objective:** As an idd-claude 運用者, I want 「diff が tasks.md の checkbox flip のみ」であることを決定論的に検証する, so that 親タスクであっても tasks.md 以外の実装差分が混在するケースで Reviewer 起動が誤ってスキップされない
+
+#### Acceptance Criteria
+
+1. The per-task Loop shall 当該 task の diff range（`pt_resolve_diff_range` が返す `range_start..range_end`）に含まれる **変更ファイル集合**を取得し、その集合が `tasks.md`（spec ディレクトリ配下の単一ファイル）のみで構成されることを Requirement 1 のスキップ成立条件の必要条件とする
+2. If diff range に `tasks.md` 以外のファイル（実装ファイル / テストファイル / 他の spec ファイル等）が 1 件でも含まれる, the per-task Loop shall Requirement 1 のスキップを行わず、従来通り Reviewer を起動する
+3. If diff range の解決自体が失敗した（`pt_resolve_diff_range` が rc!=0）, the per-task Loop shall Requirement 1 のスキップ判定を行わず、既存の diff-range-resolve-failed 経路に従って処理する
+4. The per-task Loop shall `tasks.md` 内の変更が当該 task ID の checkbox flip（`- [ ]` → `- [x]`）のみで構成されることを Requirement 1 のスキップ成立条件として要求する
+5. If `tasks.md` 内の変更が当該 task ID の checkbox flip 以外の編集（他 task の checkbox 編集、`_Requirements:_` 行の編集、新規行追加、コメント編集等）を含む, the per-task Loop shall Requirement 1 のスキップを行わず、従来通り Reviewer を起動する
+
+### Requirement 4: 回帰互換性
+
+**Objective:** As an idd-claude 運用者, I want 本変更が既存の per-task Reviewer 動作を破壊しない, so that 既稼働の自動開発パイプライン（既存 spec の per-task ループ実行）に regression が発生しない
+
+#### Acceptance Criteria
+
+1. When 判定対象 task が子タスク（`1.1`, `2.3.1` 等の階層下位 ID で、自身は子タスクを持たない）, the per-task Loop shall 従来通り `run_per_task_reviewer` を起動する
+2. When 判定対象 task が子タスクを持たない最上位 task（例: 単独タスク `5.` で配下に `5.1` 等が存在しない）, the per-task Loop shall 従来通り `run_per_task_reviewer` を起動する
+3. When 判定対象 task が親タスクであるが diff range に `tasks.md` 以外の変更を含む, the per-task Loop shall 従来通り `run_per_task_reviewer` を起動する
+4. When 既存の per-task Reviewer の reject → Implementer 再起動 → Reviewer round=2 / Debugger Gate → Reviewer round=3 のループに到達するケース, the per-task Loop shall 本変更導入前と同一の制御フローおよび戻り値分岐を維持する
+5. The per-task Loop shall 本変更導入前から成功していた既存 spec の per-task ループ実行において、ループ完走後の最終状態（claude-claimed → 完了ラベル遷移 / PR 作成）が本変更導入前と等価であることを保証する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The per-task Loop shall 本変更を有効化するための追加の環境変数 opt-in を要求せず、既定で Requirement 1 のスキップ判定を有効として動作する
+2. The per-task Loop shall 本変更を含まない過去の watcher バージョンが書き出した進捗（`- [x]` 済み tasks.md、既存 marker commit）と互換に動作する（既存 spec の resume 実行で破綻しない）
+3. The per-task Loop shall `tasks.md` が不在 / 当該 task ID の checkbox 行が存在しない等の異常系では Requirement 1 のスキップ判定を行わず、既存の fail-safe 経路（`pt_check_task_completed` rc=2 経路と同等の保守的扱い）に倒す
+
+### NFR 2: 観測可能性
+
+1. The per-task Loop shall Requirement 1 のスキップ発生時に、`per-task: task=<id> reviewer skipped reason=parent-task-checkbox-only-diff` の形式に相当する 1 行ログを `$LOG` に出力し、運用者が `grep reviewer skipped` で件数把握可能な状態にする
+2. The per-task Loop shall スキップ判定の根拠（子タスク存在検出 / diff range の変更ファイル集合 / tasks.md 内変更行の判定結果）を、デバッグ時に追跡可能な粒度で `$LOG` に残す（最低でも task ID と判定経路の識別子を含む）
+3. The per-task Loop shall スキップ判定が成立しなかった場合（親タスクだが diff に他ファイルを含む等）に、判定をスキップせず通常経路に進んだ旨を識別する追加ログを **新規には出さない**（既存ログ量を増やさない後方互換）
+
+### NFR 3: 性能
+
+1. The per-task Loop shall Requirement 1 のスキップ判定（子タスク存在検出 + diff range 変更ファイル集合取得 + tasks.md 内変更行内容判定）を、対象 task 1 件あたり既存の Reviewer 起動 1 回（通常数十秒〜数分）と比較して無視可能な追加レイテンシ（目安として 1 秒以内）で完了させる
+2. When Requirement 1 のスキップが成立, the per-task Loop shall Reviewer 用の `claude --print` プロセス起動を抑制し、対応する LLM 呼び出しトークンと実行時間を消費しない
+
+## Out of Scope
+
+- `run_per_task_reviewer` 関数本体（Reviewer が `review-notes.md` を書き出すか否かの挙動）のリトライ / 再生成ロジック追加。本 spec は Reviewer 起動自体を抑止する設計に倒し、Reviewer の出力不安定性は別 Issue で扱う
+- Reviewer エージェント側の prompt 改修（`review-notes.md` を必ず書き出させるための prompt 強化）。本 spec の対象外
+- Stage B Reviewer（全体 Reviewer / PR 直前のレビュー）のスキップ判定。本 spec は per-task ループ内の per-task Reviewer のみを対象とする
+- 親タスク以外の文脈で diff が `tasks.md` checkbox flip のみになるケース（人間が手動で進捗マーカーだけ進めた等）への一般化。本 spec は per-task ループが自動生成する親タスク完了マーク commit のみを対象とする
+- `tasks-generation.md` / `design-review-gate.md` 等の Architect 向け規約改訂。本変更は watcher 側のランタイム挙動のみで完結する
+- 既存 spec の `tasks.md` / `review-notes.md` への遡及的修正（retrofit）
+
+## Open Questions
+
+- なし（Issue 本文・既存実装の親タスク判定ヘルパー `pt_extract_pending_tasks` / `pt_check_task_completed`・親タスク完了マーク commit 規約 `docs(tasks): mark <id> as done` から実装可能性が確認できているため、本フェーズで人間判断を要する曖昧点はない）

--- a/docs/specs/270--bug-checkbox-flip-per-task-reviewer/review-notes.md
+++ b/docs/specs/270--bug-checkbox-flip-per-task-reviewer/review-notes.md
@@ -1,0 +1,104 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-05-29T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-270-impl--bug-checkbox-flip-per-task-reviewer
+- HEAD commit: 7154ae9803d0182b0d88cb7b3493cd0691956de8
+- Compared to: main..HEAD
+- Note: 本 spec は design-less impl 経路（`tasks.md` / `design.md` 不在）であり、Reviewer は
+  requirements.md と impl-notes.md と実装 diff のみを根拠に AC 判定を行う。
+
+## Verified Requirements
+
+### Requirement 1（親タスク + checkbox-only diff の Reviewer 起動スキップ）
+
+- 1.1 — `run_per_task_loop` 内 `local rev_rc=0` 直前で `pt_should_skip_reviewer "$task_id"` を呼び、
+  rc=0 のとき `run_per_task_reviewer` を起動せず `rev_rc=0` のまま続行
+  （`local-watcher/bin/issue-watcher.sh:3389-3394`）
+- 1.2 — スキップ成立時は `rev_rc=0` で続行し、続く `case "$rev_rc" in 0)` 分岐（approve 経路）に
+  そのまま乗る（`local-watcher/bin/issue-watcher.sh:3395-3398`）
+- 1.3 — スキップ成立時は `review-notes.md` の有無を判定する `parse_review_result` 経路を一切
+  通らないため `claude-failed` 付与は構造的に発生しない（同上 case 分岐により approve 直結）
+- 1.4 — `pt_should_skip_reviewer` 内で `pt_log "task=${task_id} reviewer skipped reason=parent-task-checkbox-only-diff range=..."`
+  を stdout に出力し、call site 側で `>> "$LOG"` リダイレクト
+  （`local-watcher/bin/issue-watcher.sh` `pt_should_skip_reviewer` 末尾 / 呼び出し L3390）
+  smoke test C-6 で grep 可能性を検証
+- 1.5 — dispatcher は対象 task のみに対する判定であり、後続 pending task はループ次反復で
+  通常処理される（コード上、while ループ構造は変更されていない）
+- 1.6 — Stage B Reviewer / PR 作成等の後続フェーズへの遷移は本変更で触れていない（per-task
+  ループの脱出条件は変更なし）
+
+### Requirement 2（「親タスク」の判定方法）
+
+- 2.1 — `pt_has_subtasks` が `^- \[[ x]\]\*? <task_id_re>\.[0-9]+(\.[0-9]+)*\.? ` の正規表現で
+  numeric 階層 prefix 子タスク行を検出。`task_id_re` は `sed -E 's/[][\\.*^$()+?{|/]/\\&/g'` で
+  安全にエスケープ。smoke test A-1, A-2 で検証
+- 2.2 — 子タスクが 0 件のとき rc=1 を返し、`pt_should_skip_reviewer` で skip 対象外として早期 return
+  （`pt_has_subtasks` 末尾 `return 1`）。smoke test A-3, A-5 で検証
+- 2.3 — 子タスク自身（例 `1.1`）に対する判定では孫タスクが無いため rc=1。smoke test A-4 で検証
+- 2.4 — regex の checkbox 部分 `\[[ x]\]\*?` で `- [ ]` / `- [x]` / `- [ ]*` / `- [x]*` の
+  4 種すべてマッチ。smoke test A-9（完了済み子で親判定成立）で検証
+- 2.5 — 同上 regex の `\*?` で deferrable 印を許容。smoke test A-2（`- [ ]* 3.1` で `3` が親判定成立）
+  で検証
+- false positive 防止（task_id `1` が `11.` を誤検出しない）も regex の `\.` 連結により担保され、
+  smoke test A-8 で明示的に検証
+
+### Requirement 3（「tasks.md only diff」の判定方法）
+
+- 3.1 — `pt_is_parent_checkbox_only_diff` の第 1 段で `git diff --name-only "${range_start}..${range_end}"`
+  → 行数 1 件 + 文字列一致 `$SPEC_DIR_REL/tasks.md` を要求。smoke test B-1 で検証
+- 3.2 — 同上判定で行数 != 1 または別ファイルを含むと rc=1。smoke test B-5（tasks.md + src.txt 混入）
+  で検証
+- 3.3 — `pt_should_skip_reviewer` 内で `pt_resolve_diff_range` 失敗時に rc=1 を return し既存経路へ
+  fallback。smoke test C-5（存在しない marker '99'）で検証
+- 3.4 — 第 2 段で `^-- \[ \] <task_id_re>\.? ` と `^\+- \[x\] <task_id_re>\.? ` の対が
+  ぴったり 1+1 件であることを `minus_match`/`plus_match` で要求、かつ `minus_count`/`plus_count`
+  （file header 除外後の総数）も 1+1 件であることを要求。smoke test B-1 で検証
+- 3.5 — `minus_count` / `plus_count` が 1+1 件を超えるケース（他編集混入）では rc=1。
+  smoke test B-6（task_id=1 を渡すが diff は 1.1 の flip のみ）/ B-7（空 diff）で検証
+
+### Requirement 4（回帰互換性）
+
+- 4.1 — 子タスク（自身は子を持たない）は `pt_has_subtasks` rc=1 で skip 対象外、`run_per_task_reviewer`
+  を従来通り起動。smoke test C-2, C-3 で検証
+- 4.2 — 単独タスク（最上位 ID + 子なし）も同様に skip 対象外。smoke test C-4 で検証
+- 4.3 — 親タスクだが他ファイル変更を含むケースは `pt_is_parent_checkbox_only_diff` rc=1 で
+  skip 対象外。smoke test B-5 で検証
+- 4.4 — round=2 / round=3 経路（`run_per_task_reviewer "$task_id" 2` / Debugger Gate / round=3）の
+  コードブロックは diff 上一切変更されていない（`git diff main..HEAD` で確認済み）
+- 4.5 — 既存挙動と等価。skip 経路に入らない場合は call site も `run_per_task_reviewer "$task_id" 1 || rev_rc=$?`
+  に従来通り倒れる（L3393）
+
+### Non-Functional Requirements
+
+- NFR 1.1 — env var による opt-in なし。dispatcher は直接呼び出しで動作（既定で有効）
+- NFR 1.2 — `tasks.md` の既存 `- [x]` / 既存 marker commit を読み取るのみで破壊操作なし
+- NFR 1.3 — `pt_has_subtasks` rc=2（fail-safe）/ `pt_resolve_diff_range` 失敗 /
+  `pt_is_parent_checkbox_only_diff` rc=1 のいずれでも skip 対象外として既存経路へ倒す。
+  smoke test A-6, A-7, C-5 で検証
+- NFR 2.1 — `pt_log "task=<id> reviewer skipped reason=parent-task-checkbox-only-diff range=..."`
+  を stdout 出力 → `>> "$LOG"` で集約。grep 可能。smoke test C-6 で検証
+- NFR 2.2 — ログに task ID + 判定経路識別子（`reason=parent-task-checkbox-only-diff`）+
+  range short SHA を含む
+- NFR 2.3 — skip 不成立時は dispatcher 内で新規ログを出さない（各 fail-safe 経路で素直に return 1）。
+  smoke test C-7 で検証
+- NFR 3.1 — 判定は `git diff` 2 回（`--name-only` + 本体）+ grep のみで構成され、軽量
+- NFR 3.2 — skip 成立時は `run_per_task_reviewer` 起動を完全に bypass（call site の if/else 分岐）
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric ID（Req 1.1〜1.6 / 2.1〜2.5 / 3.1〜3.5 / 4.1〜4.5 / NFR 1.1〜1.3 /
+NFR 2.1〜2.3 / NFR 3.1〜3.2）に対応する実装が `local-watcher/bin/issue-watcher.sh` の 3 つの
+新規関数（`pt_has_subtasks` / `pt_is_parent_checkbox_only_diff` / `pt_should_skip_reviewer`）
+および `run_per_task_loop` の Reviewer 起動直前の分岐で確認できた。23 件の smoke test
+（`docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh`）が
+全 PASS、shellcheck 警告ゼロも reviewer 側で再現確認済み。boundary 逸脱・AC 未カバー・
+missing test のいずれも検出されない。
+
+RESULT: approve

--- a/docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/tasks-parent-with-children.md
+++ b/docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/tasks-parent-with-children.md
@@ -1,0 +1,13 @@
+# Tasks
+
+- [ ] 1. 親タスク（子を持つ）
+- [ ] 1.1 子タスク A
+  - _Requirements: 1.1_
+- [ ] 1.2 子タスク B
+  - _Requirements: 1.2_
+- [ ] 2. 単独タスク（子を持たない）
+  - _Requirements: 2.1_
+- [ ] 3. もう一つの親タスク
+- [ ]* 3.1 deferrable な子タスク
+  - _Requirements: 3.1_
+- [x] 4. 既に完了済みのタスク

--- a/docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh
+++ b/docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# Issue #270 / Reviewer skip 判定ロジックのスモークテスト
+#
+# 対象関数:
+#   - pt_has_subtasks <tasks_md> <task_id>
+#   - pt_is_parent_checkbox_only_diff <task_id> <range_start> <range_end>
+#   - pt_should_skip_reviewer <task_id>（dispatcher: pt_resolve_diff_range も内部で利用）
+#
+# 検証ケース:
+#   A. pt_has_subtasks: 親 / 子 / 末端 / deferrable 子 / 完了済み親 / 不在 task_id / file 不在
+#   B. pt_is_parent_checkbox_only_diff: 親タスク + tasks.md only / 他ファイル混入 /
+#      tasks.md 内に他編集混入 / 空 diff / 範囲不正
+#   C. pt_should_skip_reviewer (E2E): 親 + checkbox-only / 子 + checkbox-only /
+#      親 + 実装差分混入 / 通常タスク
+#
+# 使い方: 本リポジトリ root から `bash docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh`
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+WATCHER_SH="$REPO_ROOT/local-watcher/bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "❌ issue-watcher.sh not found at: $WATCHER_SH" >&2
+  exit 1
+fi
+
+# 関数定義のみを抽出するための実行スコープ。issue-watcher.sh の冒頭処理（init / claim 等）を
+# 起動しないよう、source ではなく awk で関数定義部分のみを抽出して eval する。
+# ただし依存関数が多すぎるため、別アプローチで関数を直接実装ファイルから source する。
+# 冒頭で main 処理が走ると副作用が大きいため、SOURCE_ONLY モードを使わず、
+# 関数を bash subshell で利用するために、`bash -c` でラッパを書く。
+
+# 一時 git repo を作成し、その中で関数を実行する。
+TMPDIR_BASE=$(mktemp -d /tmp/idd-270-test.XXXXXX)
+HELPERS_SH="/tmp/idd-270-helpers-$$.sh"
+LOG="/tmp/idd-270-log-$$.log"
+trap 'rm -rf "$TMPDIR_BASE" "$HELPERS_SH" "$LOG"' EXIT
+
+cd "$TMPDIR_BASE"
+git init -q .
+git config user.email "test@example.com"
+git config user.name "Test User"
+
+mkdir -p docs/specs/270-fixture
+TASKS_MD_REL="docs/specs/270-fixture/tasks.md"
+TASKS_MD_ABS="$TMPDIR_BASE/$TASKS_MD_REL"
+
+# 初期 tasks.md（未完了状態）
+cat > "$TASKS_MD_ABS" <<'EOF'
+# Tasks
+
+- [ ] 1. 親タスク（子を持つ）
+- [ ] 1.1 子タスク A
+  - _Requirements: 1.1_
+- [ ] 1.2 子タスク B
+  - _Requirements: 1.2_
+- [ ] 2. 単独タスク（子を持たない）
+  - _Requirements: 2.1_
+- [ ] 3. もう一つの親タスク
+- [ ]* 3.1 deferrable な子タスク
+  - _Requirements: 3.1_
+EOF
+
+git add -A
+git commit -q -m "chore: initial tasks.md"
+BASE_SHA=$(git rev-parse HEAD)
+git branch -M main
+git checkout -q -b work
+
+# ---- ヘルパー関数を抽出して subshell に流し込む ----
+# issue-watcher.sh 全体を source すると main が走るので、関数定義のみを抽出する。
+# 簡易方針: bash の `set -n` + `compgen` を使う代わりに、必要な関数定義ブロックを sed で抜き出す。
+# pt_log / pt_warn / pt_has_subtasks / pt_is_parent_checkbox_only_diff / pt_resolve_diff_range /
+# pt_should_skip_reviewer を抽出。
+
+# 関数定義抽出関数: 関数名 → 関数本体（最初の `^<name>() {` から対応する `^}` まで）
+extract_fn() {
+  local fn="$1"
+  awk -v fn="$fn" '
+    $0 ~ ("^" fn "\\(\\) \\{$") { capture=1 }
+    capture { print }
+    capture && /^\}$/ { capture=0; exit }
+  ' "$WATCHER_SH"
+}
+
+# 必要な関数群を一時ファイルに集約
+HELPERS_SH="/tmp/idd-270-helpers-$$.sh"
+{
+  echo "#!/usr/bin/env bash"
+  echo "set -euo pipefail"
+  extract_fn pt_log
+  extract_fn pt_warn
+  extract_fn pt_has_subtasks
+  extract_fn pt_resolve_diff_range
+  extract_fn pt_is_parent_checkbox_only_diff
+  extract_fn pt_should_skip_reviewer
+} > "$HELPERS_SH"
+
+# 抽出確認
+for fn in pt_log pt_warn pt_has_subtasks pt_resolve_diff_range pt_is_parent_checkbox_only_diff pt_should_skip_reviewer; do
+  if ! grep -q "^${fn}() {" "$HELPERS_SH"; then
+    echo "❌ extract failed: $fn" >&2
+    exit 1
+  fi
+done
+
+# 共通環境変数
+export REPO_DIR="$TMPDIR_BASE"
+export SPEC_DIR_REL="docs/specs/270-fixture"
+export BASE_BRANCH="main"
+export LOG
+: > "$LOG"
+
+# ==========================================================================
+# テストフレームワーク
+# ==========================================================================
+PASS=0
+FAIL=0
+run_test() {
+  local name="$1"
+  local expected_rc="$2"
+  shift 2
+  local actual_rc=0
+  # shellcheck disable=SC2086
+  ( bash -c "set -euo pipefail; source '$HELPERS_SH'; $*" ) >/dev/null 2>&1 || actual_rc=$?
+  if [ "$actual_rc" = "$expected_rc" ]; then
+    echo "  ✅ $name (rc=$actual_rc)"
+    PASS=$((PASS + 1))
+  else
+    echo "  ❌ $name (expected rc=$expected_rc, got rc=$actual_rc)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# ==========================================================================
+# A. pt_has_subtasks のテスト
+# ==========================================================================
+echo "=== A. pt_has_subtasks ==="
+run_test "親タスク '1' は子を持つ → rc=0" 0 \
+  "pt_has_subtasks '$TASKS_MD_ABS' '1'"
+run_test "親タスク '3' は deferrable 子を持つ → rc=0" 0 \
+  "pt_has_subtasks '$TASKS_MD_ABS' '3'"
+run_test "単独タスク '2' は子なし → rc=1" 1 \
+  "pt_has_subtasks '$TASKS_MD_ABS' '2'"
+run_test "子タスク '1.1' は孫なし → rc=1" 1 \
+  "pt_has_subtasks '$TASKS_MD_ABS' '1.1'"
+run_test "存在しない task_id '99' → rc=1" 1 \
+  "pt_has_subtasks '$TASKS_MD_ABS' '99'"
+run_test "tasks.md 不在 → rc=2 (fail-safe)" 2 \
+  "pt_has_subtasks '/nonexistent/tasks.md' '1'"
+run_test "task_id 空文字 → rc=2 (fail-safe)" 2 \
+  "pt_has_subtasks '$TASKS_MD_ABS' ''"
+
+# false positive チェック: task_id `1` が `11` や `1.1` を誤検出しないこと
+cat > "/tmp/idd-270-false-pos-$$.md" <<'EOF'
+- [ ] 1. 親 1
+- [ ] 11. 別の親
+EOF
+run_test "false positive 防止: '1' は '11.' を子と認識しない → rc=1" 1 \
+  "pt_has_subtasks '/tmp/idd-270-false-pos-$$.md' '1'"
+
+# 完了済み子タスクも検出されること
+cat > "/tmp/idd-270-mixed-$$.md" <<'EOF'
+- [ ] 5. 親
+- [x] 5.1 完了済み子
+EOF
+run_test "完了済み子タスクでも親判定成立 → rc=0" 0 \
+  "pt_has_subtasks '/tmp/idd-270-mixed-$$.md' '5'"
+
+# ==========================================================================
+# B. pt_is_parent_checkbox_only_diff のテスト
+# ==========================================================================
+echo
+echo "=== B. pt_is_parent_checkbox_only_diff ==="
+
+# B-1: 親タスク 1 を `- [x]` 化する commit を作る（tasks.md only / checkbox flip のみ）
+sed -i 's/^- \[ \] 1\. 親タスク（子を持つ）$/- [x] 1. 親タスク（子を持つ）/' "$TASKS_MD_ABS"
+git add -A
+git commit -q -m "docs(tasks): mark 1 as done"
+SHA_FLIP_ONLY=$(git rev-parse HEAD)
+
+run_test "B-1: 親 task_id=1 の checkbox flip のみ → rc=0 (skip)" 0 \
+  "pt_is_parent_checkbox_only_diff '1' '$BASE_SHA' '$SHA_FLIP_ONLY'"
+
+# B-2: 範囲不正
+run_test "B-2: range_start 空 → rc=1" 1 \
+  "pt_is_parent_checkbox_only_diff '1' '' '$SHA_FLIP_ONLY'"
+run_test "B-3: task_id 空 → rc=1" 1 \
+  "pt_is_parent_checkbox_only_diff '' '$BASE_SHA' '$SHA_FLIP_ONLY'"
+
+# B-4: 別 task_id の checkbox flip（誤マッチしないこと）
+run_test "B-4: task_id=2 を渡すと task_id=1 の flip にはマッチしない → rc=1" 1 \
+  "pt_is_parent_checkbox_only_diff '2' '$BASE_SHA' '$SHA_FLIP_ONLY'"
+
+# B-5: tasks.md 以外のファイル変更を含む（実装差分混入）
+echo "implementation" > "$TMPDIR_BASE/src.txt"
+git add -A
+git commit -q -m "feat: 実装差分追加"
+SHA_WITH_IMPL=$(git rev-parse HEAD)
+run_test "B-5: tasks.md + src.txt 混在 → rc=1 (skip しない)" 1 \
+  "pt_is_parent_checkbox_only_diff '1' '$BASE_SHA' '$SHA_WITH_IMPL'"
+
+# B-6: tasks.md 内に他編集を含む（子タスクの flip 同居 = 親完了 + 子完了の連記レベル相当）
+sed -i 's/^- \[ \] 1\.1 子タスク A$/- [x] 1.1 子タスク A/' "$TASKS_MD_ABS"
+git add -A
+git commit -q -m "docs(tasks): mark 1.1 as done"
+SHA_MULTI_FLIP=$(git rev-parse HEAD)
+# 範囲: SHA_WITH_IMPL..SHA_MULTI_FLIP は tasks.md のみだが、task_id=1 の flip は含まれず 1.1 のみ。
+# task_id=1 のスキップ判定としては不成立。
+run_test "B-6: task_id=1 を渡すが diff は 1.1 の flip のみ → rc=1" 1 \
+  "pt_is_parent_checkbox_only_diff '1' '$SHA_WITH_IMPL' '$SHA_MULTI_FLIP'"
+
+# B-7: 空 diff（同一 SHA 範囲）
+run_test "B-7: 空 diff (同一 SHA) → rc=1" 1 \
+  "pt_is_parent_checkbox_only_diff '1' '$SHA_FLIP_ONLY' '$SHA_FLIP_ONLY'"
+
+# ==========================================================================
+# C. pt_should_skip_reviewer (E2E dispatcher)
+# ==========================================================================
+echo
+echo "=== C. pt_should_skip_reviewer (E2E) ==="
+
+# C 用に新 worktree シナリオを構築。
+# シナリオ:
+#   - main: 初期 tasks.md（全 [ ]）
+#   - work branch:
+#     1. mark 1.1 as done (子タスク完了マーク)
+#     2. mark 1.2 as done (子タスク完了マーク)
+#     3. mark 1 as done (親タスク完了マーク = 本機能のスキップ対象)
+#     4. mark 2 as done (単独タスク完了マーク = スキップ対象外)
+TMPDIR_E2E=$(mktemp -d /tmp/idd-270-e2e.XXXXXX)
+trap 'rm -rf "$TMPDIR_BASE" "$TMPDIR_E2E" "$HELPERS_SH" "$LOG" "/tmp/idd-270-false-pos-$$.md" "/tmp/idd-270-mixed-$$.md"' EXIT
+
+cd "$TMPDIR_E2E"
+git init -q .
+git config user.email "test@example.com"
+git config user.name "Test User"
+
+mkdir -p "docs/specs/270-fixture"
+TASKS_E2E="$TMPDIR_E2E/docs/specs/270-fixture/tasks.md"
+cat > "$TASKS_E2E" <<'EOF'
+# Tasks
+
+- [ ] 1. 親タスク（子を持つ）
+- [ ] 1.1 子タスク A
+  - _Requirements: 1.1_
+- [ ] 1.2 子タスク B
+  - _Requirements: 1.2_
+- [ ] 2. 単独タスク（子を持たない）
+  - _Requirements: 2.1_
+EOF
+git add -A
+git commit -q -m "chore: initial"
+git branch -M main
+git checkout -q -b work
+
+# 子 1.1 を完了 + 実装差分
+echo "impl 1.1" > "$TMPDIR_E2E/impl-1-1.txt"
+git add -A
+git commit -q -m "feat: 子 1.1 実装"
+sed -i 's/^- \[ \] 1\.1 子タスク A$/- [x] 1.1 子タスク A/' "$TASKS_E2E"
+git add -A
+git commit -q -m "docs(tasks): mark 1.1 as done"
+
+# 子 1.2 を完了 + 実装差分
+echo "impl 1.2" > "$TMPDIR_E2E/impl-1-2.txt"
+git add -A
+git commit -q -m "feat: 子 1.2 実装"
+sed -i 's/^- \[ \] 1\.2 子タスク B$/- [x] 1.2 子タスク B/' "$TASKS_E2E"
+git add -A
+git commit -q -m "docs(tasks): mark 1.2 as done"
+
+# 親 1 を完了（checkbox flip のみ）→ 本機能のスキップ対象
+sed -i 's/^- \[ \] 1\. 親タスク（子を持つ）$/- [x] 1. 親タスク（子を持つ）/' "$TASKS_E2E"
+git add -A
+git commit -q -m "docs(tasks): mark 1 as done"
+
+# 単独タスク 2 を完了 + 実装差分（スキップ対象外）
+echo "impl 2" > "$TMPDIR_E2E/impl-2.txt"
+git add -A
+git commit -q -m "feat: 単独 2 実装"
+sed -i 's/^- \[ \] 2\. 単独タスク（子を持たない）$/- [x] 2. 単独タスク（子を持たない）/' "$TASKS_E2E"
+git add -A
+git commit -q -m "docs(tasks): mark 2 as done"
+
+export REPO_DIR="$TMPDIR_E2E"
+export SPEC_DIR_REL="docs/specs/270-fixture"
+export BASE_BRANCH="main"
+export LOG
+: > "$LOG"
+
+cd "$TMPDIR_E2E"
+
+run_test "C-1: 親タスク '1' (checkbox-only diff) → rc=0 (skip)" 0 \
+  "cd '$TMPDIR_E2E' && pt_should_skip_reviewer '1'"
+run_test "C-2: 子タスク '1.1' (実装差分混入) → rc=1 (run reviewer)" 1 \
+  "cd '$TMPDIR_E2E' && pt_should_skip_reviewer '1.1'"
+run_test "C-3: 子タスク '1.2' (実装差分混入) → rc=1 (run reviewer)" 1 \
+  "cd '$TMPDIR_E2E' && pt_should_skip_reviewer '1.2'"
+run_test "C-4: 単独タスク '2' (子なし) → rc=1 (run reviewer)" 1 \
+  "cd '$TMPDIR_E2E' && pt_should_skip_reviewer '2'"
+
+# C-5: 親タスクだが diff range 解決失敗（存在しない task_id）
+run_test "C-5: 存在しない marker '99' → rc=1 (fail-safe)" 1 \
+  "cd '$TMPDIR_E2E' && pt_should_skip_reviewer '99'"
+
+# C-6: ログ出力確認: スキップ成立時のみログが出ること
+LOG_BEFORE=$(wc -l < "$LOG" | tr -d '[:space:]')
+( bash -c "set -euo pipefail; source '$HELPERS_SH'; cd '$TMPDIR_E2E'; pt_should_skip_reviewer '1' >> '$LOG'" ) || true
+LOG_AFTER=$(wc -l < "$LOG" | tr -d '[:space:]')
+if [ "$LOG_AFTER" -gt "$LOG_BEFORE" ] && grep -q "task=1 reviewer skipped reason=parent-task-checkbox-only-diff" "$LOG"; then
+  echo "  ✅ C-6: スキップ成立時に grep 可能ログ出力"
+  PASS=$((PASS + 1))
+else
+  echo "  ❌ C-6: ログ出力が期待形式と異なる"
+  echo "    LOG_BEFORE=$LOG_BEFORE LOG_AFTER=$LOG_AFTER"
+  echo "    LOG 内容:"
+  cat "$LOG"
+  FAIL=$((FAIL + 1))
+fi
+
+# C-7: スキップ不成立時はログを増やさない（NFR 2.3）
+LOG_BEFORE2=$(wc -l < "$LOG" | tr -d '[:space:]')
+( bash -c "set -euo pipefail; source '$HELPERS_SH'; cd '$TMPDIR_E2E'; pt_should_skip_reviewer '2' >> '$LOG'" ) || true
+LOG_AFTER2=$(wc -l < "$LOG" | tr -d '[:space:]')
+if [ "$LOG_AFTER2" = "$LOG_BEFORE2" ]; then
+  echo "  ✅ C-7: スキップ不成立時にログ増えない (NFR 2.3)"
+  PASS=$((PASS + 1))
+else
+  echo "  ❌ C-7: スキップ不成立時に新規ログが出ている"
+  diff <(head -n "$LOG_BEFORE2" "$LOG") "$LOG" || true
+  FAIL=$((FAIL + 1))
+fi
+
+# ==========================================================================
+echo
+echo "=========================================="
+echo "Results: PASS=$PASS FAIL=$FAIL"
+echo "=========================================="
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -2440,6 +2440,206 @@ pt_resolve_diff_range() {
   return 0
 }
 
+# ─── pt_has_subtasks <tasks_md_path> <task_id> ───
+#
+# tasks.md 上で指定 task_id を numeric 階層 prefix とする子タスク行が 1 件以上存在するか
+# 判定する（Issue #270 / Req 2.1, 2.4, 2.5）。
+#
+# 判定パターン（checkbox enforcement の判定パターンに整合 / .claude/rules/tasks-generation.md）:
+#   - 行頭が `- [ ]` / `- [ ]*` / `- [x]` / `- [x]*` のいずれかで開始
+#   - 続けて `<task_id>.<下位 ID>(<.下位 ID>)* `（末尾 `.` あり / なしを許容）
+#   - 例: 親 task_id=`4` に対し `- [ ] 4.1 <title>` / `- [x] 4.2.1 <title>` / `- [ ]* 4.3 <title>`
+#
+# 戻り値:
+#   0 = 子タスクが 1 件以上存在する（= 親タスクとして扱える）
+#   1 = 子タスクが 1 件も存在しない（= 通常タスク / 階層末端）
+#   2 = tasks.md 不在 / その他 fail-safe（NFR 1.3）
+#
+# Req 2.4: 子タスクの完了 / 未完了状態（`- [x]` か `- [ ]` か）に関わらず、子タスクの
+# 存在のみで親タスク判定を成立させる
+# Req 2.5: deferrable 印 `- [ ]*` も子タスク存在判定の対象に含める
+#
+# Requirements (Issue #270): 2.1, 2.4, 2.5, NFR 1.3
+pt_has_subtasks() {
+  local tasks_md="$1"
+  local task_id="$2"
+  if [ ! -f "$tasks_md" ]; then
+    return 2
+  fi
+  if [ -z "$task_id" ]; then
+    return 2
+  fi
+  # task_id を正規表現リテラルとして安全にエスケープ
+  local task_id_re
+  # shellcheck disable=SC2016
+  task_id_re=$(printf '%s' "$task_id" | sed -E 's/[][\\.*^$()+?{|/]/\\&/g')
+  # 子タスク行: `- [ ]` / `- [ ]*` / `- [x]` / `- [x]*` + ` <task_id>.<下位 ID>(...)? `
+  if grep -qE "^- \[[ x]\]\*? ${task_id_re}\.[0-9]+(\.[0-9]+)*\.? " "$tasks_md" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# ─── pt_is_parent_checkbox_only_diff <task_id> <range_start> <range_end> ───
+#
+# 指定 diff range (`range_start..range_end`) の変更内容が、`tasks.md` 1 ファイルのみで構成され、
+# かつその変更内容が指定 task_id の checkbox flip `- [ ]` → `- [x]` のみであることを判定する
+# （Issue #270 / Req 3.1, 3.4, 3.5）。
+#
+# 戻り値:
+#   0 = 条件成立（Reviewer スキップ可能）
+#   1 = 条件不成立（tasks.md 以外のファイル変更を含む / tasks.md 内に他編集を含む / fail-safe）
+#
+# 判定手順:
+#   1. `git diff --name-only <range>` で変更ファイル集合を取得し、`tasks.md` 1 件のみであることを確認
+#      - 0 件 / 2 件以上 → 不成立
+#      - 1 件だがファイル名が tasks.md でない → 不成立
+#   2. `git diff <range> -- <tasks_md>` の hunk 内行を走査し、以下のみで構成されることを確認:
+#      - 削除行 `- ` で始まる中身が `- [ ] <task_id>(\.)? ` で始まる行のみ
+#      - 追加行 `+ ` で始まる中身が `- [x] <task_id>(\.)? ` で始まる行のみ
+#      - diff header / hunk header / context 行は無視
+#   3. 削除行 1 件 + 追加行 1 件で完全に対応する（task_id checkbox flip 1 ペアのみ）こと
+#      - 他 task_id の checkbox flip / `_Requirements:_` 編集 / 新規追加 / 削除のみ等が
+#        混入すれば不成立
+#
+# Req 3.2: tasks.md 以外のファイルが 1 件でも含まれれば不成立
+# Req 3.5: tasks.md 内の変更が他編集を含めば不成立
+# NFR 1.3: 異常系（git diff 失敗等）は不成立（保守的に倒す）
+#
+# Requirements (Issue #270): 3.1, 3.2, 3.4, 3.5, NFR 1.3
+pt_is_parent_checkbox_only_diff() {
+  local task_id="$1"
+  local range_start="$2"
+  local range_end="$3"
+
+  if [ -z "$task_id" ] || [ -z "$range_start" ] || [ -z "$range_end" ]; then
+    return 1
+  fi
+
+  # spec ディレクトリ配下の tasks.md パスを canonical に決める。git diff --name-only は
+  # repo root からの相対パスで返るため、SPEC_DIR_REL/tasks.md と比較する。
+  local tasks_md_rel="${SPEC_DIR_REL:-}/tasks.md"
+  if [ -z "${SPEC_DIR_REL:-}" ]; then
+    # SPEC_DIR_REL が未設定 → fail-safe で不成立
+    return 1
+  fi
+
+  # ── (1) 変更ファイル集合の取得と検証 ──
+  local changed_files
+  if ! changed_files=$(git diff --name-only "${range_start}..${range_end}" 2>/dev/null); then
+    return 1
+  fi
+
+  # 空 diff → 不成立（checkbox flip すら無い）
+  if [ -z "$changed_files" ]; then
+    return 1
+  fi
+
+  # 変更ファイルが tasks.md ちょうど 1 件のみであることを検証
+  local changed_count
+  changed_count=$(printf '%s\n' "$changed_files" | wc -l | tr -d '[:space:]')
+  if [ "$changed_count" != "1" ]; then
+    return 1
+  fi
+  if [ "$changed_files" != "$tasks_md_rel" ]; then
+    return 1
+  fi
+
+  # ── (2) tasks.md 内の hunk 内容を走査 ──
+  local diff_body
+  if ! diff_body=$(git diff "${range_start}..${range_end}" -- "$tasks_md_rel" 2>/dev/null); then
+    return 1
+  fi
+  if [ -z "$diff_body" ]; then
+    return 1
+  fi
+
+  # task_id を正規表現リテラルとして安全にエスケープ
+  local task_id_re
+  # shellcheck disable=SC2016
+  task_id_re=$(printf '%s' "$task_id" | sed -E 's/[][\\.*^$()+?{|/]/\\&/g')
+
+  # hunk 行を分類:
+  #   - 削除行: `-` で始まるが `--- a/path` の diff file header ではない行
+  #   - 追加行: `+` で始まるが `+++ b/path` の diff file header ではない行
+  #   - その他（context / hunk header `@@` / `diff --git` / `index ` 行）: 無視
+  # 期待: 削除行 1 件 + 追加行 1 件のペアのみで、それぞれが当該 task_id の checkbox flip。
+  #
+  # 注意: 削除行の中身が `- [ ]` で始まる markdown list の場合、diff 上は `-- [ ]` のように
+  # 行頭が `--` 2 文字になる。よって `^-[^-]` で diff header を除外する素朴な regex は
+  # markdown 削除行を取りこぼす。`^--- ` を file header として明示除外する形に修正する。
+  local minus_count plus_count minus_match plus_match
+  # `- [ ] <task_id>(\.)? ` で始まる削除行 = `^-- \[ \] <task_id>(\.)? `
+  minus_match=$(printf '%s\n' "$diff_body" | grep -cE "^-- \[ \] ${task_id_re}\.? " 2>/dev/null || true)
+  # `- [x] <task_id>(\.)? ` で始まる追加行 = `^\+- \[x\] <task_id>(\.)? `
+  plus_match=$(printf '%s\n' "$diff_body" | grep -cE "^\+- \[x\] ${task_id_re}\.? " 2>/dev/null || true)
+
+  # 全削除行 / 追加行の総数: 行頭 `-` / `+` を持ち、かつ file header (`--- ` / `+++ `) ではない行。
+  # diff header / hunk header / context 行は除外する。
+  minus_count=$(printf '%s\n' "$diff_body" | grep -E '^-' | grep -cvE '^--- ' 2>/dev/null || true)
+  plus_count=$(printf '%s\n' "$diff_body" | grep -E '^\+' | grep -cvE '^\+\+\+ ' 2>/dev/null || true)
+
+  # 厳密一致: 削除行 1 件 + 追加行 1 件で、それぞれが当該 task_id の checkbox flip ペア
+  if [ "$minus_count" = "1" ] && [ "$plus_count" = "1" ] \
+     && [ "$minus_match" = "1" ] && [ "$plus_match" = "1" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# ─── pt_should_skip_reviewer <task_id> ───
+#
+# per-task Reviewer 起動直前のスキップ判定 dispatcher（Issue #270 / Req 1.1, 1.2, 1.3）。
+#
+# 以下を順に判定し、すべて成立した場合のみ「Reviewer 起動をスキップ可能」として stdout に
+# 判定根拠ログを 1 行残し、return 0。いずれか不成立 / fail-safe なら return 1。
+#
+#   1. 当該 task_id が「子タスクを 1 件以上持つ親タスク」である（pt_has_subtasks rc=0）
+#   2. pt_resolve_diff_range が成功する（marker commit が見つかる）
+#   3. 当該 task の diff range が `tasks.md` のみ + checkbox flip のみで構成される
+#      （pt_is_parent_checkbox_only_diff rc=0）
+#
+# 戻り値:
+#   0 = スキップ条件成立（Reviewer 起動不要 / approve 扱い）
+#   1 = スキップ条件不成立（通常通り Reviewer を起動すべき / fail-safe 含む）
+#
+# NFR 2.1: スキップ成立時のみ単一行ログを stdout に出力（呼び出し側で `>> "$LOG"` する規約）。
+# NFR 2.3: スキップ不成立時は新規ログを出さない（既存ログ量を増やさない後方互換）。
+#
+# Requirements (Issue #270): 1.1, 1.2, 1.3, 1.4, 2.x, 3.x, NFR 1.3, NFR 2.1, NFR 2.3
+pt_should_skip_reviewer() {
+  local task_id="$1"
+  local tasks_md="$REPO_DIR/$SPEC_DIR_REL/tasks.md"
+
+  # (1) 親タスク判定（子タスクが 1 件以上存在するか）
+  local _has_rc=0
+  pt_has_subtasks "$tasks_md" "$task_id" || _has_rc=$?
+  if [ "$_has_rc" != "0" ]; then
+    # 子タスク不在 or fail-safe → スキップ対象外（既存ログを増やさない）
+    return 1
+  fi
+
+  # (2) diff range 解決
+  local range_line range_start range_end
+  if ! range_line=$(pt_resolve_diff_range "$task_id" 2>/dev/null); then
+    return 1
+  fi
+  range_start=$(printf '%s' "$range_line" | cut -f1)
+  range_end=$(printf '%s' "$range_line" | cut -f2)
+  if [ -z "$range_start" ] || [ -z "$range_end" ]; then
+    return 1
+  fi
+
+  # (3) tasks.md only + checkbox flip only 判定
+  if ! pt_is_parent_checkbox_only_diff "$task_id" "$range_start" "$range_end"; then
+    return 1
+  fi
+
+  # スキップ成立。NFR 2.1 / Req 1.4 に従い grep 可能な単一行ログを stdout に出力。
+  pt_log "task=${task_id} reviewer skipped reason=parent-task-checkbox-only-diff range=${range_start:0:7}..${range_end:0:7}"
+  return 0
+}
+
 # ─── build_per_task_implementer_prompt <task_id> ───
 #
 # per-task Implementer 用の prompt を heredoc で組み立てて stdout に出力。
@@ -3180,8 +3380,18 @@ run_per_task_loop() {
       fi
     fi
 
+    # Issue #270: 親タスク完了マーク commit のみで構成される task の Reviewer 起動を抑止する。
+    # 親タスク（子タスクを 1 件以上持つ task）かつ diff range の変更が `tasks.md` のみ かつ
+    # その変更が当該 task ID の checkbox flip のみ なら、Reviewer は本来レビュー対象を持たず
+    # `review-notes.md` を書き出さないため `parse-failed` → `claude-failed` を引き起こす。
+    # 該当する場合のみ Reviewer 起動をスキップし approve 扱い（rev_rc=0）で続行する。
+    # 通常タスク / 子タスク / 異常系（diff range 解決失敗等）は本判定を bypass し従来経路へ。
     local rev_rc=0
-    run_per_task_reviewer "$task_id" 1 || rev_rc=$?
+    if pt_should_skip_reviewer "$task_id" >> "$LOG"; then
+      rev_rc=0
+    else
+      run_per_task_reviewer "$task_id" 1 || rev_rc=$?
+    fi
     case "$rev_rc" in
       0)
         # approve → 次 task へ


### PR DESCRIPTION
## 概要

per-task ループ実行中、親タスクの全子タスクが完了した後に watcher が積む「親タスク完了マーク commit（`tasks.md` 1 行 checkbox flip のみ）」に対して、不要な per-task Reviewer が起動されていた。Reviewer は `review-notes.md` をディスクに書き出さず（chat に `RESULT: approve` を出力するのみ）、結果として `parse_review_result` が `review-notes.md` 不在で失敗し `claude-failed` が誤付与されるバグを修正する。

`local-watcher/bin/issue-watcher.sh` に 3 つの判定ヘルパー関数（`pt_has_subtasks` / `pt_is_parent_checkbox_only_diff` / `pt_should_skip_reviewer`）を追加し、`run_per_task_loop` 内 Reviewer 起動直前でスキップ判定を行う。スキップ成立時は `rev_rc=0`（approve 扱い）で後続処理を継続する。

## 対応 Issue

Closes #270

## 関連 PR

なし（design-less impl 経路。設計 PR は走っていない）

## 実装内容

- (Req 1.1 / 1.2) `run_per_task_loop` 内 Reviewer 起動直前で `pt_should_skip_reviewer` を呼び、rc=0（skip 成立）時は `run_per_task_reviewer` を起動せず `rev_rc=0` のまま approve 経路へ継続
- (Req 2.1〜2.5) `pt_has_subtasks <tasks_md> <task_id>` — numeric 階層 prefix (`<id>.N`) を持つ子タスク行の存在判定。完了済み・deferrable・false positive 防止の regex を実装
- (Req 3.1〜3.5) `pt_is_parent_checkbox_only_diff <task_id> <range_start> <range_end>` — diff range 内変更ファイルが `tasks.md` 単独 + 当該 task_id の checkbox flip のみか判定
- (NFR 2.1) スキップ成立時の単一行ログ `task=<id> reviewer skipped reason=parent-task-checkbox-only-diff range=...` を `$LOG` に出力（`grep "reviewer skipped"` で件数把握可能）
- (NFR 1.3) `tasks.md` 不在 / diff range 解決失敗 / 子タスク不在等の異常系では skip 判定を行わず従来経路に倒す（fail-safe 設計）

## 受入基準チェック

- [x] Req 1.1: 親タスク + checkbox-only diff のとき `run_per_task_reviewer` を起動しない ← smoke test C-1, C-2, C-3, C-4
- [x] Req 1.2: スキップ成立時は `rev_rc=0`（approve 扱い）で後続継続 ← smoke test C-1
- [x] Req 1.3: `review-notes.md` 不在を理由に `claude-failed` を付与しない ← `parse_review_result` 経路を構造的に回避
- [x] Req 1.4: スキップ発生を識別可能な単一行ログを `$LOG` に出力 ← smoke test C-6
- [x] Req 2.1〜2.5: 親タスク判定の各条件 ← smoke test A-1〜A-9
- [x] Req 3.1〜3.5: tasks.md only diff 判定の各条件 ← smoke test B-1〜B-7
- [x] Req 4.1〜4.4: 子タスク / 単独タスク / 他ファイル混入 / round=2 以降は従来通り Reviewer 起動 ← smoke test C-2, C-3, C-4, B-5

## テスト結果

```
$ bash docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh
Results: PASS=23 FAIL=0

$ shellcheck local-watcher/bin/*.sh install.sh setup.sh .github/scripts/*.sh
（出力なし = 警告ゼロ）

$ shellcheck docs/specs/270--bug-checkbox-flip-per-task-reviewer/test-fixtures/test-skip-logic.sh
（出力なし = 警告ゼロ）

$ bash -n local-watcher/bin/issue-watcher.sh
syntax OK
```

## 実装上の判断

- スキップ適用範囲は round=1 のみ（round=2 / round=3 は reject 後の再起動であり本バグシナリオには到達しない）
- diff marker と markdown list marker が重なる `--` 問題（削除行の markdown `- [ ]` が `--` になる）を、`grep -cvE '^--- '` の 2 段階除外で解決
- `pt_should_skip_reviewer` の戻り値は 0（skip）/ 1（run = fail-safe 含む）のシンプルな 2 値で呼び出し側の複雑度を最小化

詳細は `docs/specs/270--bug-checkbox-flip-per-task-reviewer/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- Reviewer 判定: `RESULT: approve`（Round 1）。詳細は `docs/specs/270--bug-checkbox-flip-per-task-reviewer/review-notes.md` 参照
- base: main / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #270 のコメントを参照してください。