### PR TITLE
fix(watcher): Stage C PR verify が merged PR を取りこぼし claude-failed を誤付与する不具合を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4003,21 +4003,29 @@ cd ~/.idd-claude && git pull && ./install.sh --local
 
 Stage C（PjM / PR 作成）で `claude` が return code 0 を返しても、**PjM サブエージェントが
 1 turn で空転終了して impl PR を作らなかった**ケースや、**GitHub の eventual consistency
-（edge cache lag）で作成直後の PR が一時的に `gh pr view` から見えない**ケースがあり得ます。
+（edge cache lag）で作成直後の PR が一時的に PR 検出クエリ（`gh pr list --head`）から見えない**ケースがあり得ます。
 本機能はこれを吸収するため、Stage C 完了報告後に impl PR の実在を **retry-with-backoff で
 検証**し、確認できない場合のみ安全側に倒して `claude-failed`（`stageC-pr-missing`）へ遷移
 させます。[#110](https://github.com/hitoshiichikawa/idd-claude/issues/110) で、KeyNest #32 で
 観測された 73 秒超の edge cache lag に対応して主経路を 6 回 / 合計 135 秒へ延長し、最終
 attempt 後に List Pulls API への独立 fallback を 1 ターン追加しています。
 
+> **バグ修正（PR 検出が merged PR を取りこぼす問題）**: 当初の主経路は `gh pr view --head`
+> を用いていましたが、`gh pr view` は `--head` フラグを持たず（`gh pr list` 用）常に失敗して
+> いました。通常は fallback が救済していましたが、その fallback も `state=open` 固定だったため、
+> **PR が verify 窓（最大 135 秒）の途中で merge されると主経路・fallback の両方が PR 不在と
+> 誤判定し、merge 済みにもかかわらず `claude-failed` を誤付与**していました。主経路を
+> `gh pr list --head <branch> --state all`、fallback を `state=all` に修正し、open / merged
+> 双方を確実に検出するようにしています。
+
 ### 挙動
 
-1. **主経路**: `gh pr view --head <branch>` を待機系列 `0 5 10 20 40 60` 秒（合計 135 秒）で
-   最大 6 回リトライする
+1. **主経路**: `gh pr list --head <branch> --state all` を待機系列 `0 5 10 20 40 60` 秒（合計 135 秒）で
+   最大 6 回リトライする（`--state all` で open / merged 双方を検出する）
 2. **1 回目で即時成功した通常ケースは追加ログを出さず、本機能導入前と外形挙動が完全に同一**
    （2 回目以降で成功したときのみ `SUCCESS attempt=N/M` を記録）
 3. 主経路を使い切っても PR 不在なら、**代替経路**（List Pulls API
-   `gh api repos/{owner}/{repo}/pulls?head={owner}:<branch>&state=open`）を **1 ターンだけ**
+   `gh api repos/{owner}/{repo}/pulls?head={owner}:<branch>&state=all`）を **1 ターンだけ**
    （リトライなし）呼び、edge cache の独立性で救済を試みる
 4. それでも PR が見つからなければ `claude-failed`（`stageC-pr-missing`）へ遷移し、人間が原因を
    特定できる粒度のログを残す

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -4953,7 +4953,9 @@ ${push_stderr_tail}
 # ─── Stage C 完了直後の PR 実在 verify ヘルパー (Issue #108 / #110) ───
 #
 # Stage C の Claude 実行が return code 0 で終了した直後に、対象 branch を head と
-# する impl PR が GitHub 側で参照可能か `gh pr view --head` で verify する。GitHub の
+# する impl PR が GitHub 側で参照可能か `gh pr list --head <branch> --state all` で verify する
+# （`gh pr view` は `--head` 非対応で常に失敗し、かつ open のみ探索だと高速 merge 済み PR を
+#  取りこぼすため、list + `--state all` で open/merged 双方を検出する）。GitHub の
 # eventual consistency により PR 作成直後数十秒は当該クエリが空応答を返すケースが
 # 観測されているため、主経路は最大 6 回までリトライ可能とし、整合性遅延に起因する
 # false negative を吸収する。さらに主経路が全試行で空応答 / 失敗で終わった場合は、
@@ -4991,7 +4993,7 @@ ${push_stderr_tail}
 #     なしで gh を実行する（既存 verify_pushed_or_retry と同方針 / 既存 cron
 #     互換性のため）。1 試行・代替経路ともに `${STAGEC_VERIFY_TIMEOUT_SECS:-15}` 秒
 #     上限（Req 1.6 / 2.5 / NFR 1.3 / 1.4）。
-#   - 代替経路は List Pulls API を直接叩く `gh api repos/{owner}/{repo}/pulls?head={owner}:BRANCH&state=open`
+#   - 代替経路は List Pulls API を直接叩く `gh api repos/{owner}/{repo}/pulls?head={owner}:BRANCH&state=all`
 #     パターン。`{owner}` は `$REPO`（owner/repo 形式）から prefix を抽出。
 #     edge cache の独立性を期待する経路設計のため、代替経路自体のリトライは
 #     行わない（Req 2.6）。
@@ -5037,8 +5039,8 @@ verify_stagec_pr_or_retry() {
 
     pr_url=""
     rc=0
-    pr_url=$("${_gh_timeout[@]}" gh pr view --repo "$REPO" --head "$branch" \
-              --json url --jq '.url' 2>/dev/null) || rc=$?
+    pr_url=$("${_gh_timeout[@]}" gh pr list --repo "$REPO" --head "$branch" --state all \
+              --json url --jq '.[0].url // empty' 2>/dev/null) || rc=$?
 
     if [ "$rc" -eq 0 ] && [ -n "$pr_url" ]; then
       # 1 回目以降の試行回数判定: N >= 2 の場合のみ「リトライで成功」ログを残す
@@ -5073,7 +5075,7 @@ verify_stagec_pr_or_retry() {
   local _owner="${REPO%%/*}"
   echo "[$(date '+%F %T')] stageC PR verify fallback start (List Pulls API) issue=#${issue_number} branch=${branch} owner=${_owner}" >> "$LOG"
   local _fb_url="" _fb_rc=0 _fb_outcome=""
-  _fb_url=$("${_gh_timeout[@]}" gh api "repos/${REPO}/pulls?head=${_owner}:${branch}&state=open" \
+  _fb_url=$("${_gh_timeout[@]}" gh api "repos/${REPO}/pulls?head=${_owner}:${branch}&state=all" \
             --jq '.[0].html_url // empty' 2>/dev/null) || _fb_rc=$?
   if [ "$_fb_rc" -eq 0 ] && [ -n "$_fb_url" ]; then
     # Req 2.2 / 3.4: 代替経路で救済（主経路全失敗 / 代替経路で成功）

--- a/local-watcher/test/stagec_pr_verify_fallback_test.sh
+++ b/local-watcher/test/stagec_pr_verify_fallback_test.sh
@@ -15,7 +15,7 @@
 #         - 代替経路の呼び出しは 1 回限り（Req 2.6）
 #         - 代替経路の呼び出しに timeout コマンドを経由する（NFR 1.4 / Req 2.5）
 #         - 代替経路の URL に owner プレフィックスが含まれる
-#           （`gh api repos/{owner}/{repo}/pulls?head={owner}:BRANCH&state=open`）
+#           （`gh api repos/{owner}/{repo}/pulls?head={owner}:BRANCH&state=all`）
 #         - リトライ間 sleep は STAGEC_VERIFY_SLEEP_CMD で fake 化し
 #           テスト 1 件あたり 30 秒以内に収める（Req 5.8）
 #
@@ -55,11 +55,12 @@ if ! declare -F verify_stagec_pr_or_retry >/dev/null; then
   exit 2
 fi
 
-# サニティチェック: 代替経路の `gh api repos/.../pulls?head=...` 呼び出しが
-# 実装本体に残っていること（Issue #110 Req 2.1）
+# サニティチェック: 代替経路の `gh api repos/.../pulls?head=...&state=all` 呼び出しが
+# 実装本体に残っていること（Issue #110 Req 2.1）。`state=all` は高速 merge 済み PR を
+# 取りこぼさないための回帰ガード（state=open 固定だと merged PR を見落とす）。
 # shellcheck disable=SC2016
-if ! grep -q 'gh api "repos/\${REPO}/pulls?head=' "$WATCHER_SH"; then
-  echo "ERROR: issue-watcher.sh に代替 API 経路 (gh api repos/.../pulls?head=) が見つからない (Issue #110 Req 2.1)" >&2
+if ! grep -q 'gh api "repos/\${REPO}/pulls?head=.*&state=all"' "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh に代替 API 経路 (gh api repos/.../pulls?head=...&state=all) が見つからない (Issue #110 Req 2.1)" >&2
   exit 2
 fi
 

--- a/local-watcher/test/stagec_pr_verify_test.sh
+++ b/local-watcher/test/stagec_pr_verify_test.sh
@@ -41,7 +41,10 @@ fi
 # Issue #108: 元々の inline `gh pr view --repo "$REPO" --head "$BRANCH"` 呼び出しは
 # verify_stagec_pr_or_retry ヘルパーに置き換えられた。サニティチェックは
 # (a) 新ヘルパー関数定義と (b) Stage C 完了時の呼び出し配線、(c) ヘルパー内部の
-# gh pr view --head 呼び出し（PR URL 取得ロジック）が残っていることを確認する。
+# gh pr list --head --state all 呼び出し（PR URL 取得ロジック）が残っていることを確認する。
+# （`gh pr view` は `--head` 非対応で常に失敗し、open のみ探索だと高速 merge 済み PR を
+#  取りこぼすため、list + `--state all` で open/merged 双方を検出する。stageC-pr-missing
+#  誤検知の回帰ガード。）
 if ! grep -q "verify_stagec_pr_or_retry()" "$WATCHER_SH"; then
   echo "ERROR: issue-watcher.sh に verify_stagec_pr_or_retry 定義が見つからない (Issue #108)" >&2
   exit 2
@@ -55,8 +58,8 @@ if ! grep -q 'verify_stagec_pr_or_retry "\$BRANCH" "\$NUMBER"' "$WATCHER_SH"; th
 fi
 # 同上（"$REPO" / "$branch" の文字列リテラルを grep する）
 # shellcheck disable=SC2016
-if ! grep -q 'gh pr view --repo "\$REPO" --head "\$branch"' "$WATCHER_SH"; then
-  echo "ERROR: issue-watcher.sh に PR 実在 verify (gh pr view --head) が見つからない" >&2
+if ! grep -q 'gh pr list --repo "\$REPO" --head "\$branch" --state all' "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh に PR 実在 verify (gh pr list --head --state all) が見つからない" >&2
   exit 2
 fi
 
@@ -68,8 +71,8 @@ _test_stagec_complete() {
 
   rm -f "$_qa_reset_file_c"
   local _stagec_pr_url _stagec_verify_rc=0
-  _stagec_pr_url=$(gh pr view --repo "$REPO" --head "$BRANCH" \
-                      --json url --jq '.url' 2>/dev/null) || _stagec_verify_rc=$?
+  _stagec_pr_url=$(gh pr list --repo "$REPO" --head "$BRANCH" --state all \
+                      --json url --jq '.[0].url // empty' 2>/dev/null) || _stagec_verify_rc=$?
   if [ "$_stagec_verify_rc" -eq 0 ] && [ -n "$_stagec_pr_url" ]; then
     echo "Stage C 完了 / PR 作成済み"
     return 0
@@ -120,7 +123,7 @@ echo "--- Stage C PR verify cases ---"
 
 # Req 4.1, 4.3: gh が PR URL を返す → return 0
 gh() {
-  # gh pr view --repo X --head Y --json url --jq '.url'
+  # gh pr list --repo X --head Y --state all --json url --jq '.[0].url // empty'
   echo "https://github.com/owner/test/pull/45"
   return 0
 }
@@ -136,9 +139,9 @@ assert_eq "PR 実在あり: mark_issue_failed 未呼出 (Req 4.3)" "" "$LAST_MAR
 
 # Req 4.2: gh は成功 (rc=0) だが URL が空（--head に対応 PR が無い） → claude-failed
 gh() {
-  # gh は対応 PR 無しでも成功で終了するが --jq '.url' が空文字列 / null になる
-  # （gh pr view は head に該当 PR が無いと exit 1 を返すケースもあるが、
-  # gh 1.x の挙動差を吸収するため空文字 + 成功も同等に扱う）
+  # gh は対応 PR 無しでも成功で終了するが --jq '.[0].url // empty' が空文字列になる
+  # （gh pr list は head に該当 PR が無いと空配列 [] + exit 0 を返すため空文字 + 成功と
+  # して扱う。旧 gh pr view --head 経路が返した exit 1 ケースも空文字 + 成功と同等に吸収する）
   echo ""
   return 0
 }


### PR DESCRIPTION
## 概要

Stage C 完了直後の PR 実在 verify（`verify_stagec_pr_or_retry`）が、**impl PR を作成・merge できているのに `claude-failed`（`stageC-pr-missing`）を誤付与する**不具合を修正する。downstream リポジトリで、PR 作成 → 約 2 分で merge → その直後に `claude-failed` が付く事象として観測された。

## 原因（PR 検出が二段とも壊れていた）

`local-watcher/bin/issue-watcher.sh` の `verify_stagec_pr_or_retry`:

1. **主経路（常に失敗）**: `gh pr view --repo "$REPO" --head "$branch" --json url` の `--head` は **`gh pr view` に存在しないフラグ**（`gh pr list` 用）。実行すると `unknown flag: --head` で **PR の有無に関係なく必ず exit=1**。通常は fallback が救済するため顕在化していなかった。
2. **fallback（merged を取りこぼす）**: `gh api "repos/$REPO/pulls?head=owner:$branch&state=open"` は **`state=open` 固定**のため、既に merge 済みの PR を取りこぼす（`[]` 空応答）。

この 2 つが重なり、impl PR が **verify 窓（最大 6 回 / 合計 135 秒）の途中で merge された場合**に、主経路（全 exit=1）も fallback（merged のため open 空）も「PR 不在」と判定 → `claude-failed` を誤付与していた。高速レビュー / auto-merge で再現する。

> 実証: `gh pr view --head` → `unknown flag: --head`（rc=1）。`gh api .../pulls?head=...&state=open` は merged PR で `[]`、`state=all` で当該 PR を検出。

## 修正

- **主経路**: `gh pr list --repo "$REPO" --head "$branch" --state all --json url --jq '.[0].url // empty'` に変更。`gh pr list --head` は正しいフラグで、`--state all` により open / merged 双方を検出する（**同ファイル内の他箇所〔#213 の MERGED ガード等〕で既に使われている idiom に統一**）。
- **fallback**: List Pulls API の `state=open` → `state=all`。
- **テスト**: `stagec_pr_verify_test.sh` / `stagec_pr_verify_fallback_test.sh` の sanity grep を新コマンドへ更新し、`gh pr view --head` / `state=open` への**回帰を検出するガード**に転換。
- **README**: 「Stage C PR Verify Retry」節を実態に合わせて更新し、本バグ修正の経緯を追記。

## 検証

```
# stageC verify テスト 3 本
bash local-watcher/test/stagec_pr_verify_test.sh           # PASS: 8,  FAIL: 0
bash local-watcher/test/stagec_pr_verify_retry_test.sh     # PASS: 42, FAIL: 0
bash local-watcher/test/stagec_pr_verify_fallback_test.sh  # PASS: 35, FAIL: 0
bash local-watcher/test/stage_c_existing_pr_guard_test.sh  # PASS: 26, FAIL: 0（隣接・巻き込み確認）
shellcheck local-watcher/bin/issue-watcher.sh ...          # exit 0

# 新主経路コマンドを実 GitHub で検証
gh pr list --head <merged-PR-branch> --state all --json url --jq '.[0].url // empty'  # → PR URL（検出成功 / rc=0）
gh pr list --head <存在しないブランチ>  --state all --json url --jq '.[0].url // empty'  # → 空 / rc=0（未検出→リトライ）
```

修正前は merged PR のブランチで主経路が `unknown flag: --head`、fallback が空となり誤検知。修正後は merged PR を確実に検出する。

## 確認事項

- **デプロイ反映**: 本修正は正本（`local-watcher/bin/issue-watcher.sh`）への変更。稼働中の `~/bin/issue-watcher.sh` および `~/.idd-claude/` 配下のデプロイ済みコピーは、merge 後に install / sync 手順で再配置する必要がある（次回フェッチ前に反映推奨）。
- **挙動互換**: `gh pr list` は未検出時に `[]` + exit 0 を返す（旧 `gh pr view` の exit 1 とは別）。`--jq '.[0].url // empty'` で空文字 + rc 0 に正規化し、既存の「empty → リトライ継続」分類と整合。リトライ回数・タイムアウト・ログ書式は不変。
- **過去 spec 記録（`docs/specs/108`・`docs/specs/110`）** は当時の確定記録のため変更していない。
- 既に誤付与された downstream の `claude-failed`（merged 済み Issue）は本 PR の対象外（運用側でラベル除去）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
