### PR TITLE
fix(workflow): issue-to-pr.yml を actionlint クリーンにする（#279 の stage-a-verify 失敗の根本対処）

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -108,8 +108,11 @@ jobs:
       # ─────────────────────────────────────────────────────────────
       - name: Detect mode and slug
         id: detect
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           NUM="${{ github.event.issue.number }}"
+          # shellcheck disable=SC2012  # docs/specs/<N>-* は ASCII slug 限定。ls -d で十分（.shellcheckrc の accepted baseline と同一方針）
           SPEC_DIR=$(ls -d "docs/specs/${NUM}-"* 2>/dev/null | head -1 || true)
 
           if [ -n "$SPEC_DIR" ] && [ -f "$SPEC_DIR/requirements.md" ]; then
@@ -117,7 +120,7 @@ jobs:
             echo "mode=impl-resume" >> "$GITHUB_OUTPUT"
             echo "has_existing_spec=true" >> "$GITHUB_OUTPUT"
           else
-            SLUG=$(echo "${{ github.event.issue.title }}" \
+            SLUG=$(echo "$ISSUE_TITLE" \
               | tr '[:upper:]' '[:lower:]' \
               | sed -E 's/[^a-z0-9]+/-/g' \
               | cut -c1-40 \

--- a/repo-template/.github/workflows/issue-to-pr.yml
+++ b/repo-template/.github/workflows/issue-to-pr.yml
@@ -108,8 +108,11 @@ jobs:
       # ─────────────────────────────────────────────────────────────
       - name: Detect mode and slug
         id: detect
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           NUM="${{ github.event.issue.number }}"
+          # shellcheck disable=SC2012  # docs/specs/<N>-* は ASCII slug 限定。ls -d で十分（.shellcheckrc の accepted baseline と同一方針）
           SPEC_DIR=$(ls -d "docs/specs/${NUM}-"* 2>/dev/null | head -1 || true)
 
           if [ -n "$SPEC_DIR" ] && [ -f "$SPEC_DIR/requirements.md" ]; then
@@ -117,7 +120,7 @@ jobs:
             echo "mode=impl-resume" >> "$GITHUB_OUTPUT"
             echo "has_existing_spec=true" >> "$GITHUB_OUTPUT"
           else
-            SLUG=$(echo "${{ github.event.issue.title }}" \
+            SLUG=$(echo "$ISSUE_TITLE" \
               | tr '[:upper:]' '[:lower:]' \
               | sed -E 's/[^a-z0-9]+/-/g' \
               | cut -c1-40 \


### PR DESCRIPTION
## 背景

Issue #279 の調査中に判明した、watcher 環境と既存 workflow の構造的な穴を塞ぐ修正です。

#279 の Developer 実装は **20/20 タスク完了・shellcheck/diff クリーン**で健全でしたが、stage-a-verify gate が `tasks.md` の verify ブロック（`actionlint .github/workflows/*.yml` を含む）を REPO_DIR で独立再実行した際に失敗し、2 回連続で `claude-failed` が付与されていました。

原因は 2 段階:

1. **第一段階**: watcher マシンに `actionlint` 未インストール → `exit=127`（command not found）。→ 別途 `~/.local/bin/actionlint`（v1.7.12）を設置して解消済み。
2. **第二段階（本 PR の対象）**: actionlint 導入後、`actionlint .github/workflows/*.yml` のグロブが **#279 とは無関係の既存 `issue-to-pr.yml`** の 2 件の指摘で `exit=1` になり、依然として gate を通らない。

これは #279 固有ではなく、**verify ブロックに actionlint を含む全 spec に効く構造的な穴**です（actionlint が未導入だったため今まで顕在化していなかった）。

## 修正内容

`Detect mode and slug` step（root + repo-template 両系統、byte 一致）:

1. **script injection 警告の解消**: `${{ github.event.issue.title }}` を inline shell script に直接展開していたものを、step の `env: ISSUE_TITLE` 経由に変更し `"$ISSUE_TITLE"` で参照。actionlint 公式推奨パターンであり、挙動は差分等価かつタイトル中の特殊文字に対してより安全。
2. **SC2012 の抑止**: `ls -d "docs/specs/..."` に inline `# shellcheck disable=SC2012` を付与。root `.shellcheckrc` の accepted baseline（SC2012/SC2317）と同一方針。actionlint 内蔵 shellcheck は `.shellcheckrc` を読まないため inline 指示で揃える。

`prompt: |` ブロック内の `issue.title`/`body` 補間（shell 実行されないため actionlint 非 flag）は対象外。

## Test plan

- `actionlint .github/workflows/issue-to-pr.yml` → **exit 0**（修正前は 2 件指摘で exit 1）
- `actionlint repo-template/.github/workflows/issue-to-pr.yml` → **exit 0**
- `diff` で root↔repo-template の該当 step が byte 一致を確認
- 挙動: `$ISSUE_TITLE` 経由の SLUG 生成は従来の inline 展開と等価（tr/sed/cut パイプは不変）

## 確認事項

- 本 PR は #279 のブロッカー解消が目的ですが、scope は workflow の actionlint 整合に限定しています（#279 の実装本体は別 PR / 別途救済）。
- #279 の impl ブランチは未 push（PR 未作成）のため、本 PR が main に merge された後、#279 を最新 main 起点で再実行（または impl ブランチを rebase）することで verify を通過させる想定です。
- watcher マシンへの actionlint 導入（環境側）は本 PR の対象外（別途実施済み）。

## 関連

- Related: #279
- Related: #125 (Stage A Verify Gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)