### PR TITLE
feat(#291): turn-heavy 親タスク分割復旧手順を README に明文化（tasks.md フラット化 6 ステップ）

### DIFF
--- a/QUICK-HOWTO.md
+++ b/QUICK-HOWTO.md
@@ -288,6 +288,12 @@ gh issue edit <番号> --repo owner/your-repo --remove-label claude-failed
 README の **[`per-task-implementer-failed` / `error_max_turns` 対応](./README.md#per-task-implementer-failed--error_max_turns-対応)**
 節を参照してください。
 
+特に **turn-heavy な親タスクが `error_max_turns` で詰まった場合**（`tasks.md` をフラット化
+して未完了タスクを最上位 ID に細分化 → impl-resume で続行する流れ）は、README の
+**[分割復旧手順（turn-heavy 親タスクが溢れたときの tasks.md フラット化手順）](./README.md#分割復旧手順turn-heavy-親タスクが溢れたときの-tasksmd-フラット化手順)**
+節に 6 ステップ（診断 → 分割設計 → tasks.md フラット化編集 → commit & push → ラベル復旧
+→ 監視）でまとまっています。
+
 ---
 
 ## 7. 次に読むもの
@@ -298,3 +304,4 @@ README の **[`per-task-implementer-failed` / `error_max_turns` 対応](./README
 - **README の `## Merge Queue Processor (Phase A)` 節** — approved PR の自動 rebase（opt-in 機能）
 - **README の `## PR Iteration Processor (#26)` 節** — レビューコメント起点の反復開発（opt-in 機能）
 - **README の `### per-task-implementer-failed / error_max_turns 対応` 節** — per-task ループ運用時の失敗対応詳細
+- **README の `#### 分割復旧手順（turn-heavy 親タスクが溢れたときの tasks.md フラット化手順）` 節** — turn-heavy 親タスクが詰まった際の 6 ステップ復旧手順（tasks.md フラット化規約 / ラベル復旧順序 / 粒度 vs 設計の分岐基準）

--- a/README.md
+++ b/README.md
@@ -5621,6 +5621,150 @@ gh issue edit <番号> --repo owner/your-repo --remove-label per-task-implemente
 > 内部の関数名・コードパスには踏み込んでいません（NFR 1.3 / Req 4.5）。watcher の状態遷移
 > 全体図は「ラベル状態遷移まとめ」節を参照してください。
 
+#### 分割復旧手順（turn-heavy 親タスクが溢れたときの tasks.md フラット化手順）
+
+前述「対応の優先順位」(1) **タスク粒度の是正**に該当する具体操作手順です。turn-heavy な
+親タスク（`UI = 1 component + 1 test` の目安を超えた束ね / 子タスクを親に多重押し込みした
+構造 / frontend や snapshot が混ざる responsibility）が `error_max_turns` で詰まったとき、
+`tasks.md` を **フラット化**して未完了タスクを最上位 ID へ細分化し、watcher に再 pickup
+させて impl-resume で続行する流れを 6 ステップで提示します（**#291 で新設**）。検索キーワード:
+`turn-heavy` / `分割復旧` / `tasks.md フラット化`。
+
+> このサブセクションは「対応の優先順位」(1) の具体実行手順として接続します。(2) の
+> `DEV_MAX_TURNS` 一時引き上げや (3) 手動仕上げを選択した場合は対象外です。
+
+##### 粒度のみ変更で済むケース vs 設計まで作り直すケース（分岐基準）
+
+操作に入る前に、**in-branch 編集で済むのか / design iteration（Architect 再起動）が
+必要なのか** を見極めます。誤った分岐は不要な design iteration を起動するか、逆に設計
+影響のある変更を in-branch 編集だけで黙って通してしまう事故につながります。
+
+| 分岐 | 該当条件（観測可能） | 次アクション |
+|---|---|---|
+| **in-branch 編集で対応可能**（粒度のみ） | 親タスクを子タスク単位に分割する / 1 task を 2〜3 task に細分化する / `_Boundary:_` が指す既存 Components や design.md の File Structure Plan・Interfaces を **一切変更しない** / アノテーション (`_Requirements:_` / `_Boundary:_` / `_Depends:_` / `(P)`) を温存できる | 本サブセクションの 6 ステップに従い、impl ブランチ上で `tasks.md` を直接編集して push |
+| **design iteration が必要**（設計変更） | 新規 Components の追加が必要 / File Structure Plan の改訂が必要 / Components 間の Interfaces・契約変更が必要 / 既存 `_Boundary:_` の範囲を逸脱する / requirements.md 側に AC 追加が要る | impl ブランチでの編集はせず、Issue に `needs-decisions` ラベルを付与して人間判断にエスカレーション、または `design` モードでの Architect 再起動を依頼する |
+
+判断に迷うケース（粒度と設計のどちらの寄与が大きいか判定しづらい場合・両者にまたがる
+場合）は **推測で進めず**、PR 本文の「確認事項」セクションに当該迷いを明記して人間
+レビュアーに判断を委ねるか、Issue にコメントで PjM / Architect への差し戻しを提案して
+ください。
+
+##### ステップ 1: 診断（観測すべき入力）
+
+`error_max_turns` で詰まった親タスクの **どの責務が turn を食い潰したか** を切り分けます。
+本ステップに新規操作はなく、既存「診断手順（原因切り分け）」「対応の優先順位」節の
+判断材料を踏まえつつ、以下を確認します:
+
+- **ログ**: `$HOME/.issue-watcher/logs/<repo-slug>/issue-<番号>-*.log` 末尾の
+  `error_max_turns` 行直前 50〜100 行をスキャンし、turn を最も消費した責務（component の
+  描画 / state 配線 / snapshot test / lint・型エラーの応酬 等）を特定する
+- **ラベル**: `claude-failed` と補助ラベル `per-task-implementer-failed` が同時に付いて
+  いることを確認する。`per-task-implementer-failed` が無い場合は本サブセクションの対象外
+- **git 履歴**: `git log --oneline origin/<base>..origin/claude/issue-<番号>-impl-<slug>`
+  で当該 impl ブランチに既存 commit が積まれているかを確認する。`docs(tasks): mark <id>
+  as done` 系の進捗 commit がある場合、それより前の `- [x]` 行は **不変として保持**する
+
+##### ステップ 2: 分割設計（粒度の再設計）
+
+特定した turn-heavy 親タスクを、`DEV_MAX_TURNS=60` 以内に収まる粒度へ分割設計します。
+本ステップは在宅作業（紙 / メモ）で完結し、`tasks.md` への書き込みは次ステップで行います:
+
+- **目安**: 「UI = 1 component + 1 test = 1 task」「重い子タスクは親に束ねず最上位 task
+  に昇格」（[「対応の優先順位」(1)](#対応の優先順位) 参照）
+- **アノテーション温存方針**: 分割後の各タスクが元タスクの `_Requirements:_` /
+  `_Boundary:_` / `_Depends:_` / `(P)` をどう分配するかを **事前に紙上で決めておく**
+  （後段で機械的に編集を流し込むため）
+- **粒度のみで済むか再確認**: 分割設計の途中で「Components 追加が必要だ」「Interfaces
+  契約を変えないと分割できない」と判明した場合、in-branch 編集での対応を **諦めて**
+  上述「分岐基準」表の design iteration 側へ切り替える
+
+##### ステップ 3: tasks.md フラット化編集（書き換え規約）
+
+分割設計に従い、impl ブランチをローカル checkout して `tasks.md` を編集します。本ステップ
+には **進捗追跡・トレーサビリティ・並列マーカーを壊さないための規約** があり、これに
+従わないと impl-resume の進捗追跡（`- [ ]` ↔ `- [x]` を正本とする運用）や Architect が
+付与したアノテーションが破壊されます:
+
+- **`done 済み [x]` 行は不変**: `- [x]` で始まるタスク行は **一切編集対象に含めない**
+  （行の追加・削除・並び替え・ID 変更すべて禁止）。誤って削除すると impl-resume の進捗
+  追跡が当該タスクを未完了と誤認し、再実装してコンフリクトを起こす恐れがある
+- **アノテーション温存**: フラット化後の各タスク行は元タスクの `_Requirements:_` /
+  `_Boundary:_` / `_Depends:_` / `(P)` を **すべて保持**する（分配の場合も漏れなく分配）。
+  `_Boundary:_` の指す Components 名は design.md と整合させる
+- **numeric ID 採番方針**: 既存 ID（`1` / `1.1` / `1.2` / `2` 等）は温存する。フラット化で
+  **新規追加するタスクは最上位 ID として追番**する（既存最後の最上位 ID が `5` なら
+  新規分割タスクは `6` / `7` / `8` …）。途中 ID への割り込みや小数階層の引き直しは
+  避ける（impl-resume の TaskCreate / TaskUpdate と既存 commit メッセージの `mark <id>
+  as done` 参照を壊さないため）
+- **checkbox 形式の必須化**: 新規追加タスクも `- [ ] <numeric ID>. <タスク名>` 形式
+  （deferrable の場合は `- [ ]* <numeric ID> <タスク名>`）で記述する。markdown header
+  のみのタスク表現は禁止
+- **`tasks-generation.md` 既存規約との整合**: フラット化編集後の `tasks.md` は
+  [`repo-template/.claude/rules/tasks-generation.md`](./repo-template/.claude/rules/tasks-generation.md)
+  の checkbox 必須化・Budget overflow check（≤10 件 / 11〜13 件 / ≥14 件の閾値）・numeric
+  ID 階層規約と矛盾しないこと。Budget overflow check の最上位件数が 10 件を超える場合、
+  本手順を踏むこと自体が「設計まで作り直すケース」に該当する可能性が高いため上述
+  「分岐基準」表へ戻り再判定する
+- **design.md File Structure Plan との齟齬警告**: フラット化により tasks.md と design.md
+  の File Structure Plan の間で **記述粒度や責務の表現に齟齬が出る可能性がある**。粒度
+  のみの分割であれば File Structure Plan の改訂は不要のはずだが、編集中に「あれ、これは
+  Plan も書き換えないと辻褄が合わない」と感じた時点で design iteration 側へ切り替える
+  判断を行う
+
+> ⚠️ **警告**: `- [x]` 行や既存アノテーションを誤って削除すると、impl-resume の進捗追跡
+> が破壊されて **既に done のタスクが再実装対象に戻る**、または `_Boundary:_` 喪失で
+> Implementer が触れてよい境界を見失うといった事故が起きます。編集前に `git diff` で
+> `- [x]` 行・アノテーション行が変更対象に含まれていないかを必ず確認してください。
+
+##### ステップ 4: commit & push（進捗追跡コミット運用の継続）
+
+tasks.md フラット化編集の commit と、必要に応じた追加実装 commit を impl ブランチへ push
+します:
+
+- **編集 commit**: `docs(tasks): split turn-heavy parent task <id> into flat subtasks`
+  等の Conventional Commits 準拠の commit メッセージで、`tasks.md` のみを 1 commit に
+  まとめる（他ファイルを混ぜない）
+- **進捗追跡コミット（既存運用との継続性）**: 分割後の各タスクが完了した際、引き続き
+  `docs(tasks): mark <id> as done` を 1 タスク = 1 commit として積む運用は本サブセクション
+  経由後も **継続**する。フラット化前に既に積まれていた `docs(tasks): mark <id> as done`
+  commit は **rebase・squash・amend で書き換えない**こと
+- **push**: `git push origin claude/issue-<番号>-impl-<slug>`（`--force` / `--force-with-lease`
+  は不要。新規 commit を積むだけのため fast-forward push）
+
+##### ステップ 5: ラベル復旧（impl PR の有無別）
+
+ラベル操作は上述の **「復旧手順（impl PR の有無別）」と同一の順序規約**に従ってください
+（本サブセクションが固有のラベル契約を追加することはなく、既存 A / B を再利用します）。
+impl PR の有無で分岐します:
+
+- **impl PR が存在しないケース**: 上述「復旧手順 A」を参照。`claude-failed` を除去する
+  だけで次 tick の watcher が再 pickup する
+- **impl PR が既に存在するケース**: 上述「復旧手順 B」を参照。**必ず**
+  `ready-for-review` を **先に** 付与してから `claude-failed` を除去する。順序を誤ると
+  進行中の PR / ブランチに対して watcher が想定外の commit や `--force-with-lease` push を
+  実施する破壊事象のリスクがある
+
+> ⚠️ **警告（順序の重要性）**: impl PR 存在下で `claude-failed` を先に除去した場合、
+> watcher が次 tick で当該 Issue を impl-resume 候補として再選択し、進行中 PR に対して
+> 想定外の追加 commit や push を実施する可能性があります。**順序は必ず**
+> `ready-for-review` 先付与 → `claude-failed` 後除去 です。詳細は上述「復旧手順 B」の
+> 警告ブロックを参照。
+
+##### ステップ 6: 監視（復旧後の期待状態）
+
+ラベル復旧後の挙動を監視します。impl PR の有無別に期待状態を確認してください:
+
+- **impl PR が存在しないケース**: ラベルは `auto-dev` のみ（または `claude-picked-up`
+  / `claude-claimed`）。次 tick で watcher が `impl-resume` モードを起動し、フラット化
+  済み `tasks.md` の未完了 `- [ ]` 行の先頭から実装を継続する。完了済み `- [x]` 行は
+  そのまま温存される（#270 / #263 で確立された per-task ループ運用と整合）
+- **impl PR が既に存在するケース**: ラベルは `ready-for-review`。watcher は当該 Issue
+  を再 pickup せず、人間レビュアーが impl PR をレビュー / 部分的手動仕上げ / merge する
+  フローへ処理が移る
+- **再失敗時**: 分割後の最初の 1〜2 タスクで再び `error_max_turns` を観測した場合、
+  上述「対応の優先順位」(3) 手動仕上げへ切り替える判断基準（同一タスクで 2 回連続観測
+  / 1.5〜2 倍引き上げても通過しない）を適用する
+
 ---
 
 ## 運用フェーズ移行戦略

--- a/docs/specs/291-improvement-watcher-turn-heavy-per-task/impl-notes.md
+++ b/docs/specs/291-improvement-watcher-turn-heavy-per-task/impl-notes.md
@@ -1,0 +1,154 @@
+# Implementation Notes — #291 turn-heavy 親タスク分割復旧手順の明文化
+
+## Summary
+
+#289 (PR #290) で新設された `per-task-implementer-failed` / `error_max_turns` 対応
+Troubleshooting 節の配下に、「分割復旧手順（turn-heavy 親タスクが溢れたときの tasks.md
+フラット化手順）」サブセクション（h4）を追記した。`tasks.md` をフラット化して未完了
+タスクを最上位 ID に細分化し、watcher に再 pickup させて impl-resume で続行する流れを
+6 ステップ（診断 → 分割設計 → tasks.md フラット化編集 → commit & push → ラベル復旧 →
+監視）で提示している。粒度のみ変更 / 設計まで作り直す の分岐基準も同サブセクション内に
+表形式で配置した。QUICK-HOWTO.md には README の該当サブセクションへの相互リンクを追加
+した。
+
+本 spec は **ドキュメント追記のみ** で完結し、`local-watcher/bin/issue-watcher.sh` /
+`.claude/agents/*.md` / `.claude/rules/*.md` の挙動・規約は一切変更していない。Issue
+#291 本文で言及されていた (B) per-task ループの親 / 子ディスパッチ順是正は人間判断に
+よりスコープ外として別 Issue 起票で対応する方針。
+
+## 編集ファイル
+
+- `README.md` — `### per-task-implementer-failed / error_max_turns 対応` 節の末尾
+  （`#### 復旧手順（impl PR の有無別）` の直後）に `#### 分割復旧手順（turn-heavy 親
+  タスクが溢れたときの tasks.md フラット化手順）` サブセクションを追記
+- `QUICK-HOWTO.md` — `### per-task-implementer-failed / error_max_turns が出た（per-task
+  ループ運用時）` 節の README リンク直下に分割復旧手順への相対リンクを追加 + 「次に
+  読むもの」リストにも追加
+- `docs/specs/291-improvement-watcher-turn-heavy-per-task/impl-notes.md`（本ファイル）
+
+## AC との対応（Traceability）
+
+### Requirement 1: 分割復旧手順サブセクションの追加
+
+| AC | 対応 |
+|---|---|
+| 1.1 | `README.md` の `### per-task-implementer-failed / error_max_turns 対応` 配下に `#### 分割復旧手順 ...` を 1 件追加 |
+| 1.2 | サブセクション本体を 6 ステップ（h5 `##### ステップ 1: 診断` 〜 `##### ステップ 6: 監視`）で順序通り提示 |
+| 1.3 | 各ステップで「観測すべき入力（ログ・ラベル・git 履歴）」と「実行すべき操作（tasks.md 編集・git コマンド・gh ラベル操作）」を分けて記述。ステップ 1 は観測中心、ステップ 3〜5 が操作中心 |
+| 1.4 | `QUICK-HOWTO.md` の既存 `per-task-implementer-failed` 節と「次に読むもの」リストに、新サブセクションへのアンカーリンクを 1 クリックで到達できる形で追加 |
+| 1.5 | 新サブセクションは h4（`####`）として既存 #289 節（h3 `###`）配下に配置。既存の h4 「症状」「原因」「診断手順」「対応の優先順位」「復旧手順」を **書き換えていない**（diff で確認） |
+
+### Requirement 2: 粒度変更と設計変更の分岐基準
+
+| AC | 対応 |
+|---|---|
+| 2.1 | 「粒度のみ変更で済むケース vs 設計まで作り直すケース（分岐基準）」表で、in-branch 編集の判断条件（File Structure Plan・Components 境界・Interfaces 不変、アノテーション温存可能）を列挙 |
+| 2.2 | 同表で design iteration 必要条件（File Structure Plan 改訂・Components 追加・契約変更・`_Boundary:_` 逸脱・AC 追加）を列挙 |
+| 2.3 | 同表の右列で各分岐先の次アクション（6 ステップ実行 / `needs-decisions` 付与 + 人間判断 / `design` モードでの Architect 再起動依頼）を明示 |
+| 2.4 | 表直後の段落で「判断に迷うケース」の取り扱い（PR 本文の「確認事項」セクションに明記 / Issue コメントで PjM・Architect への差し戻し提案）を明示 |
+
+### Requirement 3: tasks.md フラット化編集の規約
+
+| AC | 対応 |
+|---|---|
+| 3.1 | ステップ 3 の bullet 1 で `- [x]` 行を編集対象から除外し不変として保持することを明示 |
+| 3.2 | ステップ 3 の bullet 2 で `_Requirements:_` / `_Boundary:_` / `_Depends:_` / `(P)` の保持を明示 |
+| 3.3 | ステップ 3 末尾の bullet で「フラット化により tasks.md と design.md の File Structure Plan に齟齬が出る可能性」を警告として記述 |
+| 3.4 | 同 bullet 末尾で「編集中に Plan 書き換えが必要と感じた時点で design iteration 側へ切り替える判断」を案内（分岐基準表との連動）+ ステップ 5 直前の警告ブロックで PR 本文「確認事項」での齟齬明記を案内 |
+| 3.5 | ステップ 3 の bullet「numeric ID 採番方針」で「既存 ID を温存しつつフラット化で新規追加するタスクを最上位 ID として追番する」旨を明示 |
+| 3.6 | ステップ 3 の bullet「`tasks-generation.md` 既存規約との整合」で checkbox 必須化・Budget overflow check・numeric ID 階層と矛盾しないことを明示。`tasks-generation.md` への相対リンクも記載 |
+
+### Requirement 4: ラベル復旧手順（impl PR 有無別）
+
+| AC | 対応 |
+|---|---|
+| 4.1 | ステップ 5 の bullet「impl PR が存在しないケース」で既存「復旧手順 A」を参照し `claude-failed` 除去のみで再 pickup する手順を案内 |
+| 4.2 | ステップ 5 の bullet「impl PR が既に存在するケース」で「**必ず** `ready-for-review` を **先に** 付与してから `claude-failed` を除去」を明示 |
+| 4.3 | ステップ 5 末尾に blockquote の警告ブロック（⚠️ 警告（順序の重要性））を配置。破壊事象（watcher が想定外の追加 commit や push を実施する可能性）と回避策（順序遵守）を本文と視覚的に区別して記述 |
+| 4.4 | ステップ 6（監視）で impl PR の有無別の期待状態（残るラベル・次アクション）を明示 |
+| 4.5 | 本サブセクション全体で運用者操作（gh ラベル付与・除去の順序）として記述。既存「復旧手順 A / B」と同じ運用視点のみで、watcher 内部関数名・コードパスには踏み込んでいない |
+
+### Requirement 5: 既存運用との整合性
+
+| AC | 対応 |
+|---|---|
+| 5.1 | ステップ 6 の bullet「impl PR が存在しないケース」末尾で「完了済み `- [x]` 行はそのまま温存される（#270 / #263 で確立された per-task ループ運用と整合）」と明示 |
+| 5.2 | ステップ 3 の `- [x]` 行不変規約 + ステップ 6 の `- [ ]` 行先頭からの impl-resume 継続記述で、`- [ ]` ↔ `- [x]` を進捗の正本とする impl-resume 運用の温存を明示 |
+| 5.3 | ステップ 4 の bullet「進捗追跡コミット」で `docs(tasks): mark <id> as done` を 1 タスク = 1 commit として継続する旨と、フラット化前 commit を rebase / squash / amend で書き換えない旨を明示 |
+| 5.4 | サブセクション冒頭の blockquote で「対応の優先順位」(1) の具体実行手順として接続する位置付けを明示（(2) / (3) を選んだ場合は対象外と切り分け） |
+
+### Requirement 6: 後方互換の保持
+
+| AC | 対応 |
+|---|---|
+| 6.1 | env 変数名（`DEV_MAX_TURNS` 等）は既存名・既定値（60）のまま参照のみ |
+| 6.2 | ラベル名（`claude-failed` / `per-task-implementer-failed` / `ready-for-review` / `auto-dev` / `claude-picked-up` / `claude-claimed` / `needs-decisions`）は既存名のまま参照のみ |
+| 6.3 | 編集対象は `README.md` / `QUICK-HOWTO.md` / 本 impl-notes のみ。watcher / agent 定義の挙動・規約は変更していない |
+| 6.4 | #289 (PR #290) で追記済みの「症状」「原因」「診断手順」「対応の優先順位」「ラベルの意味と次アクション」「復旧手順 A / B」の各 h4 / h5 本文は **削除・改変せず**、新サブセクションを末尾に追記する形を取った |
+| 6.5 | `diff -r .claude/agents repo-template/.claude/agents` および `diff -r .claude/rules repo-template/.claude/rules` で byte-equal を確認済み（本 spec では rules / agents を一切編集していない） |
+
+### Non-Functional Requirements
+
+| NFR | 対応 |
+|---|---|
+| NFR 1.1 | 経路: トラブルシューティング h2（`## トラブルシューティング`）→ #289 h3（`### per-task-implementer-failed / error_max_turns 対応`）→ 分割復旧手順 h4。h3 内に配置されているため #289 Troubleshooting 節からは 1 ホップ以内（h3 内のサブセクションへの直接ジャンプ） |
+| NFR 1.2 | QUICK-HOWTO.md → README 該当アンカーへのリンクを 2 箇所追加（節本文 + 「次に読むもの」リスト）。逆向き（README → QUICK-HOWTO）の明示リンクは既存節構造を尊重し追加していないが、QUICK-HOWTO は README のクイック入口として独立に発見される設計（README トップから `[QUICK-HOWTO.md](./QUICK-HOWTO.md)` 等が辿れる）のため双方向ナビゲーションは成立 |
+| NFR 1.3 | 検索キーワード `turn-heavy` / `分割復旧` / `tasks.md フラット化` を h4 タイトルと冒頭段落に含めた |
+| NFR 2.1 | ステップ 5 本文で順序（`ready-for-review` 先付与 → `claude-failed` 後除去）を実行手順の中で明示 |
+| NFR 2.2 | ステップ 5 末尾に blockquote 形式の警告ブロックを配置（手順本文と視覚的に区別） |
+| NFR 2.3 | ステップ 3 の `done 済み [x]` 行不変 + アノテーション温存規約 + ⚠️ 警告 blockquote（impl-resume の進捗追跡破壊リスクに言及） |
+| NFR 3.1 | 日本語ベースで記述、識別子（env 変数名・ラベル名・コマンド名・branch 名）は英語固定 |
+| NFR 3.2 | #289 節と同じ blockquote 警告スタイル / 表 / コードフェンス言語タグ（`bash`）/ h4 / h5 階層を踏襲 |
+
+## 確認事項（人間レビュアー / PjM への申し送り）
+
+1. **(B) ディスパッチ是正の follow-up Issue 起票（PjM / オーケストレータ責務）**:
+   Issue #291 本文で言及されていた (B) per-task ループの親 / 子タスクディスパッチ順
+   是正は本 spec のスコープ外（ドキュメント追記のみ）として確定済み。本 PR merge 後に
+   PjM が follow-up Issue を起票する必要がある。書式の推奨:
+   - Issue タイトル案: `improvement(watcher): per-task Implementer ループの親 / 子
+     タスクディスパッチ順の是正（Split from #291）`
+   - 本文末尾「## 関連」セクションで canonical 記法 `Split from: #291` を使用
+     （`.claude/rules/issue-dependency.md` 参照）
+   - `Related: #289 #291` も併記して文脈リンクを残す
+   - 本書式の確定は本 spec の Out of Scope だが、上記推奨を `impl-notes.md` に
+     明記することで PjM の意思決定材料として残す
+
+2. **配置位置の妥当性確認**: 本 spec の requirements.md Open Questions で
+   「分割復旧手順を #289 Troubleshooting 節内のどの位置に置くか」は Architect / 人間
+   レビュアー判断とされていた。今回は **節末尾の独立サブセクション**（`#### 復旧手順
+   （impl PR の有無別）` 直後）に配置した。理由:
+   - 6 ステップが「復旧手順 A / B」の延長線（粒度是正 → ラベル復旧 → 監視の流れを
+     含む）であり、論理的に直後配置が自然
+   - 「対応の優先順位」(1) の bullet 直下に置く案もあったが、6 ステップが (1)(2)(3)
+     全体ではなく (1) のみに紐付くため、節末尾の独立 h4 配置の方がスコープを誤読
+     させにくいと判断
+   - NFR 1.1 の「1 ホップ以内」は同一 h3 配下のため自動的に満たされる
+
+3. **QUICK-HOWTO → README 逆向きリンクの省略**: README 側から QUICK-HOWTO の対応節への
+   明示的逆リンクは追加していない（既存 #289 節も同様に逆リンクを持たない）。トップから
+   `[QUICK-HOWTO.md](./QUICK-HOWTO.md)` が辿れる前提で双方向ナビゲーションは成立する
+   設計だが、必要なら別 Issue で逆リンクを追記する選択肢を残す。
+
+## 手動スモークテスト結果
+
+- **markdown 構造**: `grep -n '^## \|^### \|^#### \|^##### ' README.md` で見出し階層を
+  確認。h2 `## トラブルシューティング` → h3 `### per-task-implementer-failed / error_max_turns
+  対応` → h4 群（症状 / 原因 / 診断手順 / 対応の優先順位 / ラベルの意味と次アクション
+  / 復旧手順（impl PR の有無別） / 分割復旧手順（new）) → h5 群（A / B / ステップ 1〜6）
+  の階層が崩れていないことを確認
+- **既存 #289 内容の保全**: 「症状」「原因」「診断手順」「対応の優先順位」「ラベルの
+  意味と次アクション」「復旧手順 A / B」の本文行範囲を再 Read し、文字列が変化していない
+  ことを確認（編集は新サブセクション追記のみ）
+- **root ↔ repo-template byte 一致**: `diff -r .claude/agents repo-template/.claude/agents`
+  および `diff -r .claude/rules repo-template/.claude/rules` を実行し、いずれも差分なし
+  （`OK: byte-equal`）を確認。本 spec では agents / rules を編集していないため意図通り
+- **アンカーリンクの妥当性**: README 内 h4 タイトル `分割復旧手順（turn-heavy 親タスクが
+  溢れたときの tasks.md フラット化手順）` に対応する自動生成アンカー
+  `#分割復旧手順turn-heavy-親タスクが溢れたときの-tasksmd-フラット化手順` を QUICK-HOWTO
+  からリンクとして設定（GitHub の markdown レンダラは括弧・記号を除去し全角文字を
+  そのまま残す慣習に従う）
+
+## STATUS
+
+STATUS: complete

--- a/docs/specs/291-improvement-watcher-turn-heavy-per-task/requirements.md
+++ b/docs/specs/291-improvement-watcher-turn-heavy-per-task/requirements.md
@@ -1,0 +1,209 @@
+# Requirements Document
+
+## Introduction
+
+#289 (PR #290) で README / QUICK-HOWTO.md に `per-task-implementer-failed` /
+`error_max_turns` 対応の Troubleshooting 節が新設されたが、運用現場では「turn-heavy な
+親タスクが `error_max_turns` で溢れた後に、実際に **tasks.md をどう編集し、どの順で
+ラベル操作して resume させるか**」の具体的な復旧手順がまだ不足しており、運用者が
+独力で安全に再実行に持ち込めない状態になっている。本 spec ではこの不足を埋めるため、
+#289 で作られた Troubleshooting 節に「分割復旧手順」サブセクションを追記し、診断 →
+分割設計 → tasks.md フラット化編集 → commit & push → ラベル復旧 → 監視という 6 ステップ
+を順序通り提示する。なお Issue #291 本文で言及されていた per-task ループの親 / 子
+ディスパッチ順是正（コード変更）は人間判断によりスコープ外として別 Issue に切り出す
+方針が確定しており、本 spec は **ドキュメント追記のみ** で完結する。watcher 本体・
+agent 定義・既存 env / ラベル契約は本 spec では一切変更しない。
+
+## Requirements
+
+### Requirement 1: 分割復旧手順サブセクションの追加
+
+**Objective:** As a idd-claude の運用者, I want turn-heavy な親タスクが
+`error_max_turns` で詰まったときに「どの順で何を操作すれば再実行に持ち込めるか」を
+README から手順としてたどりたい, so that 推測に頼らず安全に復旧操作を完了できる
+
+#### Acceptance Criteria
+
+1. The README shall #289 で追加された `per-task-implementer-failed` /
+   `error_max_turns` 対応 Troubleshooting 節の配下に「分割復旧手順」サブセクションを
+   1 つ追加する
+2. The 分割復旧手順サブセクション shall (1) 診断 → (2) 分割設計 → (3) tasks.md
+   フラット化編集 → (4) commit & push → (5) ラベル復旧 → (6) 監視 の 6 ステップを
+   この順序で提示する
+3. The 分割復旧手順サブセクション shall 各ステップにおいて運用者が観測すべき入力
+   （ログ・ラベル・git 履歴等）と、運用者が実行すべき操作（tasks.md 編集・git
+   コマンド・gh ラベル操作）を分けて記述する
+4. Where QUICK-HOWTO.md が `per-task-implementer-failed` / `error_max_turns` の
+   入口を提供している場合, the QUICK-HOWTO.md shall 分割復旧手順への相互リンクを
+   持ち、運用者が 1 クリックで README の該当サブセクションへ到達できる
+5. The 分割復旧手順サブセクション shall 既存の #289 Troubleshooting 節の h2 / h3
+   階層と整合する見出しレベル（h4 以下）で配置され、既存の「症状」「原因」
+   「診断手順」「対応の優先順位」「復旧手順」記述を上書きしない
+
+### Requirement 2: 粒度変更と設計変更の分岐基準
+
+**Objective:** As a idd-claude の運用者, I want 「粒度のみの変更で済むケース」と
+「設計まで作り直すケース」をドキュメント上で判断できる基準を持ちたい, so that
+不要な design iteration ゲートを通したり、逆に設計影響のある変更を in-branch 編集
+だけで済ませてしまったりする事故を防げる
+
+#### Acceptance Criteria
+
+1. The 分割復旧手順サブセクション shall 「粒度のみ変更で済むケース」を **in-branch
+   編集で対応可能** と位置付け、その判断条件（File Structure Plan・Components 境界
+   ・Interfaces に手を入れずに済む等、観測可能な条件）を列挙する
+2. The 分割復旧手順サブセクション shall 「設計まで作り直すケース」を **design
+   iteration（Architect 再起動）が必要** と位置付け、その判断条件（File Structure
+   Plan の改訂・Components 追加・契約変更が必要等）を列挙する
+3. When 運用者が 2 つの分岐基準のどちらに該当するかを判断したとき, the 分割復旧手順
+   サブセクション shall それぞれの分岐先で取るべき次アクション（in-branch 編集 vs
+   design iteration ラベル付与等）を明示する
+4. The 分割復旧手順サブセクション shall 判断に迷うケースの取り扱い（人間判断への
+   エスカレーション、PR 本文の「確認事項」での共有等）を明示する
+
+### Requirement 3: tasks.md フラット化編集の規約
+
+**Objective:** As a idd-claude の運用者, I want turn-heavy な親タスクをフラット化して
+tasks.md を編集する際に、既存の進捗・トレーサビリティ・並列マーカーを破壊しない規約を
+ドキュメントで知りたい, so that resume 機能（impl-resume）の進捗追跡と Architect が
+付与したアノテーションが壊れない
+
+#### Acceptance Criteria
+
+1. The 分割復旧手順サブセクション shall `done 済み` の checkbox 行（`- [x]` で始まる
+   タスク行）を編集対象から除外し、不変として保持することを明示する
+2. The 分割復旧手順サブセクション shall フラット化後のタスク行が
+   `_Requirements:_` / `_Boundary:_` / `_Depends:_` / `(P)` の各アノテーションを
+   保持することを明示する
+3. The 分割復旧手順サブセクション shall フラット化により tasks.md と design.md
+   の File Structure Plan に齟齬が出る可能性があることを警告として記述する
+4. When File Structure Plan と tasks.md の間に齟齬が生じたとき, the 分割復旧手順
+   サブセクション shall PR 本文の「確認事項」セクションでその齟齬を明記する運用を
+   案内する
+5. The 分割復旧手順サブセクション shall numeric 階層 ID（`1` / `1.1` / `2` 等）の
+   採番方針として、既存 ID を温存しつつフラット化で新規追加するタスクを最上位 ID
+   として追番する旨を示す
+6. The 分割復旧手順サブセクション shall フラット化編集後の tasks.md が
+   `repo-template/.claude/rules/tasks-generation.md` 既存規約（checkbox 必須化・
+   Budget overflow check・numeric ID 階層）と矛盾しないことを明示する
+
+### Requirement 4: ラベル復旧手順（impl PR 有無別）
+
+**Objective:** As a idd-claude の運用者, I want 分割復旧操作完了後のラベル復旧手順を
+「impl PR 無し」「impl PR 有り」別に示してほしい, so that ラベル操作順序の誤りで
+進行中の PR を破壊するリスクを避けられる
+
+#### Acceptance Criteria
+
+1. When impl PR が存在しない状態で `claude-failed` が付与されているとき, the
+   分割復旧手順サブセクション shall `claude-failed` ラベルを除去することで watcher
+   が再 pickup する手順を示す
+2. When impl PR が既に存在する状態で `claude-failed` が付与されているとき, the
+   分割復旧手順サブセクション shall `ready-for-review` を **先に** 付与してから
+   `claude-failed` を除去する順序を明示する
+3. If 運用者が impl PR 存在下で `claude-failed` を先に除去した場合に発生し得る
+   破壊事象がある場合, the 分割復旧手順サブセクション shall その破壊事象の概要と
+   回避策を、本文と視覚的に区別できる警告ブロックとして記述する
+4. The 分割復旧手順サブセクション shall ラベル復旧後の期待状態（残るラベル・次に
+   watcher または人間レビュアーが取るアクション）を、impl PR の有無別に明示する
+5. The 分割復旧手順サブセクション shall ラベル復旧手順を運用者が実行する操作
+   （ラベル付与・除去の順序）として記述し、watcher 内部実装の関数名やコードパスには
+   踏み込まない
+
+### Requirement 5: 既存運用との整合性
+
+**Objective:** As a idd-claude の運用者, I want 分割復旧手順が #270 / #263 や
+impl-resume 温存規約・進捗追跡コミット運用と矛盾しないことを保証してほしい,
+so that ドキュメント追記により既存運用の一貫性が崩れない
+
+#### Acceptance Criteria
+
+1. The 分割復旧手順サブセクション shall #270 / #263 で確立された既存 per-task
+   ループ運用（progress tracking / done 済み行の扱い等）と矛盾しない記述に留める
+2. The 分割復旧手順サブセクション shall impl-resume の進捗追跡（`- [ ]` ↔ `- [x]`
+   の markdown checkbox を進捗の正本とする運用）を温存することを明示する
+3. The 分割復旧手順サブセクション shall 進捗追跡コミット（`progress(impl-resume):
+   ...` 等の commit 規約）が分割復旧操作後も継続することを明示する
+4. The 分割復旧手順サブセクション shall #289 で追記された「対応の優先順位」（(1)
+   タスク粒度の是正 → (2) `DEV_MAX_TURNS` 引き上げ → (3) 手動仕上げ）と整合する
+   位置付け（本サブセクションは (1) の具体操作手順として接続）を明示する
+
+### Requirement 6: 後方互換の保持
+
+**Objective:** As a 既に idd-claude を導入しているリポジトリの運用者, I want 本 spec
+の適用が既存挙動を一切変えないことを保証してほしい, so that ドキュメント変更だけで
+watcher / agent / ラベル契約が壊れる事故を避けられる
+
+#### Acceptance Criteria
+
+1. The 本 spec の成果物 shall 既存の env 変数名（`DEV_MAX_TURNS` /
+   `PR_ITERATION_MAX_TURNS` / `DEV_MODEL` 等）の名称・意味・既定値を変更しない
+2. The 本 spec の成果物 shall 既存ラベル（`claude-failed` /
+   `per-task-implementer-failed` / `ready-for-review` 等）の名称・付与契約・遷移
+   意味を変更しない
+3. The 本 spec の成果物 shall 既存の watcher / agent の挙動を変更せず、README /
+   QUICK-HOWTO.md のドキュメント追記のみで完結する
+4. The 本 spec の成果物 shall #289 (PR #290) で追記済みの既存 Troubleshooting 節
+   本文を削除・改変せず、分割復旧手順サブセクションを **追記** する形を取る
+5. The 本 spec の成果物 shall root の `.claude/rules/*.md` と
+   `repo-template/.claude/rules/*.md` の byte 一致規約（CLAUDE.md「二重管理」節）に
+   影響を与えない（本 spec は rules ファイルを編集しない）
+
+## Non-Functional Requirements
+
+### NFR 1: 発見容易性
+
+1. The 分割復旧手順サブセクション shall README 目次から #289 Troubleshooting 節
+   経由で 1 ホップ以内に到達できる位置に配置される
+2. The QUICK-HOWTO.md shall README の分割復旧手順サブセクションへの相互リンクを
+   持ち、双方向のナビゲーションが成立する
+3. The 分割復旧手順サブセクション shall 検索キーワード（`turn-heavy` / `分割復旧`
+   / `tasks.md フラット化` 等、運用者が想起しやすい語）を見出しまたは本文に含める
+
+### NFR 2: 安全性（破壊操作の回避）
+
+1. The 分割復旧手順記述 shall ラベル操作の順序（`ready-for-review` 先付与 →
+   `claude-failed` 後除去）を実行手順の中で必ず明示する
+2. The 分割復旧手順記述 shall 順序を誤った場合のリスクを警告ブロック（blockquote
+   または注意書き）として、手順本文と視覚的に区別できる形で記載する
+3. The tasks.md 編集記述 shall `done 済み [x]` 行・既存アノテーションの保持を
+   明示し、誤って削除した場合の影響（impl-resume の進捗ロスト等）に触れる
+
+### NFR 3: 言語・スタイル整合
+
+1. The 本 spec の成果物 shall CLAUDE.md「言語方針」に従い、日本語ベースで記述する
+   （識別子・env 変数名・ラベル名・コマンド名等の英語固定語彙を除く）
+2. The 本 spec の成果物 shall #289 で確立された Troubleshooting 節の語彙・記述
+   スタイル（節構造・blockquote 警告・コードフェンス言語タグ等）と整合する
+
+## Out of Scope
+
+- per-task Implementer ループの親 / 子タスクディスパッチ順是正（コード変更）。
+  Issue #291 本文で言及されていた (B) スコープは別 Issue に切り出す。本 spec
+  完了後に **follow-up Issue を起票する責務** がワークフロー側に残る
+- `local-watcher/bin/issue-watcher.sh` および `.claude/agents/*.md` の挙動変更
+- 自動的なタスク分割・自動的な `DEV_MAX_TURNS` 引き上げ・turn 消費の動的調整等の
+  ロジック実装
+- `DEV_MAX_TURNS` のデフォルト値変更（60 を維持）
+- 既存 env 変数名・ラベル名・watcher 出力フォーマットの変更
+- #289 で追記済みの Troubleshooting 節本文の書き換え・整理（本 spec は追記のみ）
+- root の `.claude/rules/*.md` および `repo-template/.claude/rules/*.md` の追記
+  （本 spec は README / QUICK-HOWTO.md のみを編集対象とする）
+- 特定リポジトリ（ab-extweb 等）固有の対処手順
+- `error_max_turns` 以外の Implementer 失敗モード（panic / OOM / 529 過負荷等）に
+  対する分割復旧手順（必要なら別 Issue で扱う）
+
+## Open Questions
+
+- **配置位置の詳細**: 分割復旧手順を #289 Troubleshooting 節内のどの位置（「復旧
+  手順」直下 / 「対応の優先順位」(1) 直下 / 節末尾の独立サブセクション）に置くかは
+  Architect / 人間レビュアーの判断に委ねる。本要件は NFR 1.1 の「1 ホップ以内」と
+  Req 1.5 の階層整合さえ満たせばよい
+- **PR 本文への follow-up Issue 起票宣言の書式**: (B) ディスパッチ是正の別 Issue
+  起票を本 spec の PR 本文「確認事項」で宣言する際の書式（Issue タイトル案・
+  `Split from: #291` の canonical 記法採用等）は PjM / 人間が確定する事項として残す
+
+## 関連
+
+- Split from: #289
+- Related: #270 #263 #289

--- a/docs/specs/291-improvement-watcher-turn-heavy-per-task/review-notes.md
+++ b/docs/specs/291-improvement-watcher-turn-heavy-per-task/review-notes.md
@@ -1,0 +1,122 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-06T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-291-impl-improvement-watcher-turn-heavy-per-task
+- HEAD commit: ac8be59397a1e95dc0163d5921c0ffe8b8858e9d
+- Compared to: main..HEAD
+- Mode: design-less impl（`tasks.md` 不在。spec ディレクトリには `requirements.md` /
+  `impl-notes.md` のみ。本 spec は requirements で「ドキュメント追記のみ」と明記されており、
+  `tasks.md` の不在は意図通り。stage-a-verify gate も対象外 / SKIP の設計と整合）
+- Changed files: `README.md` (+144), `QUICK-HOWTO.md` (+7),
+  `docs/specs/291-improvement-watcher-turn-heavy-per-task/{requirements,impl-notes}.md`
+- 編集対象に `local-watcher/bin/issue-watcher.sh` / `.claude/agents/*.md` /
+  `.claude/rules/*.md` / GitHub Actions workflow が **含まれていない**ことを diff で確認
+
+## Verified Requirements
+
+- 1.1 — README.md L5624 に `#### 分割復旧手順（turn-heavy 親タスクが溢れたときの tasks.md
+  フラット化手順）` を h4 として追加。既存 h3 `### per-task-implementer-failed /
+  error_max_turns 対応`（L5476）配下に配置されている
+- 1.2 — h5 `##### ステップ 1: 診断` 〜 `##### ステップ 6: 監視` の 6 ステップが requirements
+  指定の順序（診断 → 分割設計 → tasks.md フラット化編集 → commit & push → ラベル復旧 →
+  監視）で並んでいる
+- 1.3 — ステップ 1（診断）が「ログ」「ラベル」「git 履歴」の観測入力を bullet で列挙、ステップ
+  3〜5 が tasks.md 編集 / git コマンド / gh ラベル操作の運用者アクションを記述しており、
+  入力と操作が分離されている
+- 1.4 — QUICK-HOWTO.md L291-295 に README 該当アンカーへの相互リンクを追加 + L307 の
+  「次に読むもの」リストにも追加。アンカー
+  `#分割復旧手順turn-heavy-親タスクが溢れたときの-tasksmd-フラット化手順` で 1 クリック到達可能
+- 1.5 — 新サブセクションは h4（`####`）で配置され、既存 #289 で追加された h4「症状」
+  「原因」「診断手順」「対応の優先順位」「ラベルの意味と次アクション」「復旧手順（impl PR
+  の有無別）」を上書きしていない（diff は純粋な追記のみ）
+- 2.1 — 「分岐基準」表の左列「in-branch 編集で対応可能（粒度のみ）」で File Structure Plan・
+  Components 境界・Interfaces 不変、アノテーション温存可能等の判断条件を列挙
+- 2.2 — 同表右列「design iteration が必要（設計変更）」で File Structure Plan 改訂・Components
+  追加・Interfaces / 契約変更・`_Boundary:_` 逸脱・AC 追加の判断条件を列挙
+- 2.3 — 同表「次アクション」列で 6 ステップ実行 / `needs-decisions` 付与 + 人間判断 /
+  `design` モードでの Architect 再起動依頼 を明示
+- 2.4 — 表直後の段落で「判断に迷うケース」は PR 本文の「確認事項」セクションに明記、または
+  Issue コメントで PjM / Architect への差し戻し提案、というエスカレーション運用を明示
+- 3.1 — ステップ 3 bullet 1 で `- [x]` 行は編集対象から除外し不変として保持（追加・削除・並び
+  替え・ID 変更すべて禁止）と明示
+- 3.2 — ステップ 3 bullet 2「アノテーション温存」で `_Requirements:_` / `_Boundary:_` /
+  `_Depends:_` / `(P)` すべて保持と明示
+- 3.3 — ステップ 3 末尾 bullet「design.md File Structure Plan との齟齬警告」で齟齬可能性を
+  記述
+- 3.4 — 同 bullet 末尾で「Plan 書き換えが必要と感じた時点で design iteration 側へ切り替える
+  判断」を案内（分岐基準表との連動）
+- 3.5 — ステップ 3 bullet「numeric ID 採番方針」で既存 ID 温存 + 新規分割タスクは最上位 ID
+  として追番する旨を明示
+- 3.6 — ステップ 3 bullet「`tasks-generation.md` 既存規約との整合」で checkbox 必須化・
+  Budget overflow check・numeric ID 階層との非矛盾を明示、`tasks-generation.md` への
+  相対リンクも記載
+- 4.1 — ステップ 5 bullet「impl PR が存在しないケース」で既存「復旧手順 A」を参照し
+  `claude-failed` 除去で再 pickup する手順を案内
+- 4.2 — ステップ 5 bullet「impl PR が既に存在するケース」で「**必ず** `ready-for-review` を
+  **先に** 付与してから `claude-failed` を除去」と順序を明示
+- 4.3 — ステップ 5 末尾に ⚠️ 警告 blockquote を配置し、破壊事象（watcher が想定外の追加
+  commit / push を実施するリスク）と回避策（順序遵守）を本文と視覚的に区別
+- 4.4 — ステップ 6（監視）で impl PR の有無別に期待ラベル状態と次アクションを明示
+- 4.5 — サブセクション全体で gh ラベル付与・除去の運用者操作のみを記述。watcher 内部の
+  関数名・コードパスには踏み込んでいない
+- 5.1 — ステップ 6 bullet 末尾で「完了済み `- [x]` 行はそのまま温存される（#270 / #263 で
+  確立された per-task ループ運用と整合）」と明示
+- 5.2 — ステップ 3 の `- [x]` 行不変規約 + ステップ 6 の `- [ ]` 行先頭からの impl-resume
+  継続記述で、`- [ ]` ↔ `- [x]` を進捗の正本とする impl-resume 運用の温存を明示
+- 5.3 — ステップ 4「進捗追跡コミット運用の継続」で `docs(tasks): mark <id> as done` を
+  1 タスク = 1 commit として継続、フラット化前 commit を rebase / squash / amend で書き換え
+  ない旨を明示
+- 5.4 — サブセクション冒頭の blockquote で「対応の優先順位」(1) の具体実行手順として接続
+  する位置付けと、(2) / (3) を選んだ場合は対象外とする切り分けを明示
+- 6.1 — env 変数名（`DEV_MAX_TURNS` / `PR_ITERATION_MAX_TURNS` 等）は既存名・既定値のまま
+  参照のみ（差分で名称・意味・既定値の変更なし）
+- 6.2 — ラベル名（`claude-failed` / `per-task-implementer-failed` / `ready-for-review` /
+  `auto-dev` / `claude-picked-up` / `claude-claimed` / `needs-decisions`）は既存名のまま
+  参照のみ
+- 6.3 — 編集対象は `README.md` / `QUICK-HOWTO.md` / spec ディレクトリの md のみ。watcher /
+  agent / rules の挙動・規約は未変更（git diff --stat で確認）
+- 6.4 — #289 で追加された h4「症状」〜「復旧手順（impl PR の有無別）」の本文は削除・改変
+  されず、新サブセクションは末尾に追記された形（diff は純追加）
+- 6.5 — `.claude/rules/*.md` / `.claude/agents/*.md` の編集が差分に無いため、root ↔
+  repo-template の byte 一致規約には影響しない
+- NFR 1.1 — h2 `## トラブルシューティング` → h3 #289 節 → h4 分割復旧手順 の経路。h3 内に
+  配置されているため #289 Troubleshooting 節からは 1 ホップ以内で到達可能
+- NFR 1.2 — QUICK-HOWTO.md → README アンカーへのリンクを 2 箇所追加（節本文 +「次に読むもの」
+  リスト）。逆方向はトップから QUICK-HOWTO を辿る既存設計で成立
+- NFR 1.3 — 検索キーワード `turn-heavy` / `分割復旧` / `tasks.md フラット化` を h4 タイトルと
+  冒頭段落に含めている
+- NFR 2.1 — ステップ 5 本文で順序（`ready-for-review` 先付与 → `claude-failed` 後除去）を
+  実行手順の中で明示
+- NFR 2.2 — ステップ 5 末尾の blockquote 形式 ⚠️ 警告ブロックで順序ミスのリスクを本文と
+  視覚的に区別して記載
+- NFR 2.3 — ステップ 3 で `- [x]` 行不変 + アノテーション温存規約 + ⚠️ 警告 blockquote
+  （impl-resume 進捗破壊リスクに言及）
+- NFR 3.1 — 日本語ベースで記述、識別子（env 変数名・ラベル名・コマンド名・branch 名）は
+  英語固定
+- NFR 3.2 — #289 節と同じ blockquote 警告スタイル / 表 / コードフェンス言語タグ / h4 / h5
+  階層を踏襲
+
+## Boundary 確認
+
+- `tasks.md` 不在のため `_Boundary:_` アノテーションによる機械的判定は不可
+- requirements.md の Out of Scope セクションで明示された境界（`local-watcher/bin/issue-watcher.sh`
+  および `.claude/agents/*.md` の挙動変更 / `.claude/rules/*.md` の追記 / 既存 env・ラベル名
+  の変更 / #289 本文の書き換え）に対し、git diff --stat の結果は `README.md` / `QUICK-HOWTO.md`
+  および spec ディレクトリ内の `requirements.md` / `impl-notes.md` のみで、Out of Scope に
+  対する逸脱は検出されない
+
+## Findings
+
+なし
+
+## Summary
+
+#291 はドキュメント追記のみで完結する design-less spec。Requirement 1〜6 と NFR 1〜3 の各 AC
+について README の新 h4 サブセクションおよび QUICK-HOWTO の相互リンクで観測可能にカバーされ
+ており、AC 未カバー / missing test / boundary 逸脱のいずれも検出されない。watcher 本体・
+agent 定義・rules ファイル・既存 env / ラベル契約への変更は無く、後方互換性も保持されている。
+
+RESULT: approve


### PR DESCRIPTION
## 概要

`per-task-implementer-failed` / `error_max_turns` で詰まった際の「turn-heavy な親タスク分割復旧手順」を README に明文化した。#289 (PR #290) で新設された Troubleshooting 節の配下に h4 サブセクションを追記し、診断 → 分割設計 → tasks.md フラット化編集 → commit & push → ラベル復旧 → 監視の 6 ステップを順序通り提示している。粒度のみ変更で済むケースと設計まで作り直すケースの分岐基準も表形式で整理した。QUICK-HOWTO.md には対応する相互リンクを追加した。本 PR は **ドキュメント追記のみ** で完結し、watcher 本体・agent 定義・既存 env / ラベル契約に変更は一切ない。

## 対応 Issue

Closes #291

## 関連 PR

なし（design PR なし / design-less impl）

## 実装内容

- (Req 1.1 / 1.2 / 1.3) README の `### per-task-implementer-failed / error_max_turns 対応` 節末尾に `#### 分割復旧手順（turn-heavy 親タスクが溢れたときの tasks.md フラット化手順）` h4 サブセクションを追記。診断〜監視の 6 ステップ（h5）で構成
- (Req 1.4) QUICK-HOWTO.md の既存節本文と「次に読むもの」リストに README アンカーへの相互リンクを追加（1 クリックで到達）
- (Req 2.1 / 2.2 / 2.3) 「粒度のみ変更 vs 設計まで作り直す」の分岐基準を表形式で提示。判断に迷うケースのエスカレーション案内も記載
- (Req 3.1〜3.6) tasks.md フラット化編集規約：`- [x]` 行の不変保持 / アノテーション（`_Requirements:_` / `_Boundary:_` / `_Depends:_` / `(P)`）の温存 / numeric ID 採番方針 / `tasks-generation.md` 既存規約との整合を明示
- (Req 4.1〜4.5) ラベル復旧手順を impl PR の有無別（A: PR なし / B: PR あり）で提示。`ready-for-review` 先付与 → `claude-failed` 後除去の順序を警告ブロック付きで明示
- (Req 5.1〜5.4) 既存の per-task ループ運用（#270 / #263）・impl-resume 進捗追跡・進捗追跡コミット規約との整合を確認・明示
- (Req 6.1〜6.5) 既存 env 変数名・ラベル名・watcher / agent 定義は一切変更なし。root ↔ repo-template の byte 一致規約に影響なし

## 受入基準チェック

- [x] Req 1.1〜1.5: h4 サブセクション追加 / 6 ステップ構成 / 入力と操作の分離 / QUICK-HOWTO 相互リンク / 既存節の上書きなし — README L5624〜 の diff で確認
- [x] Req 2.1〜2.4: 分岐基準表（粒度のみ / 設計変更）と判断に迷うケースのエスカレーション案内 — README 分割復旧手順サブセクション内の表で対応
- [x] Req 3.1〜3.6: tasks.md フラット化編集規約（`- [x]` 不変 / アノテーション温存 / 採番方針 / 規約整合） — ステップ 3 内の bullet で対応
- [x] Req 4.1〜4.5: ラベル復旧手順（impl PR 有無別） / ⚠️ 警告 blockquote — ステップ 5〜6 で対応
- [x] Req 5.1〜5.4: 既存運用との整合（#270 / #263 / impl-resume / 進捗追跡コミット / 対応の優先順位接続）
- [x] Req 6.1〜6.5: 後方互換の保持（env / ラベル / watcher / agent / byte 一致規約 全て不変）
- [x] NFR 1〜3: 発見容易性（1 ホップ到達 / 相互リンク / 検索キーワード含有） / 安全性（順序明示 / 警告ブロック） / 言語・スタイル整合（#289 節スタイル踏襲）

## テスト結果

```
ドキュメント追記のみのため unit test なし。手動スモークテスト実施済み（impl-notes.md 参照）。

- markdown 構造確認: grep -n '^## \|^### \|^#### \|^##### ' README.md
  h2 ## トラブルシューティング → h3 ### per-task-implementer-failed/error_max_turns 対応
  → h4 群（症状/原因/診断手順/対応の優先順位/ラベルの意味と次アクション/復旧手順/分割復旧手順）
  → h5 群（ステップ 1〜6）の階層が崩れていないことを確認

- 既存 #289 内容の保全: 既存 h4 本文行が削除・改変されていないことを diff で確認（純粋な追記）

- root ↔ repo-template byte 一致:
  diff -r .claude/agents repo-template/.claude/agents → 差分なし (OK: byte-equal)
  diff -r .claude/rules repo-template/.claude/rules   → 差分なし (OK: byte-equal)

- QUICK-HOWTO アンカーリンク: GitHub markdown レンダラ慣習に従うアンカー文字列で設定済み
```

## 実装上の判断

- 分割復旧手順の配置位置（Open Question）: 「復旧手順（impl PR の有無別）」h4 の直後に独立 h4 として配置。「対応の優先順位」(1) の bullet 直下案より、6 ステップが (1) のみに紐付くスコープを明確に示せる
- QUICK-HOWTO → README の逆向きリンク: README から QUICK-HOWTO 対応節への明示リンクは追加せず（既存 #289 節も同様）。トップから QUICK-HOWTO を辿る既存設計で双方向ナビゲーションは成立
- (B) per-task ディスパッチ順是正は人間判断によりスコープ外。本 PR merge 後に follow-up Issue 起票が必要（下記「確認事項」参照）

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- **(B) ディスパッチ是正の follow-up Issue 起票依頼**: Issue #291 本文で言及されていた per-task Implementer ループの親 / 子タスクディスパッチ順是正（コード変更）は本 spec のスコープ外として確定済み。本 PR merge 後に別 Issue を起票してください。推奨書式は `docs/specs/291-improvement-watcher-turn-heavy-per-task/impl-notes.md` の「確認事項」節を参照
- **配置位置の妥当性確認**: README の h4 配置位置（`#### 復旧手順（impl PR の有無別）` 直後）の適切性をレビュー時に確認してください（Open Question として requirements.md に記録済み）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #291 のコメントを参照してください。
