### PR TITLE
spec(#294): PreToolUse guard hook で base/force push を機械 deny（G0/G1/G2 初版設計）

### DIFF
--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/design.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/design.md
@@ -1,0 +1,553 @@
+# Design Document
+
+## Overview
+
+**Purpose**: idd-claude の watcher が起動する Claude Code エージェント（Triage / PM /
+Architect / Developer / Reviewer / Iteration / Security Review 等）に対し、Claude Code の
+`PreToolUse` フック機構を介して **base ブランチ宛 push** と **無条件 force push** と
+**guard install dir の自己改変** を機械的に deny する初版（G0 + G1 + G2）を導入する。違反を
+事後 Reviewer で検出するループ（1 違反 = Developer + Reviewer 1 サイクル分の turn 浪費）を
+止め、規約違反を実行前点で潰す。
+
+**Users**: idd-claude を self-hosting 運用している運用者（人間）と、その watcher 配下で
+fresh session を起動するエージェント群が直接対象。consumer repo への配布は本 Issue では
+扱わず、別 Issue で承認・起票する前提。
+
+**Impact**: 既定 OFF の **opt-in（`IDD_CLAUDE_HOOKS_ENABLED=true`）**。未有効時は既存挙動と
+完全同一（既存 cron 登録文字列・env var 名・ラベル名・exit code 意味は不変）。有効時のみ
+watcher が `claude --print` 起動時に `--settings <絶対パス>` を付与し、Claude Code が
+PreToolUse フックを呼び出して Bash / Edit / Write / NotebookEdit を検査する。
+
+### Goals
+
+- G0 / G1 / G2 を同一初版でリリース（人間 Decision 1: Option A）
+- user-scope 専用配布（`~/.idd-claude/hooks/` 等。worktree 外。人間 Decision 2: Option A）
+- **fail-closed**: opt-in 時に claude version 不足 / smoke test 失敗 → 黙って fallback せず
+  非ゼロ exit
+- **PoC で確認済みの 29 件テストマトリクスを fixture 化**して回帰検証可能にする
+- `shellcheck` 警告ゼロ
+
+### Non-Goals
+
+- role/spec guard / secrets guard / `bypassPermissions` 廃止（後続 Issue）
+- `repo-template/` 経由での consumer 配布（後続 Issue。本 Issue では起票責務は持たないが、
+  Architect は別 Issue 起票が必要である旨を PR 本文 / README で明示）
+- `sh -c "..."` / `$(...)` / wrapper script 内部の push 捕捉（literal 解析の原理的限界）
+- guard hook 設定の動的書き換え / 実行時切り替え
+- 既存 `bypassPermissions` 全 tool allowlist 化
+
+## Architecture
+
+### Existing Architecture Analysis
+
+- `local-watcher/bin/issue-watcher.sh` は単一の bash 巨大スクリプトで、`set -euo pipefail`
+  配下で動作する。モジュール分割は `local-watcher/bin/modules/*.sh` を `REQUIRED_MODULES`
+  配列で `source` する形態（`core_utils.sh` / `quota-aware.sh` / `stage-a-verify.sh` 等）
+- `claude --print "$prompt" --model ... --permission-mode bypassPermissions --max-turns ...`
+  形式の起動が **15 箇所以上**散在する（Triage / Developer / 設計 PR / per-task / Reviewer /
+  Security Review / Iteration 各 stage）。すべて `qa_run_claude_stage <label> <reset_file> --
+  claude ...` 経由で起動される
+- 既存 `qa_run_claude_stage`（`modules/quota-aware.sh`）は **引数列を `"$@"` でそのまま実行**
+  する設計。よって「`claude` の前段に `--settings` を挿入する」のではなく「呼び出し側で
+  `claude ... --settings <path>` のように引数列を組み立てる」アプローチが自然
+- `install.sh` は user-scope 配置を前提（`$HOME/bin`, `$HOME/bin/modules`, `$HOME/.issue-watcher/logs`）。
+  sudo は禁止。`local-watcher/bin/*.sh` / `*.tmpl` をワイルドカード一括配置する `copy_glob_to_homebin`
+  を既備
+- 二重管理規約: `.claude/agents` / `.claude/rules` は root と `repo-template/` の **byte 一致同期**
+  が必須。本 Issue は agents/rules を変更しないため抵触しない
+
+### Architecture Pattern & Boundary Map
+
+採用パターン: **opt-in gate + per-call argument injection + 外部 settings.json 参照**
+
+```mermaid
+flowchart LR
+  subgraph Watcher["issue-watcher.sh (cron)"]
+    A[boot] --> B{IDD_CLAUDE_HOOKS_ENABLED=true?}
+    B -- no --> C[既存挙動: claude ... をそのまま実行]
+    B -- yes --> D[guard_hook_preflight<br/>version + smoke test]
+    D -- fail --> E[stderr に理由出力<br/>非ゼロ exit]
+    D -- ok --> F[CLAUDE_HOOK_ARGS=--settings $SETTINGS_ABS]
+    F --> C2[claude ... ${CLAUDE_HOOK_ARGS[@]}]
+  end
+  C2 -.PreToolUse.-> H[~/.idd-claude/hooks/idd-guard.sh]
+  H -->|deny JSON| C2
+  H -.log.-> L[$IDD_HOOK_LOG]
+```
+
+**Architecture Integration**:
+- 採用パターン: opt-in gate + 引数列拡張 + 外部 settings.json 参照（claude 標準の
+  `--settings <path>` を利用）
+- 機能境界: (a) `modules/guard-hook.sh`（preflight / argument 構築） / (b) `local-watcher/hooks/`
+  配下の hook script + settings.json テンプレ / (c) `install.sh` による user-scope 配置 /
+  (d) `issue-watcher.sh` 内の各 claude 起動箇所への `${CLAUDE_HOOK_ARGS[@]}` 注入
+- 既存パターンの維持: `qa_run_claude_stage` の signature・呼び出し側の `claude --print ...
+  --permission-mode bypassPermissions` 形態・REQUIRED_MODULES 配列・`set -euo pipefail`
+- 新規コンポーネントの根拠:
+  - guard-hook.sh モジュール: preflight ロジックを単一責任で分離（既存 module 分割パターン踏襲）
+  - `local-watcher/hooks/`: source repo 内で hook script / settings テンプレを所有し、
+    `install.sh` が user-scope (`~/.idd-claude/hooks/`) に配置する経路を新設
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Frontend / CLI | — | — | バックエンド機能のみ |
+| Backend / Services | bash 4+ | guard hook 本体 / watcher module | `set -euo pipefail` |
+| Hook ランタイム | Claude Code `--settings` + `hooks.PreToolUse` | matcher = `Bash\|Edit\|Write\|NotebookEdit` | PoC 検証バージョン: claude 2.1.167 |
+| Data / Storage | ローカルファイル（user-scope） | hook script / settings.json / log | `~/.idd-claude/hooks/` 既定 |
+| Messaging / Events | stdin/stdout JSON（PreToolUse 契約） | hook ↔ Claude Code | hook は exit 0 + JSON で deny を表現 |
+| Infrastructure / Runtime | cron / launchd | watcher 起動 | sudo 禁止 / user-scope |
+
+## File Structure Plan
+
+### New Files
+
+```
+local-watcher/
+├── hooks/                                    # user-scope に配置される hook 一式の source
+│   ├── idd-guard.sh                          # PreToolUse フック本体（Bash/Edit/Write/NotebookEdit 検査）
+│   ├── idd-guard-settings.json               # settings.json テンプレ（hook command の placeholder を含む）
+│   └── README.md                             # 配置先・env var 契約・既知の限界（短文）
+└── bin/
+    └── modules/
+        └── guard-hook.sh                     # preflight / argument 構築モジュール
+                                              #   gh_log / gh_warn / gh_error (gh prefix は guard-hook)
+                                              #   gh_is_enabled  : opt-in 厳密判定
+                                              #   gh_preflight   : version check + smoke test
+                                              #   gh_build_args  : CLAUDE_HOOK_ARGS 配列を組み立て
+                                              #   gh_resolve_dir : install dir 解決（env override）
+
+docs/specs/294-feat-watcher-pretooluse-guard-hook-base/
+└── test-fixtures/
+    ├── run-tests.sh                          # 29 件マトリクスのドライバ（hook を直接起動）
+    ├── cases/
+    │   ├── g1-base-push-bare.json            # `git push origin main`
+    │   ├── g1-base-push-srcdst.json          # `git push origin HEAD:main`
+    │   ├── g1-base-push-delete.json          # `git push origin :main`
+    │   ├── g1-base-push-plus-refspec.json    # `git push origin +main`
+    │   ├── g1-base-push-with-C.json          # `git -C path push origin main`
+    │   ├── g1-base-push-implicit-remote.json # `git push main`
+    │   ├── g2-force-short.json               # `git push -f origin feature`
+    │   ├── g2-force-long.json                # `git push --force origin feature`
+    │   ├── g2-force-refspec-plus.json        # `git push origin +feature:feature`
+    │   ├── g2-allow-lease.json               # `git push --force-with-lease origin feature`
+    │   ├── g2-allow-lease-value.json         # `git push --force-with-lease=ref:sha ...`
+    │   ├── g0-edit-self.json                 # Edit on ~/.idd-claude/hooks/idd-guard.sh
+    │   ├── g0-write-self.json                # Write on ~/.idd-claude/hooks/idd-guard-settings.json
+    │   ├── g0-bash-rm-self.json              # Bash `rm ~/.idd-claude/hooks/idd-guard.sh`
+    │   ├── g0-bash-sed-i-self.json           # Bash `sed -i ... ~/.idd-claude/hooks/...`
+    │   ├── allow-normal-push.json            # `git push origin feature` (allow)
+    │   ├── allow-non-git-bash.json           # 通常 Bash (`ls -la`) (allow)
+    │   └── ...                               # 計 29 件（G0:5 / G1:6 / G2:5 / allow:13 想定。run-tests.sh が期待値表を持つ）
+    └── expected.tsv                          # ケース名 / 期待 verdict (deny|allow) / 期待 reason 部分文字列
+```
+
+### Modified Files
+
+- `local-watcher/bin/issue-watcher.sh`
+  - Config ブロックに guard hook 系 env var の default 宣言を追加（`IDD_CLAUDE_HOOKS_ENABLED`,
+    `IDD_CLAUDE_HOOKS_DIR`, `IDD_CLAUDE_HOOKS_MIN_VERSION`, `IDD_HOOK_LOG`）
+  - `REQUIRED_MODULES` 配列に `guard-hook.sh` を末尾追加
+  - 起動初期化フェーズに `gh_preflight` 呼び出しを追加（opt-in 時のみ。失敗で exit）
+  - 全 `claude --print ...` 起動行に `"${CLAUDE_HOOK_ARGS[@]}"` を付与（既存 15+ 箇所）。
+    `CLAUDE_HOOK_ARGS` は配列で、opt-out 時は **空配列**、opt-in 時は `(--settings <abs>)`
+- `install.sh`
+  - `INSTALL_LOCAL` ブロックに `local-watcher/hooks/` 配下の user-scope 配置を追加
+    （`~/.idd-claude/hooks/` 既定。`IDD_CLAUDE_HOOKS_DIR` env で override 可能）
+  - `settings.json` テンプレ中の `__IDD_HOOK_PATH__` placeholder を絶対パスに sed 置換
+  - 配置後の hint メッセージに opt-in 手順（`IDD_CLAUDE_HOOKS_ENABLED=true` の渡し方）を追記
+- `README.md`
+  - 新節「Guard Hook (PreToolUse) opt-in」を追加: opt-in 手順 / env var 一覧 / fail-closed
+    挙動 / 既知の限界（NFR 3.1〜3.4 を網羅） / 後続 Issue で consumer 配布する旨
+
+> **二重管理規約**: 本 Issue は `.claude/agents` / `.claude/rules` を変更しない。`diff -r`
+> 検証は本 Issue では影響を受けない。`repo-template/` 配下にも追加しない（Req 6.2 / 6.3 /
+> NFR 4.1）。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Interfaces | Files |
+|---|---|---|---|---|
+| 1.1〜1.4 | 既定 OFF / opt-in gate / 既存 env var 不変 / sudo 不要 | `gh_is_enabled` / `gh_build_args` / `issue-watcher.sh` Config | `IDD_CLAUDE_HOOKS_ENABLED` 厳密一致 | `modules/guard-hook.sh`, `issue-watcher.sh` |
+| 2.1〜2.7 | G1: base 宛 push 全形態 deny | `idd-guard.sh` push 解析 | PreToolUse JSON (in/out) | `hooks/idd-guard.sh`, `test-fixtures/cases/g1-*.json` |
+| 3.1〜3.5 | G2: 無条件 force deny / `--force-with-lease` 通す | `idd-guard.sh` flag 解析 | PreToolUse JSON | `hooks/idd-guard.sh`, `test-fixtures/cases/g2-*.json` |
+| 4.1〜4.4 | G0: install dir 自己保護 (Edit/Write robust, Bash best-effort) | `idd-guard.sh` path matcher | tool_name + tool_input 判定 | `hooks/idd-guard.sh`, `test-fixtures/cases/g0-*.json` |
+| 5.1〜5.5 | fail-closed: version check + smoke test, fallback なし | `gh_preflight` | claude `--version` / dry-run hook invoke | `modules/guard-hook.sh`, `issue-watcher.sh` |
+| 6.1〜6.4 | user-scope のみ配布 / repo-template 追加なし / 別 Issue 起票前提 | `install.sh` 配置 + PR 本文記載 | — | `install.sh`, `README.md` |
+| NFR 1.1〜1.3 | 既存挙動互換 / sudo なし / env override 可 | `gh_resolve_dir` / Config default | — | `modules/guard-hook.sh`, `issue-watcher.sh` |
+| NFR 2.1〜2.2 | shellcheck 警告ゼロ | 全新規/変更 .sh | — | 全 .sh |
+| NFR 3.1〜3.4 | 既知の限界を README 明記 | — | — | `README.md` |
+| NFR 4.1〜4.2 | 二重管理規約に新規追加なし | — | — | （`repo-template/` 配下に何も置かない） |
+
+## Components and Interfaces
+
+### Watcher Module: guard-hook.sh
+
+#### gh_is_enabled
+
+| Field | Detail |
+|---|---|
+| Intent | `IDD_CLAUDE_HOOKS_ENABLED` の **厳密 `true` 一致**判定（Req 1.1） |
+| Requirements | 1.1, 1.2 |
+
+**Contracts**: Service [x]
+
+##### Service Interface
+
+```bash
+# 戻り値: 0 = opt-in 有効, 1 = それ以外（未設定 / 空 / true 以外）
+gh_is_enabled() { [ "${IDD_CLAUDE_HOOKS_ENABLED:-}" = "true" ]; }
+```
+
+- Preconditions: なし
+- Postconditions: 副作用なし
+- Invariants: `True` / `1` / `yes` は **すべて false 扱い**（typo 安全側）
+
+#### gh_resolve_dir
+
+| Field | Detail |
+|---|---|
+| Intent | guard install dir の絶対パスを解決（既定 `$HOME/.idd-claude/hooks`、env で override 可） |
+| Requirements | 1.4, 4.1, 6.1, NFR 1.3 |
+
+##### Service Interface
+
+```bash
+# stdout: 絶対パス (e.g. /home/user/.idd-claude/hooks)
+gh_resolve_dir() { printf '%s' "${IDD_CLAUDE_HOOKS_DIR:-$HOME/.idd-claude/hooks}"; }
+```
+
+- Postconditions: 末尾スラッシュなし。物理存在は問わない（呼び出し側が判定）
+
+#### gh_preflight
+
+| Field | Detail |
+|---|---|
+| Intent | opt-in 時の fail-closed ゲート（claude version 確認 + smoke test） |
+| Requirements | 5.1, 5.2, 5.3, 5.4, 5.5 |
+
+##### Service Interface
+
+```bash
+# 戻り値: 0 = pass, 非ゼロ = fail（呼び出し側で exit）
+# stderr に失敗理由を出力する
+gh_preflight() { ... }
+```
+
+- 内部処理（決定論順序）:
+  1. `IDD_CLAUDE_HOOKS_MIN_VERSION` を読む（既定値は `2.1.167`。PoC 検証バージョン）
+  2. `claude --version` の stdout を取得し、semver 比較（`2.1.167` 形式の整数 3 つを `.` で
+     split → 辞書順ではなく **数値比較**）。`2.1.167` 未満なら stderr に
+     「claude version X.Y.Z is below required <MIN>」を出して `return 11`
+  3. install dir の存在確認: `idd-guard.sh` と `idd-guard-settings.json` の **両ファイル**が
+     `$(gh_resolve_dir)` 配下に存在しなければ `return 12`
+  4. smoke test: `idd-guard.sh` を **stdin に固定 fixture JSON**（`{"tool_name":"Bash",
+     "tool_input":{"command":"echo idd-guard-smoke-ok"}}`）で起動し、exit 0 + stdout が
+     有効 JSON で `decision != "deny"` であることを確認。失敗で `return 13`
+  5. すべて通れば `return 0`
+- Postconditions: 副作用は stderr 出力のみ
+
+#### gh_build_args
+
+| Field | Detail |
+|---|---|
+| Intent | claude 起動引数列に追加すべき配列を `CLAUDE_HOOK_ARGS` グローバル配列に組み立てる |
+| Requirements | 1.1, 1.2 |
+
+##### Service Interface
+
+```bash
+# 副作用: CLAUDE_HOOK_ARGS グローバル配列を設定する
+#   opt-out 時: 空配列 ()
+#   opt-in 時: (--settings <絶対パス>)
+gh_build_args() { ... }
+```
+
+- Postconditions: 呼び出し側は `claude --print "$prompt" ... "${CLAUDE_HOOK_ARGS[@]}"` の形で
+  展開する。**空配列は引数を一切追加しない**（Req 1.1, 1.2 の「一切付与しない」を満たす）
+- 注: `set -u` 配下で空配列展開 `"${ARR[@]}"` は bash 4.4+ で安全。CLAUDE.md は bash 4+ 要求
+
+### Hook Script: idd-guard.sh
+
+| Field | Detail |
+|---|---|
+| Intent | PreToolUse 経由で呼び出され、Bash / Edit / Write / NotebookEdit を検査して deny/allow を返す |
+| Requirements | 2.1〜2.7, 3.1〜3.5, 4.1〜4.4 |
+
+**Responsibilities & Constraints**
+- stdin から PreToolUse JSON を読み、stdout に decision JSON を出して exit 0
+  （allow も deny も exit 0。non-zero は Claude Code 側でエラー扱いとなり別経路）
+- `tool_name` で分岐:
+  - `Bash` → command 文字列を抽出し G1 / G2 / G0(Bash) 解析
+  - `Edit` / `Write` / `NotebookEdit` → file_path / notebook_path を抽出し G0 path 一致判定
+  - その他 → allow（明示 allow JSON ではなく **decision フィールドを返さない** = Claude 側のデフォルト判定）
+- 環境変数契約:
+  - `IDD_HOOK_BASE_BRANCH`（必須。watcher が `$BASE_BRANCH` を渡す。未設定で
+    `main` フォールバック）
+  - `IDD_CLAUDE_HOOKS_DIR`（任意。G0 path 判定の install dir。未設定で
+    `$HOME/.idd-claude/hooks`）
+  - `IDD_HOOK_LOG`（任意。設定時は deny/allow 判定を 1 行 append。未設定で no-op）
+
+**Dependencies**
+- Inbound: Claude Code PreToolUse runtime（stdin JSON） — Critical
+- Outbound: stdout JSON（deny / no-decision）, optional `$IDD_HOOK_LOG` への append
+- External: jq（JSON パース） — Critical
+
+**Contracts**: Service [x]
+
+##### G1 解析ロジック（Req 2.1〜2.6）
+
+1. command 文字列を bash の `read -ra` 相当で token 分割する（**top-level 文字列のみ**。
+   `sh -c "..."` / `$(...)` の中身は解析しない。NFR 3.1 で限界明記）
+2. 先頭 token が `git` でなければ G1 対象外
+3. 続く token のうち先頭から **global options を skip**: `-C <path>` / `--git-dir=...` /
+   `--work-tree=...` / `-c <key>=<value>` の繰り返し（Req 2.5）
+4. 次の token が `push` でなければ G1 対象外
+5. `push` 以降の token のうち non-flag token を順に取得。先頭 non-flag を remote 候補、
+   その次以降を refspec 候補とする。**remote 引数省略の場合（先頭 non-flag がそのまま
+   refspec 形）も判定対象**（Req 2.6）
+6. refspec 一覧から dst を抽出:
+   - `+<dst>` / `:<dst>` / `<src>:<dst>` の dst 部
+   - 単独 token（`:` 含まず `+` 接頭辞なし）の場合は **dst = token**
+   - `:<dst>` は削除形 → dst を取り出す（Req 2.3）
+7. dst が `$IDD_HOOK_BASE_BRANCH` と一致する refspec が 1 件でもあれば **deny**
+8. deny 理由: `"base branch push denied: ref=<ref-name>"` を decision JSON の `reason` に
+   含める（Req 2.7）
+
+##### G2 解析ロジック（Req 3.1〜3.5）
+
+1. push token 列に `-f` または `--force` が含まれれば **deny**（Req 3.1, 3.2）
+2. push 引数列に `--force-with-lease` または `--force-with-lease=...` が含まれる場合:
+   - 同時に `--force` / `-f` が無く、かつ dst が `$IDD_HOOK_BASE_BRANCH` 以外 → **allow**
+     （Req 3.4）
+   - 同時に `--force` / `-f` がある場合は無条件 force と同等 → **deny**
+3. refspec token が `+...` 接頭辞を持ち、dst が `$IDD_HOOK_BASE_BRANCH` 以外でも **deny**
+   （Req 3.3。base 宛 `+<base>` は G1 でも deny されるが、Req 3.3 は base 以外でも対象）
+4. deny 理由: `"unconditional force push denied: use --force-with-lease"` を含める（Req 3.5）
+
+> G1 と G2 はどちらも deny 対象になり得る。**G1 を先に判定し**、base 宛なら G1 reason を
+> 返す（運用者にとって base 違反であることが優先メッセージとして有用）。
+
+##### G0 解析ロジック（Req 4.1〜4.4）
+
+1. `tool_name` が `Edit` / `Write` / `NotebookEdit` の場合:
+   - `tool_input.file_path` または `tool_input.notebook_path` を取得
+   - 絶対パスに正規化（`$HOME` 展開）
+   - `$IDD_CLAUDE_HOOKS_DIR` 配下にプレフィックス一致すれば **deny**（Req 4.1, 4.2）
+2. `tool_name` が `Bash` の場合（best-effort, Req 4.3, 4.4）:
+   - command 文字列に install dir の絶対パスもしくは `~/.idd-claude/hooks` リテラルが
+     含まれ、かつ mutation 系コマンドキーワード（`rm` / `mv` / `cp` の dst 側 / `sed -i` /
+     `chmod` / `>` / `>>` / `tee` / `cat >`）が同時に含まれれば **deny**
+   - **literal 一致のみ。`sh -c "..."` / `$(...)` 内部は解析しない**
+3. deny 理由: `"guard install dir self-mutation denied: path=<resolved-path>"`
+4. Req 4.4 の「best-effort 明示」: README NFR 3.3 で記述
+
+##### Decision JSON 出力契約
+
+deny 時の例（Claude Code PreToolUse 契約に従う）:
+
+```json
+{
+  "decision": "block",
+  "reason": "base branch push denied: ref=main"
+}
+```
+
+allow 時（decision フィールドを出さず、Claude 側のデフォルト判定に委ねる）:
+
+```json
+{}
+```
+
+> 正確なフィールド名（`decision` / `reason` / `permissionDecision` 等）は Claude Code 公式
+> ドキュメントの PreToolUse hook 契約に従う。PoC スクリプト（Issue #294 本文の `<details>`）
+> が 29/29 で green になっている事実から、PoC で採用された JSON 書式をそのまま採用する。
+> 実装時に PoC 書式から外れる必要が生じた場合は Open Questions に記載のうえ確認する。
+
+### Hook Settings: idd-guard-settings.json
+
+| Field | Detail |
+|---|---|
+| Intent | claude `--settings` に渡す JSON。`hooks.PreToolUse` で `idd-guard.sh` を起動 |
+| Requirements | 1.1, 1.2 |
+
+**Contract**: State [x]（静的設定ファイル）
+
+スキーマ（PoC 検証済みフォーマットを踏襲）:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__IDD_HOOK_PATH__"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `__IDD_HOOK_PATH__` は install.sh が **絶対パス**に sed 置換する（例:
+  `/home/user/.idd-claude/hooks/idd-guard.sh`）
+- 相対パス禁止（claude の cwd 依存を避ける）
+
+### Install Path Mapping (install.sh 編集箇所)
+
+| Source (source repo) | Destination (user-scope) | 配置タイミング |
+|---|---|---|
+| `local-watcher/hooks/idd-guard.sh` | `$IDD_CLAUDE_HOOKS_DIR/idd-guard.sh`（既定 `~/.idd-claude/hooks/idd-guard.sh`） | `--local` / `--all` |
+| `local-watcher/hooks/idd-guard-settings.json` | `$IDD_CLAUDE_HOOKS_DIR/idd-guard-settings.json` | 同上（sed で `__IDD_HOOK_PATH__` 置換） |
+| `local-watcher/hooks/README.md` | `$IDD_CLAUDE_HOOKS_DIR/README.md` | 同上 |
+| `local-watcher/bin/modules/guard-hook.sh` | `$HOME/bin/modules/guard-hook.sh` | 既存 `copy_glob_to_homebin` で自動配置 |
+
+- 配置は既存の `copy_template_file` / `copy_glob_to_homebin` を再利用（once-only safe-overwrite
+  挙動を踏襲）
+- 配置完了後の hint に opt-in 手順を 1 ブロックで提示（cron 行に `IDD_CLAUDE_HOOKS_ENABLED=true`
+  を付ける例）
+
+## Data Models
+
+### Hook Invocation State
+
+PreToolUse hook は **stateless**（毎回 fresh process）。永続状態は持たない。
+副作用は optional `$IDD_HOOK_LOG` への 1 行 append のみ。
+
+### Env Var Contract
+
+| Var | Scope | Default | Override | Owner |
+|---|---|---|---|---|
+| `IDD_CLAUDE_HOOKS_ENABLED` | watcher 全体 | （未設定 = 無効） | env / cron / launchd | 運用者 |
+| `IDD_CLAUDE_HOOKS_DIR` | watcher + install + hook | `$HOME/.idd-claude/hooks` | env | 運用者 |
+| `IDD_CLAUDE_HOOKS_MIN_VERSION` | watcher（preflight） | `2.1.167`（PoC 検証バージョン） | env | 運用者 |
+| `IDD_HOOK_BASE_BRANCH` | hook（内部用） | `$BASE_BRANCH` の値（watcher が export） | env | watcher |
+| `IDD_HOOK_LOG` | hook（任意） | （未設定 = no-op） | env | 運用者 |
+
+> watcher は preflight 通過後、`export IDD_HOOK_BASE_BRANCH="$BASE_BRANCH"` を 1 度だけ行う。
+> claude プロセスは export 環境を継承し、PreToolUse hook プロセスにも継承される。
+
+## Error Handling
+
+### Error Strategy
+
+- **opt-out 時**: 一切のエラー経路を追加しない（既存挙動と完全同一）
+- **opt-in 時の preflight fail**: 黙って fallback せず **非ゼロ exit**（Req 5.5）。
+  cron なら次サイクルで再評価、launchd なら再起動でリトライ
+- **hook 自身の解析エラー**: 解析不能（JSON parse 失敗 / jq 不在）の場合は **fail-open**
+  ではなく **fail-closed**（exit 0 + `decision=block` で `reason="guard hook internal error: ..."`
+  を返す）。理由: NFR 1.1 の「黙って無効化される fallback を持たない」を hook レベルでも
+  踏襲し、guard が壊れているのに通常実行が継続するリスクを排除
+
+### Error Categories and Responses
+
+- **User / Operator Errors**:
+  - opt-in したが install dir が無い → preflight rc=12, stderr に「install.sh --local を
+    再実行してください」を提示し exit
+  - claude version 不足 → preflight rc=11, stderr に「Claude Code を <MIN> 以上に更新するか
+    `IDD_CLAUDE_HOOKS_MIN_VERSION` を緩めてください」を提示し exit
+- **System Errors**:
+  - smoke test 失敗 → preflight rc=13, stderr に hook stdout/stderr 末尾 N 行を添えて exit
+  - jq 不在 → hook 内で exit 0 + block JSON（fail-closed）
+- **Business Logic Errors（deny 判定）**:
+  - G1 / G2 / G0 のいずれも reason に **どの規約**で deny したかを含めて Claude 側に返す
+    （Claude Code がエージェントにフィードバック）
+
+### Exit Codes (新規)
+
+| Code | Source | Meaning |
+|---|---|---|
+| 11 | watcher preflight | claude version unmet |
+| 12 | watcher preflight | install dir incomplete |
+| 13 | watcher preflight | smoke test failed |
+| 0 + decision=block | hook | deny |
+| 0 + 空 JSON | hook | allow |
+
+> 既存 exit code（`run_per_task_implementer` の 0/1/99 等）の **意味は変更しない**（Req 1.3）。
+
+## Testing Strategy
+
+### Unit Tests (hook 単体, fixture-based)
+
+`docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh` が
+ドライバとなり、`cases/*.json` を stdin に流して hook を起動、stdout の decision JSON と
+`expected.tsv` を突き合わせる。**29 件**を網羅:
+
+- G0（自己保護, 5 件）: Edit / Write / NotebookEdit / Bash-rm / Bash-sed-i
+- G1（base 宛 push, 6 件）: bare / `HEAD:base` / `:base` / `+base` / `-C path` / 暗黙 remote
+- G2（force, 5 件）: `-f` / `--force` / `+<src>:<dst>` / `--force-with-lease` allow /
+  `--force-with-lease=value` allow
+- Allow 系（13 件）: 通常 push / 通常 Bash / Edit 非対象 path / コメント混入 / 別 base / 等
+
+### Integration Tests
+
+- `install.sh --dry-run --local` で配置予定が NEW/SKIP/OVERWRITE 行に現れる
+- `install.sh --local` を新規 `$HOME` で実行 → 配置済みファイルが存在し、`idd-guard-settings.json`
+  の `command` が絶対パスに sed 置換されている
+- `IDD_CLAUDE_HOOKS_ENABLED=` (未設定) で watcher を起動 → 既存挙動と diff なし（既存
+  smoke test の cron-like minimal PATH と組み合わせる）
+- `IDD_CLAUDE_HOOKS_ENABLED=true` + claude version 不足を模擬 → 非ゼロ exit / stderr 出力
+
+### Static Analysis
+
+- `shellcheck local-watcher/hooks/idd-guard.sh local-watcher/bin/modules/guard-hook.sh
+  install.sh local-watcher/bin/issue-watcher.sh` 警告ゼロ（NFR 2.1）
+- jq の `--exit-status` を活用し parse 失敗を捕捉
+
+### Performance/Load
+
+- hook は PreToolUse ごとに新規プロセスで起動するため、**起動オーバーヘッド < 200ms 目安**
+  （bash + jq 1 回起動）。性能要件は要件側に存在しないため目安のみ
+
+## Security Considerations
+
+- guard hook 自身は user-scope（権限要求なし）に閉じる。sudo 不要（Req 1.4 / NFR 1.2）
+- `$IDD_CLAUDE_HOOKS_DIR` 配下を G0 で自己保護することで「guard を有効化したエージェントが
+  guard を無効化する」自己改変ループを防ぐ（Req 4.*）
+- hook script は `set -euo pipefail` を宣言し、jq 不在を fail-closed で扱う
+- 既存 `bypassPermissions` は廃止しない（Out of Scope）。本機能は **追加レイヤー**として
+  振る舞う（既存 model trust + 新規 mechanical deny）
+
+## Migration Strategy
+
+opt-in のため migration は不要だが、以下の運用順序を README に明記:
+
+1. `install.sh --local` 再実行で hook 一式を user-scope に配置
+2. `claude --version` で `2.1.167+` を確認（または `IDD_CLAUDE_HOOKS_MIN_VERSION` を緩める）
+3. cron / launchd 行に `IDD_CLAUDE_HOOKS_ENABLED=true` を追加（既存 env var はそのまま）
+4. 次サイクルから guard 有効。違反検知時は claude 側に block reason が返り、エージェントが
+   別経路を取る
+
+ロールバック: `IDD_CLAUDE_HOOKS_ENABLED` を外せば即座に opt-out（hook 関連ファイル削除は
+不要）
+
+## Supporting References
+
+- Claude Code Hooks 公式: <https://docs.claude.com/en/docs/claude-code/hooks>（PreToolUse
+  契約 / `matcher` / decision JSON 書式）
+- Claude Code Settings 公式: <https://docs.claude.com/en/docs/claude-code/settings>
+  （`--settings <path>` フラグの引数仕様）
+
+> 上記 2 URL は本設計で参照すべき一次情報。実装時に PoC 書式と公式仕様で書式が異なる場合は
+> PoC 書式（29/29 green）を優先しつつ、書式相違を impl-notes.md に記録する。
+
+## Open Questions / 確認事項
+
+1. **Claude Code の `--settings` の優先順位**: `~/.claude/settings.json`（既存ユーザー設定）
+   と `--settings <path>`（本機能）の併用時、hooks がマージされるか上書きされるかは公式
+   ドキュメントの確認が必要。本設計は **`--settings <path>` を渡せば hook が確実に起動する**
+   ことを前提とする。実装時に hooks がユーザー側 settings.json で override される挙動が
+   発覚した場合は impl-notes.md に記録のうえ、対処方針（合成 settings.json を `--settings`
+   で渡す等）を再検討する
+2. **decision JSON フィールド名**: 設計時点では PoC（Issue #294 本文）の書式
+   （`{"decision":"block","reason":"..."}`）を採用。公式仕様で `permissionDecision` /
+   `hookSpecificOutput` 等の別書式が canonical であれば実装時に PoC 形式と公式仕様の差分を
+   確認し、PoC 書式が公式仕様の許容範囲に収まることを impl-notes.md に記録する
+3. **`IDD_CLAUDE_HOOKS_MIN_VERSION` の既定値**: PoC 検証済みの `2.1.167` を採用するが、
+   将来 Claude Code がより新しい minor で hook 契約を変更する場合に備え、運用者が env で
+   緩める / 引き上げる手順を README に明記する

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/requirements.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/requirements.md
@@ -1,0 +1,130 @@
+# Requirements Document
+
+## Introduction
+
+idd-claude では現在、すべてのエージェント実行を `--permission-mode bypassPermissions`（god-mode）
+で走らせており、「base ブランチへの直接 push 禁止」「無条件 force push 禁止」といった重要規約は
+散文ドキュメントでしか宣言されていない。違反は事後の Reviewer 検出ループでしか拾えず、
+1 違反あたり Developer + Reviewer の 1 サイクル分の turn を浪費する構造的問題がある。
+
+本 Issue（[#294](https://github.com/hitoshiichikawa/idd-claude/issues/294)）は、Claude Code の
+`PreToolUse` フック機構（claude 2.1.167 で PoC 検証済み、G0/G1/G2 合計 29/29 テスト green）を
+利用し、外部 `settings.json` 経由で機械的に違反を deny する初版を導入する。初版は **opt-in
+（`IDD_CLAUDE_HOOKS_ENABLED=true` で有効化、未設定時は導入前と完全同一挙動）** であり、
+watcher 自身の self-hosting 運用での fail-closed 動作を含む。
+
+配布スコープは **user-scope 専用**（worktree 外の `~/.idd-claude/hooks/` 等）に限定する。
+`repo-template/` 経由で consumer repo に配布する適用は本 Issue では扱わず、**後続の別 Issue
+として起票が必要**（人間による承認条件として明示）。
+
+## Requirements
+
+### Requirement 1: 後方互換性（既定 OFF / opt-in gate）
+
+**Objective:** As an idd-claude 運用者, I want guard hook が未有効時に従来の挙動を一切変えないことを保証したい, so that 既存の cron / launchd 登録および全 consumer repo の動作に regression を起こさず段階的に導入できる
+
+#### Acceptance Criteria
+
+1. While 環境変数 `IDD_CLAUDE_HOOKS_ENABLED` の値が文字列 `true` と完全一致しない（未設定 / 空文字 / `false` / `True` / `1` 等を含む）状態, the watcher shall claude CLI 起動時に guard hook を参照する設定（`--settings` 相当）を一切付与しない
+2. While `IDD_CLAUDE_HOOKS_ENABLED` が `true` と完全一致しない状態, the watcher shall guard hook 導入前と同一の引数列・同一の環境変数集合で claude CLI を起動する
+3. The watcher shall 既存の環境変数名（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `TRIAGE_MODEL` / `DEV_MODEL` / `BASE_BRANCH` 等）の意味と既存ラベル名と既存 exit code 意味を本機能導入によって変更しない
+4. The watcher shall 本機能のために sudo / root 権限を必要とする手順を追加しない
+
+### Requirement 2: G1 — base ブランチ宛 push の機械 deny
+
+**Objective:** As an idd-claude 運用者, I want エージェントが `$BASE_BRANCH` 宛に push しようとした全ての形を実行前に deny したい, so that base ブランチへの直接 push 規約違反を Reviewer 事後検出ループに頼らず防げる
+
+#### Acceptance Criteria
+
+1. When エージェントが `git push <remote> <BASE_BRANCH>` 形式で base ブランチへ push しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+2. When エージェントが `git push <remote> HEAD:<BASE_BRANCH>` 形式（src:dst 構文）で base ブランチへ push しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+3. When エージェントが `git push <remote> :<BASE_BRANCH>` 形式（remote 側 base ブランチの削除）を実行しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+4. When エージェントが `git push <remote> +<BASE_BRANCH>` 形式（先頭 `+` による force refspec）で base ブランチへ push しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+5. When エージェントが `git -C <path> push ...` や `git --git-dir=... push ...` のような global オプション付き形式で base ブランチへ push しようとしたとき, the PreToolUse guard hook shall global オプションを除去した後の push 引数列を解析して deny する
+6. When エージェントが remote 引数を省略した `git push <BASE_BRANCH>` または `git push HEAD:<BASE_BRANCH>` 形式（暗黙 remote）で base ブランチへ push しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+7. If guard hook が deny した場合, the PreToolUse guard hook shall 標準エラーまたは deny 理由メッセージに「base ブランチ宛 push が deny された」旨と当該 ref 名を含めて出力する
+
+### Requirement 3: G2 — 無条件 force push の機械 deny
+
+**Objective:** As an idd-claude 運用者, I want `--force-with-lease` ではない無条件 force push の全形を実行前に deny したい, so that 共有ブランチ上の他者コミットを暗黙に上書きする事故を防げる
+
+#### Acceptance Criteria
+
+1. When エージェントが `git push -f ...` 形式の push を実行しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+2. When エージェントが `git push --force ...` 形式の push を実行しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+3. When エージェントが refspec の先頭に `+` を付けた `git push <remote> +<src>:<dst>` 形式（base ブランチ以外への force refspec を含む）を実行しようとしたとき, the PreToolUse guard hook shall 当該 Bash 実行を deny する
+4. Where push 引数列に `--force-with-lease` または `--force-with-lease=<value>` が含まれ, and dst が `$BASE_BRANCH` 以外, the PreToolUse guard hook shall 当該 push を許容する
+5. If guard hook が無条件 force を理由に deny した場合, the PreToolUse guard hook shall deny 理由メッセージに「無条件 force push が deny された（`--force-with-lease` を使用すること）」旨を含めて出力する
+
+### Requirement 4: G0 — guard install dir の自己保護
+
+**Objective:** As an idd-claude 運用者, I want guard hook 自身の設定ファイルとスクリプト群がエージェントから改変されないように保護したい, so that guard を有効化したエージェント自身が guard を無効化する自己改変ループを防げる
+
+#### Acceptance Criteria
+
+1. When エージェントが guard install dir（`~/.idd-claude/hooks/` 配下、env var で override 可）配下のファイルを Edit ツールで変更しようとしたとき, the PreToolUse guard hook shall 当該 Edit 実行を deny する
+2. When エージェントが guard install dir 配下のファイルを Write ツールで作成または上書きしようとしたとき, the PreToolUse guard hook shall 当該 Write 実行を deny する
+3. When エージェントが Bash ツールで guard install dir 配下のファイルを変更する明示的なコマンド（`rm` / `mv` / リダイレクト書き込み / `sed -i` / `chmod` 等のキーワードを含み、対象パスが guard install dir 配下にマッチするもの）を実行しようとしたとき, the PreToolUse guard hook shall best-effort で当該 Bash 実行を deny する
+4. The PreToolUse guard hook shall Edit / Write 経由の自己改変を robust に検出し、Bash 経由の検出は best-effort であって全件捕捉を保証しないことを deny 理由または README に明示する
+
+### Requirement 5: fail-closed 起動ゲート
+
+**Objective:** As an idd-claude 運用者, I want hooks を有効化したのに前提条件（claude version / smoke test）が満たされない場合は静かに fallback せず明示的に停止してほしい, so that guard が黙って無効化された状態で長時間運用が継続するリスクを排除できる
+
+#### Acceptance Criteria
+
+1. When `IDD_CLAUDE_HOOKS_ENABLED=true` の状態で watcher が claude CLI 起動を準備するとき, the watcher shall claude CLI の version を取得して `IDD_CLAUDE_HOOKS_MIN_VERSION`（env で override 可）と比較する
+2. If claude CLI の version が `IDD_CLAUDE_HOOKS_MIN_VERSION` 未満, the watcher shall claude CLI 起動を中止して標準エラーに version 不足の理由を出力した上で非ゼロ exit する
+3. When `IDD_CLAUDE_HOOKS_ENABLED=true` の状態で watcher が起動準備するとき, the watcher shall guard hook の smoke test（hook 設定の syntax 確認 / 必要ファイル存在確認 等の最小検証）を実行する
+4. If smoke test が失敗, the watcher shall claude CLI 起動を中止して標準エラーに smoke test 失敗の理由を出力した上で非ゼロ exit する
+5. The watcher shall fail-closed 停止時に guard を黙って無効化して claude CLI を起動する fallback 経路を持たない
+
+### Requirement 6: 配布スコープの限定とフォローアップ Issue 起票
+
+**Objective:** As an idd-claude 運用者, I want 初版の配布範囲を user-scope 単独に限定し、consumer repo への展開は別 Issue として独立に承認したい, so that idd-claude self-hosting だけで先行検証してから consumer 影響範囲を判断できる
+
+#### Acceptance Criteria
+
+1. The guard hook 一式（settings.json / hook script）shall worktree 外の user-scope ディレクトリ（既定 `~/.idd-claude/hooks/`）に配置される
+2. The 本 Issue の成果物 shall `repo-template/` 配下に guard hook 関連ファイルを追加しない
+3. The 本 Issue の成果物 shall consumer repo の `.claude/` 配下に guard hook 関連ファイルを配布しない
+4. The 本 Issue 完了時 shall consumer repo への guard hook 適用を扱う別 Issue が起票されている（人間による Option A 承認条件として明示された前提）
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性と運用安全性
+
+1. While `IDD_CLAUDE_HOOKS_ENABLED` が `true` 以外, the watcher shall 本機能導入前と完全に同一の cron 登録文字列 / 環境変数 default / ラベル名 / exit code 意味で動作する
+2. The 本機能 shall root 権限を要求する手順を含まない（user-scope 前提を維持）
+3. The watcher shall `IDD_CLAUDE_HOOKS_MIN_VERSION` を環境変数で override 可能にし、既定値をハードコードせず env default で上書きできる
+
+### NFR 2: 静的解析と品質
+
+1. The 本機能で追加または変更される bash スクリプト shall `shellcheck` を警告ゼロで通過する
+2. The 本機能で追加または変更される `.github/workflows/*.yml` shall（該当する場合）`actionlint` を警告ゼロで通過する
+
+### NFR 3: 既知の限界の文書化
+
+1. The README または同等のユーザー可視ドキュメント shall「top-level Bash 文字列のみを解析するため `sh -c "..."` / `$(...)` / wrapper script 内部の push は捕捉できない」旨を明記する
+2. The README または同等のユーザー可視ドキュメント shall「bare `git push`（引数なし）かつ現ブランチが偶然 base と一致するケースは literal 解析では判定不能」旨を明記する
+3. The README または同等のユーザー可視ドキュメント shall「G0 の Bash 経由 mutation 検出は best-effort であり全件捕捉を保証しない」旨を明記する
+4. The README または同等のユーザー可視ドキュメント shall「本初版は role/spec guard / secrets guard / `bypassPermissions` 廃止を含まない」旨を明記する
+
+### NFR 4: 二重管理規約への影響最小化
+
+1. The 本機能 shall guard hook 一式を user-scope 配置とすることで、root `.claude/` と `repo-template/.claude/` の byte 一致同期規約に新規ファイルを追加しない
+2. While 採用形態として外部参照設計を採るとき, the consumer repo の `.claude/` 配下 shall 本機能による新規ファイル配置を受けない
+
+## Out of Scope
+
+- role/spec guard（Reviewer の read-only 強制等）— 後続 Issue
+- secrets guard（`.env` / `*.pem` 等の staged path ブロック）— 後続 Issue
+- Bash 経由の任意書き換えの全面ブロック（`sh -c "..."` / `$(...)` / wrapper script 内部処理は原理的に literal からは捕捉不能であり、初版では限界として README に明記するに留める）
+- `bypassPermissions` の廃止 / 全 tool allowlist 化
+- `repo-template/` 経由での consumer repo への guard hook 配布（**後続 Issue として別途起票が必要**。本 Issue では起票責務を持たないが、Option A 承認条件として「consumer 適用 Issue を起票する」前提が明示されている）
+- guard hook 設定の動的書き換え / 実行時切り替え（env による静的 opt-in のみ）
+
+## Open Questions
+
+- `IDD_CLAUDE_HOOKS_MIN_VERSION` の初期値（PoC 検証済みの `2.1.167` をそのまま既定とするか、より緩めるか）は Architect / 人間判断に委ねる。要件としては「env で override 可能であること」のみを規定し、既定値の具体値は design.md 側で確定する
+- guard install dir のパスを env var で override する場合の env var 名（例 `IDD_CLAUDE_HOOKS_DIR`）は実装命名の領分のため design.md に委ねる

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -1,0 +1,126 @@
+# Implementation Plan
+
+実装は **G0 + G1 + G2 を同一初版**で完了させる（人間 Decision 1: Option A）。配布は
+**user-scope のみ**（人間 Decision 2: Option A）。`repo-template/` への追加は本 Issue では
+**禁止**（Req 6.2 / 6.3 / NFR 4.1）。
+
+- [ ] 1. guard hook script (`idd-guard.sh`) と settings テンプレを新規作成
+  - `local-watcher/hooks/idd-guard.sh` を新規作成。`set -euo pipefail` 宣言。stdin から
+    PreToolUse JSON を `jq` で読み、`tool_name` で分岐
+  - G1 push 解析: `git` global options (`-C` / `--git-dir=` / `--work-tree=` / `-c k=v`) を
+    skip → `push` 検出 → refspec から dst 抽出 → `$IDD_HOOK_BASE_BRANCH` 一致で deny
+    （bare / `HEAD:base` / `:base` / `+base` / `-C path` / 暗黙 remote すべて対応）
+  - G2 force 解析: `-f` / `--force` 検出で deny、`--force-with-lease(=...)` で base 以外なら
+    allow、`+<src>:<dst>` の `+` 接頭辞で base 以外でも deny
+  - G0 自己保護: `Edit` / `Write` / `NotebookEdit` の file_path/notebook_path が
+    `$IDD_CLAUDE_HOOKS_DIR` 配下なら deny、`Bash` は mutation キーワード（`rm` / `mv` /
+    `sed -i` / `chmod` / `>` / `>>` / `tee`）+ install dir リテラルの両方を含む場合のみ
+    best-effort deny
+  - decision JSON は `{"decision":"block","reason":"..."}` 書式（PoC 採用）。allow は `{}`
+  - jq 不在 / JSON parse 失敗は **fail-closed**（exit 0 + block JSON）
+  - `$IDD_HOOK_LOG` 設定時は 1 行 append（任意）
+  - `local-watcher/hooks/idd-guard-settings.json` を新規作成。`matcher: "Bash|Edit|Write|NotebookEdit"` /
+    `command: "__IDD_HOOK_PATH__"` placeholder を含む
+  - `local-watcher/hooks/README.md` を新規作成（配置先・env var 契約・既知の限界の短文）
+  - shellcheck 警告ゼロ
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 4.4, NFR 2.1_
+
+- [ ] 2. test fixtures（29 件マトリクス）と driver スクリプトを作成
+  - `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/*.json` を
+    29 件作成（G0:5 / G1:6 / G2:5 / Allow:13）。Issue #294 本文の PoC 29 件マトリクスに準拠
+  - `expected.tsv` で各ケースの期待 verdict（deny|allow）と reason 部分一致文字列を宣言
+  - `run-tests.sh` を新規作成（fixture を順次 stdin に流して hook を起動し、verdict と
+    reason を expected.tsv と突合。1 件でも mismatch なら非ゼロ exit）
+  - `IDD_HOOK_BASE_BRANCH=main` / `IDD_CLAUDE_HOOKS_DIR=$HOME/.idd-claude/hooks` を export
+    した状態で実行
+  - 29/29 green を確認
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3_
+  - _Depends: 1_
+
+- [ ] 3. watcher module (`guard-hook.sh`) を新規作成
+  - `local-watcher/bin/modules/guard-hook.sh` を新規作成（既存 module 分割パターン踏襲）
+  - `gh_log` / `gh_warn` / `gh_error` ロガー（`guard-hook:` prefix、`[$REPO]` 3 段書式）
+  - `gh_is_enabled`: `IDD_CLAUDE_HOOKS_ENABLED` の **厳密 `true` 一致**判定（typo 安全側）
+  - `gh_resolve_dir`: install dir 絶対パス解決（既定 `$HOME/.idd-claude/hooks`、env override）
+  - `gh_preflight`: claude version 比較 → install dir 完全性 → smoke test の順で fail-closed
+    判定（rc 11/12/13）。stderr に運用者向け復旧ヒントを出力
+  - `gh_build_args`: グローバル配列 `CLAUDE_HOOK_ARGS` を opt-out 時 `()` / opt-in 時
+    `(--settings <絶対パス>)` で構築
+  - shellcheck 警告ゼロ
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 5.1, 5.2, 5.3, 5.4, 5.5, NFR 1.1, NFR 1.3, NFR 2.1_
+
+- [ ] 4. `issue-watcher.sh` を guard hook 対応に編集
+  - Config ブロックに env var の default 宣言を追加（`IDD_CLAUDE_HOOKS_ENABLED` /
+    `IDD_CLAUDE_HOOKS_DIR` / `IDD_CLAUDE_HOOKS_MIN_VERSION=2.1.167` / `IDD_HOOK_LOG`）。
+    **既存 env var 名・既定値は一切変更しない**
+  - `REQUIRED_MODULES` 配列末尾に `guard-hook.sh` を追加
+  - 起動初期化フェーズ（モジュール source 直後、TRIAGE_TEMPLATE 存在チェック付近）で
+    `gh_is_enabled && { gh_preflight || exit $?; export IDD_HOOK_BASE_BRANCH="$BASE_BRANCH"; }`
+    相当の処理を追加し、その後 `gh_build_args` を呼んで `CLAUDE_HOOK_ARGS` を構築
+  - 全 `claude --print "$prompt" ... --max-turns ...` 起動箇所（Triage / Developer /
+    Reviewer / Architect / per-task Implementer / per-task Reviewer / Iteration / Security
+    Review 等、grep `claude \\\\$` 相当で網羅される 15+ 箇所）の末尾に
+    `"${CLAUDE_HOOK_ARGS[@]}"` を追加
+  - opt-out 時は配列が空 → 既存挙動と diff なし（NFR 1.1 / Req 1.1, 1.2 を担保）
+  - shellcheck 警告ゼロ
+  - _Requirements: 1.1, 1.2, 1.3, 5.1, 5.2, 5.3, 5.4, 5.5, NFR 1.1, NFR 2.1_
+  - _Depends: 3_
+
+- [ ] 5. `install.sh` に hook 一式の user-scope 配置を追加
+  - `INSTALL_LOCAL` ブロックに `local-watcher/hooks/*` を `$IDD_CLAUDE_HOOKS_DIR`（既定
+    `$HOME/.idd-claude/hooks`）に配置する処理を追加（既存 `copy_template_file` 再利用）
+  - `idd-guard.sh` は `--executable` 付与
+  - `idd-guard-settings.json` 配置時に `__IDD_HOOK_PATH__` placeholder を絶対パスに sed
+    置換（dry-run 時は置換予定だけログに出す）
+  - 配置完了後の hint メッセージに opt-in 手順 1 ブロックを追記（cron 行に
+    `IDD_CLAUDE_HOOKS_ENABLED=true` を加える例 / fail-closed の挙動 / 別 Issue で consumer
+    配布される旨）
+  - sudo 要求を追加しない（既存規約維持）
+  - `repo-template/` 配下には何も追加しない（Req 6.2, 6.3 / NFR 4.1 / 4.2）
+  - shellcheck 警告ゼロ
+  - _Requirements: 1.4, 6.1, 6.2, 6.3, NFR 1.2, NFR 2.1, NFR 4.1, NFR 4.2_
+  - _Depends: 1_
+
+- [ ] 6. `README.md` に「Guard Hook (PreToolUse) opt-in」節を追加
+  - opt-in 手順（`install.sh --local` 再実行 → `claude --version` 確認 → cron に
+    `IDD_CLAUDE_HOOKS_ENABLED=true` を追加）
+  - env var 一覧（`IDD_CLAUDE_HOOKS_ENABLED` / `IDD_CLAUDE_HOOKS_DIR` /
+    `IDD_CLAUDE_HOOKS_MIN_VERSION` / `IDD_HOOK_BASE_BRANCH` / `IDD_HOOK_LOG`、それぞれの
+    既定値と上書き方法）
+  - fail-closed 挙動と exit code 11/12/13 の意味
+  - 既知の限界（NFR 3.1〜3.4 全て）:
+    - top-level Bash 文字列のみ解析、`sh -c "..."` / `$(...)` / wrapper 内部は捕捉不能
+    - 引数なし `git push` で現ブランチが偶然 base と一致するケースは literal 解析不可
+    - G0 の Bash 経由 mutation 検出は best-effort
+    - 本初版は role/spec / secrets guard / `bypassPermissions` 廃止を含まない
+  - 後続 Issue（consumer 配布）が別途必要である旨を migration note として明記（Req 6.4 /
+    人間 Decision 2 の承認条件）
+  - ロールバック（env を外せば即 opt-out）
+  - _Requirements: 6.4, NFR 1.3, NFR 3.1, NFR 3.2, NFR 3.3, NFR 3.4_
+
+- [ ] 7. 統合スモークテスト・手動検証
+  - `install.sh --dry-run --local` で hook 配置が NEW/SKIP/OVERWRITE 行に現れる
+  - 使い捨て `$HOME` で `install.sh --local` 実行 → 配置済みファイル存在 + settings.json の
+    placeholder 置換確認
+  - `IDD_CLAUDE_HOOKS_ENABLED=` 未設定で watcher を `REPO=owner/test REPO_DIR=/tmp/test`
+    として起動 → 既存 dry-run（処理対象なし）と diff なし
+  - `IDD_CLAUDE_HOOKS_ENABLED=true` + 偽の `IDD_CLAUDE_HOOKS_MIN_VERSION=99.0.0` で起動 →
+    exit code 11 で停止、stderr に version 不足理由
+  - cron-like minimal PATH (`env -i HOME=$HOME PATH=/usr/bin:/bin bash -c ...`) で依存 CLI
+    が解決される
+  - `bash docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh`
+    で 29/29 green
+  - 結果を PR 本文の Test Plan に記載
+  - _Requirements: 1.1, 1.2, 5.1, 5.2, 5.3, 5.4, 5.5, 6.1_
+  - _Depends: 2, 4, 5_
+
+## Verify
+
+本 spec の実装後、stage-a-verify gate watcher が独立再実行する verify コマンドを以下の
+構造化ブロックで宣言する。`shellcheck` は新規/編集対象の全 bash スクリプトを対象とし、
+fixture driver で hook の 29 件マトリクスを実行する。
+
+<!-- stage-a-verify -->
+```sh
+shellcheck install.sh local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/guard-hook.sh local-watcher/hooks/idd-guard.sh && bash docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh
+```


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用** です。実装コードは含まれません。
`docs/specs/294-feat-watcher-pretooluse-guard-hook-base/` 配下の requirements / design / tasks を merge するためのゲートです。

## 対応 Issue

Refs #294

## 含まれる成果物

- `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/requirements.md` — 要件定義（PM 成果物）
- `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/design.md` — 設計書（Architect 成果物）
- `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md` — 実装タスク分割

## 関連 Issue / PR

なし

## Summary

- **G0 + G1 + G2 全部を同一初版でリリース**（人間 Decision 1: Option A）。G1 = base ブランチ宛 push 機械 deny、G2 = 無条件 force push deny、G0 = guard install dir 自己保護
- **user-scope 専用配布**（`~/.idd-claude/hooks/`）に限定（人間 Decision 2: Option A）。`repo-template/` や consumer repo への配布は本 Issue では扱わない
- **fail-closed 起動ゲート**: `IDD_CLAUDE_HOOKS_ENABLED=true` 時に claude version 不足 / smoke test 失敗があれば黙って fallback せず非ゼロ exit
- **PoC で確認済みの 29 件テストマトリクスを fixture 化**して回帰検証可能にする設計
- **consumer 配布のための後続 Issue 起票が必要**（Req 6.4 / 人間 Decision 2 の承認条件として明示）

## 設計の要点

- **install dir**: `~/.idd-claude/hooks/`（既定）。`IDD_CLAUDE_HOOKS_DIR` env で override 可
- **`IDD_CLAUDE_HOOKS_MIN_VERSION` 既定値**: `2.1.167`（PoC 検証バージョン）。env で緩める / 引き上げ可能
- **fail-closed smoke test**: preflight が exit 0 + allow JSON を返すことを確認。失敗で rc=13、stderr に理由を出力し非ゼロ exit
- **`--settings` 注入方式**: 全 `claude --print ...` 起動箇所の末尾に `"${CLAUDE_HOOK_ARGS[@]}"` を付与。opt-out 時は空配列（既存挙動と diff なし）
- **モジュール命名**: `local-watcher/bin/modules/guard-hook.sh`（関数 prefix `gh_`）。既存モジュール分割パターン踏襲
- **二重管理規約への影響**: `.claude/agents` / `.claude/rules` は変更しないため byte 一致同期規約に抵触しない。`repo-template/` 配下にも何も追加しない

## タスク分割

tasks.md の 7 タスク:

1. guard hook script (`idd-guard.sh`) と settings テンプレを新規作成
2. test fixtures（29 件マトリクス）と driver スクリプトを作成
3. watcher module (`guard-hook.sh`) を新規作成
4. `issue-watcher.sh` を guard hook 対応に編集
5. `install.sh` に hook 一式の user-scope 配置を追加
6. `README.md` に「Guard Hook (PreToolUse) opt-in」節を追加
7. 統合スモークテスト・手動検証

## 確認事項

- **Claude Code `--settings` の優先順位**: `~/.claude/settings.json`（既存ユーザー設定）と `--settings <path>` 併用時に hooks がマージされるか上書きされるかは未確認。実装時に確認が必要
- **decision JSON フィールド名**: 設計時点では PoC の書式（`{"decision":"block","reason":"..."}`）を採用。公式仕様で `permissionDecision` 等の別書式が canonical な場合は impl-notes.md に記録
- **`IDD_CLAUDE_HOOKS_MIN_VERSION` 既定値**: `2.1.167`（PoC 検証バージョン）の妥当性は人間判断に委ねる。env で緩める手順を README に明記する設計
- **本 PR は設計のみ**: 実装コード（`local-watcher/`, `install.sh`, `README.md`, hook script 等）は含まない。merge 後に Developer フェーズで別 PR として実装が作成される
- **consumer 適用のための後続 Issue 起票**: Req 6.4 に明示のとおり、本 Issue 完了時に「consumer repo への guard hook 適用を扱う別 Issue」が起票されている必要がある（人間 Decision 2 の承認条件）。PjM / 人間が本 PR merge 後に起票することを忘れないよう注意

## base ブランチ検証

base: main / baseRefName: main / OK

## レビュー観点

- requirements.md の FR / NFR / AC に過不足はないか
- design.md のモジュール構成・公開 IF が FR をカバーしているか
- 既存コードの再利用が検討されているか、重複実装が混じっていないか
- tasks.md の分割粒度が独立コミット可能か

## 次のステップ

- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
- 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
- やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から `awaiting-design-review` ラベルを外すと実装が自動開始します。
