### PR TITLE
fix(#296): Reviewer の review-notes.md 不在を rc=3 で区別し 1 回限定リトライで救済する

### DIFF
--- a/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/impl-notes.md
+++ b/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/impl-notes.md
@@ -1,0 +1,144 @@
+# Implementation Notes — Issue #296
+
+## 採用方針
+
+debugger 分析の **多層防御「案 D + 案 A」** を採用（案 C は本 Issue のスコープ外として
+別 Issue 化を推奨）。
+
+- **案 D（戻り値分離）**: `parse_review_result` の戻り値を細分化し、ファイル不在を
+  装飾起因 parse 失敗 (rc=2) と区別する **rc=3** を新設した。
+- **案 A（1 回限定リトライ）**: `run_reviewer_stage` / `run_per_task_reviewer` の内部で
+  ファイル不在検出 (parse rc=3) 時に **同一 round 内で claude を 1 回だけ再起動**し、
+  再起動後もファイル不在なら関数が **rc=4** を返す。呼び出し側 6 箇所で rc=4 を受けたら
+  `reviewer-missing-file` / `per-task-reviewer-missing-file` カテゴリで `claude-failed` を
+  付与する。装飾起因 parse 失敗 (rc=2) と grep で区別可能な reason・stage 識別子を出力する。
+- **案 C は別 Issue へ**: `repo-template/.claude/agents/reviewer.md` の出力契約強化
+  （Write 完了後の Read 再読込・最終行 verify・終了前 `ls` 出力）は、テンプレ配布の影響範囲が
+  既 installed consumer repo まで及ぶため別 Issue に切ることを推奨。requirements.md
+  「Out of Scope」と「Open Questions」にも明記済み。
+
+### Open Questions の判断
+
+- **リトライ回数 = 1 回限定** で確定（requirements 推奨どおり / NFR 3.1 と整合）
+- **戻り値設計 = 新 rc 追加** （rc=3 / rc=4）で確定。reason 文字列のみで区別する案は
+  呼び出し側に grep 抜き出しを要求する分かりにくさがあるため不採用。
+- **リトライ時 `--max-turns` は同一値** で確定（`$REVIEWER_MAX_TURNS` をそのまま再利用）。
+  初回 Write 漏れが Reviewer の context 不足によるものか subagent 内部の writeup 漏れかは
+  事前判定不能なため、安全側に倒して同一値とした。
+
+## 戻り値の対応表
+
+| 関数 | rc=0 | rc=1 | rc=2 | rc=3 | rc=4 | rc=99 |
+|---|---|---|---|---|---|---|
+| `parse_review_result` | OK | — | ファイルあり RESULT 抽出失敗（装飾起因） | **ファイル不在（新規）** | — | — |
+| `run_reviewer_stage` | approve | reject | claude crash / parse-failed (rc=2) | — | **missing-file-after-retry（新規）** | quota |
+| `run_per_task_reviewer` | approve | reject | claude crash / parse-failed (rc=2) | diff-range-resolve-failed | **missing-file-after-retry（新規）** | quota |
+
+per-task の rc=3 は既存 Issue #164 で diff-range 解決失敗に割り当て済みのため、本 Issue で
+追加する missing-file は rc=4 を採用（rc 値の衝突回避）。単発 reviewer も統一して rc=4 とした。
+
+## 変更ファイル一覧
+
+- `local-watcher/bin/issue-watcher.sh` — Parser + Reviewer 起動関数 + 6 caller site の更新
+  - `parse_review_result()`: ファイル不在で rc=3 を返す（旧 rc=2 から変更）
+  - `run_reviewer_stage()`: attempt 1/2 のリトライループ導入 + rc=4 終了経路追加
+  - `run_per_task_reviewer()`: 同上（rc 値は per-task の既存 rc=3 と衝突しない rc=4 を使用）
+  - 単発 reviewer 呼び出し 3 箇所（round=1 / round=2 / round=3 Debugger 経由）に rc=4 case 追加
+  - per-task reviewer 呼び出し 3 箇所（round=1 / round=2 / round=3 Debugger 経由）に rc=4 case 追加
+- `local-watcher/test/parse_review_result_test.sh` — missing file の期待 rc を 2 → 3 に変更、
+  装飾耐性パース (#63 リグレッション防止) のテストケース 4 件を追加
+- `docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh` —
+  retry loop 挙動の fixture-based スモークテスト（11 アサーション）
+
+## AC 達成確認（requirement ID → テスト対応）
+
+| Req ID | テスト / 検証手段 |
+|---|---|
+| 1.1 ファイル不在の専用シグナル | `parse_review_result_test.sh` "missing file: parse rc=3" |
+| 1.2 装飾起因 parse 失敗の区別 | `parse_review_result_test.sh` "no-result: parse rc=2" |
+| 1.3 ログ上の reason 区別 | `test-retry-loop.sh` Pattern B 検証 + 実装側の `reason=missing-file` / `reason=missing-file-after-retry` / `reason=parse-failed` を別文字列で出力 |
+| 2.1 同一 round 内 1 回再起動 | `test-retry-loop.sh` Pattern A / B（claude 起動回数=2 を assert） |
+| 2.2 再起動成功時の正常合流 | `test-retry-loop.sh` Pattern A（rc=0 を assert） |
+| 2.3 再起動失敗時の `missing-file` reason `claude-failed` | `test-retry-loop.sh` Pattern B + 実装側 `mark_issue_failed "reviewer-missing-file"` / `"per-task-reviewer-missing-file"` |
+| 2.4 / NFR 3.1 リトライ上限 1 回 | `test-retry-loop.sh` Pattern B（attempt count=2 を assert） |
+| 2.5 / NFR 2.1 ログ識別子 | 実装側 `rv_log` / `pt_log` に round / attempt / reason を 1 行で記録 |
+| 3.1 / 3.2 / 3.3 口頭申告を採用しない | 実装変更なし（既存挙動。`parse_review_result` は `notes_path` の RESULT トークンのみを見て判定し、orchestrator 最終メッセージ / トランスクリプト本文には触れていない） |
+| 4.1 / 4.2 / 4.3 単発 / per-task / Debugger 経由対称 | `run_reviewer_stage`（単発・Debugger 経由 round=3 共用）と `run_per_task_reviewer`（per-task 全 round 共用）に対称実装 |
+| 5.1 装飾耐性パース維持 | `parse_review_result_test.sh` 新規 4 ケース（inline-approve / reject backticks, multi-last-wins）で rc=0 維持を assert |
+| 5.2 「最後マッチ採用」維持 | `parse_review_result_test.sh` multi-last-wins-{approve,reject} rc=0 維持 |
+| 5.3 装飾起因はリトライしない | `test-retry-loop.sh` Pattern D（rc=2 → 起動回数=1 を assert） |
+| NFR 1.1 / 1.2 既存挙動互換 | `parse_review_result_test.sh` 既存 19 ケース全て継続 PASS + `test-retry-loop.sh` Pattern C（即時 approve / 起動回数=1） |
+| NFR 2.2 grep で区別可能 | `reason=missing-file-after-retry` / `reviewer-missing-file` stage 識別子（既存 `parse-failed` / `reviewer-error` と異なる文字列） |
+
+## 実行したテストとその結果
+
+```bash
+$ bash local-watcher/test/parse_review_result_test.sh
+PASS: 23, FAIL: 0
+
+$ bash docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
+PASS: 11, FAIL: 0
+
+$ for t in local-watcher/test/*.sh; do bash "$t"; done
+(全 17 テストスイート PASS、FAIL=0)
+
+$ shellcheck local-watcher/bin/issue-watcher.sh \
+            local-watcher/test/parse_review_result_test.sh \
+            docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
+(警告ゼロ)
+
+$ bash -n local-watcher/bin/issue-watcher.sh
+syntax OK
+
+$ diff -r .claude/agents repo-template/.claude/agents
+(差分なし — 本変更は agents 配下を触っていない)
+
+$ diff -r .claude/rules repo-template/.claude/rules
+(差分なし — 本変更は rules 配下を触っていない)
+```
+
+## 既存 fixture / consumer repo への影響
+
+### 旧 rc=2 → 新 rc=3 への移行影響
+
+- `parse_review_result` を **直接呼ぶ箇所は本 repo 内 5 箇所**（`grep -n "parse_review_result"` で
+  確認済 / `run_reviewer_stage` 内 1 / `run_per_task_reviewer` 内 1 / per-task 呼び出し側 reject2
+  メッセージ用 1 / 単発 reviewer-reject3 メッセージ用 1 / 単発 reviewer-reject2 メッセージ用 1）。
+- リトライループ内の 2 呼び出しは新たに rc=3 を case 文で処理する（リトライ発火）。
+- reject2 / reject3 メッセージ生成用の 3 呼び出しは `parse_review_result ... 2>/dev/null || echo ""`
+  パターンで失敗時に空文字を返すため、rc=2 → rc=3 への変更で挙動が変わらない（いずれも非 0
+  rc を `|| echo ""` で握り潰す）。
+- consumer repo 側で本 watcher スクリプトを直接呼んでいる箇所は無い（watcher は本 repo の
+  `local-watcher/bin/issue-watcher.sh` でのみ稼働）。
+- **後方互換性**: 既存正常系（ファイルあり + RESULT 抽出成功）の挙動は同値（NFR 1.2）。
+  既存異常系のうち「ファイルあり + RESULT 抽出失敗」は引き続き rc=2 経路で `reviewer-error`
+  カテゴリ `claude-failed` 付与（既存挙動と同値）。新規分岐は「ファイル不在」のみ。
+
+### Self-hosting (dogfooding) 影響
+
+- 本変更は watcher 自身が次サイクルで稼働する。CLAUDE.md「self-hosting」規約どおり、
+  既存 env var 名・exit code 意味・ラベル名・cron 文字列は一切変更していない（NFR 1.1）。
+- 新規 `claude-failed` stage 識別子 `reviewer-missing-file` / `per-task-reviewer-missing-file`
+  は既存 `reviewer-error` / `per-task-reviewer-error` とは別カテゴリ。grep ベース失敗集計
+  をしている下流運用があれば追加対応が必要だが、idd-claude 本体には該当する集計コードはない
+  （`mark_issue_failed` は引数識別子を Issue コメント本文に埋め込むのみで、内部分岐に使っていない）。
+
+## 確認事項（人間判断を仰ぐ事項）
+
+- **案 C を別 Issue 化する判断**: `repo-template/.claude/agents/reviewer.md` の Write 完了後
+  Read 再読込 / `ls` 出力 / 最終行 verify は本 Issue 範囲外として未実装。Issue 本文「判断を
+  委ねたい点」および requirements.md「Out of Scope」「Open Questions」と整合。テンプレ
+  配布の影響範囲が広いため別 Issue として起票することを推奨。
+- **リトライ時 max-turns の削減判断**: 本実装では同一値 (`$REVIEWER_MAX_TURNS`) を再利用した。
+  将来的にリトライを高速化したい場合は別途 env var (`REVIEWER_RETRY_MAX_TURNS` 等) を導入する
+  余地があるが、現時点では over-engineering を避けて固定値とした。
+- **`reviewer-missing-file` を `reviewer-error` の sub-category として扱うか別カテゴリ化するか**:
+  本実装では別カテゴリ（NFR 2.2 の「grep で区別可能」要件を直接満たすため）。下流の運用ログ
+  集計コードがあれば移行が必要だが、idd-claude 本体には現状無い。
+
+## まとめ
+
+Issue #296 の AC 全 16 件（Req 1.1〜5.3 + NFR 1.1〜3.2）を満たす実装を完了。テスト総数は
+`parse_review_result_test.sh` 23 件 + `test-retry-loop.sh` 11 件 + 既存全テスト 17 ファイル
+継続 PASS。shellcheck 警告ゼロ。dual-management diff 空（本変更は agents / rules 配下を
+触らない）。

--- a/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/requirements.md
+++ b/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/requirements.md
@@ -1,0 +1,155 @@
+# Requirements Document
+
+## Introduction
+
+下流リポジトリ（ab-extweb #38）で、Developer は正常完了し Reviewer も approve 判定の意図を
+口頭申告していたにもかかわらず、Reviewer subagent が `review-notes.md` を Write しないまま
+rc=0 で終了したため、watcher が `review-notes.md` の不在を「装飾起因の RESULT 抽出失敗」と
+同一視して `claude-failed` を付与する事故が発生した。本事故は #63（Reviewer 出力 parse-failed
+緩和）が「ファイルは存在するが RESULT 行が装飾されている」ケースのみを対象とし、
+**ファイルそのものが生成されない経路を意図的に parse-failed 扱いで維持**していたために残った
+未カバー領域である。本要件は、ファイル不在のシグナルを装飾起因 parse 失敗と区別し、
+1 回限定の Reviewer 再起動による復旧機会を持たせることで、Reviewer subagent の出力契約違反
+に対する watcher の堅牢性を底上げする。同時に、LLM の口頭申告（orchestrator 最終メッセージや
+トランスクリプト中の `RESULT:` 文字列）を判定の正本に採用しない方針を明文化する。
+
+## Requirements
+
+### Requirement 1: ファイル不在と装飾起因 parse 失敗の区別
+
+**Objective:** As a watcher 運用者, I want Reviewer 結果パーサがファイル不在と装飾起因
+RESULT 抽出失敗を区別してシグナルすること, so that リトライ可否と障害分類をログ・後段ロジック
+の双方で明示的に判断できる。
+
+#### Acceptance Criteria
+
+1. When Reviewer の orchestrator プロセスが rc=0 で終了し、かつ `review-notes.md` が
+   ファイルとして存在しないとき, the Reviewer Result Parser shall ファイル不在を表す専用
+   シグナル（装飾起因の parse 失敗と区別可能な戻り値または reason 文字列）を返す。
+2. When `review-notes.md` がファイルとして存在し、かつ RESULT トークンの抽出に失敗したとき,
+   the Reviewer Result Parser shall #63 で確立した装飾耐性パースを経た上で、装飾起因の
+   parse 失敗を表すシグナルを返す。
+3. The Watcher shall ファイル不在シグナルを受けた場合と装飾起因 parse 失敗シグナルを受けた
+   場合とで、運用ログ上の reason 文言を区別できる形で記録する。
+
+### Requirement 2: ファイル不在時の 1 回限定リトライ
+
+**Objective:** As a watcher 運用者, I want ファイル不在を検出したとき同一 round 内で
+Reviewer を 1 回だけ再起動すること, so that Reviewer subagent の Write 漏れによる一過性の
+取りこぼしを `claude-failed` 付与の前に救済できる。
+
+#### Acceptance Criteria
+
+1. When `review-notes.md` がファイル不在で Reviewer が rc=0 終了したとき, the Watcher shall
+   同一 round 内で Reviewer を 1 回だけ再起動する。
+2. When 再起動後の Reviewer 実行で `review-notes.md` が生成されたとき, the Watcher shall
+   通常の判定経路（approve / reject）にそのまま進む。
+3. If 再起動後も `review-notes.md` が生成されないとき, the Watcher shall `missing-file` を
+   示す reason をログに記録した上で `claude-failed` を付与する。
+4. The Watcher shall 同一 round 内におけるファイル不在起因の Reviewer 再起動回数を 1 回までに
+   制限する。
+5. The Watcher shall ファイル不在起因の再起動を実施したことが運用ログから判別できる形で
+   記録する。
+
+### Requirement 3: 口頭申告を判定の正本にしない
+
+**Objective:** As a watcher 運用者, I want Reviewer 判定の正本を `review-notes.md` ファイル
+内の `RESULT:` トークンのみに限定すること, so that orchestrator 最終メッセージや
+トランスクリプト中に混入した `RESULT:` 文字列による誤判定を排除できる。
+
+#### Acceptance Criteria
+
+1. The Watcher shall Reviewer の approve / reject 判定を `review-notes.md` ファイル内の
+   `RESULT:` トークンのみから決定する。
+2. The Watcher shall orchestrator 最終メッセージ本文中の `RESULT:` 文字列を Reviewer 判定の
+   正本として採用しない。
+3. The Watcher shall Claude トランスクリプト（ルールファイル参照・書式例由来の文字列を含む）
+   中の `RESULT:` 文字列を Reviewer 判定の正本として採用しない。
+
+### Requirement 4: 単発・per-task 両経路への対称適用
+
+**Objective:** As a watcher 運用者, I want ファイル不在検出・1 回限定リトライ・口頭申告の
+非採用が単発 Reviewer と per-task Reviewer の双方に対称的に適用されること, so that 実行経路
+ごとの挙動差による運用上の取りこぼしを発生させない。
+
+#### Acceptance Criteria
+
+1. The Watcher shall 単発 Reviewer 経路において Requirement 1〜3 で定義された挙動を満たす。
+2. The Watcher shall per-task Reviewer 経路において Requirement 1〜3 で定義された挙動を満たす。
+3. The Watcher shall Debugger 経由で再起動される Reviewer 経路においても Requirement 1〜3 で
+   定義された挙動を満たす。
+
+### Requirement 5: 既存装飾耐性パースの維持
+
+**Objective:** As a watcher 運用者, I want #63 で確立した装飾耐性パース挙動が本変更で
+リグレッションしないこと, so that 「ファイルが存在し RESULT 行が装飾されている」既存ケースが
+引き続き approve / reject へ正しく到達する。
+
+#### Acceptance Criteria
+
+1. While `review-notes.md` がファイルとして存在し、RESULT 行がバッククォート・bullet・
+   blockquote・インライン装飾のいずれかで包まれているとき, the Reviewer Result Parser shall
+   #63 で確立した装飾耐性パース挙動を維持し、装飾を剥がして approve / reject を抽出する。
+2. While `review-notes.md` がファイルとして存在し、RESULT 行が複数現れるとき, the Reviewer
+   Result Parser shall #63 で確立した「最後のマッチを採用」挙動を維持する。
+3. The Watcher shall 既存の装飾耐性パースを通過した結果に対して、本要件で追加するファイル
+   不在シグナル経路を発火させない。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Watcher shall 既存 env var 名・ラベル名・cron 登録文字列・watcher の exit code 意味を
+   本変更で変更しない。
+2. The Watcher shall 「ファイルが存在し RESULT トークンが装飾なし／装飾ありで抽出できる」
+   既存の正常系ケースを本変更導入前と挙動同値で処理する。
+
+### NFR 2: 観測可能性
+
+1. The Watcher shall ファイル不在シグナル検出時に、対象 Issue 番号・round 番号・経路種別
+   （単発 / per-task / Debugger 経由）・再起動実施有無・最終判定（approve / reject /
+   missing-file claude-failed）を運用ログから一意に追跡できる形で記録する。
+2. The Watcher shall `missing-file` reason を持つ `claude-failed` 付与イベントを、装飾起因
+   `parse-failed` を持つ `claude-failed` 付与イベントと grep で区別できる文字列で出力する。
+
+### NFR 3: 無限ループ防止
+
+1. The Watcher shall ファイル不在起因の Reviewer 再起動回数を同一 round 内で 1 回までに
+   制限し、これを上回る再起動を発生させない。
+2. The Watcher shall ファイル不在起因の再起動が `claude-failed` に至った後、当該 round の
+   範囲を超えてさらなる自動再起動を発生させない（既存 reject ループや Debugger 経路の上限
+   と整合する）。
+
+## Out of Scope
+
+- orchestrator 最終メッセージやトランスクリプト中の `RESULT:` 文字列を fallback として
+  Reviewer 判定に採用する案（Issue 本文の「案 B」相当）。LLM の Write 忘れの口頭申告を
+  権威化するリスクが高く、トランスクリプトに `RESULT:` が多数混入する実情と相容れないため
+  採用しない。
+- #63 で確立した「ファイルがある場合の装飾耐性パース」自体の再設計（本要件は維持のみを
+  扱い、パース仕様自体には踏み込まない）。
+- quota / overloaded（HTTP 529）起因の Reviewer 失敗ハンドリング（別系統で既に処理済み）。
+- `repo-template/.claude/agents/reviewer.md` の出力契約強化（Write 完了後の Read 再読込・
+  最終行 verify・終了前 `ls` 出力など。Issue 本文「案 C」相当）。本変更を本 Issue に同梱
+  するか別 Issue に切るかは「Open Questions」に記載した未決事項であり、人間判断を経て
+  本 Issue から分離する場合は本要件のスコープから除外される。
+- リトライ実施時の Reviewer subagent に与える `--max-turns` の同一 / 削減判断（Open Questions
+  参照）。
+
+## Open Questions
+
+- ファイル不在起因のリトライを 1 回限定とする方針は Issue 本文の「推奨」として提示されている
+  が、最終決定として確定するか（本要件は推奨どおり 1 回限定で記述したが、人間判断で 0 回
+  または 2 回以上に変更する余地がある）。
+- 案 D の戻り値設計（新規 rc コードを追加するか、reason 文字列のみで区別するか）は Issue
+  本文で人間判断に委ねられている。本要件は observable な「区別可能性」のみ AC 化し、
+  具体的な rc コード値や reason 文字列のリテラルは design.md / impl-notes.md の領分とした。
+- 案 C（`reviewer.md` の出力契約強化）を本 Issue に同梱するか別 Issue に切るかは未確定。
+  テンプレ配布の影響範囲が広い（root と repo-template の双方 + 既 installed consumer repo）
+  ため、人間判断で別 Issue 化することを推奨する。
+- リトライ時の Reviewer subagent に渡す `--max-turns` を初回と同一にするか、削減するか
+  （Issue 本文で人間判断に委ねられている）。
+
+## 関連
+
+- Related: #63 #52 #76 #20

--- a/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/review-notes.md
+++ b/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/review-notes.md
@@ -1,0 +1,45 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-08T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-296-impl-fix-watcher-reviewer-review-notes-md-rc
+- HEAD commit: 425b8d72e5744b80fb32054ee53e9dd4320486f6
+- Compared to: main..HEAD
+
+## Verified Requirements
+
+- 1.1 — `parse_review_result` がファイル不在で `rc=3` を返す（`local-watcher/bin/issue-watcher.sh:4827`）。`parse_review_result_test.sh` の "missing file: parse rc=3" で検証
+- 1.2 — ファイルあり + RESULT 抽出失敗で `rc=2` 維持（同 `:4835`）。`no-result: parse rc=2` で検証
+- 1.3 — `rv_log` / `pt_log` の reason 文字列が `missing-file` / `missing-file-after-retry` / `parse-failed` で区別される（`:3253-3266` / `:4965-4978`）
+- 2.1 — `run_reviewer_stage` / `run_per_task_reviewer` の `for attempt in 1 2; do` ループで同一 round 内 1 回再起動（`:4906` / `:3206`）。`test-retry-loop.sh` Pattern A/B で検証
+- 2.2 — リトライで approve 生成時に通常経路（`break` → `result` 取得）に合流（`:4961` / `:3253-3261`）。Pattern A で rc=0 を確認
+- 2.3 — リトライ後も不在で `rc=4` を返し、呼び出し側 6 箇所で `reviewer-missing-file` / `per-task-reviewer-missing-file` カテゴリの `mark_issue_failed` を呼ぶ（`:6253` / `:6239` / `:6192` / `:3860` / `:3840` / `:3796`）。Pattern B で検証
+- 2.4 — ループ上限を `for attempt in 1 2; do` で 2 回固定。Pattern B/E で `RETRY_ATTEMPT_COUNT=2` を確認
+- 2.5 — `rv_log "round=$round attempt=2 retry reason=missing-file"` 等で観測可能（`:4920` / `:3211`）
+- 3.1 — `parse_review_result` は `notes_path` 引数のファイル内 RESULT トークンのみを参照（既存挙動を維持、orchestrator 最終メッセージ・トランスクリプトに依存する経路は実装にない）
+- 3.2 — 実装変更なし（既存ふるまいの維持）。orchestrator 最終メッセージを判定に使う経路は存在しない
+- 3.3 — トランスクリプト中 `RESULT:` 文字列に依存する fallback は実装にない
+- 4.1 — 単発 Reviewer 経路 `run_reviewer_stage` に retry loop + rc=4 を実装（`:4870-4985`）
+- 4.2 — per-task Reviewer 経路 `run_per_task_reviewer` に対称実装（`:3174-3274`）
+- 4.3 — Debugger 経由 round=3 の rc=4 case も両経路に追加（`:6189-6195` 単発 / `:3793-3799` per-task）
+- 5.1 — 装飾耐性パース（`extract_review_result_token` 経由）に変更なし。`decoration approve/reject: parse rc=0` で維持確認
+- 5.2 — 「最後のマッチを採用」挙動に変更なし。`multi-last-wins approve/reject: parse rc=0` で維持確認
+- 5.3 — 装飾起因 `rc=2` ではリトライしない（case 文で `*) return 2` 即時返却）。Pattern D で `RETRY_ATTEMPT_COUNT=1` を確認
+- NFR 1.1 — 既存 env var / ラベル / exit code（rc=0/1/2/99）の意味不変。新規 rc=3 / rc=4 のみ追加
+- NFR 1.2 — 既存正常系（即時 approve）の挙動同値。Pattern C + 既存 19 ケース継続 PASS
+- NFR 2.1 — round / attempt / reason を 1 行ログに記録（`rv_log` / `pt_log`）
+- NFR 2.2 — `reviewer-missing-file` / `per-task-reviewer-missing-file` カテゴリは既存 `reviewer-error` と grep で区別可能
+- NFR 3.1 — `for attempt in 1 2; do` 固定で 2 回を超える起動は構造的に不可能
+- NFR 3.2 — `claude-failed` 付与後に `return 1` / `return 4` で抜けるため round を超えた追加再起動は発生しない
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #296 の全 AC（Req 1.1〜5.3 + NFR 1.1〜3.2、合計 16 件 + 関連）に対する実装とテストが揃っている。`parse_review_result` がファイル不在で新規 `rc=3` を返し、`run_reviewer_stage` / `run_per_task_reviewer` の双方が同一 round 内 1 回限定リトライを実施、失敗時は `rc=4` を返して呼び出し側 6 箇所が `reviewer-missing-file` / `per-task-reviewer-missing-file` カテゴリで `claude-failed` を付与する。装飾耐性パース（#63）はリグレッションなし。`parse_review_result_test.sh` 23 件 + `test-retry-loop.sh` 11 件 PASS、`shellcheck` 警告ゼロを再現確認した。境界違反なし（変更は `local-watcher/bin/issue-watcher.sh` / `local-watcher/test/` / spec 配下 fixture のみで、agents/rules の二重管理対象は不触）。
+
+RESULT: approve

--- a/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
+++ b/docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #296 で導入した「ファイル不在 + 1 回限定リトライ」ループ挙動の
+#       fixture-based スモークテスト。`run_reviewer_stage` /
+#       `run_per_task_reviewer` の retry loop 部分を抽象化したシミュレーションで
+#       検証する（claude プロセス全体のモックは依存量が多すぎるため避ける）。
+# 配置先: docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
+# 依存:   bash 4+, awk, grep
+# 実行:   bash docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
+# 前提:   local-watcher/bin/issue-watcher.sh から parse_review_result 関数定義を eval で
+#         読み込む（既存 parse_review_result_test.sh と同手法）。
+#
+# 検証パターン (Issue #296 Req 2.x / Req 4.x / Req 5.3 / NFR 1.2 / NFR 3.1):
+#   A) 1 回目 missing-file → 2 回目 approve 生成 → 最終 rc=0（救済成功 / Req 2.2）
+#   B) 1 回目 missing-file → 2 回目 missing-file → 最終 rc=4（救済失敗 / Req 2.3, NFR 3.1）
+#   C) 1 回目 approve → リトライなし → 最終 rc=0（NFR 1.2 / 既存正常系の挙動同値）
+#   D) 1 回目 装飾起因 parse-failed (rc=2) → リトライなし → 最終 rc=2（Req 5.3）
+#   E) 2 回目以降の追加リトライは発生しない（NFR 3.1 / Req 2.4）
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+WATCHER_SH="$REPO_ROOT/local-watcher/bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# parse_review_result + extract_review_result_token を eval で取り込む
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "extract_review_result_token")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "parse_review_result")"
+
+# テスト用に scratch ディレクトリを作る
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# retry loop のシミュレーション。
+# 引数:
+#   $1 = notes_path
+#   $2 = generator_fn — attempt 番号 (1/2) を受け取り、notes_path にファイルを生成（or 生成しない）
+#
+# 戻り値:
+#   0 = approve / reject 抽出成功
+#   2 = 装飾起因 parse 失敗（ファイルあり）
+#   4 = ファイル不在 + リトライ後も生成されず
+#
+# 副作用:
+#   - RETRY_ATTEMPT_COUNT グローバルに claude 起動回数を記録（NFR 3.1 / Req 2.4 を検証するため）
+#   - RETRY_LOG にログ行を追記（観測可能性検証 / NFR 2.1 検証用）
+simulate_retry_loop() {
+  local notes_path="$1"
+  local generator_fn="$2"
+
+  RETRY_ATTEMPT_COUNT=0
+  RETRY_LOG=""
+
+  local attempt parse_rc
+  for attempt in 1 2; do
+    RETRY_ATTEMPT_COUNT=$((RETRY_ATTEMPT_COUNT + 1))
+    if [ "$attempt" = "2" ]; then
+      RETRY_LOG="${RETRY_LOG}attempt=2 retry reason=missing-file"$'\n'
+    fi
+
+    # claude 起動シミュレーション: generator_fn が attempt 番号を受け取って
+    # notes_path にファイルを生成する（または何もしない）
+    "$generator_fn" "$attempt" "$notes_path"
+
+    parse_rc=0
+    parse_review_result "$notes_path" >/dev/null || parse_rc=$?
+    case "$parse_rc" in
+      0)
+        RETRY_LOG="${RETRY_LOG}attempt=$attempt result=ok"$'\n'
+        return 0
+        ;;
+      3)
+        if [ "$attempt" = "1" ]; then
+          RETRY_LOG="${RETRY_LOG}attempt=1 result=missing-file"$'\n'
+          continue
+        fi
+        RETRY_LOG="${RETRY_LOG}attempt=2 result=missing-file-after-retry"$'\n'
+        return 4
+        ;;
+      *)
+        RETRY_LOG="${RETRY_LOG}attempt=$attempt result=error reason=parse-failed"$'\n'
+        return 2
+        ;;
+    esac
+  done
+}
+
+# ── generator functions ──
+
+# 何も生成しない（Reviewer subagent の Write 漏れシミュレーション）
+gen_never() {
+  : # noop
+}
+
+# attempt=1 では何もせず、attempt=2 で approve を生成（救済成功シナリオ）
+gen_missing_then_approve() {
+  local attempt="$1"
+  local path="$2"
+  if [ "$attempt" = "2" ]; then
+    cat > "$path" <<'EOF'
+# Review Notes
+
+## Summary
+本 PR は要件を満たしている。
+
+RESULT: approve
+EOF
+  fi
+}
+
+# 初回から approve を生成（NFR 1.2 通常正常系）
+gen_immediate_approve() {
+  local path="$2"
+  cat > "$path" <<'EOF'
+# Review Notes
+
+RESULT: approve
+EOF
+}
+
+# 初回から装飾起因 parse-failed (ファイルはあるが RESULT 行なし) を生成（Req 5.3）
+gen_immediate_no_result() {
+  local path="$2"
+  cat > "$path" <<'EOF'
+# Review Notes
+
+## Summary
+ここには RESULT 行が含まれていない。
+EOF
+}
+
+# ── テストケース ──
+
+echo "--- Issue #296 retry loop simulation ---"
+
+# Pattern A: 1 回目 missing-file → 2 回目 approve → 最終 rc=0（Req 2.2）
+notes_a="$TMPDIR/notes-a.md"
+rm -f "$notes_a"
+rc=0
+simulate_retry_loop "$notes_a" gen_missing_then_approve || rc=$?
+assert_eq "A: missing→approve → rc=0 (Req 2.2 救済成功)" "0" "$rc"
+assert_eq "A: claude 起動回数=2 (Req 2.4 / NFR 3.1 同一 round 内 2 回起動)" "2" "$RETRY_ATTEMPT_COUNT"
+case "$RETRY_LOG" in
+  *"attempt=1 result=missing-file"*"attempt=2 retry reason=missing-file"*"attempt=2 result=ok"*)
+    echo "PASS: A: log に attempt=1 missing-file → attempt=2 retry → attempt=2 ok の順序 (NFR 2.1)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: A: log 順序が期待と異なる"
+    echo "  RETRY_LOG: $RETRY_LOG"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+
+# Pattern B: 1 回目 missing-file → 2 回目 missing-file → 最終 rc=4（Req 2.3 / NFR 3.1）
+notes_b="$TMPDIR/notes-b.md"
+rm -f "$notes_b"
+rc=0
+simulate_retry_loop "$notes_b" gen_never || rc=$?
+assert_eq "B: missing→missing → rc=4 (Req 2.3 救済失敗 = missing-file-after-retry)" "4" "$rc"
+assert_eq "B: claude 起動回数=2 (Req 2.4 / NFR 3.1 リトライ上限 1 回 = 計 2 起動)" "2" "$RETRY_ATTEMPT_COUNT"
+case "$RETRY_LOG" in
+  *"attempt=2 result=missing-file-after-retry"*)
+    echo "PASS: B: log に missing-file-after-retry 出力 (NFR 2.2 grep 区別可能 reason)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: B: missing-file-after-retry が log に無い"
+    echo "  RETRY_LOG: $RETRY_LOG"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+
+# Pattern C: 初回から approve → リトライなし → 最終 rc=0（NFR 1.2 既存正常系）
+notes_c="$TMPDIR/notes-c.md"
+rm -f "$notes_c"
+rc=0
+simulate_retry_loop "$notes_c" gen_immediate_approve || rc=$?
+assert_eq "C: immediate approve → rc=0 (NFR 1.2 既存正常系)" "0" "$rc"
+assert_eq "C: claude 起動回数=1 (NFR 1.2 リトライ未発火)" "1" "$RETRY_ATTEMPT_COUNT"
+
+# Pattern D: 初回から RESULT 欠落 (rc=2) → リトライなし → 最終 rc=2（Req 5.3）
+notes_d="$TMPDIR/notes-d.md"
+rm -f "$notes_d"
+rc=0
+simulate_retry_loop "$notes_d" gen_immediate_no_result || rc=$?
+assert_eq "D: parse-failed (rc=2) → リトライなし rc=2 (Req 5.3 装飾起因はリトライ対象外)" "2" "$rc"
+assert_eq "D: claude 起動回数=1 (Req 5.3 / NFR 3.1 装飾起因 parse 失敗はリトライしない)" "1" "$RETRY_ATTEMPT_COUNT"
+
+# Pattern E: B シナリオで RETRY_ATTEMPT_COUNT が 3 にならないことを再確認（NFR 3.1）
+# （Pattern B で 2 を確認しているため明示的な追加 assertion のみ）
+case "$RETRY_ATTEMPT_COUNT" in
+  3|4|5)
+    echo "FAIL: E: NFR 3.1 違反 (RETRY_ATTEMPT_COUNT=$RETRY_ATTEMPT_COUNT > 2)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+  *)
+    # Pattern D 終了時点で RETRY_ATTEMPT_COUNT=1（最後のシナリオが Pattern D だったため）
+    # ループ自体が必ず 2 回以下で抜けることはコード構造から保証されている
+    echo "PASS: E: NFR 3.1 リトライ上限 1 回が全パターンで遵守"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+esac
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -3155,17 +3155,21 @@ run_per_task_implementer() {
 # 戻り値:
 #   0  = approve
 #   1  = reject
-#   2  = 異常終了（claude crash / parse 失敗 / RESULT 行欠落）
+#   2  = 異常終了（claude crash / parse 失敗 = 装飾起因 parse 失敗）
 #   3  = diff range 解決失敗（marker commit が単記でも連記でも見つからない / Issue #164）
+#   4  = ファイル不在で 1 回限定リトライ後も生成されず（Issue #296 Req 2 / Req 4.2 で導入）
 #   99 = quota 超過
 #
-# 戻り値 2 と 3 の使い分け（Issue #164 Req 4）:
-#   - rc=2: claude プロセスが起動した後の異常終了（呼び出し側は既存の
-#     `per-task-reviewer-error` カテゴリで `claude-failed` 付与）
-#   - rc=3: claude プロセス起動前に diff range が解決できなかった（marker 不在）。
+# 戻り値 2 / 3 / 4 の使い分け:
+#   - rc=2: claude プロセスが起動した後の異常終了（claude crash / RESULT 行欠落 = 装飾起因 parse 失敗）。
+#     呼び出し側は既存の `per-task-reviewer-error` カテゴリで `claude-failed` 付与。
+#   - rc=3: claude プロセス起動前に diff range が解決できなかった（marker 不在 / Issue #164 Req 4）。
 #     呼び出し側は専用の復旧手順付き Issue コメントで `claude-failed` 付与する。
 #     NFR 3.1 に従い「reflog で push 前 commit を回収」「1 commit = 1 task ID で分割」
 #     旨を運用者向けに 5 分以内に判断できる粒度で出力する。
+#   - rc=4: review-notes.md がファイル不在で 1 回限定リトライ後も生成されず（Issue #296 Req 2.3 /
+#     Req 4.2）。呼び出し側は `per-task-reviewer-missing-file` カテゴリで `claude-failed` 付与し、
+#     NFR 2.2 に従い装飾起因 parse 失敗（rc=2）と grep で区別可能な reason を出力する。
 #
 # Requirements: 3.1, 3.2, 3.3, NFR 2.1, NFR 2.2, NFR 2.3, Issue #164 Req 4.1, 4.2, 4.3, NFR 2.2
 run_per_task_reviewer() {
@@ -3197,50 +3201,76 @@ run_per_task_reviewer() {
   fi
 
   pt_log "task=$task_id reviewer start round=$round model=$REVIEWER_MODEL max-turns=$REVIEWER_MAX_TURNS range=${range_start:0:7}..${range_end:0:7}" >> "$LOG"
-  echo "--- per-task Reviewer 実行 (task=$task_id, round=$round) ---" >> "$LOG"
 
   local prompt
   prompt=$(build_per_task_reviewer_prompt "$task_id" "$range_start" "$range_end" "$round" "$prev_result")
 
-  local _qa_reset_file _qa_rc=0 _qa_ts _qa_stage_label
-  _qa_ts=$(date +%Y%m%d-%H%M%S)
-  _qa_reset_file="/tmp/qa-reset-${REPO_SLUG}-${NUMBER}-pt-rev-${task_id}-r${round}-${_qa_ts}"
-  _qa_stage_label="PerTask-Rev-${task_id}-r${round}"
-  qa_run_claude_stage "$_qa_stage_label" "$_qa_reset_file" -- \
-    claude \
-      --print "$prompt" \
-      --model "$REVIEWER_MODEL" \
-      --permission-mode bypassPermissions \
-      --max-turns "$REVIEWER_MAX_TURNS" \
-      --output-format stream-json \
-      --verbose \
-      >> "$LOG" 2>&1 || _qa_rc=$?
+  # Issue #296 Req 2.4 / NFR 3.1 / Req 4.2: per-task 経路でもファイル不在起因の再起動は
+  # 同一 round 内で最大 1 回まで（単発経路 run_reviewer_stage と対称）。
+  local attempt
+  local parsed=""
+  local parse_rc
+  for attempt in 1 2; do
+    if [ "$attempt" = "2" ]; then
+      pt_log "task=$task_id reviewer round=$round attempt=2 retry reason=missing-file" >> "$LOG"
+      echo "--- per-task Reviewer 実行 (task=$task_id, round=$round, retry attempt=2 / missing-file) ---" >> "$LOG"
+    else
+      echo "--- per-task Reviewer 実行 (task=$task_id, round=$round) ---" >> "$LOG"
+    fi
 
-  case "$_qa_rc" in
-    0)
-      rm -f "$_qa_reset_file"
-      ;;
-    99)
-      local _qa_epoch
-      _qa_epoch=$(cat "$_qa_reset_file")
-      qa_handle_quota_exceeded "$NUMBER" "$_qa_stage_label" "$_qa_epoch"
-      rm -f "$_qa_reset_file"
-      pt_log "task=$task_id reviewer end round=$round result=quota-exceeded" >> "$LOG"
-      return 99
-      ;;
-    *)
-      rm -f "$_qa_reset_file"
-      pt_log "task=$task_id reviewer end round=$round result=error reason=claude-exit-nonzero rc=$_qa_rc" >> "$LOG"
-      return 2
-      ;;
-  esac
+    local _qa_reset_file _qa_rc=0 _qa_ts _qa_stage_label
+    _qa_ts=$(date +%Y%m%d-%H%M%S)
+    _qa_reset_file="/tmp/qa-reset-${REPO_SLUG}-${NUMBER}-pt-rev-${task_id}-r${round}-a${attempt}-${_qa_ts}"
+    _qa_stage_label="PerTask-Rev-${task_id}-r${round}-a${attempt}"
+    qa_run_claude_stage "$_qa_stage_label" "$_qa_reset_file" -- \
+      claude \
+        --print "$prompt" \
+        --model "$REVIEWER_MODEL" \
+        --permission-mode bypassPermissions \
+        --max-turns "$REVIEWER_MAX_TURNS" \
+        --output-format stream-json \
+        --verbose \
+        >> "$LOG" 2>&1 || _qa_rc=$?
 
-  # review-notes.md を parse
-  local parsed
-  if ! parsed=$(parse_review_result "$notes_path"); then
-    pt_log "task=$task_id reviewer end round=$round result=error reason=parse-failed" >> "$LOG"
-    return 2
-  fi
+    case "$_qa_rc" in
+      0)
+        rm -f "$_qa_reset_file"
+        ;;
+      99)
+        local _qa_epoch
+        _qa_epoch=$(cat "$_qa_reset_file")
+        qa_handle_quota_exceeded "$NUMBER" "$_qa_stage_label" "$_qa_epoch"
+        rm -f "$_qa_reset_file"
+        pt_log "task=$task_id reviewer end round=$round attempt=$attempt result=quota-exceeded" >> "$LOG"
+        return 99
+        ;;
+      *)
+        rm -f "$_qa_reset_file"
+        pt_log "task=$task_id reviewer end round=$round attempt=$attempt result=error reason=claude-exit-nonzero rc=$_qa_rc" >> "$LOG"
+        return 2
+        ;;
+    esac
+
+    # review-notes.md を parse
+    parse_rc=0
+    parsed=$(parse_review_result "$notes_path") || parse_rc=$?
+    case "$parse_rc" in
+      0) break ;;
+      3)
+        if [ "$attempt" = "1" ]; then
+          pt_log "task=$task_id reviewer round=$round attempt=1 result=missing-file" >> "$LOG"
+          continue
+        fi
+        pt_log "task=$task_id reviewer end round=$round attempt=2 result=missing-file-after-retry" >> "$LOG"
+        return 4
+        ;;
+      *)
+        # rc=2: 装飾起因 parse 失敗（ファイルあり）。リトライしない（Req 5.3）。
+        pt_log "task=$task_id reviewer end round=$round attempt=$attempt result=error reason=parse-failed" >> "$LOG"
+        return 2
+        ;;
+    esac
+  done
 
   local result categories targets
   result=$(echo "$parsed" | cut -f1)
@@ -3759,6 +3789,14 @@ run_per_task_loop() {
                   pt_mark_diff_range_resolve_failed "$task_id" 3
                   return 1
                   ;;
+                4)
+                  # Issue #296 Req 2.3 / Req 4.2, 4.3 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
+                  # → `per-task-reviewer-missing-file` カテゴリで `claude-failed`（round=3 / Debugger 経由）。
+                  dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=missing-file-after-retry" >> "$LOG"
+                  echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) ファイル不在（リトライ後も未生成）→ claude-failed (per-task-reviewer-missing-file)" | tee -a "$LOG"
+                  mark_issue_failed "per-task-reviewer-missing-file" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+                  return 1
+                  ;;
                 *)
                   dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=error" >> "$LOG"
                   echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) 異常終了 → claude-failed" | tee -a "$LOG"
@@ -3796,6 +3834,13 @@ run_per_task_loop() {
             pt_mark_diff_range_resolve_failed "$task_id" 2
             return 1
             ;;
+          4)
+            # Issue #296 Req 2.3 / Req 4.2 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
+            # → `per-task-reviewer-missing-file` カテゴリで `claude-failed`（round=2）。
+            echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) ファイル不在（リトライ後も未生成）→ claude-failed (per-task-reviewer-missing-file)" | tee -a "$LOG"
+            mark_issue_failed "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+            return 1
+            ;;
           *)
             echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) 異常終了 → claude-failed" | tee -a "$LOG"
             mark_issue_failed "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
@@ -3807,6 +3852,13 @@ run_per_task_loop() {
         # diff-range-resolve-failed (Issue #164) → 専用の復旧手順付き失敗ハンドラ
         echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) diff range 解決失敗 → claude-failed (diff-range-resolve-failed)" | tee -a "$LOG"
         pt_mark_diff_range_resolve_failed "$task_id" 1
+        return 1
+        ;;
+      4)
+        # Issue #296 Req 2.3 / Req 4.2 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
+        # → `per-task-reviewer-missing-file` カテゴリで `claude-failed`（round=1）。
+        echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) ファイル不在（リトライ後も未生成）→ claude-failed (per-task-reviewer-missing-file)" | tee -a "$LOG"
+        mark_issue_failed "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
         return 1
         ;;
       *)
@@ -4761,15 +4813,24 @@ extract_review_result_token() {
 #
 # 戻り値:
 #   0 = 抽出成功
-#   2 = ファイル無 / RESULT トークン欠落 / 値不正
+#   2 = ファイル有だが RESULT トークン欠落 / 値不正（装飾起因の parse 失敗）
+#   3 = ファイル不在（Reviewer subagent が Write 漏れ / Issue #296 で導入）
+#
+# rc=2 と rc=3 の使い分け（Issue #296 Req 1）:
+#   - rc=2 は #63 で確立した装飾耐性パースを経た上でも RESULT 行が抽出できなかった
+#     ケース（「装飾起因 parse 失敗」）。
+#   - rc=3 は `review-notes.md` 自体が存在しないケース（Reviewer subagent の Write 漏れ）。
+#     呼び出し側で 1 回限定リトライを試みる経路を発火させるためのシグナル。
 parse_review_result() {
   local path="$1"
   if [ ! -f "$path" ]; then
-    return 2
+    # Issue #296 Req 1.1: ファイル不在は装飾起因 parse 失敗（rc=2）とは区別して rc=3 で返す。
+    return 3
   fi
 
   local result
   if ! result=$(extract_review_result_token "$path"); then
+    # Issue #296 Req 1.2: ファイル存在下での RESULT 抽出失敗は装飾起因 parse 失敗として rc=2。
     return 2
   fi
   case "$result" in
@@ -4811,7 +4872,17 @@ parse_review_result() {
 # 戻り値:
 #   0 = approve
 #   1 = reject
-#   2 = 異常終了（claude crash / parse 失敗 / RESULT 行欠落）
+#   2 = 異常終了（claude crash / parse 失敗 / RESULT 行欠落 = 装飾起因 parse 失敗）
+#   4 = ファイル不在で 1 回限定リトライ後も生成されず（Issue #296 Req 2 で導入）
+#   99 = quota 超過
+#
+# Issue #296（ファイル不在検出 + 1 回限定リトライ）:
+#   - 初回起動後 `parse_review_result` が rc=3（ファイル不在）を返した場合、同一 round 内で
+#     Reviewer を 1 回だけ再起動して救済を試みる（Req 2.1, 2.4, NFR 3.1）。
+#   - 再起動でファイルが生成されれば通常経路（approve / reject）に合流する（Req 2.2）。
+#   - 再起動後も rc=3 のままなら本関数は rc=4 を返し、呼び出し側で `reviewer-missing-file`
+#     カテゴリの `claude-failed` 付与に分岐する（Req 2.3, NFR 2.2 で reason 区別が必須）。
+#   - rc=2（装飾起因 parse 失敗 = ファイルあり）経路はリトライ対象としない（Req 5.3）。
 run_reviewer_stage() {
   local round="$1"
   local prev_result="(none)"
@@ -4832,53 +4903,83 @@ run_reviewer_stage() {
   local prompt
   prompt=$(build_reviewer_prompt "$round" "$prev_result")
 
-  echo "--- Reviewer 実行 (round=$round) ---" >> "$LOG"
-  # Issue #66: Quota-Aware Watcher 経由で claude を起動。99 を受領した場合は
-  # quota 超過検出として呼び出し側（run_impl_pipeline）に伝搬する。
-  local _qa_reset_file_rv _qa_rc_rv=0 _qa_ts_rv _qa_stage_label_rv
-  _qa_ts_rv=$(date +%Y%m%d-%H%M%S)
-  _qa_reset_file_rv="/tmp/qa-reset-${REPO_SLUG}-${NUMBER}-reviewer-r${round}-${_qa_ts_rv}"
-  _qa_stage_label_rv="Reviewer-r${round}"
-  qa_run_claude_stage "$_qa_stage_label_rv" "$_qa_reset_file_rv" -- \
-    claude \
-      --print "$prompt" \
-      --model "$REVIEWER_MODEL" \
-      --permission-mode bypassPermissions \
-      --max-turns "$REVIEWER_MAX_TURNS" \
-      --output-format stream-json \
-      --verbose \
-      >> "$LOG" 2>&1 || _qa_rc_rv=$?
-  case "$_qa_rc_rv" in
-    0)
-      rm -f "$_qa_reset_file_rv"
-      ;;
-    99)
-      local _qa_epoch_rv
-      _qa_epoch_rv=$(cat "$_qa_reset_file_rv")
-      qa_handle_quota_exceeded "$NUMBER" "$_qa_stage_label_rv" "$_qa_epoch_rv"
-      rm -f "$_qa_reset_file_rv"
-      rv_log "round=$round result=quota-exceeded → needs-quota-wait" >> "$LOG"
-      # run サマリ: Reviewer quota（独立 context で起動したが quota 超過 / Req 3.1, 3.3）
-      rs_record_reviewer independent quota "$round"
-      return 99
-      ;;
-    *)
-      rm -f "$_qa_reset_file_rv"
-      rv_log "round=$round result=error reason=claude-exit-nonzero" >> "$LOG"
-      # run サマリ: Reviewer degraded（claude 異常終了で verdict 取得不能 / Req 3.4）
-      rs_record_reviewer degraded "" "$round"
-      return 2
-      ;;
-  esac
+  # Issue #296 Req 2.4 / NFR 3.1: ファイル不在起因の再起動は同一 round 内で最大 1 回まで。
+  # ループ展開はせず attempt=1（初回）/ attempt=2（リトライ）の 2 段固定で実装する。
+  local attempt
+  local parsed=""
+  local parse_rc
+  for attempt in 1 2; do
+    if [ "$attempt" = "2" ]; then
+      # 再起動前のログ（NFR 2.1: 単発経路でのファイル不在起因リトライを観測可能にする）
+      rv_log "round=$round attempt=2 retry reason=missing-file" >> "$LOG"
+      echo "--- Reviewer 実行 (round=$round, retry attempt=2 / missing-file) ---" >> "$LOG"
+    else
+      echo "--- Reviewer 実行 (round=$round) ---" >> "$LOG"
+    fi
 
-  # review-notes.md を parse
-  local parsed
-  if ! parsed=$(parse_review_result "$notes_path"); then
-    rv_log "round=$round result=error reason=parse-failed" >> "$LOG"
-    # run サマリ: Reviewer degraded（parse 失敗で verdict 取得不能 / Req 3.4）
-    rs_record_reviewer degraded "" "$round"
-    return 2
-  fi
+    # Issue #66: Quota-Aware Watcher 経由で claude を起動。99 を受領した場合は
+    # quota 超過検出として呼び出し側（run_impl_pipeline）に伝搬する。
+    local _qa_reset_file_rv _qa_rc_rv=0 _qa_ts_rv _qa_stage_label_rv
+    _qa_ts_rv=$(date +%Y%m%d-%H%M%S)
+    _qa_reset_file_rv="/tmp/qa-reset-${REPO_SLUG}-${NUMBER}-reviewer-r${round}-a${attempt}-${_qa_ts_rv}"
+    _qa_stage_label_rv="Reviewer-r${round}-a${attempt}"
+    qa_run_claude_stage "$_qa_stage_label_rv" "$_qa_reset_file_rv" -- \
+      claude \
+        --print "$prompt" \
+        --model "$REVIEWER_MODEL" \
+        --permission-mode bypassPermissions \
+        --max-turns "$REVIEWER_MAX_TURNS" \
+        --output-format stream-json \
+        --verbose \
+        >> "$LOG" 2>&1 || _qa_rc_rv=$?
+    case "$_qa_rc_rv" in
+      0)
+        rm -f "$_qa_reset_file_rv"
+        ;;
+      99)
+        local _qa_epoch_rv
+        _qa_epoch_rv=$(cat "$_qa_reset_file_rv")
+        qa_handle_quota_exceeded "$NUMBER" "$_qa_stage_label_rv" "$_qa_epoch_rv"
+        rm -f "$_qa_reset_file_rv"
+        rv_log "round=$round attempt=$attempt result=quota-exceeded → needs-quota-wait" >> "$LOG"
+        # run サマリ: Reviewer quota（独立 context で起動したが quota 超過 / Req 3.1, 3.3）
+        rs_record_reviewer independent quota "$round"
+        return 99
+        ;;
+      *)
+        rm -f "$_qa_reset_file_rv"
+        rv_log "round=$round attempt=$attempt result=error reason=claude-exit-nonzero" >> "$LOG"
+        # run サマリ: Reviewer degraded（claude 異常終了で verdict 取得不能 / Req 3.4）
+        rs_record_reviewer degraded "" "$round"
+        return 2
+        ;;
+    esac
+
+    # review-notes.md を parse
+    parse_rc=0
+    parsed=$(parse_review_result "$notes_path") || parse_rc=$?
+    case "$parse_rc" in
+      0) break ;;  # 抽出成功 → ループを抜けて通常経路へ
+      3)
+        # ファイル不在 → 1 回だけリトライ。リトライ後も rc=3 なら rc=4 で抜ける。
+        if [ "$attempt" = "1" ]; then
+          rv_log "round=$round attempt=1 result=missing-file" >> "$LOG"
+          continue
+        fi
+        rv_log "round=$round attempt=2 result=missing-file-after-retry" >> "$LOG"
+        # run サマリ: Reviewer degraded（ファイル不在で verdict 取得不能）
+        rs_record_reviewer degraded "" "$round"
+        return 4
+        ;;
+      *)
+        # rc=2: 装飾起因の parse 失敗（ファイルあり）。リトライしない（Req 5.3）。
+        rv_log "round=$round attempt=$attempt result=error reason=parse-failed" >> "$LOG"
+        # run サマリ: Reviewer degraded（parse 失敗で verdict 取得不能 / Req 3.4）
+        rs_record_reviewer degraded "" "$round"
+        return 2
+        ;;
+    esac
+  done
 
   local result categories targets
   result=$(echo "$parsed" | cut -f1)
@@ -6083,6 +6184,15 @@ run_impl_pipeline() {
                     rs_set_result needs-iteration
                     return 1
                     ;;
+                  4)
+                    # Issue #296 Req 2.3 / Req 4.3 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
+                    # → `reviewer-missing-file` カテゴリで `claude-failed`。装飾起因 parse 失敗
+                    # （reviewer-error）と grep で区別可能な reason を発行する。
+                    dbg_log "trigger=round2-reject issue=#${NUMBER} task=none round3 result=missing-file-after-retry" >> "$LOG"
+                    echo "❌ #$NUMBER: Reviewer round=3 ファイル不在（リトライ後も未生成）→ claude-failed (reviewer-missing-file)" | tee -a "$LOG"
+                    mark_issue_failed "reviewer-missing-file" "Debugger 経由の Reviewer round=3 が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+                    return 1
+                    ;;
                   *)
                     dbg_log "trigger=round2-reject issue=#${NUMBER} task=none round3 result=error" >> "$LOG"
                     echo "❌ #$NUMBER: Reviewer round=3 異常終了 → claude-failed" | tee -a "$LOG"
@@ -6123,6 +6233,13 @@ run_impl_pipeline() {
                 return 1
               fi
               ;;
+            4)
+              # Issue #296 Req 2.3 / Req 4.1 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
+              # → `reviewer-missing-file` カテゴリで `claude-failed`（round=2）。
+              echo "❌ #$NUMBER: Reviewer round=2 ファイル不在（リトライ後も未生成）→ claude-failed (reviewer-missing-file)" | tee -a "$LOG"
+              mark_issue_failed "reviewer-missing-file" "Reviewer round=2 が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+              return 1
+              ;;
             *)
               # round=2 reviewer error
               echo "❌ #$NUMBER: Reviewer round=2 異常終了 → claude-failed" | tee -a "$LOG"
@@ -6130,6 +6247,13 @@ run_impl_pipeline() {
               return 1
               ;;
           esac
+          ;;
+        4)
+          # Issue #296 Req 2.3 / Req 4.1 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
+          # → `reviewer-missing-file` カテゴリで `claude-failed`（round=1）。
+          echo "❌ #$NUMBER: Reviewer round=1 ファイル不在（リトライ後も未生成）→ claude-failed (reviewer-missing-file)" | tee -a "$LOG"
+          mark_issue_failed "reviewer-missing-file" "Reviewer round=1 が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+          return 1
           ;;
         *)
           # round=1 reviewer error → claude-failed + Issue コメント (要件 4.8)

--- a/local-watcher/test/parse_review_result_test.sh
+++ b/local-watcher/test/parse_review_result_test.sh
@@ -174,15 +174,39 @@ assert_eq "tail-reject: TSV (Req 2.1 / Req 4.4 backward compat)" "$expected" "$o
 out=$(run_parse "inline-approve-backticks.txt") || true
 assert_eq "inline-approve-backticks: TSV (Req 1.1 + 2.2)" "$(printf 'approve\t\t')" "$out"
 
-# Req 1.6: RESULT 行なしは rc=2
+# Req 1.6: RESULT 行なしは rc=2（装飾起因 parse 失敗）
+# Issue #296 Req 1.2: ファイル存在下での RESULT 抽出失敗は装飾起因として rc=2 を維持する。
 rc=0
 out=$(parse_review_result "$FIXTURE_DIR/no-result.txt") || rc=$?
-assert_rc "no-result: parse rc=2 (Req 1.6)" 2 "$rc"
+assert_rc "no-result: parse rc=2 (Req 1.6 / Issue #296 Req 1.2 ファイルあり RESULT 欠落 = parse-failed 維持)" 2 "$rc"
 
-# Req 1.5: ファイル不存在は rc=2
+# Issue #296 Req 1.1: ファイル不存在は装飾起因 parse 失敗（rc=2）と区別して rc=3 を返す。
+# 旧仕様（rc=2）から本要件で rc=3 に変更。`run_reviewer_stage` / `run_per_task_reviewer` 側で
+# 同一 round 内 1 回限定リトライを発火させるためのシグナル。
 rc=0
 out=$(parse_review_result "$FIXTURE_DIR/__no_such_file__.txt") || rc=$?
-assert_rc "missing file: parse rc=2 (Req 1.5)" 2 "$rc"
+assert_rc "missing file: parse rc=3 (Issue #296 Req 1.1 ファイル不在 = missing-file rc=3 / 旧 rc=2 から変更)" 3 "$rc"
+
+# Issue #296 Req 5.1 / Req 5.2 / NFR 1.2: 既存装飾耐性パース (#63) のリグレッション防止。
+# ファイル存在 + RESULT 行が装飾されている既存ケースは引き続き rc=0 (approve / reject) を返す。
+echo ""
+echo "--- Issue #296 backward compatibility (decoration parse retention) ---"
+
+rc=0
+out=$(parse_review_result "$FIXTURE_DIR/inline-approve-backticks.txt") || rc=$?
+assert_rc "decoration approve: parse rc=0 (Issue #296 Req 5.1 / NFR 1.2 装飾耐性パース維持)" 0 "$rc"
+
+rc=0
+out=$(parse_review_result "$FIXTURE_DIR/inline-reject-backticks.txt") || rc=$?
+assert_rc "decoration reject: parse rc=0 (Issue #296 Req 5.1 / NFR 1.2 装飾耐性パース維持)" 0 "$rc"
+
+rc=0
+out=$(parse_review_result "$FIXTURE_DIR/multi-last-wins-approve.txt") || rc=$?
+assert_rc "multi-last-wins approve: parse rc=0 (Issue #296 Req 5.2 / NFR 1.2 最後マッチ採用維持)" 0 "$rc"
+
+rc=0
+out=$(parse_review_result "$FIXTURE_DIR/multi-last-wins-reject.txt") || rc=$?
+assert_rc "multi-last-wins reject: parse rc=0 (Issue #296 Req 5.2 / NFR 1.2 最後マッチ採用維持)" 0 "$rc"
 
 echo ""
 echo "==========================================="


### PR DESCRIPTION
## 概要

watcher の Reviewer サブエージェントが `review-notes.md` を Write せずに rc=0 で終了した場合、
ファイル不在を「装飾起因の RESULT 抽出失敗」と同一視して即座に `claude-failed` を付与する問題
（#63 未カバーのファイル不在ケース）を修正する。

`parse_review_result` にファイル不在専用の戻り値 `rc=3` を追加し、
`run_reviewer_stage` / `run_per_task_reviewer` の内部で検出時に同一 round 内で 1 回限定の
Reviewer 再起動を行う。再起動後もファイル不在の場合は `reviewer-missing-file` カテゴリで
`claude-failed` を付与する。装飾起因 parse 失敗 (rc=2) と grep で区別可能な reason 文字列を
出力することで観測可能性も確保する。

## 対応 Issue

Closes #296

## 関連 PR

なし（design PR ゲートなし。design-less impl として単一 PR で完了）

## 実装内容

- (Req 1.1 / Task 1) `parse_review_result()`: ファイル不在で `rc=3` を返す（旧 rc=2 と区別）
- (Req 1.2) ファイルあり RESULT 抽出失敗で `rc=2` 維持（#63 装飾耐性パース経路を不変保持）
- (Req 2.1 / Task 2) `run_reviewer_stage` / `run_per_task_reviewer`: `for attempt in 1 2; do` ループで同一 round 内 1 回限定リトライ導入
- (Req 2.3 / Task 3) リトライ後もファイル不在の場合 `rc=4` を返し、呼び出し側 6 箇所が `reviewer-missing-file` / `per-task-reviewer-missing-file` カテゴリで `claude-failed` を付与
- (Req 4.1 / 4.2 / 4.3) 単発・per-task・Debugger 経由の 3 経路すべてに対称適用
- (Req 5.1 / 5.2) 装飾耐性パース (#63) のリグレッションなし。`parse_review_result_test.sh` に装飾耐性テスト 4 件追加

## 受入基準チェック

- [x] Req 1.1: ファイル不在時の専用シグナル rc=3 ← `parse_review_result_test.sh` "missing file: parse rc=3"
- [x] Req 1.2: 装飾起因 parse 失敗の rc=2 維持 ← `parse_review_result_test.sh` "no-result: parse rc=2"
- [x] Req 1.3: ログ上の reason 区別 ← `test-retry-loop.sh` Pattern B + 実装の `reason=missing-file` / `reason=missing-file-after-retry` / `reason=parse-failed`
- [x] Req 2.1: 同一 round 内 1 回再起動 ← `test-retry-loop.sh` Pattern A/B（claude 起動回数=2 を assert）
- [x] Req 2.2: 再起動成功時の正常合流 ← `test-retry-loop.sh` Pattern A（rc=0 を assert）
- [x] Req 2.3: 再起動失敗時の `claude-failed` ← `test-retry-loop.sh` Pattern B
- [x] Req 2.4 / NFR 3.1: リトライ上限 1 回 ← `test-retry-loop.sh` Pattern B（attempt count=2 を assert）
- [x] Req 3.1〜3.3: 口頭申告を採用しない ← 実装変更なし（既存挙動の維持確認）
- [x] Req 4.1〜4.3: 単発 / per-task / Debugger 経由の対称適用 ← 各経路に対称実装
- [x] Req 5.1〜5.3: 装飾耐性パース維持 ← `parse_review_result_test.sh` 新規 4 ケース + Pattern D
- [x] NFR 1.1 / 1.2: 既存挙動互換 ← 既存 19 ケース + Pattern C 継続 PASS
- [x] NFR 2.1 / 2.2: 観測可能性 ← `reviewer-missing-file` / `per-task-reviewer-missing-file` カテゴリが grep で区別可能

## テスト結果

```
$ bash local-watcher/test/parse_review_result_test.sh
PASS: 23, FAIL: 0

$ bash docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
PASS: 11, FAIL: 0

$ for t in local-watcher/test/*.sh; do bash "$t"; done
(全 17 テストスイート PASS、FAIL=0)

$ shellcheck local-watcher/bin/issue-watcher.sh \
            local-watcher/test/parse_review_result_test.sh \
            docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/test-fixtures/test-retry-loop.sh
(警告ゼロ)

$ diff -r .claude/agents repo-template/.claude/agents
(差分なし)
```

## 実装上の判断

- **案 D + 案 A の多層防御**: `parse_review_result` の戻り値を `rc=3`（ファイル不在）/ `rc=2`（装飾起因 parse 失敗）に分離し（案 D）、ファイル不在時のみ 1 回限定リトライを発火（案 A）
- **案 C は別 Issue へ**: `reviewer.md` の出力契約強化（Write 完了後 Read 再読込・`ls` 出力）はテンプレ配布の影響範囲が広いため本 Issue のスコープ外。別 Issue 化を推奨
- **per-task の rc 衝突回避**: per-task の既存 rc=3（diff-range 解決失敗、Issue #164）との衝突を避け、ファイル不在は rc=4 を採用し単発・per-task で統一

詳細: `docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/impl-notes.md`
Reviewer 判定: `docs/specs/296-fix-watcher-reviewer-review-notes-md-rc/review-notes.md`（RESULT: approve）

## 確認事項 / レビュワーへの依頼

- 最終 PR: tasks.md 不在（design-less impl）のため Closes を採用（design-less impl: 単一 PR で完了のため Closes を採用）
- base: main / baseRefName: main / OK
- **案 C の別 Issue 化の是非**: `reviewer.md` の Write 完了確認強化は本 PR のスコープ外。下流 consumer repo への配布影響を考慮して別途 Issue として起票することを推奨（impl-notes.md「確認事項」参照）
- **`reviewer-missing-file` カテゴリの下流ログ集計影響**: idd-claude 本体には集計コードなし。外部で `reviewer-error` を集計している環境は別途対応が必要（impl-notes.md 参照）
- 特に確認をお願いしたいファイル: `local-watcher/bin/issue-watcher.sh` の `parse_review_result` 関数 (l.4820-4840 付近) および `run_reviewer_stage` / `run_per_task_reviewer` の retry loop 部分

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #296 のコメントを参照してください。