### PR TITLE
feat(#292): design-review-gate に Task turn 予算 sanity check（過大 task 検出）観点を追加

### DIFF
--- a/.claude/rules/design-review-gate.md
+++ b/.claude/rules/design-review-gate.md
@@ -31,6 +31,102 @@ Architect が `design.md` を書き終える前に、このゲートに従って
 - 投機的抽象化（将来スコープのためだけに存在するコンポーネント／アダプタ／インターフェース）を排除しているか
 - tasks.md で直接参照できない程に曖昧なセクションは、確定前に書き直す
 
+## Task turn 予算 sanity check（過大 task 検出）
+
+`tasks.md` ドラフトの確定直前に、Architect は各タスクが `DEV_MAX_TURNS`（既定 60）以内に
+収まる粒度であるかを **判断レビューの一環として** 点検します。本観点は、`tasks-generation.md`
+の「turn 予算ガイドライン（per-task Implementer ループ運用時の粒度指針）」で示した **タスク
+生成段階の指針** に対し、`design-review-gate.md` 側で **自己レビュー時の検出観点** を補う形で
+機能します（生成 vs レビューの役割分担）。
+
+本観点は **推奨（指針）レベル** であり、reject 条件ではありません。Mechanical Checks 節には
+属さず（後述の理由）、機械的な数値強制（CI / pre-commit / Mechanical Check による自動 reject）も
+行いません。観点に該当する task を発見した場合、Architect は当該 task の分割または最上位昇格を
+**検討** し、判断結果（分割するか据え置くか）を `design.md` / `tasks.md` に反映します。
+
+### 背景: 層対称分割の落とし穴
+
+frontend / UI / テストが重い責務は、backend / pure logic と比べて **turn コスト密度が高い**
+（描画・状態・スタイル・スナップショット・visual regression 等のコンテキストを並行で抱える
+ため）。「層ごとに対称に分割する」だけで安心していると、frontend 側のタスクだけが
+`error_max_turns` を踏み抜く事故が発生します（例: 「API クライアント lib(+test) + 複数
+component(+test)」を 1 タスクにまとめた事例）。
+
+このため、Architect 自己レビュー時には **turn コスト密度を意識した分割** に視点を切り替え、
+以下のシグナルで過大 task を点検することを推奨します。
+
+### 検出シグナル
+
+以下のシグナルのいずれかに該当する task は、過大 task の可能性を **点検対象** とします
+（必ず分割せよという意味ではなく、判断レビューの俎上に乗せるための観点列挙）:
+
+1. **異種責務の同居**: 1 つのタスクに「API クライアント lib(+test)」「複数 component(+test)」
+   「状態管理 / Store(+test)」「スタイル / theme 変更」等の **異種責務** が混在していないか。
+   同居していれば責務単位での分割を検討する
+2. **兄弟比突出**: 同階層の兄弟タスクと比較して、当該タスクの **詳細項目数** または
+   **想定新規ファイル数** が突出していないか。兄弟比の倍率や項目数の絶対値は **目安** であり
+   厳密な閾値は定めない（Open Question (b) の通り、定量強制はしない）
+3. **新規ファイル件数の目安**: 1 タスクで新規追加するファイル数が多い場合（**目安として 3 件
+   以上**）、分割を検討する。なお 3 件はあくまで **目安** であり、ファイル粒度（小ユーティリティの
+   集合体か / 大規模 component 1 件か）で実コストは大きく異なるため、絶対閾値としては運用しない
+4. **重い子タスクの同居**: 重い子タスク（`1.1` / `1.2` …）が同一親の下に複数同居していないか。
+   同居している場合、子を親から切り出して **最上位 task（`2` / `3` …）への昇格** を検討する
+   （子は独立 commit 単位として消化されるため、昇格させた方が turn 予算管理が容易）
+5. **turn コスト密度差**: frontend / UI / テスト重責務は backend より turn コスト密度が高い。
+   層対称分割（frontend 1 タスク + backend 1 タスク等）ではなく、**turn コスト密度を意識した
+   分割**（frontend を細かく刻み、backend を統合する等）が望ましい場面がある
+
+### 是正方針: 責務不変の粒度分割
+
+過大 task を検出した場合の是正は、**`design.md` の責務・コンポーネント構成を変えず、tasks の
+切り方のみを調整する** ことを基本とします（責務不変の粒度分割）。具体的には:
+
+- 異種責務同居タスクを **責務単位の独立タスク** に分割する（例: 「API lib + UI」 → 「API lib」
+  と「UI」を別タスクに）
+- 重い子タスクを **最上位 task に昇格** させる（親から切り出して `2` / `3` … として独立 commit
+  単位にする）
+- 兄弟比が突出しているタスクを **複数タスクに分解** する（責務単位 / ファイル単位の自然な
+  境界で分ける）
+
+`design.md` 側の責務再設計が必要と判断される場合のみ、judgment review に戻して再検討します
+（観点違反を理由に design 側の責務を強制的に書き換える運用は採用しない）。
+
+### Mechanical Checks 節に含めない理由
+
+本観点を **Mechanical Checks に含めない** のは以下の理由です（Mechanical Checks は機械的に
+判定可能な項目に限定するため）:
+
+- タスクごとの turn 消費量は実装難度・既存コードベースの状態・テスト規模に依存し、設計段階で
+  正確な事前見積もりが難しい
+- ファイル数 / 兄弟比などのシグナルは **必要条件にも十分条件にもならない**（小ファイル 5 件 <
+  大ファイル 1 件のケースが普通にある）。数値強制すると false-positive が頻発する
+- `DEV_MAX_TURNS` 既定値（60）は将来変更され得る。機械 enforcement に紐付けると数値追従コストが
+  発生する
+- 推奨どまりにすることで Architect / 人間設計者が判断材料として活用しつつ、reject 判定の自動化は
+  既存 Mechanical Checks（Requirements traceability / File Structure Plan 充填 / orphan component /
+  Budget overflow / checkbox enforcement / verify block well-formed）に集約できる
+
+### 既存規約との関係
+
+- [`tasks-generation.md`](./tasks-generation.md) の「turn 予算ガイドライン（per-task Implementer
+  ループ運用時の粒度指針）」節（#289 で追加）と **役割分担** します:
+  - `tasks-generation.md` 側 = **タスク生成段階** の粒度指針（fresh session 仕様 / 粒度指針 /
+    強度の項）
+  - 本節 = **Architect 自己レビュー段階** の検出観点（5 シグナル / 是正方針）
+- 既存「レビュー・ループ」節の **最大 2 パス** 規約および `/goal` 自動ループ運用節は変更しません
+  （本観点は判断レビュー側の観点追加であり、ループ手順自体は変えない）
+- Mechanical Checks 節（Requirements traceability / File Structure Plan 充填 / orphan component /
+  Budget overflow / checkbox enforcement / verify block well-formed）の判定基準は変更しません
+- 既に main に merge 済みの spec の `design.md` / `tasks.md` に対する **遡及的な違反検出は
+  要求しません**（retrofit は本観点のスコープ外）
+
+### 適用タイミング
+
+Architect は `tasks.md` ドラフトの確定直前、判断レビュー（要件カバレッジ / アーキテクチャ準備 /
+実行可能性）を通過し、Mechanical Checks（Budget overflow check など）が pass した後の段階で
+本観点を点検することを推奨します。本観点に該当する task を発見した場合は、上記「是正方針」に
+従って tasks の切り方を調整してから確定します。
+
 ## Mechanical Checks（自動確認項目）
 
 判断レビューの前に、機械的に確認します:

--- a/.claude/rules/tasks-generation.md
+++ b/.claude/rules/tasks-generation.md
@@ -151,6 +151,16 @@ fresh な Claude session で Implementer が起動され、各タスクの turn 
 > 是正で対処することが推奨される（詳細な対応優先順は README「`per-task-implementer-failed` /
 > `error_max_turns` 対応」節を参照）。
 
+### Architect 自己レビュー時の検出観点との相互参照（#292）
+
+本節（タスク生成段階の粒度指針）と対になる **Architect 自己レビュー段階の検出観点** は、
+[`design-review-gate.md`](./design-review-gate.md) の「Task turn 予算 sanity check（過大 task
+検出）」節を参照してください。同節では本節の粒度指針を踏まえた上で、`tasks.md` 確定直前に
+点検すべき 5 つの検出シグナル（異種責務同居 / 兄弟比突出 / 新規ファイル件数の目安 / 重い子タスク
+同居 / turn コスト密度差）と是正方針（責務不変の粒度分割）を観点として列挙しています。生成
+（本節）と自己レビュー検出（`design-review-gate.md` 側）の双方を参照することで、過大 task の
+発生確率を運用前に下げられます。
+
 ## 構造化 verify ブロック（stage-a-verify gate の input 契約）
 
 stage-a-verify gate (#125) は Stage A（Developer 実装）完了直前に、`tasks.md` 中の

--- a/docs/specs/292-improvement-rules-design-tasks-task-turn/impl-notes.md
+++ b/docs/specs/292-improvement-rules-design-tasks-task-turn/impl-notes.md
@@ -1,0 +1,122 @@
+# Implementation Notes — #292
+
+## 概要
+
+Architect の自己レビューゲートに「Task turn 予算 sanity check（過大 task 検出）」の **観点
+（指針レベル）** を追加する design-less impl。`design-review-gate.md` 本体に新節を 1 つ追加し、
+`tasks-generation.md` の既存「turn 予算ガイドライン」節からの相互参照を 1 サブ節として追記
+した。root と `repo-template/` の二系統に byte 一致で反映済み。
+
+## 変更ファイル一覧
+
+- `.claude/rules/design-review-gate.md` — 新節「Task turn 予算 sanity check（過大 task 検出）」を
+  「実行可能性レビュー」節の **直後**かつ「Mechanical Checks」節の **手前** に追加（判断レビュー側）
+- `.claude/rules/tasks-generation.md` — 既存「turn 予算ガイドライン」節の末尾に
+  「Architect 自己レビュー時の検出観点との相互参照（#292）」サブ節を追加
+- `repo-template/.claude/rules/design-review-gate.md` — root と byte 一致
+- `repo-template/.claude/rules/tasks-generation.md` — root と byte 一致
+
+`diff --stat` 結果（参考）:
+
+```
+.claude/rules/design-review-gate.md               | 96 +++++++++++++++++++++++
+.claude/rules/tasks-generation.md                 | 10 +++
+repo-template/.claude/rules/design-review-gate.md | 96 +++++++++++++++++++++++
+repo-template/.claude/rules/tasks-generation.md   | 10 +++
+4 files changed, 212 insertions(+)
+```
+
+**insertions のみ、deletions = 0**。既存節の本文は 1 文字も変更していない。
+
+## 追加内容のサマリ
+
+### `design-review-gate.md` 側の新節
+
+節名: `## Task turn 予算 sanity check（過大 task 検出）`
+
+構成:
+
+- 冒頭: 推奨レベルである旨と、`tasks-generation.md` の turn 予算ガイドラインとの役割分担を明示
+- 「背景: 層対称分割の落とし穴」サブ節
+- 「検出シグナル」サブ節（5 件、Req 2.1〜2.5 に対応）
+  1. 異種責務の同居 (API クライアント lib + 複数 component 等)
+  2. 兄弟比突出 (詳細項目数 / 想定新規ファイル数)
+  3. 新規ファイル件数の目安 (目安として 3 件以上)
+  4. 重い子タスクの同居 (最上位 task への昇格を検討)
+  5. turn コスト密度差 (frontend > backend)
+- 「是正方針: 責務不変の粒度分割」サブ節
+- 「Mechanical Checks 節に含めない理由」サブ節
+- 「既存規約との関係」サブ節（`tasks-generation.md` との役割分担 / レビュー・ループ / Mechanical
+  Checks 不変 / retrofit 不要を明示）
+- 「適用タイミング」サブ節
+
+### `tasks-generation.md` 側の相互参照
+
+「強度（推奨どまり / Mechanical Check 不在）」サブ節と「構造化 verify ブロック」節の間に、新規
+サブ節「Architect 自己レビュー時の検出観点との相互参照（#292）」を 1 つ挿入。`design-review-gate.md`
+側の新節へリンクを張る記述で完結。
+
+## Requirements 達成確認
+
+| Req ID | 内容 | 達成箇所 |
+|---|---|---|
+| 1.1 | `design-review-gate.md` に sanity check の節 / 箇条書きを 1 つ以上 | 新節「Task turn 予算 sanity check（過大 task 検出）」 |
+| 1.2 | `tasks-generation.md` の turn 予算ガイドライン節と相互参照 | 「Architect 自己レビュー時の検出観点との相互参照（#292）」サブ節 |
+| 1.3 | 既存 Mechanical Checks を削除・改変しない | git diff: deletions=0 / 該当節本文は無変更 |
+| 1.4 | 「最大 2 パス」/ `/goal` 自動ループ節を変更しない | 「レビュー・ループ」「`/goal` による自動ループ運用」節は無変更 |
+| 1.5 | 判断レビュー側（または独立節）への配置 | 「実行可能性レビュー」と「Mechanical Checks」の間に独立節として配置 |
+| 2.1 | API クライアント + 複数 component 等の異種責務同居 | 検出シグナル #1 |
+| 2.2 | 兄弟比 / 詳細項目数 / 新規ファイル数の突出 | 検出シグナル #2 |
+| 2.3 | 新規ファイル数 3 件以上の目安 | 検出シグナル #3 |
+| 2.4 | 重い子タスクの同居 → 最上位昇格 | 検出シグナル #4 |
+| 2.5 | frontend > backend の turn コスト密度 | 検出シグナル #5 + 「背景」サブ節 |
+| 3.1 | 推奨（指針）レベル / reject 条件として宣言しない | 冒頭で明示、「Mechanical Checks 節に含めない理由」で補強 |
+| 3.2 | Mechanical Checks 節には追加しない | 新節は Mechanical Checks の **手前**（判断レビュー側）に配置 |
+| 3.3 | 数値閾値は「目安」と明示 | 「目安として 3 件以上」「目安」と明記、絶対閾値としては運用しないと明記 |
+| 3.4 | 該当時の Architect の振る舞い | 冒頭「分割または最上位昇格を **検討** し判断結果を design.md / tasks.md に反映」と明記 |
+| 3.5 | watcher / agent コードの挙動変更を伴わない | 追記は markdown のみ。`local-watcher/` および `.claude/agents/` は無変更 |
+| 4.1 | `design-review-gate.md` の両系統 byte 一致 | `cp` で複製、`diff -r` で確認済 |
+| 4.2 | `tasks-generation.md` の両系統 byte 一致 | `cp` で複製、`diff -r` で確認済 |
+| 4.3 | `diff -r .claude/rules repo-template/.claude/rules` が空 | 確認済（"RULES DIFF CLEAN AFTER COPY"） |
+| 4.4 | 片系統だけの更新を許容しない | 両系統に同時反映済 |
+| 4.5 | `repo-template/CLAUDE.md` のエージェント参照ルール一覧を変更しない | 無変更 |
+| 5.1 | Mechanical Checks 既存判定基準を変更しない | Budget overflow / checkbox enforcement / verify well-formed 節は無変更 |
+| 5.2 | 既存 traceability 規約を変更しない | requirements.md / design.md / tasks.md の関係は無変更 |
+| 5.3 | 最大 2 パス / `/goal` 自動ループ手順を変更しない | 該当節は無変更 |
+| 5.4 | merge 済み spec への retrofit 不要 | 「既存規約との関係」サブ節で明記 |
+| 5.5 | env 変数名 / ラベル名 / 既定値の意味を変更しない | `DEV_MAX_TURNS` の意味・既定値 60 への言及はあるが変更なし |
+| 6.1 | #289 の `tasks-generation.md` 節を削除・改変しない | git diff: 既存サブ節（fresh session / 粒度指針 / 強度）は無変更、insertions のみ |
+| 6.2 | #289 と差別化し、検出観点を補う形で記述 | `design-review-gate.md` 側は「自己レビュー時の検出観点」、`tasks-generation.md` 側は「タスク生成段階の粒度指針」と役割分担を明示 |
+| 6.3 | 両節間の相互リンク | `tasks-generation.md` → `design-review-gate.md` のリンクを新サブ節で、`design-review-gate.md` → `tasks-generation.md` のリンクを「既存規約との関係」サブ節および冒頭で配置 |
+| 6.4 | README / QUICK-HOWTO を変更しない | 無変更 |
+| NFR 1.1 | h2 / h3 階層を破壊しない | 新節を h2、サブ節を h3 で追加（既存スタイル踏襲） |
+| NFR 1.2 | 日本語ベース | EARS / env / ラベル名以外は日本語で記述 |
+| NFR 1.3 | 既存 Mechanical Checks と語彙・記述スタイルを揃える | 既存節と同様の構成（サブ節での詳細化、関連節への相互リンク） |
+| NFR 2.1 | 2 ホップ以内で到達できる目次配置 | `design-review-gate.md` の h2 直下（1 ホップ）に配置 |
+| NFR 2.2 | `tasks-generation.md` 「turn 予算ガイドライン」から 1 ホップ | 同節末尾のサブ節からリンク |
+| NFR 2.3 | 検索キーワード（`turn 予算` / `過大 task` / `sanity check`）を含む | 節名「Task turn 予算 sanity check（過大 task 検出）」がすべて含む |
+| NFR 3.1 | watcher / agent / install / GHA の挙動変更なし | markdown のみの変更 |
+| NFR 3.2 | Claude Code v2.1.139 未満含む後方互換 | 既存後方互換規約を踏襲 |
+
+## 確認事項（人間レビュー向け）
+
+- 新節の配置位置を「実行可能性レビュー」直後 / 「Mechanical Checks」手前としたが、別案として
+  「レビュー・ループ」節の手前（Mechanical Checks 後）に置くことも検討可能。判断レビュー側
+  という位置付け（Req 1.5）には現案がより整合する
+- 検出シグナル #3 の「目安として 3 件以上」という具体数値は、Open Question (b) の暫定方針
+  どおり requirements.md の Req 2.3 に基づいて採用。文中で「**目安** であり絶対閾値として
+  運用しない」と緩めている
+- 特定 repo の事例引用（ab-extweb 等）は本文に含めず、汎用的な事例（「API クライアント lib +
+  複数 component」）で言及するに留めた（requirements.md Out of Scope と整合）
+
+## 検証結果
+
+- `diff -r .claude/rules repo-template/.claude/rules` → exit 0（差分なし）
+- `git diff --stat .claude/rules repo-template/.claude/rules` → 4 files changed, 212
+  insertions(+), 0 deletions(-)（既存節の本文は無変更を担保）
+- 既存 Mechanical Checks（Budget overflow / checkbox enforcement / verify block well-formed）の
+  判定基準セクションは git diff 上で改変ゼロ
+- 既存「turn 予算ガイドライン（per-task Implementer ループ運用時の粒度指針）」「構造化 verify
+  ブロック」節は git diff 上で改変ゼロ（追加サブ節は既存サブ節末尾と新節の間に挿入）
+
+STATUS: complete

--- a/docs/specs/292-improvement-rules-design-tasks-task-turn/requirements.md
+++ b/docs/specs/292-improvement-rules-design-tasks-task-turn/requirements.md
@@ -1,0 +1,204 @@
+# Requirements Document
+
+## Introduction
+
+#289 で per-task Implementer ループの `error_max_turns` に対する Troubleshooting と
+tasks 生成の turn 予算ガイドラインを **ドキュメント** として整備したが、それは「設計済みの
+tasks に対する事後の運用対処」と「Architect / 人間設計者向けの一般的な粒度指針」までで、
+**Architect が自己レビューを締めるタイミング**で「過大 task の可能性」を観点として明示的に
+点検する手順は規約に含まれていない。実例として、frontend 層を「API クライアント lib(+test) +
+複数 component(+test)」のように層対称分割でひと固まりにした task が `error_max_turns` を
+踏み抜く事象が観測されている（ab-extweb #8 task 5 等）。本 spec では、Architect の
+**設計書 / tasks 自己レビューゲート**に「Task turn 予算 sanity check（過大 task 検出）」を
+**観点（指針レベル）**として追加し、tasks 生成段階で過大 task を発見しやすくする。検出は
+ドメイン非依存の定性ヒューリスティック寄りで構成し、CI による機械強制や数値閾値の reject
+判定は導入しない。既存の Mechanical Checks / traceability / 「最大 2 パス」自己レビュー
+ループの挙動は変更しない。
+
+## Requirements
+
+### Requirement 1: Architect 自己レビューへの観点追加（配置）
+
+**Objective:** As a Architect エージェントおよび人間設計者, I want tasks.md 確定直前の
+自己レビューで「Task turn 予算 sanity check（過大 task 検出）」を一貫した観点として参照
+したい, so that 過大 task を運用前（設計段階）に発見し、`error_max_turns` の発生確率を
+下げられる
+
+#### Acceptance Criteria
+
+1. The `design-review-gate.md` shall 「Task turn 予算 sanity check（過大 task 検出）」を
+   観点とした節または箇条書きを 1 つ以上含む
+2. The `tasks-generation.md` の既存「turn 予算ガイドライン」節 shall 上記 sanity check の
+   観点と相互参照されるリンクまたは記述を持つ
+3. The `design-review-gate.md` への追記 shall 既存 Mechanical Checks（Requirements
+   traceability / File Structure Plan 充填 / orphan component / Budget overflow check /
+   checkbox enforcement check / verify block well-formed check）を **削除・改変しない**
+   形で行われる
+4. The `design-review-gate.md` への追記 shall 既存「レビュー・ループ」節の「最大 2 パスで
+   確定」規約および `/goal` 自動ループ運用節を変更しない
+5. The 追記された観点 shall Architect が判断レビューの一環として参照することを想定した
+   配置（「アーキテクチャ準備レビュー」「実行可能性レビュー」などの判断レビュー側、
+   または独立した節）に置かれる
+
+### Requirement 2: 検出シグナル（観点）の明示
+
+**Objective:** As a Architect エージェントおよび人間設計者, I want 過大 task を疑うべき
+具体的な観測シグナルを観点として持ちたい, so that 「層対称で分割した」だけで安心せず、
+turn コスト密度の観点で再点検できる
+
+#### Acceptance Criteria
+
+1. The 追記された観点 shall 「1 タスクに API クライアント lib(+test) と複数 component(+test)
+   等の異種責務が混在しているか」を検出シグナルの 1 つとして列挙する
+2. The 追記された観点 shall 「同階層の兄弟タスクと比較して、当該タスクの詳細項目数または
+   想定新規ファイル数が突出していないか」を検出シグナルの 1 つとして列挙する
+3. The 追記された観点 shall 「1 タスクで新規追加するファイル数が多い場合（目安として 3 件
+   以上）に分割を検討する」旨を検出シグナルの 1 つとして列挙する
+4. The 追記された観点 shall 「重い子タスクが同一親に複数同居していないか。同居していれば
+   最上位 task への昇格を検討する」旨を検出シグナルの 1 つとして列挙する
+5. The 追記された観点 shall frontend / UI / テストが重い責務は backend より turn コスト密度
+   が高いため、層対称分割ではなく turn コスト密度を意識した分割が望ましい旨を明示する
+
+### Requirement 3: 強度（推奨どまり / 機械 reject しない）
+
+**Objective:** As a idd-claude の保守者, I want 本観点追加が機械強制（CI / Mechanical Check
+の reject 条件）に昇格しないことを保証してほしい, so that ドメイン依存性の高い判定で
+auto-dev パイプラインを誤 reject させない
+
+#### Acceptance Criteria
+
+1. The 追記された観点 shall 強度を「推奨（指針）」レベルとして明示し、reject 条件として
+   宣言しない
+2. The 追記された観点 shall `design-review-gate.md` の Mechanical Checks 節には **追加しない**
+   （Mechanical Checks は機械的に判定可能な項目に限定するため）
+3. The 追記された観点 shall 数値閾値（例: 「ファイル数 3 以上で必ず分割」「兄弟比 N 倍で必ず
+   分割」等）を **強制条件としては定義しない**。数値が登場する場合は「目安」と明示する
+4. If 観点に該当する task が発見された場合, the Architect shall 当該 task の分割または最上位
+   昇格を **検討** し、判断結果（分割するか据え置くか）を design.md / tasks.md に反映する
+5. The 追記された観点 shall watcher / agent 実装コード（`local-watcher/bin/issue-watcher.sh` /
+   `.claude/agents/*.md`）の挙動変更を伴わない
+
+### Requirement 4: 二重管理規約への準拠（root と repo-template の byte 一致）
+
+**Objective:** As a idd-claude の保守者, I want 本 spec の成果物が root の `.claude/rules/`
+と `repo-template/.claude/rules/` の両系統に byte 一致で反映されることを保証してほしい,
+so that idd-claude self-hosting と consumer repo の双方で同じ規約が稼働する
+
+#### Acceptance Criteria
+
+1. The 本 spec の成果物 shall `.claude/rules/design-review-gate.md` と
+   `repo-template/.claude/rules/design-review-gate.md` の双方に **byte 一致**で反映される
+2. The 本 spec の成果物 shall `.claude/rules/tasks-generation.md` と
+   `repo-template/.claude/rules/tasks-generation.md` の双方への相互参照追加が必要な場合、
+   双方に **byte 一致**で反映される
+3. The 本 spec の成果物 shall `diff -r .claude/rules repo-template/.claude/rules` が
+   空（exit 0）になることを完了条件に含める
+4. The 本 spec の成果物 shall CLAUDE.md「二重管理」節および既存規約に従い、いずれか片系統
+   だけの更新を許容しない
+5. The 本 spec の成果物 shall `repo-template/CLAUDE.md` のエージェント参照ルール一覧（PM /
+   Architect / Developer が参照するルール）を変更しない
+
+### Requirement 5: 既存挙動の非回帰
+
+**Objective:** As a 既に idd-claude を導入しているリポジトリの運用者, I want 本 spec の
+適用が既存ルールの判定境界 / トレーサビリティ / 自己レビューループの挙動を変えないことを
+保証してほしい, so that ルール追加だけで既存 spec / 既存 PR が壊れる事故を避けられる
+
+#### Acceptance Criteria
+
+1. The 本 spec の成果物 shall 既存 Mechanical Checks（Budget overflow check の 10 / 11 / 13 /
+   14 件境界、checkbox enforcement check の判定パターン、verify block well-formed check の
+   well-formed 条件）の判定基準を変更しない
+2. The 本 spec の成果物 shall 既存 traceability（requirements.md numeric ID → design.md 参照
+   → tasks.md `_Requirements:_` の鎖）の規約を変更しない
+3. The 本 spec の成果物 shall 既存「最大 2 パス」自己レビューループおよび `/goal` 自動ループ
+   運用節の手順を変更しない
+4. The 本 spec の成果物 shall 既に main に merge 済みの spec の `design.md` / `tasks.md` に
+   対する **遡及的な違反検出を要求しない**（retrofit は本 spec のスコープ外）
+5. The 本 spec の成果物 shall 既存 env 変数名（`DEV_MAX_TURNS` 等）・ラベル名
+   （`claude-failed` / `per-task-implementer-failed` 等）・既定値の意味を変更しない
+
+### Requirement 6: #289 成果物との役割分担
+
+**Objective:** As a Architect エージェントおよび人間設計者, I want 本 spec の追記内容が
+#289 で導入された `tasks-generation.md` 「turn 予算ガイドライン」節と役割を分担して
+重複しないことを期待する, so that 同じ規約が 2 箇所に重複してドリフトする事故を避けられる
+
+#### Acceptance Criteria
+
+1. The 本 spec の追記 shall #289 で `tasks-generation.md` に追加された「turn 予算ガイド
+   ライン」節（fresh session 仕様 / 粒度指針 / 強度の項）を **削除・改変しない**
+2. The 本 spec の追記 shall #289 の「粒度指針（推奨）」と差別化して、Architect 自己レビュー
+   時に **どのシグナルで点検するか**（検出観点）を補う形で記述する
+3. The 本 spec の追記 shall #289 の `tasks-generation.md` 節と `design-review-gate.md` 追記
+   の間で相互リンクを設け、運用者がいずれの起点からも他方に到達できるようにする
+4. The 本 spec の追記 shall README / QUICK-HOWTO の `error_max_turns` Troubleshooting 節
+   （#289 で追加）を変更しない
+
+## Non-Functional Requirements
+
+### NFR 1: 既存ドキュメント構造との整合性
+
+1. The 追記内容 shall `design-review-gate.md` および `tasks-generation.md` の既存 h2 / h3
+   階層構造を破壊せず、既存節の一意性を保つ
+2. The 追記内容 shall CLAUDE.md「言語方針」に従い、日本語ベースで記述する（識別子・env 変数名・
+   ラベル名・EARS トリガーキーワード等の英語固定語彙は除く）
+3. The 追記内容 shall 既存 Mechanical Checks 節と語彙・記述スタイルを揃え、Architect が
+   同等の粒度で参照できるようにする
+
+### NFR 2: 発見容易性
+
+1. The 追記された観点 shall `design-review-gate.md` の目次（h2 / h3 の見出し階層）から
+   2 ホップ以内で到達できる位置に配置される
+2. The 追記された観点 shall `tasks-generation.md` 「turn 予算ガイドライン」節からの相互
+   リンクを持ち、tasks 生成時の起点からも 1 ホップで参照できる
+3. The 追記された観点 shall 検索キーワード（`turn 予算` / `過大 task` / `sanity check`）の
+   いずれかを見出しまたは本文に含み、運用者がテキスト検索で発見できるようにする
+
+### NFR 3: ドキュメント変更のみで完結（実装挙動の非変更）
+
+1. The 本 spec の成果物 shall watcher / agent / install スクリプト / GitHub Actions
+   workflow の挙動を変更せず、ルール markdown への追記のみで完結する
+2. The 本 spec の成果物 shall idd-claude が稼働する Claude Code バージョン（v2.1.139 未満
+   含む）に依存した必須機能を追加しない（既存後方互換規約を踏襲）
+
+## Out of Scope
+
+- 過大 task 検出の **CI / Mechanical Check による reject 強制**（数値閾値強制を含む）
+- watcher / agent 実装コード（`local-watcher/bin/issue-watcher.sh` および
+  `.claude/agents/*.md`）の挙動変更
+- 過大 task の **自動分割ロジック**、自動 `DEV_MAX_TURNS` 引き上げ、累積 turn 制御
+- `DEV_MAX_TURNS` のデフォルト値変更（60 を維持）
+- 既に main に merge 済みの spec / tasks.md への遡及適用（retrofit）
+- README / QUICK-HOWTO の Troubleshooting 節への追記（#289 の役割であり本 spec のスコープ外）
+- 特定リポジトリ（ab-extweb 等）に固有の事例記述を **規約本文の必須要素として要求すること**
+  （事例引用の可否は Open Questions で扱う）
+- Triage / Reviewer / Debugger 等 Architect 以外のエージェントの自己レビューゲート変更
+
+## Open Questions
+
+- **配置先の選択（Issue 委ね事項 a）**: 本観点を (i) `design-review-gate.md` のみに配置し
+  `tasks-generation.md` から相互参照、(ii) `tasks-generation.md` のみに観点として置き
+  `design-review-gate.md` から相互参照、(iii) 両方に本体を二重掲載、のいずれにするか。
+  本要件では **(i) を暫定方針**として採用する（Architect 自己レビュー時点が一次トリガー
+  であり、`design-review-gate.md` を本体にして `tasks-generation.md` から相互参照する形で
+  ドリフトを最小化する）。Architect / 人間レビュアーの判断で (ii) / (iii) への切り替えを
+  許容する（Req 1.1 / 1.2 の相互参照保証を満たす限り）
+- **数値例の踏み込み度（Issue 委ね事項 b）**: 「ファイル数 3 以上」「兄弟比 N 倍」等の数値を
+  観点本文に **目安として明記**するか、定性表現（「突出していないか」）に留めるか。本要件
+  では Req 2.3 で「目安として 3 件以上」を採用し、Req 3.3 で「強制条件としては定義しない」
+  と緩めている。design / 実装フェーズで再評価する余地を残す（#289 と同様、将来
+  `DEV_MAX_TURNS` 既定が変わった際の追従コストとのバランスを考慮）
+- **ab-extweb #8 task 5 事例引用の可否（Issue 委ね事項 c）**: 規約本文に specific repo
+  （ab-extweb）の事例を引用するか否か。本要件では Out of Scope に列挙したとおり、
+  **特定 repo の事例を規約本文の必須要素としては要求しない**ことを暫定方針とする
+  （OSS テンプレートとしての汎用性を優先）。Architect / 人間レビュアーの判断で「設計判断の
+  motivating example」として匿名化または一般化した形で言及する余地は残す
+- **`design-review-gate.md` 配下の節タイトル**: 暫定的に「Task turn 予算 sanity check
+  （過大 task 検出）」を Issue タイトルから踏襲しているが、最終的な節名は Architect の
+  裁量で調整可能（NFR 2.3 の検索キーワード保有を満たす限り）
+
+## 関連
+
+- Parent: #289
+- Related: #289

--- a/docs/specs/292-improvement-rules-design-tasks-task-turn/review-notes.md
+++ b/docs/specs/292-improvement-rules-design-tasks-task-turn/review-notes.md
@@ -1,0 +1,70 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-08T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-292-impl-improvement-rules-design-tasks-task-turn
+- HEAD commit: b79898e3222d6ddafdad32ba85425f7f9531e289
+- Compared to: main..HEAD
+- Note: design-less impl（`design.md` / `tasks.md` 不在）。判定は requirements.md の AC と
+  diff（4 files / 212 insertions / 0 deletions）の突き合わせで行う。CLAUDE.md には
+  `## Feature Flag Protocol` 節が無いため flag 観点は適用外（opt-out）。
+
+## Verified Requirements
+
+- 1.1 — `.claude/rules/design-review-gate.md` に新節「Task turn 予算 sanity check（過大 task 検出）」を追加（diff +96 行）
+- 1.2 — `.claude/rules/tasks-generation.md` の「turn 予算ガイドライン」節末尾にサブ節「Architect 自己レビュー時の検出観点との相互参照（#292）」を追加し相互参照リンク設置
+- 1.3 — diff は insertions のみ（deletions=0）。Mechanical Checks 節（Requirements traceability / File Structure Plan 充填 / orphan component / Budget overflow / checkbox enforcement / verify block well-formed）の本文は無変更
+- 1.4 — 「レビュー・ループ」節および `/goal` 自動ループ運用節は diff に登場せず無変更
+- 1.5 — 新節は「実行可能性レビュー」直後、「Mechanical Checks」の手前に独立節として配置（判断レビュー側）
+- 2.1 — 検出シグナル #1「異種責務の同居」で `API クライアント lib(+test)` / 複数 component(+test) / 状態管理 / スタイルを列挙
+- 2.2 — 検出シグナル #2「兄弟比突出」で詳細項目数 / 想定新規ファイル数の兄弟比を列挙
+- 2.3 — 検出シグナル #3「新規ファイル件数の目安」で「**目安として 3 件以上**」と明記
+- 2.4 — 検出シグナル #4「重い子タスクの同居」で最上位 task への昇格検討を列挙
+- 2.5 — 検出シグナル #5「turn コスト密度差」および「背景: 層対称分割の落とし穴」サブ節で frontend > backend の密度差を明示
+- 3.1 — 冒頭で「**推奨（指針）レベル**」「reject 条件ではありません」と明示
+- 3.2 — 新節は Mechanical Checks の **手前** に配置、独立サブ節「Mechanical Checks 節に含めない理由」で補強
+- 3.3 — 数値は「**目安**」と明記、「絶対閾値としては運用しない」と緩めている
+- 3.4 — 冒頭で「当該 task の分割または最上位昇格を **検討** し、判断結果（分割するか据え置くか）を `design.md` / `tasks.md` に反映」と明記
+- 3.5 — diff に `local-watcher/` / `.claude/agents/` の変更なし（markdown 規約のみ変更）
+- 4.1 — `.claude/rules/design-review-gate.md` と `repo-template/.claude/rules/design-review-gate.md` の双方に同一差分が存在
+- 4.2 — `.claude/rules/tasks-generation.md` と `repo-template/.claude/rules/tasks-generation.md` の双方に同一差分が存在
+- 4.3 — `diff -r .claude/rules repo-template/.claude/rules` → exit 0（"RULES DIFF CLEAN"）
+- 4.4 — 両系統に同時反映済
+- 4.5 — `repo-template/CLAUDE.md` は diff に登場せず無変更
+- 5.1 — Budget overflow / checkbox enforcement / verify block well-formed 節は無変更（diff は新節挿入のみ）
+- 5.2 — requirements.md / design.md / tasks.md の traceability 規約は無変更
+- 5.3 — 「最大 2 パス」/ `/goal` 自動ループ手順は無変更
+- 5.4 — 「既存規約との関係」サブ節で「既に main に merge 済みの spec への遡及的な違反検出は要求しません」と明記
+- 5.5 — `DEV_MAX_TURNS`（既定 60）の言及は説明用途のみで既定値は変更されていない
+- 6.1 — `tasks-generation.md` の既存サブ節（fresh session 仕様 / 粒度指針 / 強度）は無変更（insertions のみ）
+- 6.2 — `design-review-gate.md` 側 = 自己レビュー検出観点、`tasks-generation.md` 側 = 生成段階の指針、と役割分担を明示
+- 6.3 — `tasks-generation.md` → `design-review-gate.md` のリンクを新サブ節で、`design-review-gate.md` → `tasks-generation.md` のリンクを「既存規約との関係」で双方向設置
+- 6.4 — README / QUICK-HOWTO は diff に登場せず無変更
+- NFR 1.1 — h2（新節）/ h3（サブ節）の階層を既存スタイルに合わせて追加
+- NFR 1.2 — 日本語ベース（識別子・env var 名・EARS キーワードのみ英語）
+- NFR 1.3 — 既存 Mechanical Checks 節と同等の節構成（サブ節での詳細化 / 相互リンク）
+- NFR 2.1 — `design-review-gate.md` の h2 直下（1 ホップ）に配置
+- NFR 2.2 — `tasks-generation.md` 「turn 予算ガイドライン」節末尾のサブ節からリンク（1 ホップ）
+- NFR 2.3 — 節名「Task turn 予算 sanity check（過大 task 検出）」が検索キーワード 3 種すべてを含む
+- NFR 3.1 — markdown のみの変更。watcher / agent / install / GHA は diff に無し
+- NFR 3.2 — 既存後方互換規約を踏襲（追加機能は markdown 観点のみ）
+
+## Boundary 確認
+
+design-less impl のため tasks.md / `_Boundary:_` アノテーションは不在。requirements.md / impl-notes.md
+で示された変更対象（`.claude/rules/design-review-gate.md` / `.claude/rules/tasks-generation.md` および
+repo-template 側の対応ファイル）のみが diff に含まれており、境界逸脱は無し。
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric ID（1.1〜1.5 / 2.1〜2.5 / 3.1〜3.5 / 4.1〜4.5 / 5.1〜5.5 / 6.1〜6.4 /
+NFR 1.1〜1.3 / 2.1〜2.3 / 3.1〜3.2）が design-review-gate.md / tasks-generation.md 両系統への追記で
+適切にカバーされており、二重管理規約（`diff -r` clean）も満たされている。boundary 逸脱なし。
+
+RESULT: approve

--- a/repo-template/.claude/rules/design-review-gate.md
+++ b/repo-template/.claude/rules/design-review-gate.md
@@ -31,6 +31,102 @@ Architect が `design.md` を書き終える前に、このゲートに従って
 - 投機的抽象化（将来スコープのためだけに存在するコンポーネント／アダプタ／インターフェース）を排除しているか
 - tasks.md で直接参照できない程に曖昧なセクションは、確定前に書き直す
 
+## Task turn 予算 sanity check（過大 task 検出）
+
+`tasks.md` ドラフトの確定直前に、Architect は各タスクが `DEV_MAX_TURNS`（既定 60）以内に
+収まる粒度であるかを **判断レビューの一環として** 点検します。本観点は、`tasks-generation.md`
+の「turn 予算ガイドライン（per-task Implementer ループ運用時の粒度指針）」で示した **タスク
+生成段階の指針** に対し、`design-review-gate.md` 側で **自己レビュー時の検出観点** を補う形で
+機能します（生成 vs レビューの役割分担）。
+
+本観点は **推奨（指針）レベル** であり、reject 条件ではありません。Mechanical Checks 節には
+属さず（後述の理由）、機械的な数値強制（CI / pre-commit / Mechanical Check による自動 reject）も
+行いません。観点に該当する task を発見した場合、Architect は当該 task の分割または最上位昇格を
+**検討** し、判断結果（分割するか据え置くか）を `design.md` / `tasks.md` に反映します。
+
+### 背景: 層対称分割の落とし穴
+
+frontend / UI / テストが重い責務は、backend / pure logic と比べて **turn コスト密度が高い**
+（描画・状態・スタイル・スナップショット・visual regression 等のコンテキストを並行で抱える
+ため）。「層ごとに対称に分割する」だけで安心していると、frontend 側のタスクだけが
+`error_max_turns` を踏み抜く事故が発生します（例: 「API クライアント lib(+test) + 複数
+component(+test)」を 1 タスクにまとめた事例）。
+
+このため、Architect 自己レビュー時には **turn コスト密度を意識した分割** に視点を切り替え、
+以下のシグナルで過大 task を点検することを推奨します。
+
+### 検出シグナル
+
+以下のシグナルのいずれかに該当する task は、過大 task の可能性を **点検対象** とします
+（必ず分割せよという意味ではなく、判断レビューの俎上に乗せるための観点列挙）:
+
+1. **異種責務の同居**: 1 つのタスクに「API クライアント lib(+test)」「複数 component(+test)」
+   「状態管理 / Store(+test)」「スタイル / theme 変更」等の **異種責務** が混在していないか。
+   同居していれば責務単位での分割を検討する
+2. **兄弟比突出**: 同階層の兄弟タスクと比較して、当該タスクの **詳細項目数** または
+   **想定新規ファイル数** が突出していないか。兄弟比の倍率や項目数の絶対値は **目安** であり
+   厳密な閾値は定めない（Open Question (b) の通り、定量強制はしない）
+3. **新規ファイル件数の目安**: 1 タスクで新規追加するファイル数が多い場合（**目安として 3 件
+   以上**）、分割を検討する。なお 3 件はあくまで **目安** であり、ファイル粒度（小ユーティリティの
+   集合体か / 大規模 component 1 件か）で実コストは大きく異なるため、絶対閾値としては運用しない
+4. **重い子タスクの同居**: 重い子タスク（`1.1` / `1.2` …）が同一親の下に複数同居していないか。
+   同居している場合、子を親から切り出して **最上位 task（`2` / `3` …）への昇格** を検討する
+   （子は独立 commit 単位として消化されるため、昇格させた方が turn 予算管理が容易）
+5. **turn コスト密度差**: frontend / UI / テスト重責務は backend より turn コスト密度が高い。
+   層対称分割（frontend 1 タスク + backend 1 タスク等）ではなく、**turn コスト密度を意識した
+   分割**（frontend を細かく刻み、backend を統合する等）が望ましい場面がある
+
+### 是正方針: 責務不変の粒度分割
+
+過大 task を検出した場合の是正は、**`design.md` の責務・コンポーネント構成を変えず、tasks の
+切り方のみを調整する** ことを基本とします（責務不変の粒度分割）。具体的には:
+
+- 異種責務同居タスクを **責務単位の独立タスク** に分割する（例: 「API lib + UI」 → 「API lib」
+  と「UI」を別タスクに）
+- 重い子タスクを **最上位 task に昇格** させる（親から切り出して `2` / `3` … として独立 commit
+  単位にする）
+- 兄弟比が突出しているタスクを **複数タスクに分解** する（責務単位 / ファイル単位の自然な
+  境界で分ける）
+
+`design.md` 側の責務再設計が必要と判断される場合のみ、judgment review に戻して再検討します
+（観点違反を理由に design 側の責務を強制的に書き換える運用は採用しない）。
+
+### Mechanical Checks 節に含めない理由
+
+本観点を **Mechanical Checks に含めない** のは以下の理由です（Mechanical Checks は機械的に
+判定可能な項目に限定するため）:
+
+- タスクごとの turn 消費量は実装難度・既存コードベースの状態・テスト規模に依存し、設計段階で
+  正確な事前見積もりが難しい
+- ファイル数 / 兄弟比などのシグナルは **必要条件にも十分条件にもならない**（小ファイル 5 件 <
+  大ファイル 1 件のケースが普通にある）。数値強制すると false-positive が頻発する
+- `DEV_MAX_TURNS` 既定値（60）は将来変更され得る。機械 enforcement に紐付けると数値追従コストが
+  発生する
+- 推奨どまりにすることで Architect / 人間設計者が判断材料として活用しつつ、reject 判定の自動化は
+  既存 Mechanical Checks（Requirements traceability / File Structure Plan 充填 / orphan component /
+  Budget overflow / checkbox enforcement / verify block well-formed）に集約できる
+
+### 既存規約との関係
+
+- [`tasks-generation.md`](./tasks-generation.md) の「turn 予算ガイドライン（per-task Implementer
+  ループ運用時の粒度指針）」節（#289 で追加）と **役割分担** します:
+  - `tasks-generation.md` 側 = **タスク生成段階** の粒度指針（fresh session 仕様 / 粒度指針 /
+    強度の項）
+  - 本節 = **Architect 自己レビュー段階** の検出観点（5 シグナル / 是正方針）
+- 既存「レビュー・ループ」節の **最大 2 パス** 規約および `/goal` 自動ループ運用節は変更しません
+  （本観点は判断レビュー側の観点追加であり、ループ手順自体は変えない）
+- Mechanical Checks 節（Requirements traceability / File Structure Plan 充填 / orphan component /
+  Budget overflow / checkbox enforcement / verify block well-formed）の判定基準は変更しません
+- 既に main に merge 済みの spec の `design.md` / `tasks.md` に対する **遡及的な違反検出は
+  要求しません**（retrofit は本観点のスコープ外）
+
+### 適用タイミング
+
+Architect は `tasks.md` ドラフトの確定直前、判断レビュー（要件カバレッジ / アーキテクチャ準備 /
+実行可能性）を通過し、Mechanical Checks（Budget overflow check など）が pass した後の段階で
+本観点を点検することを推奨します。本観点に該当する task を発見した場合は、上記「是正方針」に
+従って tasks の切り方を調整してから確定します。
+
 ## Mechanical Checks（自動確認項目）
 
 判断レビューの前に、機械的に確認します:

--- a/repo-template/.claude/rules/tasks-generation.md
+++ b/repo-template/.claude/rules/tasks-generation.md
@@ -151,6 +151,16 @@ fresh な Claude session で Implementer が起動され、各タスクの turn 
 > 是正で対処することが推奨される（詳細な対応優先順は README「`per-task-implementer-failed` /
 > `error_max_turns` 対応」節を参照）。
 
+### Architect 自己レビュー時の検出観点との相互参照（#292）
+
+本節（タスク生成段階の粒度指針）と対になる **Architect 自己レビュー段階の検出観点** は、
+[`design-review-gate.md`](./design-review-gate.md) の「Task turn 予算 sanity check（過大 task
+検出）」節を参照してください。同節では本節の粒度指針を踏まえた上で、`tasks.md` 確定直前に
+点検すべき 5 つの検出シグナル（異種責務同居 / 兄弟比突出 / 新規ファイル件数の目安 / 重い子タスク
+同居 / turn コスト密度差）と是正方針（責務不変の粒度分割）を観点として列挙しています。生成
+（本節）と自己レビュー検出（`design-review-gate.md` 側）の双方を参照することで、過大 task の
+発生確率を運用前に下げられます。
+
 ## 構造化 verify ブロック（stage-a-verify gate の input 契約）
 
 stage-a-verify gate (#125) は Stage A（Developer 実装）完了直前に、`tasks.md` 中の


### PR DESCRIPTION
## 概要

Architect が `tasks.md` 確定直前の自己レビューで「Task turn 予算 sanity check（過大 task 検出）」を
観点として参照できるよう、`design-review-gate.md` に専用節を追加した。
あわせて `tasks-generation.md` の「turn 予算ガイドライン」節末尾に相互参照サブ節を追記し、
生成段階（tasks-generation.md）と自己レビュー段階（design-review-gate.md）の間で双方向リンクを確立した。
root と `repo-template/` の両系統に byte 一致で反映し、`diff -r` clean を確認済み。

## 対応 Issue

Closes #292

## 関連 PR

なし（設計 PR は走っていない。design-less impl）

## 実装内容

- (Req 1.1 / 1.5) `design-review-gate.md` の「実行可能性レビュー」直後・「Mechanical Checks」手前に独立節「Task turn 予算 sanity check（過大 task 検出）」を追加（判断レビュー側）
- (Req 2.1〜2.5) 5 つの検出シグナル（異種責務同居 / 兄弟比突出 / 新規ファイル件数目安 / 重い子タスク同居 / turn コスト密度差）を列挙
- (Req 3.1〜3.4) 強度を「推奨（指針）レベル」と明示、Mechanical Checks 節への追加は行わず、数値は「目安」として緩める
- (Req 1.2 / 6.3) `tasks-generation.md` 「turn 予算ガイドライン」節末尾に「Architect 自己レビュー時の検出観点との相互参照（#292）」サブ節を追加し双方向リンクを設置
- (Req 4.1〜4.4) `repo-template/.claude/rules/` の両ファイルに byte 一致で反映（`diff -r` exit 0 確認済）
- (Req 3.5 / NFR 3.1) `local-watcher/` / `.claude/agents/` への変更なし。insertions のみ、deletions = 0

## 受入基準チェック

- [x] Req 1.1: `design-review-gate.md` に新節が存在する
- [x] Req 1.2: `tasks-generation.md` からの相互参照あり
- [x] Req 1.3: deletions=0。既存 Mechanical Checks 節本文は無変更
- [x] Req 1.4: 「最大 2 パス」/ `/goal` 自動ループ節は無変更
- [x] Req 2.1〜2.5: 検出シグナル 5 件が新節に列挙済み
- [x] Req 3.1〜3.3: 推奨レベル明示・Mechanical Checks 外・数値は目安
- [x] Req 4.3: `diff -r .claude/rules repo-template/.claude/rules` → exit 0
- [x] Req 5.1〜5.5: 既存判定基準・traceability・レビューループ手順は無変更

## テスト結果

```
$ diff -r .claude/rules repo-template/.claude/rules
（出力なし / exit 0）

git diff --stat .claude/rules repo-template/.claude/rules:
4 files changed, 212 insertions(+), 0 deletions(-)

変更ファイル:
  .claude/rules/design-review-gate.md               +96 行
  .claude/rules/tasks-generation.md                 +10 行
  repo-template/.claude/rules/design-review-gate.md +96 行
  repo-template/.claude/rules/tasks-generation.md   +10 行
```

## 実装上の判断

- 新節の配置位置: 「実行可能性レビュー」直後・「Mechanical Checks」手前（判断レビュー側）を選択（Req 1.5 に対応）。別案は「Mechanical Checks 後」だが、機械的チェックではなく Architect の判断材料として参照させる趣旨で現配置を採用
- 検出シグナル #3 の「目安として 3 件以上」は requirements.md Req 2.3 の明示指定に基づき採用。「**目安**であり絶対閾値として運用しない」と緩める文言を併記
- ab-extweb 等の特定 repo 事例は汎用 OSS テンプレートとしての観点から本文に含めず、汎用的な例示（「API クライアント lib + 複数 component」）に留めた（requirements.md Out of Scope と整合）

## 確認事項 / レビュワーへの依頼

- Reviewer の独立レビュー結果は `docs/specs/292-improvement-rules-design-tasks-task-turn/review-notes.md` を参照（RESULT: approve）
- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後に検証済み）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #292 のコメントを参照してください。
