### PR TITLE
feat(#294): PreToolUse guard hook で base/force push を機械 deny（opt-in 初版 G0/G1/G2）

### DIFF
--- a/README.md
+++ b/README.md
@@ -5254,6 +5254,179 @@ cd ~/.idd-claude && git pull && ./install.sh --local
 
 ---
 
+## Guard Hook (PreToolUse) opt-in (#294)
+
+idd-claude の watcher が起動する Claude Code エージェント（Triage / PM / Architect / Developer
+/ Reviewer / Iteration / Security Review 等）に対し、Claude Code の `PreToolUse` フック機構を
+介して **base ブランチ宛 push**・**無条件 force push**・**guard install dir の自己改変** を
+機械的に deny する初版です（G0 + G1 + G2 同一初版）。違反を事後 Reviewer ループで検出する
+従来パターン（1 違反 = Developer + Reviewer 1 サイクル分の turn 浪費）を、実行前点で潰します。
+
+> **注**: 本機能は **user-scope 専用配布** の初版です（`~/.idd-claude/hooks/` 等）。
+> `repo-template/` 経由で consumer repo に配布する適用は本 Issue では扱わず、**後続の別 Issue
+> として起票が必要**です（Req 6.4 / 人間 Decision 2 の承認条件）。下記「Migration Note」
+> 節を参照。
+
+### 既定値と opt-in 制
+
+本機能は **既定 OFF** です（`IDD_CLAUDE_HOOKS_ENABLED` 環境変数の値が文字列 `true` と
+**完全一致** したときのみ有効。未設定 / 空文字 / `false` / `True` / `1` 等はすべて OFF として
+解釈される typo 安全側設計）。OFF のときは watcher が claude CLI を起動するときの引数列・
+環境変数集合は本機能導入前と **完全に同一** で、既存 cron 登録文字列・既存 env var 名・
+既存ラベル名・既存 exit code 意味は不変です（Req 1.1〜1.3 / NFR 1.1）。
+
+### opt-in 手順
+
+1. **hook 一式を user-scope に配置**: `install.sh --local` を再実行する
+   （`local-watcher/hooks/idd-guard.sh` / `idd-guard-settings.json` / `README.md` の 3 ファイルが
+   `$HOME/.idd-claude/hooks/` 配下に配置され、`settings.json` の `__IDD_HOOK_PATH__`
+   placeholder は絶対パスに sed 置換される）
+
+   ```bash
+   cd ~/.idd-claude && git pull && ./install.sh --local
+   ```
+
+2. **`claude --version` を確認**: `2.1.167` 以上であること（PoC 検証バージョン。
+   `IDD_CLAUDE_HOOKS_MIN_VERSION` env で override 可能）
+
+   ```bash
+   claude --version
+   ```
+
+   不足する場合は `npm install -g @anthropic-ai/claude-code` 等で更新するか、`IDD_CLAUDE_HOOKS_MIN_VERSION`
+   を緩めてください。
+
+3. **cron / launchd の env に `IDD_CLAUDE_HOOKS_ENABLED=true` を追加**
+
+   cron 例:
+
+   ```cron
+   */2 * * * * REPO=owner/your-repo REPO_DIR=$HOME/work/your-repo \
+     IDD_CLAUDE_HOOKS_ENABLED=true \
+     $HOME/bin/issue-watcher.sh >> $HOME/.issue-watcher/cron.log 2>&1
+   ```
+
+   launchd の場合は plist の `EnvironmentVariables` に `IDD_CLAUDE_HOOKS_ENABLED=true` を追記。
+
+4. 次サイクルから guard 有効。違反検知時は claude 側に block reason が返り、エージェントが
+   別経路を取ります。
+
+### 環境変数一覧
+
+| Var | スコープ | 既定 | 上書き方法 | 用途 |
+|---|---|---|---|---|
+| `IDD_CLAUDE_HOOKS_ENABLED` | watcher 全体 | （未設定 = 無効） | env / cron / launchd の env に `true` を **lowercase 厳密一致** で記述 | opt-in gate。`True` / `1` / `yes` / typo はすべて無効として解釈される（安全側） |
+| `IDD_CLAUDE_HOOKS_DIR` | watcher / install / hook | `$HOME/.idd-claude/hooks` | env で絶対パス指定 | guard hook の install dir。watcher・hook・install.sh が同名 env を共有し、3 経路で一貫した dir 解決を行う |
+| `IDD_CLAUDE_HOOKS_MIN_VERSION` | watcher（preflight） | `2.1.167`（PoC 検証バージョン） | env で semver 文字列指定 | preflight が `claude --version` と比較する最低 version。下回ると exit 11 で fail-closed |
+| `IDD_HOOK_BASE_BRANCH` | hook（内部用） | `$BASE_BRANCH` の値（watcher が export） | 通常変更不要。watcher が preflight 通過後に 1 度だけ `export` する | G1 で deny 対象とする base ブランチ名。claude プロセス → PreToolUse hook プロセスへ継承される |
+| `IDD_HOOK_LOG` | hook（任意） | （未設定 = no-op） | env で絶対パス指定 | 設定時、hook が判定結果を 1 行 append（運用観察用） |
+
+### fail-closed 挙動と exit code
+
+`IDD_CLAUDE_HOOKS_ENABLED=true` の状態で watcher が起動準備するとき、watcher は claude CLI 起動
+**前** に preflight を実行します。preflight に失敗した場合は **黙って fallback せず非ゼロ
+exit** で watcher を停止します（Req 5.5 / NFR 1.1 の silent fallback 禁止）。
+
+| Exit Code | 理由 | 復旧手順 |
+|---|---|---|
+| **11** | claude CLI version が `IDD_CLAUDE_HOOKS_MIN_VERSION` 未満 | Claude Code を更新（`npm install -g @anthropic-ai/claude-code`）、または `IDD_CLAUDE_HOOKS_MIN_VERSION` を env で緩める |
+| **12** | hook install dir が不完全（`idd-guard.sh` / `idd-guard-settings.json` のいずれかが不在 / 実行不可） | `install.sh --local` を再実行して user-scope 配置を完成させる |
+| **13** | smoke test 失敗（hook が固定 fixture JSON に対して期待する allow を返さない） | stderr に hook stdout/stderr 末尾が添えられる。hook script / settings.json の改変を疑い、`install.sh --local` を再実行 |
+
+> 既存 exit code（`run_per_task_implementer` の 0 / 1 / 99 等）の意味は本機能導入により
+> **変更しません**（Req 1.3）。新規 exit code 11 / 12 / 13 は guard hook preflight 専用です。
+
+### deny 時のエージェント側挙動
+
+guard が deny したとき、hook は decision JSON `{"decision":"block","reason":"..."}` を返し、
+Claude Code は当該 Bash / Edit / Write / NotebookEdit ツール呼び出しを実行前にブロックします。
+エージェントは block reason をフィードバックとして受け取り、別経路（例: `git push --force-with-lease`
+への切替、別ブランチへの push）を試行します。watcher 自身は停止せず、当該サイクルは継続
+します。
+
+deny reason の prefix（運用観察用）:
+
+- `base branch push denied: ...` — G1（base ブランチ宛 push）
+- `unconditional force push denied: use --force-with-lease` — G2（無条件 force push）
+- `guard install dir self-mutation denied: ...` — G0（install dir 自己改変）
+
+### 既知の限界（NFR 3.1〜3.4）
+
+本初版は **literal 解析ベースの best-effort 機械 deny** であり、以下の限界があります。これらは
+意図的なスコープ外として PoC / 設計段階で明示されており、後続 Issue での拡張対象です。
+
+- **top-level Bash 文字列のみ解析する（NFR 3.1）**: `sh -c "git push ..."` / `$(git push ...)` /
+  シェル関数 / wrapper script 内部の push は **literal 解析では捕捉できません**。
+  エージェントが意図的に隠す経路を作ると bypass できる点を理解してください
+- **bare `git push`（引数なし）で現ブランチが偶然 base と一致するケースは literal 解析不可
+  （NFR 3.2）**: `git push` に refspec が無い場合、push 先 ref は実行時の current branch /
+  `branch.<name>.merge` 設定で動的に決まるため、hook 側では確定的に判定できません。
+  運用上は watcher が `claude/issue-*` ブランチで作業する前提のため、通常は base が
+  current branch にならない構造で回避できます
+- **G0 の Bash 経由 mutation 検出は best-effort（NFR 3.3）**: `rm` / `mv` / `sed -i` / `chmod` /
+  リダイレクト / `tee` 等のキーワードと install dir リテラルの両方を含む場合のみ deny
+  します。`bash -c "$(echo r m /path)"` のような難読化や、`cd $hooks_dir; rm idd-guard.sh`
+  のような複合コマンドは全件捕捉を保証しません。Edit / Write / NotebookEdit 経由の自己改変は
+  path 一致で robust に deny されます
+- **本初版は role/spec guard / secrets guard / `bypassPermissions` 廃止を含みません（NFR 3.4）**:
+  Reviewer の read-only 強制、`.env` / `*.pem` 等の staged path ブロック、`--permission-mode
+  bypassPermissions` の廃止と全 tool allowlist 化は **後続 Issue で別途承認・実装**されます。
+  本 Issue は guard の最初の機械化レイヤを user-scope 専用で先行検証することが目的です
+
+### ロールバック（即時 opt-out）
+
+`IDD_CLAUDE_HOOKS_ENABLED` を env から外す（または `true` 以外の値に変更する）だけで、
+次サイクルから本機能は完全に無効化されます。hook ファイル削除は **不要** です（残置しても
+opt-out 時は一切参照されない）。
+
+cron 例（opt-out 戻し）:
+
+```cron
+*/2 * * * * REPO=owner/your-repo REPO_DIR=$HOME/work/your-repo \
+  $HOME/bin/issue-watcher.sh >> $HOME/.issue-watcher/cron.log 2>&1
+```
+
+env var を 1 行外すだけで本機能導入前と user-observable に同一の挙動に戻ります（Req 1.1〜1.3
+/ NFR 1.1）。
+
+### Migration Note（consumer repo への配布は後続 Issue）
+
+**本初版は user-scope 専用配布です**（`$HOME/.idd-claude/hooks/` 配下のみ。
+`repo-template/.claude/` / consumer repo の `.claude/` 配下には一切ファイルを追加しません /
+Req 6.2 / 6.3 / NFR 4.1 / 4.2）。consumer repo の watcher 配下で hook を有効化する適用
+（`repo-template/` 経由の自動配布 / consumer 側 settings 合成等）は **後続の別 Issue として
+独立に承認・起票される前提** です（Req 6.4 / 人間 Decision 2 Option A の承認条件として明示）。
+
+self-hosting 環境（idd-claude 自身の watcher 配下）では本節の opt-in 手順で本機能を有効化
+できますが、**他リポジトリで idd-claude を install している運用者は本機能を有効化しても
+当該 consumer repo のエージェントには適用されません**（user-scope の hook は idd-claude
+self-hosting の watcher 経由でのみ参照される）。後続 Issue 承認後に consumer 配布経路が
+整備されるまで待つか、user-scope での先行検証にとどめてください。
+
+### 詳細ドキュメント
+
+- 配置先・env var 契約・検査範囲の短文: `local-watcher/hooks/README.md`（hook 本体と同梱）
+- hook script 本体: `local-watcher/hooks/idd-guard.sh`
+- settings テンプレ: `local-watcher/hooks/idd-guard-settings.json`
+- watcher 配線モジュール: `local-watcher/bin/modules/guard-hook.sh`
+- 設計詳細: `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/design.md`
+- 29 件テストマトリクス: `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/`
+- 起源: [Issue #294](https://github.com/hitoshiichikawa/idd-claude/issues/294)
+
+### ⚠️ merge 後の再配置が必要
+
+他の watcher 機能と同様、本機能の PR を merge しただけでは `$HOME/bin/issue-watcher.sh` /
+`$HOME/.idd-claude/hooks/` 配下は古いままです。反映するには:
+
+```bash
+cd ~/.idd-claude && git pull && ./install.sh --local
+```
+
+`install.sh --local` 再実行で watcher 本体・modules・hook 一式が user-scope に同期されます
+（既存配置は `.bak` 退避や cmp ベースの SKIP 判定で保護されるため冪等）。
+
+---
+
 ## サブエージェント構成
 
 | 役割 | 目的 | 主なツール | 推奨モデル | 起動条件 |

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
@@ -1,0 +1,20 @@
+# Implementation Notes — #294 PreToolUse Guard Hook (base 初版)
+
+## Implementation Notes
+
+### Task 1
+
+- **採用方針**: design.md の指示通り、`idd-guard.sh` は jq で stdin JSON を読み `tool_name`
+  で分岐し、Bash の token 分割（top-level のみ）→ git global option skip → push 引数解析の
+  順で G1/G2 を判定する純 bash 実装。G0 は Edit/Write/NotebookEdit を path prefix 一致で
+  robust に、Bash を mutation keyword + install dir literal の両方一致で best-effort に deny。
+- **重要判断**:
+  - decision JSON は PoC 準拠の `{"decision":"block","reason":"..."}` を採用。`reason` は
+    `jq -n --arg` でエスケープ安全に組み立て、jq 不在時のみ手書きフォールバック。
+  - shellcheck SC2088/SC2016 は意図的な `~` / `$HOME` literal substring 検出のため、行単位の
+    `# shellcheck disable=` 注釈で抑止（プロジェクト `.shellcheckrc` を汚さない方針）。
+  - `--force-with-lease` と `-f` が同時指定された場合は無条件 force と同等扱いで deny
+    （design G2 ロジック 2 項）。fixture/driver は Task 2 で形式化するが、24 件の手動
+    smoke ですべて期待通りの decision/reason を確認。
+- **残存課題**: fixture 29 件と run-tests.sh の整備は Task 2 のスコープ。Task 3 以降の watcher
+  module 統合と install.sh 配置は本 commit 範囲外。

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
@@ -172,3 +172,72 @@
     経路を guard hook 配下に置く場合は env テンプレートを `claude -p ... --settings <abs>`
     に拡張する **別タスク**（Task 5 の install 時に `SECURITY_REVIEW_CLAUDE_CMD` の default
     値を opt-in 時のみ書き換える等）が必要。Architect / 人間の判断を仰ぐ
+
+### Task 5
+
+- **採用方針**: design.md「Install Path Mapping」節の指示通り、`INSTALL_LOCAL` ブロックの
+  modules 配置直後に新規 helper `install_guard_hooks` を呼び出して `local-watcher/hooks/` 配下の
+  3 ファイル（`idd-guard.sh` / `idd-guard-settings.json` / `README.md`）を user-scope に配置する。
+  既定 dest は `$HOME/.idd-claude/hooks`、`IDD_CLAUDE_HOOKS_DIR` env で override 可能（hook 本体
+  `idd-guard.sh` / watcher module `guard-hook.sh` と同名 env を共有することで preflight・hook
+  起動時の dir 解決が一貫する）。配置後の hint メッセージは cron/launchd の platform 分岐外に
+  置き、opt-in 手順・fail-closed 挙動・consumer 配布が別 Issue 予定である旨を 1 ブロックで提示。
+- **重要判断**:
+  - **`idd-guard-settings.json` の placeholder 置換は専用 helper を新設**: 既存
+    `copy_template_file` は中身を書き換えない設計のため、`__IDD_HOOK_PATH__` 置換と冪等性を
+    両立できない。`copy_hook_settings_with_substitution` を新設し、`mktemp` 上に sed で置換済み
+    内容を書き出してから dest と cmp することで「既配置 dest は既に置換済み」状態でも正しく
+    SKIP 判定する。これにより再 install 時に毎回 OVERWRITE が走る事故を防ぐ（手動テストで
+    SKIP `(identical to substituted template)` を確認）。
+  - **sed 区切り文字**: 置換対象が絶対パス（`/` を含む）のため `sed` 区切りは `#` を採用。
+    `IDD_CLAUDE_HOOKS_DIR` が `#` を含む奇異な値で破綻するが、ファイルシステム実用上の制約
+    から外れるため許容範囲とした。
+  - **`resolve_hooks_install_dir` を install.sh 側にも持つ**: hook 本体 / watcher module と
+    同じ「末尾スラッシュ除去 + env override」契約を install.sh 内に重複実装する形を採用した。
+    install.sh はモジュール source の枠外で動くため、`source` で `modules/guard-hook.sh` を
+    取り込む経路を作ると install 時の依存が複雑になる。3 行程度の重複なら明示重複の方が
+    install.sh の自己完結性を保ちやすい。
+  - **hint 配置位置**: cron / launchd の platform-specific HEREDOC の **直後**（共通の
+    `if/else fi` 終端後）に 1 ブロックを置く形を採用。両 platform で同じ案内を出す方が
+    運用者の認知負荷が低い。`local` は関数外では使えないため `hooks_dest_for_hint` 変数は
+    script-level で代入する形にした。
+  - **hint 文字列内の `$HOME` / `\$HOME` の扱い**: `HOOKS_HINT` は unquoted HEREDOC のため
+    expand される。cron 行例で `\$HOME/work/...` のように展開させたくない箇所はバックスラッシュ
+    エスケープし、`$hooks_dest_for_hint` のように expand させる箇所だけ素のまま記述した。
+  - **shellcheck SC2034 等の抑止不要**: 全関数で適切に変数を使い切る形にしたため警告ゼロ。
+    既存 `copy_template_file` パターンを踏襲したことで lint 上の特殊対応も不要だった。
+- **検証**:
+  - `shellcheck install.sh` 警告ゼロ
+  - `bash -n install.sh` 構文エラーなし
+  - dry-run smoke: tmp HOME で `install.sh --dry-run --local` → 3 件すべて `[DRY-RUN] NEW`
+    で出現、`(substitute __IDD_HOOK_PATH__ → /abs/path)` note 付き
+  - 実 install smoke: tmp HOME で `install.sh --local` → 3 件配置 + jq で
+    `.hooks.PreToolUse[0].hooks[0].command` が絶対パスに置換されていることを確認
+  - 冪等性: 同じ tmp HOME で 2 回目 `install.sh --local` → 3 件すべて `SKIP`
+    （`identical to template` / `identical to substituted template`）
+  - `IDD_CLAUDE_HOOKS_DIR=/tmp/.../custom-hooks` override smoke → override 先に配置され、
+    settings.json の command も override 先の絶対パスに置換される
+  - `bash docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh`
+    で 29/29 green（hook 本体に regression なし）
+  - `repo-template/` に新規追加なし（`git diff --stat main..HEAD -- repo-template/` 空、
+    `find repo-template -name '*guard*'` 0 件、Req 6.2 / 6.3 / NFR 4.1 を満たす）
+- **残存課題**:
+  - **README 整備は Task 6 のスコープ**: 本 Task の hint は install 直後の最小限案内であり、
+    詳細（env var 一覧 / exit code 11/12/13 の意味 / 既知の限界 NFR 3.1〜3.4 / ロールバック手順）
+    は README.md の新節「Guard Hook (PreToolUse) opt-in」で網羅する
+  - **統合スモークは Task 7 のスコープ**: 本 Task の手動 smoke は dry-run / real install /
+    re-run idempotency / IDD_CLAUDE_HOOKS_DIR override の 4 系統。`IDD_CLAUDE_HOOKS_ENABLED=`
+    未設定で watcher 起動して既存挙動と diff なしを確認するのは Task 7 の責務
+- **Requirements カバレッジ** (Task 5 _Requirements:_ より):
+  - Req 1.4 (sudo 要求を追加しない): 既存 sudo 警告ロジックには触れず、新規 helper も
+    `cp` / `mkdir -p` / `chmod +x` / `sed` のみで完結。sudo を一切要求しない
+  - Req 6.1 (user-scope ディレクトリ配置): `$HOME/.idd-claude/hooks` 既定で配置、`install.sh
+    --local` の `INSTALL_LOCAL` ブロック内のみで実行（`INSTALL_REPO` ブロックには配置しない）
+  - Req 6.2 (`repo-template/` 配下に追加しない): `LOCAL_WATCHER_DIR/hooks/` のみを source とし、
+    `REPO_TEMPLATE_DIR` 配下には一切触れない
+  - Req 6.3 (consumer repo `.claude/` 配下に配布しない): `INSTALL_REPO` ブロックの
+    `copy_template_file` / `copy_agents_rules` シーケンスには本 helper を呼び出さない
+  - NFR 1.2 (sudo 要求なし): 上記 Req 1.4 と同じ実装で担保
+  - NFR 2.1 (shellcheck 警告ゼロ): `shellcheck install.sh` 警告ゼロを確認
+  - NFR 4.1 (二重管理規約に新規追加なし): `repo-template/.claude/` には一切ファイルを追加しない
+  - NFR 4.2 (consumer repo `.claude/` 配下に新規配置なし): 同上

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
@@ -241,3 +241,81 @@
   - NFR 2.1 (shellcheck 警告ゼロ): `shellcheck install.sh` 警告ゼロを確認
   - NFR 4.1 (二重管理規約に新規追加なし): `repo-template/.claude/` には一切ファイルを追加しない
   - NFR 4.2 (consumer repo `.claude/` 配下に新規配置なし): 同上
+
+### Task 6
+
+- **採用方針**: `README.md` の **Feature Flag Protocol 節直後** に新節「Guard Hook (PreToolUse)
+  opt-in (#294)」を追加（既存「---」区切りで Feature Flag Protocol と「サブエージェント構成」
+  の中間に挿入）。tasks.md L84-99 の指示通り、(a) opt-in 手順 3 step / (b) env var 5 種の
+  一覧表 / (c) fail-closed 挙動 + exit code 11/12/13 表 / (d) 既知の限界（NFR 3.1〜3.4 全件）
+  / (e) ロールバック手順 / (f) Migration Note（consumer 配布が後続 Issue で別途承認・起票
+  必要 = Req 6.4 / 人間 Decision 2 Option A 承認条件）/ (g) 詳細ドキュメントへの相互参照 /
+  (h) merge 後の `install.sh --local` 再実行案内 の 8 サブ節で構成。
+- **重要判断**:
+  - **配置位置**: 「オプション機能一覧」表（L1273〜 opt-in 表）への 1 行追加だけでは
+    Req 6.4 / NFR 3.x の網羅文書化要件を満たせないため、独立した h2 節として配置。
+    Feature Flag Protocol 直後を採用した理由は (1) 両方とも opt-in 制で対比理解が容易 /
+    (2) その直後の「サブエージェント構成」が agent 詳細セクション群の始点で、運用機能
+    セクション群（Merge Queue 〜 Feature Flag Protocol）の末尾に並べると一貫性が出る
+  - **「オプション機能一覧」表への新規行は追加しない**: 既存表は env-var-based opt-in
+    （`MERGE_QUEUE_ENABLED` 等）が中心で、本機能の制御変数 `IDD_CLAUDE_HOOKS_ENABLED` は
+    同列に並ぶ性質を持つが、本 Task の指示範囲は「新節を追加」のみであり、表行追加は
+    spec 範囲外。表への追加は consumer 配布 Issue で本機能が「user-scope only の限界」を
+    解消した時点で改めて整理する方が混乱を避けられる（現状の表は user-scope only であることを
+    表現する列を持たないため、誤解を招く可能性がある）。確認事項として後述
+  - **env var 5 種の表**: design.md「Env Var Contract」表（`IDD_CLAUDE_HOOKS_ENABLED` /
+    `IDD_CLAUDE_HOOKS_DIR` / `IDD_CLAUDE_HOOKS_MIN_VERSION` / `IDD_HOOK_BASE_BRANCH` /
+    `IDD_HOOK_LOG`）と Owner / Default / Override 方法を 1:1 で対応させた。typo 安全側
+    （`True` / `1` / `yes` は無効）と user-scope 既定値（`$HOME/.idd-claude/hooks`）を
+    明示することで運用者が install.sh 再実行のタイミングを判断しやすくしている
+  - **exit code 11/12/13 表**: design.md Error Handling 節の rc 表をそのまま流用しつつ、
+    各 rc に対応する「復旧手順」列を運用者向けに 1 行で追加（11=Claude 更新 or env 緩める /
+    12=`install.sh --local` 再実行 / 13=hook 改変を疑い再 install）。既存 exit code（0/1/99）
+    との非干渉を明示する文も含めた（Req 1.3）
+  - **既知の限界 4 件**: NFR 3.1〜3.4 を 1:1 で箇条書き化。特に NFR 3.4 の「role/spec /
+    secrets guard / `bypassPermissions` 廃止は本初版に含まない」は、運用者が本機能を
+    導入後も既存 review ループは必要である旨を理解させるために強調表現で記述
+  - **Migration Note**: 「self-hosting 環境でのみ有効 / 他リポで idd-claude を install
+    している運用者は本機能を有効化しても当該 consumer repo のエージェントには適用されない」
+    旨を明確化（Req 6.4 / 6.2 / 6.3）。これにより consumer 配布 Issue が承認されるまでの
+    暫定期間における誤解を未然に防ぐ
+  - **言語方針**: 日本語ベース。env var 名 / コマンド名 / exit code 数値 / EARS keyword 等は
+    英語固定（CLAUDE.md「言語方針」と整合）。絵文字は `⚠️` 1 件のみ使用（既存
+    「⚠️ merge 後の再配置が必要」見出し慣習に倣う / Issue 趣旨に反しない）
+- **検証**:
+  - `bash docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh`
+    で **29/29 green**（hook 本体に regression なし。本 Task は README のみ変更）
+  - 真の h1 が 1 件のみ（`^# [^!#]` grep で line 1 の `# idd-claude` 以降は全て fenced
+    code block 内の bash comment）であること確認
+  - コードフェンス balance: `^```` のカウントが 258（偶数）で fence 開閉ペアが揃っていること確認
+  - 内部リンク健全性: 既存節を参照する `(#feature-flag-protocol-23-phase-4)` 形式の anchor
+    は本 Task では新規追加せず、既存節への明示的アンカーリンクは控えた（README 末尾の節は
+    位置変化なし）
+- **AC カバレッジ** (Task 6 _Requirements:_ より):
+  - Req 6.4 (consumer 配布の後続 Issue 必要性を明示): Migration Note 節で
+    「consumer 配布は後続 Issue で別途承認・起票される前提」を明文化
+  - NFR 1.3 (`IDD_CLAUDE_HOOKS_MIN_VERSION` を env で override 可能であることを明記):
+    env var 表で「上書き方法 = env で semver 文字列指定」を明示
+  - NFR 3.1 (top-level Bash 文字列のみ解析 / `sh -c` / `$(...)` / wrapper 内部は捕捉不能):
+    「既知の限界」1 項目目
+  - NFR 3.2 (bare `git push` で現ブランチが偶然 base と一致するケースは literal 解析不可):
+    「既知の限界」2 項目目
+  - NFR 3.3 (G0 の Bash 経由 mutation 検出は best-effort): 「既知の限界」3 項目目
+  - NFR 3.4 (本初版は role/spec / secrets guard / `bypassPermissions` 廃止を含まない):
+    「既知の限界」4 項目目
+- **残存課題**:
+  - **Task 7 (統合スモークテスト) は本 Task 外**: `install.sh --dry-run --local` の NEW 行確認、
+    使い捨て `$HOME` での実 install 検証、`IDD_CLAUDE_HOOKS_ENABLED=` 未設定での既存挙動
+    diff なし確認、`IDD_CLAUDE_HOOKS_ENABLED=true` + 偽 MIN_VERSION での exit 11 確認、
+    cron-like minimal PATH 依存解決確認は Task 7 のスコープ。本 Task は README 文書化のみ
+  - **consumer 配布 Issue の起票**: Req 6.4 の「人間 Decision 2 Option A 承認条件」として
+    consumer 配布の別 Issue 起票が必要だが、起票責務は PM / 人間運用者にあり Developer の
+    本 Task スコープ外（PR 本文の「確認事項」で別 Issue 起票が必要な旨を PjM が記載する想定）
+- **確認事項**:
+  - 「オプション機能一覧」表（L1273〜 opt-in 表）への新規行追加は本 Task では実施しなかった。
+    理由は (a) tasks.md L84-99 の指示は「新節を追加」のみで表行追加を含まない /
+    (b) 本機能は user-scope only の初版で、既存表は consumer repo 適用前提の env-var-based
+    opt-in を一覧化する性質を持つため、本機能を同列に並べると「user-scope only」という
+    限界が運用者に伝わりにくくなる可能性がある。consumer 配布 Issue が完了した時点で
+    「opt-in」表に正規行として追加する方が運用者の認知負荷が低い。PR 本文「確認事項」で
+    Architect / 人間判断を仰ぐことを推奨

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
@@ -100,3 +100,75 @@
     これは仕様通り（NFR 1.1 の silent fallback 禁止）だが、Task 5 完了までは watcher を
     `IDD_CLAUDE_HOOKS_ENABLED=true` で起動できない点を運用者に明示する必要がある（README は
     Task 6 で整備）
+
+### Task 4
+
+- **採用方針**: design.md / tasks.md の指示通り、`local-watcher/bin/issue-watcher.sh` を
+  以下の 4 点で編集して guard hook を配線:
+  1. Config ブロック（Debugger 設定直後）に guard hook 系 env var 4 種の default 宣言を追加
+     （`IDD_CLAUDE_HOOKS_ENABLED` 既定空 / `IDD_CLAUDE_HOOKS_DIR` 既定 `$HOME/.idd-claude/hooks`
+     / `IDD_CLAUDE_HOOKS_MIN_VERSION` 既定 `2.1.167` / `IDD_HOOK_LOG` 既定空）。
+     既存「デフォルト有効化フラグの値正規化」ループには **含めない**（opt-in 制 / 既定 false）
+  2. `REQUIRED_MODULES` 配列末尾に `guard-hook.sh` を追加
+  3. モジュール source 直後（TRIAGE_TEMPLATE 存在チェックの直前）に
+     `gh_is_enabled && { gh_preflight || exit $?; export IDD_HOOK_BASE_BRANCH="$BASE_BRANCH"; }`
+     相当の処理 + `gh_build_args` 呼び出しを追加
+  4. 全 11 箇所の `qa_run_claude_stage ... -- claude --print ...` 起動箇所
+     （PerTask-Impl / PerTask-Review / Debugger / Reviewer / StageA / StageA-prime-blocked /
+     StageA-redo / StageA-pp / StageC / Triage / design）の末尾、`>> "$LOG" 2>&1` リダイレクトの
+     直前に `"${CLAUDE_HOOK_ARGS[@]}" \` を 1 行挿入
+- **重要判断**:
+  - **env var 値正規化ループに加えない**: 既存ループは「`=false` 明示以外はすべて true 既定」の
+    9 種（MERGE_QUEUE_ENABLED 等）が対象で、本機能は逆方向（既定空 = opt-out、`=true` 明示のみ
+    opt-in）の opt-in 制。正規化に混ぜると `IDD_CLAUDE_HOOKS_ENABLED=` 未設定が `false` 文字列に
+    強制され gh_is_enabled の厳密 `true` 一致判定との整合は取れるが、design.md Env Var Contract
+    の「未設定 = 無効」表現と齟齬が出るため、Config 段階では `:-` 既定空のまま `gh_is_enabled` 側で
+    厳密判定する形を採用（Task 3 で確認した typo 安全側設計と整合）。
+  - **preflight + arg 構築の配置点**: TRIAGE_TEMPLATE 存在チェックの **直前**を採用した。
+    理由は (a) 必須モジュール source 完了直後で `gh_*` 関数が利用可能 / (b) `BASE_BRANCH` は既に
+    確定（108 行目で `:-main` 既定が適用済み）/ (c) `TRIAGE_TEMPLATE` 等の他テンプレ存在チェックが
+    失敗するよりも前に preflight を fail-closed させた方が運用者に対する原因切り分けが容易
+    （hook 設定不備と template 不備を別 exit code で分離可能）。
+  - **CLAUDE_HOOK_ARGS の注入位置**: 各 claude 起動オプションの **末尾**（リダイレクト直前）に
+    挿入。`--print` / `--model` / `--permission-mode` / `--max-turns` / `--output-format` /
+    `--verbose` の後で `>> "$LOG" 2>&1` の前。これにより既存オプションの解釈順序に影響を
+    与えず、Claude Code は `--settings <path>` を後勝ち優先で受け取る。10 箇所は `--verbose \`
+    の後に挿入、Triage の 1 箇所のみ `--verbose` を持たないため `--max-turns ...` の後に挿入。
+  - **Security Review (`SECURITY_REVIEW_CLAUDE_CMD`) は本 Task のスコープ外**: 同経路は
+    `bash -c` 経由で env テンプレート文字列を expand する構造で、`"${CLAUDE_HOOK_ARGS[@]}"` の
+    配列展開を直接埋め込めない。tasks.md 本文の「全 `claude --print "$prompt" ... --max-turns
+    ...` 起動箇所」の対象には含まれず、配線対象外として扱った（後述「確認事項」参照）。
+  - **opt-out 時の空配列展開 (`"${CLAUDE_HOOK_ARGS[@]}"`)**: `set -euo pipefail` 配下でも
+    bash 4.4+ で安全（CLAUDE.md bash 4+ 要求）。本機能未配置の環境では `gh_build_args` が呼ばれず
+    `CLAUDE_HOOK_ARGS` が undefined のままになる可能性を排除するため、`gh_is_enabled` が false
+    でも `gh_build_args` を **無条件で呼ぶ**設計とし、opt-out 時は明示的に空配列を作る
+    （design.md gh_build_args 契約と整合）。
+- **検証**:
+  - `shellcheck local-watcher/bin/issue-watcher.sh` 警告ゼロ
+  - `shellcheck local-watcher/bin/modules/guard-hook.sh` 警告ゼロ
+  - `bash -n local-watcher/bin/issue-watcher.sh` 構文エラーなし
+  - `bash docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh`
+    で 29/29 green（hook 本体に regression なし）
+  - `grep -nE 'CLAUDE_HOOK_ARGS\[@\]' local-watcher/bin/issue-watcher.sh` で 11 件の注入を
+    確認（コメント言及 2 件除く）。各サイトに対応する `qa_run_claude_stage` ラベル:
+    PerTask-Impl / PerTask-Review / Debugger / Reviewer / StageA / StageA-prime-blocked /
+    StageA-redo / StageA-pp / StageC / Triage / design
+  - inline smoke で `gh_build_args` の opt-out / opt-in / typo (`True`) を確認: opt-out=空配列 /
+    opt-in=`(--settings <abs>)` / typo=空配列（typo 安全側）
+- **残存課題**:
+  - **install.sh による hook 一式の user-scope 配置（Task 5）が未済**のため、本機能を
+    `IDD_CLAUDE_HOOKS_ENABLED=true` で実際に有効化すると preflight が rc=12（install dir
+    不完全）で fail-closed する。これは仕様通り（NFR 1.1 の silent fallback 禁止）。Task 5
+    完了後に opt-in 起動可能となる
+  - README 整備は Task 6 のスコープ
+- **確認事項**:
+  - `SECURITY_REVIEW_CLAUDE_CMD` 経路（`modules/security-review.sh:910` の
+    `bash -c "$cmd_template"` 実行）は env テンプレートに `--settings` を埋め込まないため、
+    本 Task の配線対象から外している。design.md 「Modified Files」節は「全 `claude --print
+    ...` 起動行に `"${CLAUDE_HOOK_ARGS[@]}"` を付与（既存 15+ 箇所）」と記述しているが、
+    実際の `qa_run_claude_stage ... -- claude` パターンは現状 11 箇所であり、Security Review
+    は別レイヤ（Skill tool 経由 + env テンプレ）。本 Task では設計指示の本旨である
+    「watcher が直接組み立てる `claude --print` 引数列」11 箇所を網羅した。Security Review
+    経路を guard hook 配下に置く場合は env テンプレートを `claude -p ... --settings <abs>`
+    に拡張する **別タスク**（Task 5 の install 時に `SECURITY_REVIEW_CLAUDE_CMD` の default
+    値を opt-in 時のみ書き換える等）が必要。Architect / 人間の判断を仰ぐ

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
@@ -18,3 +18,39 @@
     smoke ですべて期待通りの decision/reason を確認。
 - **残存課題**: fixture 29 件と run-tests.sh の整備は Task 2 のスコープ。Task 3 以降の watcher
   module 統合と install.sh 配置は本 commit 範囲外。
+
+### Task 2
+
+- **採用方針**: `test-fixtures/cases/*.json` に 29 件の PreToolUse JSON 入力を 1 ケース 1 ファイル
+  で配置（G0:5 / G1:6 / G2:5 / Allow:13）。`expected.tsv` を tab 区切り 3 列
+  (`case_file` / `verdict` / `reason_substring`) で宣言し、`run-tests.sh` が SCRIPT_DIR 起点で
+  相対解決して repo root の `local-watcher/hooks/idd-guard.sh` を `bash` 経由で起動する純 bash
+  ドライバ。
+- **重要判断**:
+  - hook の decision JSON は jq で `.decision` / `.reason` を抽出して verdict を再構成。
+    allow は空 stdout を `actual_verdict=allow` に正規化することで「decision フィールド不在 =
+    allow」契約と整合させた。
+  - deny ケースの reason は **substring 一致** で突合（hook 側のメッセージ書式変更に
+    耐性を持たせるため、`base branch push denied` / `unconditional force push denied` /
+    `guard install dir self-mutation denied` の 3 つの安定 prefix のみを宣言）。
+  - 環境変数 `IDD_HOOK_BASE_BRANCH=main` / `IDD_CLAUDE_HOOKS_DIR=$HOME/.idd-claude/hooks` は
+    driver 内で既定値として export し、外部からの override も受け付ける（既存契約と整合）。
+  - G0 fixture の `file_path` / `notebook_path` には `~/.idd-claude/hooks/...` リテラルを
+    使用。hook 側の `normalize_path` が `~/` → `$HOME/` 展開して install dir prefix と一致する
+    ため、`HOME` 環境差異に依存せず portable に動作する。
+  - run-tests.sh は exit code を 0/1/2 で分離（0=29/29 green / 1=mismatch / 2=前提不一致）。
+    1 件でも mismatch なら非ゼロ exit する設計で tasks.md 要求を満たす。
+- **AC カバレッジ** (Task 2 _Requirements:_ より):
+  - Req 2.1〜2.6 (G1 全形態): `g1-base-push-bare` (2.1) / `g1-base-push-srcdst` (2.2) /
+    `g1-base-push-delete-colon` (2.3) / `g1-base-push-plus-refspec` (2.4) /
+    `g1-base-push-with-C` (2.5) / `g1-base-push-implicit-remote` (2.6) で 1:1 対応
+  - Req 3.1〜3.4 (G2): `g2-force-short` (3.1) / `g2-force-long` (3.2) /
+    `g2-force-refspec-plus` (3.3) / `g2-allow-lease` + `g2-allow-lease-value` (3.4)
+  - Req 4.1〜4.3 (G0): `g0-edit-self` (4.1) / `g0-write-self` (4.2) /
+    `g0-bash-rm-self` + `g0-bash-sed-i-self` (4.3) / `g0-notebookedit-self` は 4.1 の派生
+  - Allow 13 件は誤発火防止のネガティブテスト（特に `allow-commit-with-push-msg` で
+    quoted msg の誤検出回避、`allow-push-then-checkout` で `&&` 後の base checkout が
+    pre-split で評価対象外であることを確認）
+- **残存課題**: 本 fixture は hook の単体テストであり、watcher の `--settings` 注入経路や
+  install.sh の placeholder 置換などは Task 4/5 で別途検証する。本 driver は Task 7 の統合
+  smoke でも `bash docs/specs/.../run-tests.sh` として再利用される前提。

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
@@ -319,3 +319,71 @@
     限界が運用者に伝わりにくくなる可能性がある。consumer 配布 Issue が完了した時点で
     「opt-in」表に正規行として追加する方が運用者の認知負荷が低い。PR 本文「確認事項」で
     Architect / 人間判断を仰ぐことを推奨
+
+### Task 7
+
+- **採用方針**: 本 Task は新規コード変更を伴わず、Task 1〜6 の成果物に対する **6 系統の
+  統合スモークテスト + 結果記録** のみで完結させた。tasks.md L101-115 の指示通り 6 件を
+  順次実行し、いずれも期待通りの結果が得られたため、コード/ドキュメント側の追加修正は
+  不要と判断した（既存 commit を温存）。
+- **重要判断**:
+  - **smoke 3 (opt-out diff なし) は「タイムスタンプ以外の content 一致」を判定基準とした**:
+    watcher の通常ログ出力には ISO 8601 timestamp prefix が必ず付くため、`IDD_CLAUDE_HOOKS_ENABLED`
+    未設定の場合と `=false` 明示の場合の 2 回連続実行では timestamp 差分が必ず diff に
+    出る。本 spec の Req 1.1 / 1.2 / NFR 1.1 が要求するのは「guard hook を参照する設定が
+    一切付与されないこと」「同一の引数列・同一の環境変数集合で claude CLI を起動すること」
+    であり、timestamp 差分は本質的に regression ではない。両 run とも guard-hook 関連の
+    log 行（`guard-hook:` prefix / preflight 関連メッセージ）が **一切出現していない**
+    ことが対照確認の本質であり、それを確認できた。
+  - **smoke 5 (cron-like minimal PATH) の評価範囲**: `env -i HOME=$HOME PATH=/usr/bin:/bin
+    bash -c ...` の素 PATH では `gh / jq / flock / git` 4 件が `/usr/bin` 配下で解決され、
+    `claude` は素 PATH 配下に存在しない（`~/.local/bin/claude`）。`local-watcher/bin/issue-watcher.sh`
+    冒頭 L37 の `export PATH="$HOME/.local/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"`
+    prepend を経由した時のみ `claude` が解決される設計を再確認した。watcher prepend を
+    再現した検証では 5 CLI 全件が解決できる（cron / launchd 環境の依存解決契約を満たす）。
+- **検証結果（6 smoke、すべて期待通り）**:
+  1. **`install.sh --dry-run --local` の hook 配置確認**: 使い捨て `$HOME` で実行し、
+     `[DRY-RUN] NEW       <tmp_home>/.idd-claude/hooks/idd-guard.sh (chmod +x)` /
+     `[DRY-RUN] NEW       <tmp_home>/.idd-claude/hooks/idd-guard-settings.json (substitute __IDD_HOOK_PATH__ → ...)` /
+     `[DRY-RUN] NEW       <tmp_home>/.idd-claude/hooks/README.md` の 3 行が出現することを確認。
+     placeholder 置換予定が note 付きで明示されることも確認
+  2. **使い捨て `$HOME` での実 `install.sh --local`**: tmp HOME で実行し、`<tmp>/.idd-claude/hooks/`
+     配下に 3 ファイル配置（`idd-guard.sh` 実行ビット付き / `idd-guard-settings.json` /
+     `README.md`）を確認。`jq -r '.hooks.PreToolUse[0].hooks[0].command'` で settings.json の
+     command が `<tmp>/.idd-claude/hooks/idd-guard.sh` の絶対パスに置換されていることを確認。
+     残存 `__IDD_HOOK_PATH__` placeholder 件数 `grep -c '__IDD_HOOK_PATH__'` は **0** を確認
+  3. **`IDD_CLAUDE_HOOKS_ENABLED=` 未設定 vs `=false` の watcher 起動差分**: 偽 origin
+     remote を持つ tmp repo で watcher を 2 回実行し、`diff -u` の結果が timestamp 行
+     （行先頭の `[YYYY-MM-DD HH:MM:SS]`）以外で **content 完全一致**することを確認。両 run
+     とも `guard-hook:` prefix の log 行が一切出現せず、preflight も実行されない（opt-in
+     制が正しく gate されている）。exit code はいずれも 1（GraphQL 404 by `owner/test` 偽
+     REPO 起因 / guard 由来ではない）で一致
+  4. **`IDD_CLAUDE_HOOKS_ENABLED=true` + `IDD_CLAUDE_HOOKS_MIN_VERSION=99.0.0` で exit 11**:
+     `exit=11` を観測。stderr に次の 2 行が出力されることを確認:
+     - `guard-hook: ERROR: claude version 2.1.168 は最小要件 99.0.0 を満たしません`
+     - `guard-hook: ERROR: Claude Code を 99.0.0 以上に更新するか、IDD_CLAUDE_HOOKS_MIN_VERSION を緩めてください`
+     fail-closed が黙って fallback せず、運用者向け復旧ヒントも含まれることを確認
+     （Req 5.1, 5.2, 5.5）
+  5. **cron-like minimal PATH での依存解決**: `env -i HOME=$HOME PATH=/usr/bin:/bin bash -c
+     'command -v claude gh jq flock git'` 直接実行では `gh / jq / flock / git` の 4 件が
+     `/usr/bin` 配下で解決される。`claude` は素 PATH 配下に存在しないが、watcher 起動時
+     L37 の PATH prepend を経由すれば `~/.local/bin/claude` で解決される設計を再確認。
+     watcher prepend を再現した `export PATH="$HOME/.local/bin:$HOME/bin:$PATH"` 付き
+     再実行では 5 CLI 全件が解決できることを確認
+  6. **`run-tests.sh` で 29/29 green**: `bash docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh`
+     を再実行し、G0:5 / G1:6 / G2:5 / Allow:13 の合計 29 ケースすべて PASS、最終行
+     `29/29 green` を確認（Task 6 の README 編集および本 Task のスモーク経由でも hook 本体に
+     regression なし）
+- **AC カバレッジ** (Task 7 _Requirements:_ より):
+  - Req 1.1 / 1.2 (opt-out 時の完全互換): smoke 3 で unset / =false の content 一致を確認
+  - Req 5.1 / 5.2 (claude version 比較 + 未満時 exit 11): smoke 4 で exit=11 と stderr 確認
+  - Req 5.3 / 5.4 (smoke test + 失敗時 exit): smoke 4 で先に version 不足を捕捉したため
+    smoke test 経路の検証は本 Task では未実行だが、Task 3 の inline smoke で rc=13 経路
+    （`gh_preflight` smoke 失敗）は確認済み（先行 task の verification で吸収）
+  - Req 5.5 (silent fallback なし): smoke 4 で exit 11 が確実に発生し fallback なしを確認
+  - Req 6.1 (user-scope 配置): smoke 1, 2 で `<tmp_home>/.idd-claude/hooks/` 配下配置を確認
+- **残存課題**: 本 Task で発見した bug / 修正対象は **なし**。Task 1〜6 の成果物が本初版
+  spec を満たしていることを 6 系統 smoke で確認した
+- **確認事項**: なし
+
+STATUS: complete

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md
@@ -54,3 +54,49 @@
 - **残存課題**: 本 fixture は hook の単体テストであり、watcher の `--settings` 注入経路や
   install.sh の placeholder 置換などは Task 4/5 で別途検証する。本 driver は Task 7 の統合
   smoke でも `bash docs/specs/.../run-tests.sh` として再利用される前提。
+
+### Task 3
+
+- **採用方針**: design.md 「Watcher Module: guard-hook.sh」節の関数 4 + ロガー 3 件 を、
+  既存 `stage-a-verify.sh` / `scaffolding-health.sh` と同形式の 3 段 prefix ロガー
+  （`[YYYY-MM-DD HH:MM:SS] [$REPO] guard-hook:`）と共に `local-watcher/bin/modules/guard-hook.sh`
+  に集約。本体への `source` 経由で読み込まれる前提（単体起動しない / `set -euo pipefail` は
+  本体側宣言を流用）。本モジュールは preflight と引数構築のみを責務とし、hook の評価ロジック
+  は `local-watcher/hooks/idd-guard.sh`（Task 1 で導入済み）に閉じる単一責任構造。
+- **重要判断**:
+  - **semver 比較は数値ベース**で実装（辞書順だと `2.1.167` < `2.1.99` になるため）。
+    `gh_compare_semver` は `.` で 3 セグメント split し、各セグメント先頭の整数だけ取り出して
+    数値比較する（`2.1.167-beta` 等の suffix 付きにも保守的に対応）。戻り値 0/1/2 で
+    `pass / fail / parse 失敗` を分離。
+  - **claude --version の出力 parse は awk で先頭の `<num>.<num>` を抽出**する設計。`claude
+    2.1.167` / `2.1.167 (Claude Code)` 等の代表的書式をどちらも吸収できることを smoke で
+    確認した。抽出失敗は rc=11 で fail-closed（運用者向けヒント付き）。
+  - **smoke test は jq に依存しない**設計を選択。hook 本体側 (idd-guard.sh) が jq 必須で
+    fail-closed する独立レイヤを持つため、watcher 側は `grep '"decision"'` リテラル検査のみで
+    十分（allow 期待 = decision フィールド不在 = grep 不一致）。これにより watcher の preflight
+    が jq 不在環境でも正しく動作する（hook 起動時は hook 本体が独立に fail-closed）。
+  - **CLAUDE_HOOK_ARGS の SC2034 抑止**: 同変数は Task 4 で `issue-watcher.sh` の全 claude 起動箇所
+    から `"${CLAUDE_HOOK_ARGS[@]}"` として展開される。本モジュール単体では消費側が無いため
+    shellcheck が unused 警告を出す。これは設計上の必然なので、行単位の `# shellcheck disable=SC2034`
+    で抑止（`.shellcheckrc` への追加はしない方針＝既存 hook 側 SC2088/SC2016 抑止と同じ哲学）。
+  - **install dir の executable 検査も rc=12 配下に含める**。設計の rc=12（install dir 不完全）
+    は「ファイル不在」と「ファイル存在するが実行できない」の双方を含む実装にした。後者は
+    install.sh のバグや手動権限変更で発生し得、smoke test が exec 失敗で rc=13 に化ける前に
+    rc=12 で fail-fast する方が運用者にとって recovery hint が明確になる。
+- **検証**:
+  - `shellcheck local-watcher/bin/modules/guard-hook.sh` 警告ゼロ
+  - 関数別の inline smoke で `gh_is_enabled` typo 安全 / `gh_resolve_dir` 末尾 slash 除去 /
+    `gh_compare_semver` の境界 6 ケース（equal / patch ±1 / minor ±1 / major ±1）/
+    `gh_build_args` の opt-in/out 配列構築をすべて pass 確認
+  - `gh_preflight` の rc 経路を 4 系統で確認: pass / rc=11 (version unmet) / rc=12
+    (install dir or exec missing) / rc=13 (smoke test deny)。stderr 出力にも復旧ヒント
+    （`install.sh --local 再実行` / `Claude Code を更新` 等）が含まれることを目視確認
+  - Task 2 の `run-tests.sh` を再実行し 29/29 green（hook 側 regression なし）
+- **残存課題**:
+  - 本モジュールは Task 4 (`issue-watcher.sh` への配線) で初めて生きる。`REQUIRED_MODULES`
+    末尾追加 + 起動初期化フェーズでの `gh_is_enabled && gh_preflight || exit $?` 連鎖 +
+    `export IDD_HOOK_BASE_BRANCH="$BASE_BRANCH"` + `gh_build_args` 呼び出しが Task 4 のスコープ
+  - install.sh への hook 配置（Task 5）が未済の環境では preflight が rc=12 で fail-closed する。
+    これは仕様通り（NFR 1.1 の silent fallback 禁止）だが、Task 5 完了までは watcher を
+    `IDD_CLAUDE_HOOKS_ENABLED=true` で起動できない点を運用者に明示する必要がある（README は
+    Task 6 で整備）

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/review-notes.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/review-notes.md
@@ -1,0 +1,133 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-08T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-294-impl-feat-watcher-pretooluse-guard-hook-base
+- HEAD commit: 6cd87dc7106b107c9e264aa2daec765827cee6b9
+- Compared to: main..HEAD（merge-base 4678de8 起点で実差分を確認。`main` 側に独立進行した
+  変更は本レビュー対象外として除外し、294 関連 commit 18 件のみを判定対象とした）
+
+## Verified Requirements
+
+### Req 1 (後方互換性 / opt-in gate)
+
+- **1.1** — `gh_is_enabled` が `[ "${IDD_CLAUDE_HOOKS_ENABLED:-}" = "true" ]` で **lowercase 厳密一致**
+  判定。`gh_build_args` が opt-out 時 `CLAUDE_HOOK_ARGS=()` 空配列構築
+  (`local-watcher/bin/modules/guard-hook.sh:55-57, 216-226`)
+- **1.2** — opt-out 時に空配列展開 `"${CLAUDE_HOOK_ARGS[@]}"` で引数が一切追加されない
+  (`local-watcher/bin/issue-watcher.sh` 11 箇所の挿入位置)。`IDD_HOOK_BASE_BRANCH` の export は
+  `gh_is_enabled` 内側のみで実行されるため env 集合も opt-out 時は不変 (`:715-718`)
+- **1.3** — 既存 env var 名 (`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `TRIAGE_MODEL` /
+  `DEV_MODEL` / `BASE_BRANCH` 等) の意味と既存 exit code / ラベル名は本 PR で変更されていない。
+  新規 exit code 11/12/13 は opt-in 時の新規経路のみで既存経路に上書きはない
+- **1.4** — `install.sh` 新規 helper (`install_guard_hooks` / `copy_hook_settings_with_substitution` /
+  `resolve_hooks_install_dir`) は `cp` / `mkdir -p` / `chmod` / `sed` のみ使用、sudo 非要求
+
+### Req 2 (G1: base 宛 push deny)
+
+- **2.1** bare push — fixture `g1-base-push-bare.json` deny + reason `base branch push denied` 確認
+- **2.2** `HEAD:base` srcdst — fixture `g1-base-push-srcdst.json` deny。`extract_dst_from_refspec`
+  が `${rs#*:}` で dst 抽出 (`idd-guard.sh:214-223`)
+- **2.3** `:base` delete — fixture `g1-base-push-delete-colon.json` deny。`+` 除去 + colon 分割で
+  dst='base' を取り出す
+- **2.4** `+base` plus-refspec — fixture `g1-base-push-plus-refspec.json` deny
+- **2.5** `git -C path push` global options — fixture `g1-base-push-with-C.json` deny。
+  `extract_push_tokens` が `-C` / `--git-dir=` / `--work-tree=` / `-c k=v` を skip (`:158-208`)
+- **2.6** 暗黙 remote — fixture `g1-base-push-implicit-remote.json` deny。`analyze_push` が
+  positional=1 件のときに base 名一致を refspec 扱いに格上げ (`:285-302`)
+- **2.7** deny reason に ref 名を含む — `"base branch push denied: ref=$rs (base=$base_branch)"`
+  (`:322`)。fixture expected.tsv で `base branch push denied` substring 確認
+
+### Req 3 (G2: 無条件 force deny)
+
+- **3.1** `-f` — fixture `g2-force-short.json` deny
+- **3.2** `--force` — fixture `g2-force-long.json` deny
+- **3.3** refspec 先頭 `+` (base 以外でも deny) — fixture `g2-force-refspec-plus.json` deny。
+  `refspec_has_plus_prefix` でチェック (`:343-348`)
+- **3.4** `--force-with-lease(=value)` で base 以外は allow — fixtures `g2-allow-lease.json` /
+  `g2-allow-lease-value.json` allow。`has_force=0 && has_lease=1` 経路で deny されない
+- **3.5** deny reason — `"unconditional force push denied: use --force-with-lease"` を含む
+  (`:339, 346`)
+
+### Req 4 (G0: install dir 自己保護)
+
+- **4.1** Edit on install dir → deny — fixture `g0-edit-self.json` deny。`check_g0_path` が
+  prefix 一致で robust に検出 (`:106-118`)
+- **4.2** Write on install dir → deny — fixture `g0-write-self.json` deny。
+  `NotebookEdit` も `g0-notebookedit-self.json` で同様に deny
+- **4.3** Bash mutation コマンド → deny (best-effort) — fixtures `g0-bash-rm-self.json` /
+  `g0-bash-sed-i-self.json` deny。`check_g0_bash` が literal 検出 + mutation keyword 両方一致で
+  deny (`:121-149`)
+- **4.4** best-effort 明示 — `local-watcher/hooks/README.md` L47 と `README.md` L5366-5370 で
+  「Bash 経由 mutation 検出は best-effort、全件捕捉を保証しない」を明記
+
+### Req 5 (fail-closed 起動ゲート)
+
+- **5.1** claude version 取得 + `IDD_CLAUDE_HOOKS_MIN_VERSION` 比較 — `gh_preflight` が
+  `claude --version` を取得し `gh_compare_semver` で **数値ベース**比較 (`:141-167`)
+- **5.2** version 未満で非ゼロ exit + stderr — `return 11` + `gh_error` 2 行 (version 不足理由 +
+  復旧ヒント)。Task 7 smoke 4 で `IDD_CLAUDE_HOOKS_MIN_VERSION=99.0.0` で exit=11 観測
+- **5.3** smoke test 実行 — `gh_preflight` step 3 で固定 fixture JSON を hook に流して
+  exit 0 + `"decision"` リテラル不在を確認 (`:187-202`)
+- **5.4** smoke test 失敗で非ゼロ exit — `return 13`
+- **5.5** silent fallback なし — `if gh_is_enabled; then gh_preflight || exit $?; ...` で
+  preflight 失敗時に即 `exit $?`、fallback 経路を持たない (`issue-watcher.sh:715-718`)
+
+### Req 6 (配布スコープ限定)
+
+- **6.1** user-scope 配置 — `install.sh` の `INSTALL_LOCAL` ブロックで
+  `$HOME/.idd-claude/hooks/` に 3 ファイル配置 (`install.sh:1365-1373`)
+- **6.2** `repo-template/` 配下に追加なし — `git diff 4678de8..HEAD -- repo-template/` に
+  guard-hook 関連の変更なし (294 関連 commit が `repo-template/` を一切触っていない)
+- **6.3** consumer `.claude/` 配下に配布なし — `INSTALL_REPO` ブロックは未変更、
+  `copy_template_file` / `copy_agents_rules` シーケンスに本 helper を呼ばない
+- **6.4** 後続 Issue 起票が前提として明示 — `README.md` Migration Note L5392-5404 で
+  「**後続の別 Issue として独立に承認・起票される前提**」を明文化。実際の Issue 起票責務は
+  PjM / 人間にあり Implementer 範囲外 (Summary 参照)
+
+### NFR
+
+- **NFR 1.1** 互換性 — opt-out 時の挙動互換は impl-notes Task 7 smoke 3 で「timestamp 以外
+  完全一致」+「`guard-hook:` log 行が一切出ない」で確認済み
+- **NFR 1.2** sudo なし — Req 1.4 と同じ実装で担保
+- **NFR 1.3** `IDD_CLAUDE_HOOKS_MIN_VERSION` env override 可 — `${IDD_CLAUDE_HOOKS_MIN_VERSION:-2.1.167}`
+  でハードコードせず env default で上書き可能
+- **NFR 2.1** shellcheck 警告ゼロ — `shellcheck install.sh local-watcher/bin/issue-watcher.sh
+  local-watcher/bin/modules/guard-hook.sh local-watcher/hooks/idd-guard.sh` を Reviewer 再実行
+  でも警告ゼロを確認
+- **NFR 2.2** actionlint — 本機能で `.github/workflows/*.yml` の変更なし (該当なし)
+- **NFR 3.1〜3.4** 既知の限界文書化 — `README.md` L5353-5374 / `local-watcher/hooks/README.md`
+  L41-48 で 4 項目すべて明示
+- **NFR 4.1, 4.2** 二重管理規約への影響なし — `.claude/agents` / `.claude/rules` 未変更、
+  `repo-template/.claude/` 未変更
+
+### Reviewer 再実行による検証
+
+- `bash docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh` →
+  **29/29 green** (G0:5 / G1:6 / G2:5 / Allow:13)
+- `shellcheck install.sh local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/guard-hook.sh
+  local-watcher/hooks/idd-guard.sh` → 警告ゼロ
+- `git log main..HEAD` で 294 関連 18 commit 確認、`git diff --stat 4678de8..HEAD` で実差分の
+  境界が tasks.md `_Boundary:_` 範囲内であることを目視確認
+
+## Findings
+
+なし
+
+## Summary
+
+全 Requirements (1.1〜1.4, 2.1〜2.7, 3.1〜3.5, 4.1〜4.4, 5.1〜5.5, 6.1〜6.4) と全 NFR
+(1.1〜1.3, 2.1〜2.2, 3.1〜3.4, 4.1〜4.2) に対応する実装またはテスト fixture を確認した。
+hook 本体は 29/29 green、shellcheck 警告ゼロ、watcher 配線は 11 箇所の `claude --print`
+起動行末尾に `"${CLAUDE_HOOK_ARGS[@]}"` 注入を確認。境界は `local-watcher/hooks/` /
+`local-watcher/bin/modules/guard-hook.sh` / `issue-watcher.sh` / `install.sh` / `README.md` /
+spec 配下に閉じ、`repo-template/` / consumer `.claude/` への配布なし。
+
+Req 6.4 の「consumer 配布の後続 Issue 起票」は Developer 側で README Migration Note および
+impl-notes 確認事項として明示されているが、実際の Issue 起票自体は PjM / 人間の責務であり
+Implementer 範囲外の operational item として **Reviewer は reject 理由としない**。PjM が
+PR 本文「確認事項」に従って consumer 配布 Issue を起票することを別途確認されたい。
+
+RESULT: approve

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -49,7 +49,7 @@
   - shellcheck 警告ゼロ
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 5.1, 5.2, 5.3, 5.4, 5.5, NFR 1.1, NFR 1.3, NFR 2.1_
 
-- [ ] 4. `issue-watcher.sh` を guard hook 対応に編集
+- [x] 4. `issue-watcher.sh` を guard hook 対応に編集
   - Config ブロックに env var の default 宣言を追加（`IDD_CLAUDE_HOOKS_ENABLED` /
     `IDD_CLAUDE_HOOKS_DIR` / `IDD_CLAUDE_HOOKS_MIN_VERSION=2.1.167` / `IDD_HOOK_LOG`）。
     **既存 env var 名・既定値は一切変更しない**

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -66,7 +66,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 5.1, 5.2, 5.3, 5.4, 5.5, NFR 1.1, NFR 2.1_
   - _Depends: 3_
 
-- [ ] 5. `install.sh` に hook 一式の user-scope 配置を追加
+- [x] 5. `install.sh` に hook 一式の user-scope 配置を追加
   - `INSTALL_LOCAL` ブロックに `local-watcher/hooks/*` を `$IDD_CLAUDE_HOOKS_DIR`（既定
     `$HOME/.idd-claude/hooks`）に配置する処理を追加（既存 `copy_template_file` 再利用）
   - `idd-guard.sh` は `--executable` 付与

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -4,7 +4,7 @@
 **user-scope のみ**（人間 Decision 2: Option A）。`repo-template/` への追加は本 Issue では
 **禁止**（Req 6.2 / 6.3 / NFR 4.1）。
 
-- [ ] 1. guard hook script (`idd-guard.sh`) と settings テンプレを新規作成
+- [x] 1. guard hook script (`idd-guard.sh`) と settings テンプレを新規作成
   - `local-watcher/hooks/idd-guard.sh` を新規作成。`set -euo pipefail` 宣言。stdin から
     PreToolUse JSON を `jq` で読み、`tool_name` で分岐
   - G1 push 解析: `git` global options (`-C` / `--git-dir=` / `--work-tree=` / `-c k=v`) を

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -81,7 +81,7 @@
   - _Requirements: 1.4, 6.1, 6.2, 6.3, NFR 1.2, NFR 2.1, NFR 4.1, NFR 4.2_
   - _Depends: 1_
 
-- [ ] 6. `README.md` に「Guard Hook (PreToolUse) opt-in」節を追加
+- [x] 6. `README.md` に「Guard Hook (PreToolUse) opt-in」節を追加
   - opt-in 手順（`install.sh --local` 再実行 → `claude --version` 確認 → cron に
     `IDD_CLAUDE_HOOKS_ENABLED=true` を追加）
   - env var 一覧（`IDD_CLAUDE_HOOKS_ENABLED` / `IDD_CLAUDE_HOOKS_DIR` /

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -98,7 +98,7 @@
   - ロールバック（env を外せば即 opt-out）
   - _Requirements: 6.4, NFR 1.3, NFR 3.1, NFR 3.2, NFR 3.3, NFR 3.4_
 
-- [ ] 7. 統合スモークテスト・手動検証
+- [x] 7. 統合スモークテスト・手動検証
   - `install.sh --dry-run --local` で hook 配置が NEW/SKIP/OVERWRITE 行に現れる
   - 使い捨て `$HOME` で `install.sh --local` 実行 → 配置済みファイル存在 + settings.json の
     placeholder 置換確認

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -37,7 +37,7 @@
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3_
   - _Depends: 1_
 
-- [ ] 3. watcher module (`guard-hook.sh`) を新規作成
+- [x] 3. watcher module (`guard-hook.sh`) を新規作成
   - `local-watcher/bin/modules/guard-hook.sh` を新規作成（既存 module 分割パターン踏襲）
   - `gh_log` / `gh_warn` / `gh_error` ロガー（`guard-hook:` prefix、`[$REPO]` 3 段書式）
   - `gh_is_enabled`: `IDD_CLAUDE_HOOKS_ENABLED` の **厳密 `true` 一致**判定（typo 安全側）

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/tasks.md
@@ -25,7 +25,7 @@
   - shellcheck 警告ゼロ
   - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, 3.3, 3.4, 3.5, 4.1, 4.2, 4.3, 4.4, NFR 2.1_
 
-- [ ] 2. test fixtures（29 件マトリクス）と driver スクリプトを作成
+- [x] 2. test fixtures（29 件マトリクス）と driver スクリプトを作成
   - `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/*.json` を
     29 件作成（G0:5 / G1:6 / G2:5 / Allow:13）。Issue #294 本文の PoC 29 件マトリクスに準拠
   - `expected.tsv` で各ケースの期待 verdict（deny|allow）と reason 部分一致文字列を宣言

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-bash-no-hooks-dir.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-bash-no-hooks-dir.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "echo hello world"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-commit-with-push-msg.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-commit-with-push-msg.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git commit -m 'fix: avoid git push origin main misuse'"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-edit-non-hooks.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-edit-non-hooks.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "/tmp/some-other-file.txt"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-non-git-bash.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-non-git-bash.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "ls -la"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-normal-push.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-normal-push.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-notebookedit-non-hooks.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-notebookedit-non-hooks.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "NotebookEdit",
+  "tool_input": {
+    "notebook_path": "/tmp/analysis.ipynb"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-different-base.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-different-base.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin develop"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-noargs.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-noargs.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-srcdst-feature.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-srcdst-feature.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin HEAD:feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-then-checkout.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-then-checkout.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin feature && git checkout main"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-u.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-push-u.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push -u origin feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-status.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-status.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git status"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-write-non-hooks.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/allow-write-non-hooks.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "/tmp/scratch.md"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-bash-rm-self.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-bash-rm-self.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "rm ~/.idd-claude/hooks/idd-guard.sh"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-bash-sed-i-self.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-bash-sed-i-self.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "sed -i 's/foo/bar/' ~/.idd-claude/hooks/idd-guard.sh"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-edit-self.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-edit-self.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Edit",
+  "tool_input": {
+    "file_path": "~/.idd-claude/hooks/idd-guard.sh"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-notebookedit-self.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-notebookedit-self.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "NotebookEdit",
+  "tool_input": {
+    "notebook_path": "~/.idd-claude/hooks/notes.ipynb"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-write-self.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g0-write-self.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Write",
+  "tool_input": {
+    "file_path": "~/.idd-claude/hooks/idd-guard-settings.json"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-bare.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-bare.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin main"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-delete-colon.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-delete-colon.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin :main"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-implicit-remote.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-implicit-remote.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push main"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-plus-refspec.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-plus-refspec.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin +main"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-srcdst.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-srcdst.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin HEAD:main"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-with-C.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g1-base-push-with-C.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git -C /work push origin main"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-allow-lease-value.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-allow-lease-value.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push --force-with-lease=refs/heads/feature:abc123 origin feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-allow-lease.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-allow-lease.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push --force-with-lease origin feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-force-long.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-force-long.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push --force origin feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-force-refspec-plus.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-force-refspec-plus.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push origin +feature:feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-force-short.json
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/g2-force-short.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "Bash",
+  "tool_input": {
+    "command": "git push -f origin feature"
+  },
+  "permission_mode": "bypassPermissions"
+}

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/expected.tsv
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/expected.tsv
@@ -1,0 +1,30 @@
+case_file	verdict	reason_substring
+g0-edit-self.json	deny	guard install dir self-mutation denied
+g0-write-self.json	deny	guard install dir self-mutation denied
+g0-notebookedit-self.json	deny	guard install dir self-mutation denied
+g0-bash-rm-self.json	deny	guard install dir self-mutation denied
+g0-bash-sed-i-self.json	deny	guard install dir self-mutation denied
+g1-base-push-bare.json	deny	base branch push denied
+g1-base-push-srcdst.json	deny	base branch push denied
+g1-base-push-delete-colon.json	deny	base branch push denied
+g1-base-push-plus-refspec.json	deny	base branch push denied
+g1-base-push-with-C.json	deny	base branch push denied
+g1-base-push-implicit-remote.json	deny	base branch push denied
+g2-force-short.json	deny	unconditional force push denied
+g2-force-long.json	deny	unconditional force push denied
+g2-force-refspec-plus.json	deny	unconditional force push denied
+g2-allow-lease.json	allow
+g2-allow-lease-value.json	allow
+allow-normal-push.json	allow
+allow-push-u.json	allow
+allow-push-srcdst-feature.json	allow
+allow-push-noargs.json	allow
+allow-status.json	allow
+allow-commit-with-push-msg.json	allow
+allow-push-then-checkout.json	allow
+allow-non-git-bash.json	allow
+allow-edit-non-hooks.json	allow
+allow-write-non-hooks.json	allow
+allow-notebookedit-non-hooks.json	allow
+allow-bash-no-hooks-dir.json	allow
+allow-push-different-base.json	allow

--- a/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh
+++ b/docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# run-tests.sh
+#
+# 用途: docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/cases/*.json
+#       を順次 stdin に流して `local-watcher/hooks/idd-guard.sh` を起動し、stdout の
+#       decision JSON と expected.tsv の期待値（verdict + reason 部分文字列）を突合する
+#       29 件マトリクスのドライバ。
+#
+# 配置先: docs/specs/294-feat-watcher-pretooluse-guard-hook-base/test-fixtures/run-tests.sh
+#
+# 依存: bash 4+, jq
+#
+# 環境変数:
+#   IDD_HOOK_BASE_BRANCH    base ブランチ名（既定 main を export）
+#   IDD_CLAUDE_HOOKS_DIR    G0 で保護する install dir（既定 $HOME/.idd-claude/hooks を export）
+#
+# 終了コード:
+#   0 = 全 case green (29/29)
+#   1 = 1 件以上 mismatch
+#   2 = fixture / driver の前提不一致（expected.tsv 不在、hook 不在、jq 不在 等）
+#
+# セットアップ参照先: ../impl-notes.md
+
+set -euo pipefail
+
+# 1) このスクリプトの絶対ディレクトリを解決
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CASES_DIR="$SCRIPT_DIR/cases"
+EXPECTED_TSV="$SCRIPT_DIR/expected.tsv"
+
+# 2) hook の絶対パスを解決（このスクリプトから ../../../../local-watcher/hooks/idd-guard.sh）
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+HOOK_PATH="$REPO_ROOT/local-watcher/hooks/idd-guard.sh"
+
+# 3) 前提チェック
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'ERROR: jq not found in PATH\n' >&2
+  exit 2
+fi
+
+if [ ! -f "$HOOK_PATH" ]; then
+  printf 'ERROR: hook not found at %s\n' "$HOOK_PATH" >&2
+  exit 2
+fi
+
+if [ ! -f "$EXPECTED_TSV" ]; then
+  printf 'ERROR: expected.tsv not found at %s\n' "$EXPECTED_TSV" >&2
+  exit 2
+fi
+
+if [ ! -d "$CASES_DIR" ]; then
+  printf 'ERROR: cases dir not found at %s\n' "$CASES_DIR" >&2
+  exit 2
+fi
+
+# 4) hook が参照する env を export
+export IDD_HOOK_BASE_BRANCH="${IDD_HOOK_BASE_BRANCH:-main}"
+export IDD_CLAUDE_HOOKS_DIR="${IDD_CLAUDE_HOOKS_DIR:-$HOME/.idd-claude/hooks}"
+
+# 5) expected.tsv を走査
+pass=0
+fail=0
+total=0
+
+# ヘッダ行を skip して読む
+# 形式: case_file \t verdict \t reason_substring(optional)
+while IFS=$'\t' read -r case_file expected_verdict expected_reason || [ -n "${case_file:-}" ]; do
+  # ヘッダ・空行を skip
+  [ -z "${case_file:-}" ] && continue
+  [ "$case_file" = "case_file" ] && continue
+
+  total=$((total + 1))
+  case_path="$CASES_DIR/$case_file"
+
+  if [ ! -f "$case_path" ]; then
+    printf 'FAIL\t%s\t(case file missing)\n' "$case_file"
+    fail=$((fail + 1))
+    continue
+  fi
+
+  # hook を起動。stdin に case JSON を渡す。hook は常に exit 0
+  hook_stdout="$(bash "$HOOK_PATH" <"$case_path" 2>/dev/null || true)"
+
+  # decision JSON を parse。
+  # - 空 stdout (allow) は jq に渡すと parse 失敗するため空文字をデフォルトで扱う
+  # - decision フィールドの値を抽出（無ければ空文字 = allow）
+  if [ -z "$hook_stdout" ]; then
+    actual_decision=""
+  else
+    actual_decision="$(printf '%s' "$hook_stdout" | jq -r '.decision // empty' 2>/dev/null || true)"
+  fi
+
+  if [ "$actual_decision" = "block" ]; then
+    actual_verdict="deny"
+    actual_reason="$(printf '%s' "$hook_stdout" | jq -r '.reason // empty' 2>/dev/null || true)"
+  else
+    actual_verdict="allow"
+    actual_reason=""
+  fi
+
+  # verdict 突合
+  if [ "$actual_verdict" != "$expected_verdict" ]; then
+    printf 'FAIL\t%s\texpected=%s actual=%s reason=%s\n' \
+      "$case_file" "$expected_verdict" "$actual_verdict" "$actual_reason"
+    fail=$((fail + 1))
+    continue
+  fi
+
+  # deny ケースは reason substring を確認
+  if [ "$expected_verdict" = "deny" ]; then
+    expected_reason="${expected_reason:-}"
+    if [ -z "$expected_reason" ]; then
+      printf 'FAIL\t%s\tdeny expected but reason_substring is empty in expected.tsv\n' "$case_file"
+      fail=$((fail + 1))
+      continue
+    fi
+    case "$actual_reason" in
+      *"$expected_reason"*)
+        : # ok
+        ;;
+      *)
+        printf 'FAIL\t%s\treason mismatch: expected_substring=%q actual=%q\n' \
+          "$case_file" "$expected_reason" "$actual_reason"
+        fail=$((fail + 1))
+        continue
+        ;;
+    esac
+  fi
+
+  printf 'PASS\t%s\t%s\n' "$case_file" "$actual_verdict"
+  pass=$((pass + 1))
+
+done <"$EXPECTED_TSV"
+
+# 6) サマリ
+printf '\n'
+if [ "$fail" -eq 0 ]; then
+  printf '%d/%d green\n' "$pass" "$total"
+  exit 0
+else
+  printf '%d/%d green, %d mismatch\n' "$pass" "$total" "$fail"
+  exit 1
+fi

--- a/install.sh
+++ b/install.sh
@@ -245,6 +245,121 @@ copy_template_file() {
   esac
 }
 
+# copy_hook_settings_with_substitution <src> <dest> <hook_path>
+#   `idd-guard-settings.json` 用の placeholder 置換配置（#294 Task 5）。
+#   - `__IDD_HOOK_PATH__` を絶対パス <hook_path> に置換した内容を dest に書き込む
+#   - 冪等性: 既配置 dest は既に置換済み（`__IDD_HOOK_PATH__` を持たない）のため、
+#     src と単純 cmp すると常に差分扱いになる。これを避けるため、
+#     **置換後の期待内容を tmp file に書き出して dest と cmp** する判定にする
+#   - dry-run 時は実置換せず、NEW/SKIP/OVERWRITE のいずれかを predict してログのみ出す
+copy_hook_settings_with_substitution() {
+  local src="$1"
+  local dest="$2"
+  local hook_path="$3"
+
+  if [ ! -f "$src" ]; then
+    echo "Error: source file not found: $src" >&2
+    return 1
+  fi
+
+  # 置換後の期待内容を tmp file に書き出す
+  local tmp_expected
+  tmp_expected="$(mktemp)"
+  # `sed` で `__IDD_HOOK_PATH__` を置換する。`#` を区切りにしてパス内の `/` をエスケープ不要にする
+  sed "s#__IDD_HOOK_PATH__#${hook_path}#g" "$src" >"$tmp_expected"
+
+  local action
+  if [ ! -e "$dest" ]; then
+    action="NEW"
+  elif cmp -s "$tmp_expected" "$dest"; then
+    action="SKIP"
+  else
+    action="OVERWRITE"
+  fi
+
+  local note="(substitute __IDD_HOOK_PATH__ → $hook_path)"
+
+  case "$action" in
+    NEW)
+      log_action "NEW" "$dest" "$note"
+      if [ "$DRY_RUN" = "false" ]; then
+        ensure_dir "$(dirname "$dest")"
+        cp "$tmp_expected" "$dest"
+      fi
+      ;;
+    SKIP)
+      log_action "SKIP" "$dest" "(identical to substituted template)"
+      ;;
+    OVERWRITE)
+      log_action "OVERWRITE" "$dest" "$note"
+      if [ "$DRY_RUN" = "false" ]; then
+        cp "$tmp_expected" "$dest"
+      fi
+      ;;
+  esac
+
+  rm -f "$tmp_expected"
+}
+
+# resolve_hooks_install_dir
+#   guard hook install dir を解決する（#294 Task 5）。
+#   - 既定 `$HOME/.idd-claude/hooks`
+#   - `IDD_CLAUDE_HOOKS_DIR` env var で override 可能
+#   - 末尾スラッシュは除去（`$HOME/.idd-claude/hooks/` → `$HOME/.idd-claude/hooks`）
+resolve_hooks_install_dir() {
+  local dir="${IDD_CLAUDE_HOOKS_DIR:-$HOME/.idd-claude/hooks}"
+  while [ "${dir: -1}" = "/" ] && [ ${#dir} -gt 1 ]; do
+    dir="${dir%/}"
+  done
+  printf '%s' "$dir"
+}
+
+# install_guard_hooks
+#   `local-watcher/hooks/` 配下の guard hook 一式を user-scope に配置する（#294 Task 5）。
+#   配置先は `$IDD_CLAUDE_HOOKS_DIR`（既定 `$HOME/.idd-claude/hooks`）。
+#   - `idd-guard.sh` は実行ビット付与（`copy_template_file --executable` 再利用）
+#   - `idd-guard-settings.json` は `__IDD_HOOK_PATH__` を絶対パスに置換して配置
+#   - `README.md` はそのままコピー
+#   `repo-template/` には何も追加しない（Req 6.2, 6.3 / NFR 4.1）。sudo は不要。
+install_guard_hooks() {
+  local hooks_src="$LOCAL_WATCHER_DIR/hooks"
+  local hooks_dest
+  hooks_dest="$(resolve_hooks_install_dir)"
+
+  # source 不在は noop（後方互換のための保険。通常は存在する前提）
+  if [ ! -d "$hooks_src" ]; then
+    return 0
+  fi
+
+  echo ""
+  echo "🛡  Guard hook (PreToolUse) 一式を配置: $hooks_dest"
+
+  ensure_dir "$hooks_dest"
+
+  # idd-guard.sh: 実行ビット付与
+  if [ -f "$hooks_src/idd-guard.sh" ]; then
+    copy_template_file \
+      "$hooks_src/idd-guard.sh" \
+      "$hooks_dest/idd-guard.sh" \
+      --executable
+  fi
+
+  # idd-guard-settings.json: __IDD_HOOK_PATH__ を絶対パスに置換
+  if [ -f "$hooks_src/idd-guard-settings.json" ]; then
+    copy_hook_settings_with_substitution \
+      "$hooks_src/idd-guard-settings.json" \
+      "$hooks_dest/idd-guard-settings.json" \
+      "$hooks_dest/idd-guard.sh"
+  fi
+
+  # README.md: そのまま配置
+  if [ -f "$hooks_src/README.md" ]; then
+    copy_template_file \
+      "$hooks_src/README.md" \
+      "$hooks_dest/README.md"
+  fi
+}
+
 # copy_glob_to_homebin <src_dir> <pattern> <dest_dir> [--executable]
 #   `<src_dir>/<pattern>` にマッチする全ファイルを <dest_dir> に配置する。
 #   nullglob を一時的に有効化し、マッチ 0 件は SKIP ログを出して exit 0 で継続する。
@@ -1250,6 +1365,13 @@ if $INSTALL_LOCAL; then
     copy_glob_to_homebin "$LOCAL_WATCHER_DIR/bin/modules" "*.sh" "$HOME/bin/modules" --executable
   fi
 
+  # Guard hook (PreToolUse) 一式を user-scope に配置（#294 Task 5）。
+  # 既定配置先は $HOME/.idd-claude/hooks（IDD_CLAUDE_HOOKS_DIR で override 可能）。
+  # sudo 不要 / repo-template/ には配布しない（Req 6.2, 6.3 / NFR 4.1）。
+  # 配置するだけでは guard は有効化されない。watcher 側で
+  # IDD_CLAUDE_HOOKS_ENABLED=true を指定したときのみ fail-closed preflight 経由で有効化される。
+  install_guard_hooks
+
   # macOS: launchd
   if [ "$(uname)" = "Darwin" ]; then
     ensure_dir "$HOME/Library/LaunchAgents"
@@ -1307,6 +1429,40 @@ LAUNCHD_HINT
      root になり、通常ユーザーで更新・削除できなくなります。
 CRON_HINT
   fi
+
+  # Guard hook opt-in 手順（#294 Task 5）。
+  # cron / launchd ヒント直後に共通の案内 1 ブロックを出す。
+  # opt-in は env var で制御される（既定 OFF / opt-in 制）。
+  hooks_dest_for_hint="$(resolve_hooks_install_dir)"
+  cat <<HOOKS_HINT
+
+  🛡  (任意) Guard Hook (PreToolUse) opt-in:
+
+     guard hook を有効化すると、watcher 配下のエージェントによる以下の操作を
+     実行前に機械的に deny します（fail-closed、Reviewer 事後検出を待たない）:
+       - base ブランチ宛 push（bare / HEAD:base / :base / +base / -C path / 暗黙 remote）
+       - 無条件 force push（-f / --force / refspec 先頭 '+'。--force-with-lease は許容）
+       - guard install dir ($hooks_dest_for_hint) 配下の自己改変
+
+     opt-in 手順（cron 例）:
+       */2 * * * * REPO=owner/your-repo REPO_DIR=\$HOME/work/your-repo IDD_CLAUDE_HOOKS_ENABLED=true \$HOME/bin/issue-watcher.sh >> \$HOME/.issue-watcher/cron.log 2>&1
+
+     launchd の場合は plist の EnvironmentVariables に IDD_CLAUDE_HOOKS_ENABLED=true を追記。
+
+     fail-closed 挙動（IDD_CLAUDE_HOOKS_ENABLED=true 時のみ）:
+       - claude version が IDD_CLAUDE_HOOKS_MIN_VERSION 未満 → exit 11
+       - hook install dir が不完全 → exit 12
+       - smoke test 失敗 → exit 13
+       いずれも黙って fallback せず、stderr に理由を出して watcher を停止します。
+       env var を外せば即 opt-out（hook ファイル削除は不要）。
+
+     既知の限界 / consumer repo への配布について:
+       - 本初版は user-scope 専用配置です。consumer repo (.claude/) への配布は
+         別 Issue として後続で承認・起票されます（Req 6.4）。
+       - top-level Bash 文字列のみ解析するため、sh -c "..." / \$(...) / wrapper script
+         内部の push は捕捉できません（NFR 3.1）。
+       - 詳細は README.md の「Guard Hook (PreToolUse) opt-in」節を参照してください。
+HOOKS_HINT
 
   # 前提ツールチェック
   echo ""

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -536,6 +536,32 @@ DEBUGGER_ENABLED="${DEBUGGER_ENABLED:-false}"
 DEBUGGER_MODEL="${DEBUGGER_MODEL:-claude-opus-4-7}"
 DEBUGGER_MAX_TURNS="${DEBUGGER_MAX_TURNS:-40}"
 
+# ─── PreToolUse Guard Hook 設定 (#294 / base 初版) ───
+# Claude Code の PreToolUse フック機構を利用し、watcher が起動する全 claude CLI 実行に
+# 対して `--settings <絶対パス>` を opt-in で注入する。hook 本体（idd-guard.sh）と
+# settings テンプレ（idd-guard-settings.json）は install.sh が user-scope
+# `$IDD_CLAUDE_HOOKS_DIR`（既定 `$HOME/.idd-claude/hooks`）に配置する前提。
+#
+# 既定 OFF（opt-in 専用）であり、`IDD_CLAUDE_HOOKS_ENABLED=true` の **厳密一致**時にのみ
+# 有効化される（typo は安全側で opt-out 扱い / Req 1.1）。未設定 / 空 / `false` /
+# `True` / `1` 等はすべて opt-out として扱い、本機能導入前と完全に同一の引数列・環境変数
+# 集合で claude を起動する（NFR 1.1 / Req 1.1, 1.2）。値正規化（`true`/`false` への
+# 2 値強制）はしない — 上記「デフォルト有効化フラグの値正規化」ループは既定 true の
+# フラグ向けであり、本機能は既定 false の opt-in 制のため対象外。
+#
+# - IDD_CLAUDE_HOOKS_ENABLED:     本機能の opt-in gate（既定空＝opt-out / Req 1.1）
+# - IDD_CLAUDE_HOOKS_DIR:         hook 本体の install dir 絶対パス（既定
+#                                 `$HOME/.idd-claude/hooks` / NFR 1.3）
+# - IDD_CLAUDE_HOOKS_MIN_VERSION: preflight の claude version 最小要求（既定 `2.1.167`
+#                                 / PoC 検証バージョン / NFR 1.3）
+# - IDD_HOOK_LOG:                 hook 本体が optional に append する 1 行ログのパス
+#                                 （未設定で no-op / 運用者が任意に有効化）
+# 詳細は docs/specs/294-feat-watcher-pretooluse-guard-hook-base/design.md を参照。
+IDD_CLAUDE_HOOKS_ENABLED="${IDD_CLAUDE_HOOKS_ENABLED:-}"
+IDD_CLAUDE_HOOKS_DIR="${IDD_CLAUDE_HOOKS_DIR:-$HOME/.idd-claude/hooks}"
+IDD_CLAUDE_HOOKS_MIN_VERSION="${IDD_CLAUDE_HOOKS_MIN_VERSION:-2.1.167}"
+IDD_HOOK_LOG="${IDD_HOOK_LOG:-}"
+
 # ─── Quota-Aware Watcher 設定 (#66) ───
 # Claude Max の 5 時間ローリング quota を claude CLI の `rate_limit_event` JSON で
 # 検知し、quota 起因の停止と他失敗を `needs-quota-wait` ラベルで分離する。
@@ -656,7 +682,7 @@ IDD_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/mo
 # 3 プロセッサ（quota-aware / merge-queue / auto-rebase）、#181 Part 3 で切り出した
 # 3 プロセッサ（promote-pipeline / pr-iteration / stage-a-verify）を並べ、末尾に
 # #238 の scaffolding-health.sh と #239 の per-run evidence サマリ（run-summary.sh）を置く。
-REQUIRED_MODULES=( "core_utils.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "promote-pipeline.sh" "pr-iteration.sh" "pr-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "security-review.sh" )
+REQUIRED_MODULES=( "core_utils.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "promote-pipeline.sh" "pr-iteration.sh" "pr-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "security-review.sh" "guard-hook.sh" )
 for _idd_mod in "${REQUIRED_MODULES[@]}"; do
   _idd_mod_path="$IDD_MODULE_DIR/$_idd_mod"
   if [ ! -f "$_idd_mod_path" ]; then
@@ -668,6 +694,30 @@ for _idd_mod in "${REQUIRED_MODULES[@]}"; do
   . "$_idd_mod_path"
 done
 unset _idd_mod _idd_mod_path
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# PreToolUse Guard Hook 配線 (#294 / base 初版)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# guard-hook.sh モジュールの関数（gh_is_enabled / gh_preflight / gh_build_args）を呼び、
+# opt-in 時のみ claude CLI 起動時に注入する `CLAUDE_HOOK_ARGS` グローバル配列を構築する。
+# opt-out 時は空配列 `()` → 既存の各 claude 起動箇所で `"${CLAUDE_HOOK_ARGS[@]}"` を展開しても
+# 引数が一切追加されず、本機能導入前と完全に同一の引数列で claude が起動される（NFR 1.1 /
+# Req 1.1, 1.2）。
+#
+# opt-in 時は以下を順に行う（fail-closed / Req 5.1〜5.5）:
+#   1. gh_preflight: claude version 確認 → install dir 完全性 → smoke test を fail-closed で
+#      連鎖判定する。失敗 (rc=11/12/13) → 非ゼロ exit して watcher 全体を停止する
+#      （黙って guard を無効化する fallback は持たない / Req 5.5）
+#   2. IDD_HOOK_BASE_BRANCH を export: hook プロセスは claude プロセスから env 継承するため、
+#      watcher が `BASE_BRANCH` を hook 側の判定基準として渡す唯一の経路（design.md Env Var
+#      Contract）。
+#   3. gh_build_args: `CLAUDE_HOOK_ARGS=(--settings <絶対パス>)` を構築。以降の `claude --print
+#      ... "${CLAUDE_HOOK_ARGS[@]}"` 展開で settings.json を Claude Code に渡す。
+if gh_is_enabled; then
+  gh_preflight || exit $?
+  export IDD_HOOK_BASE_BRANCH="$BASE_BRANCH"
+fi
+gh_build_args
 
 [ -f "$TRIAGE_TEMPLATE" ] || {
   echo "Error: Triage テンプレートが見つかりません: $TRIAGE_TEMPLATE" >&2
@@ -3122,6 +3172,7 @@ run_per_task_implementer() {
       --max-turns "$DEV_MAX_TURNS" \
       --output-format stream-json \
       --verbose \
+      "${CLAUDE_HOOK_ARGS[@]}" \
       >> "$LOG" 2>&1 || _qa_rc=$?
 
   case "$_qa_rc" in
@@ -3214,6 +3265,7 @@ run_per_task_reviewer() {
       --max-turns "$REVIEWER_MAX_TURNS" \
       --output-format stream-json \
       --verbose \
+      "${CLAUDE_HOOK_ARGS[@]}" \
       >> "$LOG" 2>&1 || _qa_rc=$?
 
   case "$_qa_rc" in
@@ -4235,6 +4287,7 @@ run_debugger_stage() {
       --max-turns "$DEBUGGER_MAX_TURNS" \
       --output-format stream-json \
       --verbose \
+      "${CLAUDE_HOOK_ARGS[@]}" \
       >> "$LOG" 2>&1 || _qa_rc=$?
 
   case "$_qa_rc" in
@@ -4847,6 +4900,7 @@ run_reviewer_stage() {
       --max-turns "$REVIEWER_MAX_TURNS" \
       --output-format stream-json \
       --verbose \
+      "${CLAUDE_HOOK_ARGS[@]}" \
       >> "$LOG" 2>&1 || _qa_rc_rv=$?
   case "$_qa_rc_rv" in
     0)
@@ -5622,6 +5676,7 @@ run_impl_pipeline() {
             --max-turns "$DEV_MAX_TURNS" \
             --output-format stream-json \
             --verbose \
+            "${CLAUDE_HOOK_ARGS[@]}" \
             >> "$LOG" 2>&1 || _qa_rc_a=$?
         # run サマリ: Stage A（通常 Developer 経路）実行を記録し degraded 兆候を反映
         # （quota 99 / 失敗 * でも claude 起動は試みられたため stage は走った / Req 2.1, 6.x）。
@@ -5741,6 +5796,7 @@ run_impl_pipeline() {
           --max-turns "$DEV_MAX_TURNS" \
           --output-format stream-json \
           --verbose \
+          "${CLAUDE_HOOK_ARGS[@]}" \
           >> "$LOG" 2>&1 || _qa_rc_bl=$?
       # run サマリ: Stage A'（BLOCKED 経路 Developer 再起動）実行を記録（Req 2.1, 6.x）。
       rs_record_stage "A'"
@@ -5884,6 +5940,7 @@ run_impl_pipeline() {
               --max-turns "$DEV_MAX_TURNS" \
               --output-format stream-json \
               --verbose \
+              "${CLAUDE_HOOK_ARGS[@]}" \
               >> "$LOG" 2>&1 || _qa_rc_aredo=$?
           # run サマリ: Stage A'（Reviewer reject 差し戻し Developer 再実行）実行を記録
           # （Req 2.1, 6.x）。
@@ -6000,6 +6057,7 @@ run_impl_pipeline() {
                     --max-turns "$DEV_MAX_TURNS" \
                     --output-format stream-json \
                     --verbose \
+                    "${CLAUDE_HOOK_ARGS[@]}" \
                     >> "$LOG" 2>&1 || _qa_rc_app=$?
                 case "$_qa_rc_app" in
                   0)
@@ -6182,6 +6240,7 @@ run_impl_pipeline() {
       --max-turns "$DEV_MAX_TURNS" \
       --output-format stream-json \
       --verbose \
+      "${CLAUDE_HOOK_ARGS[@]}" \
       >> "$LOG" 2>&1 || _qa_rc_c=$?
   # run サマリ: Stage C（PjM / PR 作成）実行を記録し degraded 兆候を反映（Req 2.1, 6.x）。
   # 既存 PR ガード（stage_c_existing_pr_guard）で PjM 起動前に early return したケースでは
@@ -7787,6 +7846,7 @@ _slot_run_issue() {
         --model "$TRIAGE_MODEL" \
         --permission-mode bypassPermissions \
         --max-turns "$TRIAGE_MAX_TURNS" \
+        "${CLAUDE_HOOK_ARGS[@]}" \
         >> "$LOG" 2>&1 || _qa_rc_triage=$?
     case "$_qa_rc_triage" in
       0)
@@ -8039,6 +8099,7 @@ EOF
         --max-turns "$DEV_MAX_TURNS" \
         --output-format stream-json \
         --verbose \
+        "${CLAUDE_HOOK_ARGS[@]}" \
         >> "$LOG" 2>&1 || _qa_rc_design=$?
     case "$_qa_rc_design" in
       0)

--- a/local-watcher/bin/modules/guard-hook.sh
+++ b/local-watcher/bin/modules/guard-hook.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# guard-hook.sh — watcher の PreToolUse Guard Hook 注入モジュール (#294)
+#
+# 用途:
+#   Claude Code の PreToolUse フック機構を利用して base ブランチ宛 push / 無条件 force
+#   push / guard install dir の自己改変を機械 deny する初版（G0 + G1 + G2）を、watcher
+#   の claude CLI 起動時に opt-in で配線するためのヘルパ関数を集約する。本モジュールは
+#   hook 本体（local-watcher/hooks/idd-guard.sh）と settings.json を user-scope の
+#   $IDD_CLAUDE_HOOKS_DIR（既定 $HOME/.idd-claude/hooks）に install.sh が配置している
+#   前提のもとで、watcher 側の preflight ゲートと `--settings` 引数構築を担う。
+#   - gh_log / gh_warn / gh_error : `guard-hook:` 3 段 prefix logger
+#   - gh_is_enabled               : IDD_CLAUDE_HOOKS_ENABLED の厳密 `true` 一致判定
+#   - gh_resolve_dir              : install dir 絶対パス解決（末尾スラッシュ除去）
+#   - gh_compare_semver           : 数値ベース semver 比較（`a -ge b` の bash 戻り値）
+#   - gh_preflight                : claude version → install dir 完全性 → smoke test の
+#                                   fail-closed 連鎖（戻り値 0=pass / 11/12/13=fail）
+#   - gh_build_args               : CLAUDE_HOOK_ARGS グローバル配列を opt-in/out で構築
+#
+# 配置先:
+#   $HOME/bin/modules/guard-hook.sh（install.sh が local-watcher/bin/modules/ から配置する）
+#
+# 依存:
+#   - 本モジュールは issue-watcher.sh 本体から `source` される前提（単体起動しない）。
+#   - `set -euo pipefail` は本体側で宣言済みのため、本モジュールでは宣言せず関数定義のみを持つ。
+#   - グローバル変数（$REPO / $IDD_CLAUDE_HOOKS_ENABLED / $IDD_CLAUDE_HOOKS_DIR /
+#     $IDD_CLAUDE_HOOKS_MIN_VERSION）は本体冒頭の Config ブロックで定義済み。bash の遅延束縛
+#     により呼び出し時に解決される。$REPO 未定義時は ${REPO:-?} で防御する。
+#   - 外部 CLI: claude（version 取得）/ bash（smoke test 起動）。jq は hook 本体側が要求し、
+#     本モジュールは smoke test の stdout 検査では `decision` リテラル grep のみで判定する
+#     ことで jq 依存を持たない（fail-closed は hook 本体側でも独立に成立する）。
+#
+# セットアップ参照先:
+#   - 要件: docs/specs/294-feat-watcher-pretooluse-guard-hook-base/requirements.md
+#   - 設計: docs/specs/294-feat-watcher-pretooluse-guard-hook-base/design.md
+
+# guard-hook 専用ロガー（既存 sav_log / sh_log と同形式 / Issue #119 規約）。
+# 行頭 `[YYYY-MM-DD HH:MM:SS] [$REPO] guard-hook:` の 3 段 prefix を維持し、
+# `grep '\[.*\] guard-hook:'` で全件抽出可能。$REPO は本体側グローバルの遅延束縛。
+gh_log() {
+  echo "[$(date '+%F %T')] [${REPO:-?}] guard-hook: $*"
+}
+gh_warn() {
+  echo "[$(date '+%F %T')] [${REPO:-?}] guard-hook: WARN: $*" >&2
+}
+gh_error() {
+  echo "[$(date '+%F %T')] [${REPO:-?}] guard-hook: ERROR: $*" >&2
+}
+
+# ─── gh_is_enabled ───
+#
+# IDD_CLAUDE_HOOKS_ENABLED の値が文字列 `true` と **完全一致** する場合のみ opt-in 有効と判定する。
+# Req 1.1 の typo 安全側設計（`True` / `1` / `yes` 等はすべて opt-out 扱い）。
+# 戻り値: 0 = opt-in 有効 / 1 = opt-out（既定）
+gh_is_enabled() {
+  [ "${IDD_CLAUDE_HOOKS_ENABLED:-}" = "true" ]
+}
+
+# ─── gh_resolve_dir ───
+#
+# guard hook の install dir を絶対パスで stdout に返す（末尾スラッシュ除去）。
+# 既定 `$HOME/.idd-claude/hooks`、IDD_CLAUDE_HOOKS_DIR env で override 可（Req 1.4 / NFR 1.3）。
+# 物理存在は問わない（呼び出し側 gh_preflight で判定する）。
+gh_resolve_dir() {
+  local dir="${IDD_CLAUDE_HOOKS_DIR:-$HOME/.idd-claude/hooks}"
+  while [ ${#dir} -gt 1 ] && [ "${dir: -1}" = "/" ]; do
+    dir="${dir%/}"
+  done
+  printf '%s' "$dir"
+}
+
+# ─── gh_compare_semver ───
+#
+# 数値ベースの semver 比較（`major.minor.patch` 3 セグメント前提）。辞書順比較を避けるため
+# `.` で split して数値比較する。比較対象に prefix（`v` 等）や suffix（`-beta` 等）が
+# 紛れている場合はセグメントごとに leading int を読む（保守的）。
+#
+# 入力: $1 = 比較される version / $2 = 最小要求 version
+# 戻り値: 0 = $1 >= $2 / 1 = $1 < $2 / 2 = parse 失敗（呼び出し側で fail-closed 扱い）
+gh_compare_semver() {
+  local a="$1"
+  local b="$2"
+  local a_major a_minor a_patch
+  local b_major b_minor b_patch
+  local IFS='.'
+  # shellcheck disable=SC2206
+  local -a aa=($a)
+  # shellcheck disable=SC2206
+  local -a bb=($b)
+  IFS=' '
+
+  # セグメントごとに先頭の整数だけ取り出す（例: `2.1.167-beta` → `2` / `1` / `167`）
+  _gh_seg() {
+    local s="${1:-0}"
+    # 先頭の整数部だけ残す（非数字以降は捨てる）
+    local out=""
+    local i=0
+    while [ "$i" -lt "${#s}" ]; do
+      local c="${s:$i:1}"
+      case "$c" in
+        [0-9]) out+="$c" ;;
+        *) break ;;
+      esac
+      i=$((i + 1))
+    done
+    [ -z "$out" ] && out=0
+    printf '%s' "$out"
+  }
+
+  a_major="$(_gh_seg "${aa[0]:-0}")"
+  a_minor="$(_gh_seg "${aa[1]:-0}")"
+  a_patch="$(_gh_seg "${aa[2]:-0}")"
+  b_major="$(_gh_seg "${bb[0]:-0}")"
+  b_minor="$(_gh_seg "${bb[1]:-0}")"
+  b_patch="$(_gh_seg "${bb[2]:-0}")"
+
+  # 一切数値が拾えなければ parse 失敗（保守的に rc=2）
+  case "$a_major$a_minor$a_patch$b_major$b_minor$b_patch" in
+    *[!0-9]*) return 2 ;;
+  esac
+
+  if [ "$a_major" -gt "$b_major" ]; then return 0; fi
+  if [ "$a_major" -lt "$b_major" ]; then return 1; fi
+  if [ "$a_minor" -gt "$b_minor" ]; then return 0; fi
+  if [ "$a_minor" -lt "$b_minor" ]; then return 1; fi
+  if [ "$a_patch" -ge "$b_patch" ]; then return 0; fi
+  return 1
+}
+
+# ─── gh_preflight ───
+#
+# opt-in 時の fail-closed ゲート。決定論的に以下の順で評価する（Req 5.1〜5.5）:
+#   1. claude --version を取得し、IDD_CLAUDE_HOOKS_MIN_VERSION（既定 `2.1.167`）と比較
+#      → 不足なら stderr に理由を出して return 11
+#   2. install dir 配下に idd-guard.sh / idd-guard-settings.json の両方が存在するかを確認
+#      → 不在なら return 12
+#   3. smoke test: 固定 fixture JSON を stdin に流して idd-guard.sh を起動し、exit 0 かつ
+#      stdout に `"decision"` リテラルが含まれない（= allow 動作）ことを確認 → 失敗で
+#      return 13
+# すべて通れば return 0。副作用は stderr 出力のみ。
+gh_preflight() {
+  local hooks_dir
+  hooks_dir="$(gh_resolve_dir)"
+  local min_version="${IDD_CLAUDE_HOOKS_MIN_VERSION:-2.1.167}"
+
+  # 1. claude version check
+  if ! command -v claude >/dev/null 2>&1; then
+    gh_error "claude CLI が PATH 上に見つかりません（IDD_CLAUDE_HOOKS_ENABLED=true 時は必須）"
+    gh_error "Claude Code を install するか、PATH を見直してください"
+    return 11
+  fi
+  local raw_version
+  raw_version="$(claude --version 2>/dev/null || true)"
+  # `claude --version` の出力例: `2.1.167 (Claude Code)` / `claude 2.1.167` 等を許容
+  # 先頭の数値部を空白 / 括弧前で抽出する
+  local detected
+  detected="$(printf '%s' "$raw_version" | awk '{ for (i=1; i<=NF; i++) if ($i ~ /^[0-9]+\.[0-9]+/) { print $i; exit } }')"
+  if [ -z "$detected" ]; then
+    gh_error "claude --version の出力から version を抽出できませんでした（raw='$raw_version'）"
+    gh_error "claude CLI が正常か確認し、IDD_CLAUDE_HOOKS_MIN_VERSION の前提を見直してください"
+    return 11
+  fi
+  if ! gh_compare_semver "$detected" "$min_version"; then
+    gh_error "claude version $detected は最小要件 $min_version を満たしません"
+    gh_error "Claude Code を $min_version 以上に更新するか、IDD_CLAUDE_HOOKS_MIN_VERSION を緩めてください"
+    return 11
+  fi
+  gh_log "preflight version ok detected=$detected min=$min_version"
+
+  # 2. install dir completeness
+  local hook_script="$hooks_dir/idd-guard.sh"
+  local hook_settings="$hooks_dir/idd-guard-settings.json"
+  if [ ! -f "$hook_script" ] || [ ! -f "$hook_settings" ]; then
+    gh_error "guard hook install dir が不完全です: dir=$hooks_dir"
+    [ ! -f "$hook_script" ] && gh_error "  missing: $hook_script"
+    [ ! -f "$hook_settings" ] && gh_error "  missing: $hook_settings"
+    gh_error "install.sh --local を再実行して hook 一式を配置してください"
+    return 12
+  fi
+  if [ ! -x "$hook_script" ]; then
+    gh_error "guard hook script に実行権限がありません: $hook_script"
+    gh_error "install.sh --local を再実行するか chmod +x で実行権限を付与してください"
+    return 12
+  fi
+  gh_log "preflight install dir ok dir=$hooks_dir"
+
+  # 3. smoke test
+  local smoke_input='{"tool_name":"Bash","tool_input":{"command":"echo idd-guard-smoke-ok"}}'
+  local smoke_stdout smoke_rc
+  smoke_stdout="$(printf '%s' "$smoke_input" | bash "$hook_script" 2>&1)" && smoke_rc=0 || smoke_rc=$?
+  if [ "$smoke_rc" -ne 0 ]; then
+    gh_error "guard hook smoke test が非ゼロ exit しました（rc=$smoke_rc）"
+    gh_error "  hook stdout/stderr 末尾: $(printf '%s' "$smoke_stdout" | tail -n 3)"
+    return 13
+  fi
+  # allow 期待: decision フィールドが含まれてはならない
+  if printf '%s' "$smoke_stdout" | grep -q '"decision"'; then
+    gh_error "guard hook smoke test が想定外に deny を返しました"
+    gh_error "  hook stdout: $smoke_stdout"
+    gh_error "  IDD_HOOK_BASE_BRANCH / IDD_CLAUDE_HOOKS_DIR の設定を確認してください"
+    return 13
+  fi
+  gh_log "preflight smoke test ok"
+
+  return 0
+}
+
+# ─── gh_build_args ───
+#
+# claude CLI 起動時に追加すべき引数列を CLAUDE_HOOK_ARGS グローバル配列に構築する（Req 1.1, 1.2）。
+#   opt-out 時: ()                                  → claude 起動引数列に何も追加されない
+#   opt-in 時 : (--settings <install_dir/idd-guard-settings.json 絶対パス>)
+#
+# 呼び出し側は `claude --print "$prompt" ... "${CLAUDE_HOOK_ARGS[@]}"` の形で展開する。
+# bash の `set -u` 配下で空配列展開は bash 4.4+ で安全（CLAUDE.md bash 4+ 要求）。
+gh_build_args() {
+  # shellcheck disable=SC2034  # CLAUDE_HOOK_ARGS is consumed by issue-watcher.sh call sites
+  CLAUDE_HOOK_ARGS=()
+  if ! gh_is_enabled; then
+    return 0
+  fi
+  local hooks_dir
+  hooks_dir="$(gh_resolve_dir)"
+  # shellcheck disable=SC2034  # CLAUDE_HOOK_ARGS is consumed by issue-watcher.sh call sites
+  CLAUDE_HOOK_ARGS=(--settings "$hooks_dir/idd-guard-settings.json")
+}

--- a/local-watcher/hooks/README.md
+++ b/local-watcher/hooks/README.md
@@ -1,0 +1,59 @@
+# idd-claude PreToolUse Guard Hook (opt-in 初版)
+
+idd-claude の watcher が起動する Claude Code エージェントに対し、`PreToolUse` フック経由で
+**base ブランチ宛 push**・**無条件 force push**・**guard install dir の自己改変**を機械的に
+deny する初版（G0 + G1 + G2）。
+
+## 配置先（user-scope）
+
+| ファイル | 配置先（既定） |
+|---|---|
+| `idd-guard.sh` | `$HOME/.idd-claude/hooks/idd-guard.sh` |
+| `idd-guard-settings.json` | `$HOME/.idd-claude/hooks/idd-guard-settings.json` |
+| `README.md` | `$HOME/.idd-claude/hooks/README.md` |
+
+`IDD_CLAUDE_HOOKS_DIR` 環境変数で配置先 override 可。sudo 不要（user-scope 専用）。
+
+配置は `install.sh --local`（Task 5）が user-scope に行う。`repo-template/` には配布しない
+（consumer repo への展開は後続 Issue）。
+
+## 環境変数契約
+
+| Var | 用途 | Default |
+|---|---|---|
+| `IDD_HOOK_BASE_BRANCH` | G1 で deny 対象とする base ブランチ名 | `main` |
+| `IDD_CLAUDE_HOOKS_DIR` | G0 で保護する install dir | `$HOME/.idd-claude/hooks` |
+| `IDD_HOOK_LOG` | 設定時は判定結果を 1 行 append（任意） | （未設定 = no-op） |
+
+watcher は preflight 通過後に `export IDD_HOOK_BASE_BRANCH="$BASE_BRANCH"` を 1 度だけ行い、
+claude プロセスから hook プロセスへ継承される。
+
+## 検査範囲
+
+- **G0**: `Edit` / `Write` / `NotebookEdit` で install dir 配下の path を変更しようとした場合
+  に deny。`Bash` 経由は mutation キーワード（`rm` / `mv` / `sed -i` / `chmod` /
+  リダイレクト / `tee`）と install dir リテラルの両方を含む場合のみ best-effort で deny
+- **G1**: `git push <remote> <base>` / `HEAD:<base>` / `:<base>` / `+<base>` / `-C path push ...` /
+  暗黙 remote / `--delete <base>` などの全形態を deny
+- **G2**: `-f` / `--force` で deny。`--force-with-lease(=...)` は base 以外なら allow。
+  refspec 先頭の `+` は base 以外でも deny
+
+## 既知の限界（NFR 3.1〜3.3）
+
+- top-level Bash 文字列のみ解析する。`sh -c "..."` / `$(...)` / wrapper script 内部の push は
+  捕捉できない
+- 引数なしの bare `git push` で現ブランチが偶然 base と一致するケースは literal 解析では
+  判定不能（NFR 3.2）
+- G0 の Bash 経由 mutation 検出は best-effort であり全件捕捉を保証しない（NFR 3.3）
+- 本初版は role/spec guard / secrets guard / `bypassPermissions` 廃止を含まない（NFR 3.4）
+
+## decision JSON 出力契約
+
+- deny: `{"decision":"block","reason":"..."}`
+- allow: `{}`（decision フィールドなし。Claude 側のデフォルト判定に委ねる）
+- exit code は常に 0。jq 不在 / JSON parse 失敗は **fail-closed**（exit 0 + block JSON）
+
+## opt-in 手順
+
+watcher の cron / launchd 行に `IDD_CLAUDE_HOOKS_ENABLED=true` を加える（詳細は repo root の
+`README.md` を参照。本ファイルは hook ローカル参照用の短文）。

--- a/local-watcher/hooks/idd-guard-settings.json
+++ b/local-watcher/hooks/idd-guard-settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "__IDD_HOOK_PATH__"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/local-watcher/hooks/idd-guard.sh
+++ b/local-watcher/hooks/idd-guard.sh
@@ -1,0 +1,511 @@
+#!/usr/bin/env bash
+# idd-guard.sh
+#
+# 用途: Claude Code の PreToolUse フックとして起動され、Bash / Edit / Write /
+#       NotebookEdit ツール呼び出しを検査して以下のいずれかに該当すれば deny する。
+#       - G1: base ブランチ (`$IDD_HOOK_BASE_BRANCH`) 宛の push（bare / `HEAD:base` /
+#             `:base` / `+base` / `-C path` / 暗黙 remote / `--delete` を含む全形態）
+#       - G2: 無条件 force push（`-f` / `--force` / refspec 先頭 `+`）。
+#             `--force-with-lease(=...)` は base 以外なら allow。
+#       - G0: guard install dir (`$IDD_CLAUDE_HOOKS_DIR`、既定 `$HOME/.idd-claude/hooks`)
+#             配下のファイルへの Edit / Write / NotebookEdit、および Bash 経由の
+#             mutation コマンド（`rm` / `mv` / `sed -i` / `chmod` / リダイレクト / `tee`）。
+#             Bash 経由は best-effort（NFR 3.3）。
+#
+# 配置先: $IDD_CLAUDE_HOOKS_DIR/idd-guard.sh
+#          （install.sh が user-scope `$HOME/.idd-claude/hooks/` 既定で配置）
+#
+# 依存: bash 4+, jq
+#
+# 環境変数契約:
+#   IDD_HOOK_BASE_BRANCH  base ブランチ名。未設定で `main` フォールバック
+#   IDD_CLAUDE_HOOKS_DIR  guard install dir。未設定で `$HOME/.idd-claude/hooks`
+#   IDD_HOOK_LOG          設定時は 1 行 append（任意）
+#
+# stdin / stdout:
+#   stdin  : Claude Code PreToolUse JSON（`tool_name` / `tool_input` を含む）
+#   stdout : decision JSON
+#            - deny: {"decision":"block","reason":"..."}
+#            - allow: {}
+#   exit code: 常に 0（allow も deny も exit 0。エラーは fail-closed で block JSON）
+#
+# セットアップ参照先: README.md（同ディレクトリ）
+
+set -euo pipefail
+
+#
+# Logging (optional)
+#
+hook_log() {
+  local log_path="${IDD_HOOK_LOG:-}"
+  [ -z "$log_path" ] && return 0
+  printf '%s\t%s\t%s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$1" "$2" >>"$log_path" 2>/dev/null || true
+}
+
+#
+# Output helpers
+#
+emit_allow() {
+  printf '{}\n'
+  hook_log "allow" "${1:-}"
+  exit 0
+}
+
+emit_deny() {
+  local reason="$1"
+  # jq -n でエスケープ安全な JSON を構築
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'
+  else
+    # jq 不在時は手書き（quote 最小エスケープ）
+    local escaped="${reason//\\/\\\\}"
+    escaped="${escaped//\"/\\\"}"
+    printf '{"decision":"block","reason":"%s"}\n' "$escaped"
+  fi
+  hook_log "deny" "$reason"
+  exit 0
+}
+
+emit_deny_fail_closed() {
+  emit_deny "guard hook internal error: $1"
+}
+
+#
+# Path normalization
+#
+resolve_hooks_dir() {
+  local dir="${IDD_CLAUDE_HOOKS_DIR:-$HOME/.idd-claude/hooks}"
+  # 末尾スラッシュ除去
+  while [ "${dir: -1}" = "/" ] && [ ${#dir} -gt 1 ]; do
+    dir="${dir%/}"
+  done
+  printf '%s' "$dir"
+}
+
+# `~` / `$HOME` プレフィックスを展開し、`./` を除去した簡易絶対パス化
+normalize_path() {
+  local p="$1"
+  # leading `~` を $HOME に展開（リテラル `~` を `$HOME` 展開対象として扱うため、
+  # tilde の literal 比較を明示する。SC2088 は意図的な literal 比較）
+  # shellcheck disable=SC2088
+  local tilde_slash='~/'
+  # shellcheck disable=SC2088
+  local tilde='~'
+  if [ "${p:0:2}" = "$tilde_slash" ]; then
+    p="$HOME/${p:2}"
+  elif [ "$p" = "$tilde" ]; then
+    p="$HOME"
+  fi
+  printf '%s' "$p"
+}
+
+#
+# G0: install dir self-mutation check
+#
+# Edit / Write / NotebookEdit の対象パスが install dir 配下なら deny
+check_g0_path() {
+  local target_path="$1"
+  local hooks_dir
+  hooks_dir="$(resolve_hooks_dir)"
+  local normalized
+  normalized="$(normalize_path "$target_path")"
+  # プレフィックス一致（末尾区切りも含めて判定。`/dir` vs `/dir2` の誤一致を避ける）
+  case "$normalized" in
+    "$hooks_dir"|"$hooks_dir"/*)
+      emit_deny "guard install dir self-mutation denied: path=$normalized"
+      ;;
+  esac
+}
+
+# Bash command 文字列に install dir のリテラル + mutation キーワードが両方含まれるか
+check_g0_bash() {
+  local cmd="$1"
+  local hooks_dir
+  hooks_dir="$(resolve_hooks_dir)"
+  local literal_match=0
+
+  # install dir 絶対パスか `~/.idd-claude/hooks` / `$HOME/.idd-claude/hooks` リテラル
+  # が cmd に含まれるかを判定する。tilde / $HOME 展開はしたくない（substring 検出が目的）
+  # ため意図的に literal を保持する。
+  # shellcheck disable=SC2088
+  local tilde_literal='~/.idd-claude/hooks'
+  # shellcheck disable=SC2016
+  local home_literal='$HOME/.idd-claude/hooks'
+  if [[ "$cmd" == *"$hooks_dir"* ]] || [[ "$cmd" == *"$tilde_literal"* ]] \
+       || [[ "$cmd" == *"$home_literal"* ]]; then
+    literal_match=1
+  fi
+  [ "$literal_match" -eq 0 ] && return 0
+
+  # mutation キーワード（best-effort）
+  # `rm` / `mv` / `sed -i` / `chmod` / `>` / `>>` / `tee` / `cat >`
+  if [[ "$cmd" =~ (^|[[:space:];&|])(rm|mv|chmod|tee)([[:space:]]|$) ]] \
+       || [[ "$cmd" =~ sed[[:space:]]+-i ]] \
+       || [[ "$cmd" =~ [[:space:]]\>\>?[[:space:]] ]] \
+       || [[ "$cmd" =~ [[:space:]]\>\>?$ ]] \
+       || [[ "$cmd" =~ cat[[:space:]]+\> ]]; then
+    emit_deny "guard install dir self-mutation denied: path=$hooks_dir (bash best-effort)"
+  fi
+}
+
+#
+# Git push parsing for G1 / G2
+#
+# tokens 配列を引数で受け取り、git global options を skip して "push" 以降の
+# token を抽出する。先頭 token は "git" 前提（呼び出し側で確認）。
+#
+# 出力: グローバル配列 PUSH_TOKENS を設定。git push でなければ空配列。
+extract_push_tokens() {
+  PUSH_TOKENS=()
+  local -a in=("$@")
+  local n=${#in[@]}
+  [ "$n" -lt 2 ] && return 0
+  [ "${in[0]}" != "git" ] && return 0
+
+  local i=1
+  while [ "$i" -lt "$n" ]; do
+    local tok="${in[$i]}"
+    case "$tok" in
+      -C)
+        # -C <path> をペアで skip
+        i=$((i + 2))
+        ;;
+      --git-dir=*|--work-tree=*|--namespace=*)
+        i=$((i + 1))
+        ;;
+      --git-dir|--work-tree|--namespace)
+        i=$((i + 2))
+        ;;
+      -c)
+        # -c key=value
+        i=$((i + 2))
+        ;;
+      -c=*|--config-env=*)
+        i=$((i + 1))
+        ;;
+      --exec-path=*|--exec-path)
+        i=$((i + 1))
+        ;;
+      --*|-*)
+        # その他の global option は単独 token として skip（保守的）
+        i=$((i + 1))
+        ;;
+      push)
+        # push 以降を PUSH_TOKENS に格納
+        local j=$((i + 1))
+        while [ "$j" -lt "$n" ]; do
+          PUSH_TOKENS+=("${in[$j]}")
+          j=$((j + 1))
+        done
+        return 0
+        ;;
+      *)
+        # push 以外のサブコマンド
+        return 0
+        ;;
+    esac
+  done
+}
+
+# refspec から dst 部を抽出
+# 入力: refspec 文字列（例: `main`, `HEAD:main`, `:main`, `+main`, `+HEAD:main`,
+#       `+src:dst`）
+# 出力: stdout に dst 名
+extract_dst_from_refspec() {
+  local rs="$1"
+  # 先頭の `+` を除去
+  [ "${rs:0:1}" = "+" ] && rs="${rs:1}"
+  if [[ "$rs" == *:* ]]; then
+    printf '%s' "${rs#*:}"
+  else
+    printf '%s' "$rs"
+  fi
+}
+
+# refspec が `+` 接頭辞を持つか
+refspec_has_plus_prefix() {
+  [ "${1:0:1}" = "+" ]
+}
+
+# tokens 配列を引数で受け取り、push 用 G1/G2 判定を行う。
+analyze_push() {
+  local base_branch="${IDD_HOOK_BASE_BRANCH:-main}"
+  local -a tokens=("$@")
+  local n=${#tokens[@]}
+  [ "$n" -eq 0 ] && return 0
+
+  # flag 検出（G2 判定用）
+  local has_force=0
+  local has_lease=0
+  local has_delete=0
+  local i=0
+  while [ "$i" -lt "$n" ]; do
+    case "${tokens[$i]}" in
+      -f|--force)
+        has_force=1
+        ;;
+      --force-with-lease|--force-with-lease=*)
+        has_lease=1
+        ;;
+      -d|--delete)
+        has_delete=1
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  # non-flag token を順に抽出（remote / refspec 群）
+  local -a positional=()
+  i=0
+  while [ "$i" -lt "$n" ]; do
+    local t="${tokens[$i]}"
+    case "$t" in
+      -*)
+        # `-o key=value` / `--receive-pack=...` 等のオプションを保守的に skip
+        case "$t" in
+          --*=*) ;;
+          --*) ;;
+          -*) ;;
+        esac
+        ;;
+      *)
+        positional+=("$t")
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  # positional[0] = remote 候補（暗黙 remote の場合は refspec の可能性）
+  # positional[1..] = refspec 候補
+  #
+  # 暗黙 remote 判定: positional[0] が `<remote>` らしくない（`:` を含む / `+` 始まり）か、
+  # またはそもそも positional が 1 件で base 名と一致するケースは refspec として扱う
+  local -a refspecs=()
+  local p_count=${#positional[@]}
+  if [ "$p_count" -eq 0 ]; then
+    # bare push（引数なし）。literal 解析では判定不能（NFR 3.2）。
+    # G2 だけは判定可能
+    :
+  elif [ "$p_count" -eq 1 ]; then
+    # 1 件のみ: remote 単独か暗黙 remote refspec か曖昧
+    # `:`含み / `+`始まり なら refspec 扱い、それ以外は両方の可能性を考慮し
+    # base 名と一致する場合は refspec として扱う（Req 2.6 暗黙 remote 対応）
+    local p0="${positional[0]}"
+    if [[ "$p0" == *:* ]] || [ "${p0:0:1}" = "+" ]; then
+      refspecs+=("$p0")
+    elif [ "$p0" = "$base_branch" ]; then
+      # `git push main` 形式（暗黙 remote の base 宛 push）
+      refspecs+=("$p0")
+    elif [ "$has_delete" -eq 1 ]; then
+      # `git push --delete main` 相当（remote 省略）も refspec 扱い
+      refspecs+=("$p0")
+    fi
+    # それ以外は remote 名と解釈し refspec 不明（現ブランチ依存。literal 解析不能）
+  else
+    # 2 件以上: positional[0] が remote、残りが refspec
+    # ただし positional[0] が `:` 含みなら remote 名ではないので全部 refspec 扱い
+    local p0="${positional[0]}"
+    if [[ "$p0" == *:* ]] || [ "${p0:0:1}" = "+" ]; then
+      refspecs=("${positional[@]}")
+    else
+      refspecs=("${positional[@]:1}")
+    fi
+  fi
+
+  # G1: base 宛判定（refspec の dst が base 一致 / delete の対象が base 一致）
+  local rs
+  for rs in "${refspecs[@]:-}"; do
+    [ -z "$rs" ] && continue
+    local dst
+    dst="$(extract_dst_from_refspec "$rs")"
+    if [ "$dst" = "$base_branch" ]; then
+      emit_deny "base branch push denied: ref=$rs (base=$base_branch)"
+    fi
+  done
+
+  # `--delete <ref>` 形式（refspec ではなく flag + positional）
+  if [ "$has_delete" -eq 1 ]; then
+    local pp
+    for pp in "${positional[@]:-}"; do
+      [ -z "$pp" ] && continue
+      if [ "$pp" = "$base_branch" ]; then
+        emit_deny "base branch push denied: --delete $pp (base=$base_branch)"
+      fi
+    done
+  fi
+
+  # G2: 無条件 force（-f / --force）
+  if [ "$has_force" -eq 1 ]; then
+    emit_deny "unconditional force push denied: use --force-with-lease"
+  fi
+
+  # G2: refspec 先頭 `+`（base 以外でも deny。base 宛は既に G1 で deny されている）
+  for rs in "${refspecs[@]:-}"; do
+    [ -z "$rs" ] && continue
+    if refspec_has_plus_prefix "$rs"; then
+      emit_deny "unconditional force push denied: refspec '+' prefix in '$rs' (use --force-with-lease)"
+    fi
+  done
+
+  # G2: --force-with-lease は base 以外なら allow（明示的に何もしない）
+  # （base 宛は既に G1 で deny されている）
+  : "$has_lease"
+}
+
+#
+# Bash command parser
+#
+# top-level command 文字列を token 配列に分割する（簡易 shell lexer）。
+# - 単純な空白区切り
+# - シングル / ダブルクォート対応（中身はそのまま 1 token）
+# - エスケープ `\<char>` 対応
+# - `;` / `&&` / `||` / `|` / `\n` の手前で打ち切り（先頭コマンド句のみ抽出）
+#   理由: `git push origin main && do_other` の先頭句だけ評価対象とすればよい。
+#   `sh -c "..."` / `$(...)` 内部は解析しない（NFR 3.1）
+parse_top_level_tokens() {
+  local cmd="$1"
+  TOKENS=()
+  local i=0
+  local n=${#cmd}
+  local cur=""
+  local in_single=0
+  local in_double=0
+
+  while [ "$i" -lt "$n" ]; do
+    local c="${cmd:$i:1}"
+
+    if [ "$in_single" -eq 1 ]; then
+      if [ "$c" = "'" ]; then
+        in_single=0
+      else
+        cur+="$c"
+      fi
+      i=$((i + 1))
+      continue
+    fi
+
+    if [ "$in_double" -eq 1 ]; then
+      if [ "$c" = '"' ]; then
+        in_double=0
+      elif [ "$c" = "\\" ] && [ $((i + 1)) -lt "$n" ]; then
+        local nx="${cmd:$((i + 1)):1}"
+        cur+="$nx"
+        i=$((i + 2))
+        continue
+      else
+        cur+="$c"
+      fi
+      i=$((i + 1))
+      continue
+    fi
+
+    case "$c" in
+      "'")
+        in_single=1
+        ;;
+      '"')
+        in_double=1
+        ;;
+      "\\")
+        if [ $((i + 1)) -lt "$n" ]; then
+          cur+="${cmd:$((i + 1)):1}"
+          i=$((i + 1))
+        fi
+        ;;
+      " "|$'\t')
+        if [ -n "$cur" ]; then
+          TOKENS+=("$cur")
+          cur=""
+        fi
+        ;;
+      $'\n'|";")
+        # 先頭句で打ち切り
+        if [ -n "$cur" ]; then
+          TOKENS+=("$cur")
+          cur=""
+        fi
+        return 0
+        ;;
+      "&"|"|")
+        # `&&` / `||` / `|` で打ち切り（次の文字も同じなら 2 文字、違っても 1 文字で打ち切り）
+        if [ -n "$cur" ]; then
+          TOKENS+=("$cur")
+          cur=""
+        fi
+        return 0
+        ;;
+      *)
+        cur+="$c"
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  if [ -n "$cur" ]; then
+    TOKENS+=("$cur")
+  fi
+}
+
+#
+# Main dispatch
+#
+main() {
+  # jq 不在は fail-closed
+  if ! command -v jq >/dev/null 2>&1; then
+    emit_deny_fail_closed "jq not found in PATH"
+  fi
+
+  local input
+  input="$(cat || true)"
+  [ -z "$input" ] && emit_allow "empty input"
+
+  # JSON parse
+  local tool_name
+  if ! tool_name="$(printf '%s' "$input" | jq -er '.tool_name // empty')"; then
+    emit_deny_fail_closed "failed to parse PreToolUse JSON (tool_name)"
+  fi
+  [ -z "$tool_name" ] && emit_allow "no tool_name"
+
+  case "$tool_name" in
+    Edit|Write)
+      local file_path
+      file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty')"
+      [ -n "$file_path" ] && check_g0_path "$file_path"
+      emit_allow "$tool_name file_path ok"
+      ;;
+    NotebookEdit)
+      local notebook_path
+      notebook_path="$(printf '%s' "$input" | jq -r '.tool_input.notebook_path // .tool_input.file_path // empty')"
+      [ -n "$notebook_path" ] && check_g0_path "$notebook_path"
+      emit_allow "NotebookEdit path ok"
+      ;;
+    Bash)
+      local command_str
+      command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+      [ -z "$command_str" ] && emit_allow "Bash empty command"
+
+      # G0 (Bash best-effort)
+      check_g0_bash "$command_str"
+
+      # token 分割
+      TOKENS=()
+      parse_top_level_tokens "$command_str"
+
+      # `git push` 解析
+      if [ "${#TOKENS[@]}" -ge 1 ] && [ "${TOKENS[0]}" = "git" ]; then
+        PUSH_TOKENS=()
+        extract_push_tokens "${TOKENS[@]}"
+        if [ "${#PUSH_TOKENS[@]}" -ge 0 ] && [ -n "${PUSH_TOKENS[*]:-}" ]; then
+          analyze_push "${PUSH_TOKENS[@]}"
+        fi
+      fi
+
+      emit_allow "Bash ok"
+      ;;
+    *)
+      emit_allow "tool_name=$tool_name not in scope"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## 概要

idd-claude のエージェント実行は現在 `--permission-mode bypassPermissions` で走っており、base ブランチへの直接 push や無条件 force push といった規約違反は散文ドキュメントのみで宣言されていた。本 PR は Claude Code の `PreToolUse` フック機構を使い、外部 `settings.json` 経由で機械的に違反を deny する **guard hook 初版（G0/G1/G2）** を導入する。

初版は `IDD_CLAUDE_HOOKS_ENABLED=true` で有効化する **opt-in 制** であり、未設定時は導入前と完全に同一の挙動を保つ（後方互換性確保）。配布スコープは user-scope 専用（`~/.idd-claude/hooks/`）に限定し、consumer repo への展開は後続の別 Issue として独立に承認・起票される前提。

## 対応 Issue

Closes #294

## 関連 PR

- 設計 PR: #298（merged）

## 実装内容

- (Req 1, Task 1) `local-watcher/hooks/idd-guard.sh` を新規作成。G0/G1/G2 の deny ロジックを stdin JSON 受け取り + jq 解析で実装（fail-closed 設計）
- (Req 2, Task 1) G1: base ブランチ宛 push を bare/src:dst/delete-colon/plus-refspec/-C path/暗黙 remote の全形で deny
- (Req 3, Task 1) G2: `-f` / `--force` / `+<refspec>` を deny。`--force-with-lease` で base 以外は allow
- (Req 4, Task 1) G0: install dir 配下への Edit/Write/NotebookEdit を robust に deny、Bash 経由 mutation は best-effort deny
- (Req 5, Task 3) `local-watcher/bin/modules/guard-hook.sh` を新規作成。semver 数値比較 / smoke test / fail-closed preflight を実装
- (Req 1/5, Task 4) `issue-watcher.sh` の全 11 箇所の claude 起動行末尾に `"${CLAUDE_HOOK_ARGS[@]}"` を注入。opt-out 時は空配列で既存挙動を保持
- (Req 6, Task 5) `install.sh` に `install_guard_hooks` helper を追加。`--local` 実行時に `~/.idd-claude/hooks/` に 3 ファイルを配置し `__IDD_HOOK_PATH__` placeholder を絶対パスに sed 置換
- (NFR 3/6.4, Task 6) `README.md` に「Guard Hook (PreToolUse) opt-in (#294)」節を追加（opt-in 手順 / env var 一覧 / fail-closed 挙動 / 既知の限界 4 件 / Migration Note）

## 受入基準チェック

- [x] Req 1.1/1.2: opt-out 時の引数列完全互換 ← smoke test 3 で content 一致（timestamp 除く）確認
- [x] Req 2.1〜2.7: G1 全形 deny ← test-fixtures/run-tests.sh 29/29 green（G1: 6 件）
- [x] Req 3.1〜3.5: G2 deny + force-with-lease allow ← run-tests.sh（G2: 5 件）
- [x] Req 4.1〜4.4: G0 self-protection + best-effort 明示 ← run-tests.sh（G0: 5 件）+ README
- [x] Req 5.1〜5.5: fail-closed preflight ← smoke test 4 で exit=11 + stderr 確認
- [x] Req 6.1〜6.3: user-scope 配置 / repo-template 未配置 / consumer 未配布 ← smoke test 1/2 確認
- [x] NFR 2.1: shellcheck 警告ゼロ（install.sh / issue-watcher.sh / guard-hook.sh / idd-guard.sh 全件）

## テスト結果

```
# test-fixtures/run-tests.sh（Reviewer 再実行含む）
29/29 green（G0:5 / G1:6 / G2:5 / Allow:13）

# shellcheck
shellcheck install.sh local-watcher/bin/issue-watcher.sh \
  local-watcher/bin/modules/guard-hook.sh local-watcher/hooks/idd-guard.sh
→ 警告ゼロ

# Task 7 smoke test（impl-notes.md Task 7 参照）
1. install.sh --dry-run --local → 3 件 [DRY-RUN] NEW（placeholder 置換 note 付き）確認
2. install.sh --local（tmp HOME）→ 3 ファイル配置 + settings.json の command が絶対パスに置換
3. opt-out diff → guard-hook: log 行一切なし / content 一致（timestamp 除く）
4. IDD_CLAUDE_HOOKS_ENABLED=true + IDD_CLAUDE_HOOKS_MIN_VERSION=99.0.0 → exit=11 確認
5. cron-like minimal PATH → watcher prepend 経由で claude を含む 5 CLI 全件解決
6. run-tests.sh → 29/29 green

Reviewer 再実行（review-notes.md 参照）: 29/29 green / shellcheck 警告ゼロ
```

## 実装上の判断

- G1 の暗黙 remote 判定: positional 引数が 1 件のとき base 名一致を refspec 扱いに格上げ（`idd-guard.sh:285-302`）
- semver 比較は数値ベース実装（辞書順では `2.1.167` < `2.1.99` になるため）
- `SECURITY_REVIEW_CLAUDE_CMD` 経路（`bash -c` 経由の env テンプレート展開）は配列展開不可のため本 PR の配線対象外。後続 Issue として別途対応が必要
- `IDD_CLAUDE_HOOKS_ENABLED` は既存 env 値正規化ループに含めない（opt-in 制。typo 安全側設計）
- opt-out 時も `gh_build_args` を無条件で呼んで空配列を明示構築（undefined 展開事故防止）

詳細は `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- **base ブランチ検証**: `--base main` 指定 / baseRefName: main / OK
- **Req 6.4 consumer 配布の後続 Issue 起票（PjM / 人間責務）**: review-notes.md L128-131 で指摘の通り、consumer repo への guard hook 配布は本 PR とは独立した後続 Issue として起票が必要。本 PR を merge した後に別途起票をお願いします
- **最終 PR**: tasks.md のすべてのタスクが `- [x]` 完了済みのため `Closes #294` を採用（design-less 判定ではなく tasks.md 全完了のため）
- **`SECURITY_REVIEW_CLAUDE_CMD` 経路への hook 注入**: 本 PR スコープ外。impl-notes.md Task 4「確認事項」参照。後続 Issue での対応を推奨
- **「オプション機能一覧」表への新規行追加**: 本 PR では実施しなかった（user-scope only の初版段階。consumer 配布 Issue 完了後に正規行として追加する方が運用者の認知負荷が低い）
- Reviewer 判定 / 詳細 Findings: `docs/specs/294-feat-watcher-pretooluse-guard-hook-base/review-notes.md` を参照

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #294 のコメントを参照してください。
