### PR TITLE
fix(#306): per-task terminal failure で診断 artifact と push 状態を保全する

### DIFF
--- a/docs/specs/306--bug-per-task-terminal-failure-reviewer/impl-notes.md
+++ b/docs/specs/306--bug-per-task-terminal-failure-reviewer/impl-notes.md
@@ -1,0 +1,178 @@
+# Implementation Notes — Issue #306
+
+## 採用方針
+
+Issue 本文で提示された **案 3（commit を試み、失敗時はコメント埋め込み fallback）** を採用。
+
+per-task ループの terminal failure 経路（`per-task-reviewer-reject2` /
+`per-task-reviewer-reject3` / `per-task-reviewer-error` /
+`per-task-reviewer-missing-file` / `debugger-notes-invalid`）で `mark_issue_failed` を
+呼ぶ直前に経由する新規ヘルパー **`publish_terminal_failure_artifacts`** を導入した。
+ヘルパーは `mark_issue_failed` を呼ぶ責務を内部で完遂し、call site は関数名差し替えのみで
+artifact 保全と push state 可視化を得られる。
+
+## 主要関数
+
+### `publish_terminal_failure_artifacts <stage> <extra_body>`
+
+`local-watcher/bin/issue-watcher.sh` の `verify_pushed_or_retry` の **直前** に追加。
+
+責務:
+
+1. **Push state 収集**（Req 2.1, 2.3, 2.4）:
+   - `git rev-parse HEAD` で local HEAD SHA
+   - `git ls-remote origin refs/heads/<branch>` で origin HEAD SHA。
+     取得失敗時は「未 push」を埋める（Req 2.3）
+   - ahead count = `git rev-list --count <origin_head>..HEAD`
+     （初回 push 前は `${BASE_BRANCH:-main}..HEAD` から算出）
+   - branch 名 / worktree path は環境変数 `BRANCH` / `REPO_DIR` から取得
+2. **Artifact 単位の状態判定**（Req 1.2, 2.2）: `review-notes.md` /
+   `debugger-notes.md` それぞれについて、内部関数 `_ptfa_artifact_status` が以下の
+   status を返す:
+   - `absent`（ファイルが存在しない）
+   - `untracked`（ファイルはあるが `git ls-files` 未 track）
+   - `modified`（tracked だが unstaged / staged な変更が残る）
+   - `tracked-unpushed`（commit 済みだが当該ファイルが origin に未反映）
+   - `tracked-pushed`（commit 済みかつ origin に反映済み）
+3. **Diagnostic commit 試行**（Req 1.1, 1.3）: いずれかの artifact が
+   `untracked` / `modified` / `tracked-unpushed` だった場合、
+   `docs(spec): preserve terminal-failure diagnostics (#<num> / stage=<stage>)` で
+   commit して `git push origin <branch>` を実行する。成功時は artifact_status を
+   `committed` で上書きし、push 後の最新 local/origin HEAD で push state 欄を更新する
+4. **Fallback 埋め込み**（Req 1.4, NFR 3.1）: commit / push が失敗した場合、
+   artifact 本文を Issue コメント本文に埋め込む。本文長が **16384 文字** を超える場合は
+   先頭 80 行 + 末尾 80 行 + `(中略 / 全文 N 文字)` の抜粋に切り替える
+   （GitHub Issue コメント 65,536 文字制限の余裕保守値）
+5. **`mark_issue_failed` を必ず呼ぶ**（Req 1.5, NFR 2.1）: 上記いずれの段階で例外が
+   起きても、最後に必ず `mark_issue_failed` を呼んで `claude-failed` ラベル付与を完遂する
+
+設計上の判断:
+
+- **既存 `verify_pushed_or_retry` には触らない**（Req 4.3 / NFR 1.1）。同関数は ahead 数
+  verify + 自動 push リトライに責務を絞っており、artifact の commit / 本文埋め込みまで
+  扱わない。本機能は新規ヘルパーとして導入し、`verify_pushed_or_retry` の意味論は不変
+- **`git reset` / `git rebase` / force push は使わない**（Req 3.4）。`git add` →
+  `git commit` → `git push origin <branch>` のみ
+- **Reviewer / Debugger サブエージェントへの git / gh 権限付与なし**（Req 3.1, 3.2, 3.3）。
+  watcher の return 後に artifact 保全の責務を担う
+- **`command -v timeout` で GNU coreutils の有無を判定**（既存
+  `verify_pushed_or_retry` と同方針 / 既存 cron 互換性のため）
+
+### 既存 helper との関係
+
+- `mark_issue_failed`（既存）: そのまま残置し、内部から呼ばれる
+- `verify_pushed_or_retry`（既存）: 触らず（Req 4.3 / NFR 1.1）
+- `pt_mark_diff_range_resolve_failed`（既存）: 触らず（Issue #164 専用復旧手順を持つ
+  別経路。本機能の対象 5 経路には含まれない）
+
+## 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `local-watcher/bin/issue-watcher.sh` | `publish_terminal_failure_artifacts` 新規追加（約 250 行）。9 箇所の per-task terminal failure 経路（reject2 / reject3 / round=1,2,3 reviewer-error / round=1,2,3 reviewer-missing-file / debugger-notes-invalid）の `mark_issue_failed` 呼出を新ヘルパー呼出に差し替え |
+| `local-watcher/test/publish_terminal_failure_artifacts_test.sh` | 新規回帰テスト（6 ケース / 29 アサーション）。ローカル bare repo を fake origin として、Req 1.1〜1.5 / 2.1〜2.4 / NFR 2.1 / NFR 3.1 を end-to-end 検証 |
+
+## テスト戦略
+
+- **既存 `verify_pushed_or_retry_test.sh` を踏襲**: bash の `awk` で関数定義のみを
+  抽出して current shell に load する extract_function パターンを採用
+- **mock 戦略**: `mark_issue_failed` を fake 関数で差し替え、call count / 引数を観測する
+- **fake origin**: `git init --bare` で作る一時 bare repo を origin として `git push`
+  を実行
+- **push 失敗シナリオ**: `chmod -R 000 <bare>/refs` で書き込み権限を奪う既存パターン
+- **長文シナリオ**: 600 行 + tail marker を含むファイルで `(中略` の存在と末尾 marker
+  の埋め込みを確認
+
+### 検証カバレッジ（Req → テストケース）
+
+| Requirement | 担保するテストケース |
+|---|---|
+| Req 1.1（artifact 保全 / コメント埋め込み or diagnostic commit push） | Case 1（commit push）, Case 3（fallback 埋め込み） |
+| Req 1.2（既に tracked + pushed なら重複保全しない） | Case 2 |
+| Req 1.3（untracked / 未 commit を保全） | Case 1, Case 3 |
+| Req 1.4（commit push 失敗時の fallback 埋め込み） | Case 3 |
+| Req 1.5（保全失敗でも `claude-failed` 完遂） | Case 1〜6 全てで `mark_issue_failed` 呼出を assert |
+| Req 2.1（branch / local HEAD / origin HEAD / ahead / worktree path） | Case 1 |
+| Req 2.2（artifact 単位の状態明示） | Case 1, Case 2 |
+| Req 2.3（origin branch 不在時の「未 push」固定表記） | Case 4 |
+| Req 2.4（カテゴリ間の一貫フォーマット） | Case 1 / 2 / 3 / 4 / 5 / 6 で同じ block を確認 |
+| Req 3.1〜3.4（Reviewer / Debugger 権限境界） | コード上で `git add` / `git commit` / `git push` が watcher 側のみで実行されることを実装で担保。`.claude/agents/*.md` には変更を加えない |
+| Req 4.1〜4.3（既存経路との一貫性） | `verify_pushed_or_retry_test.sh`（既存）が引き続き pass することを確認 |
+| Req 5.1〜5.3（回帰テストによる挙動固定） | `publish_terminal_failure_artifacts_test.sh` 全 6 ケース |
+| NFR 1.1（後方互換） | `verify_pushed_or_retry_test.sh`（既存）を破壊しないことを確認 |
+| NFR 1.2（既存必須項目を削除しない） | Case 1 で `per-task ループの Reviewer (task=...) reject` 既存 extra_body 文言の保持を assert |
+| NFR 2.1（claude-failed 完遂） | Case 1〜6 |
+| NFR 2.2（grep 可能な log） | Case 1 で `terminal-failure-artifacts` log 行を assert |
+| NFR 3.1（コメントサイズ上限） | Case 5（長文 → 要約モード） |
+
+## 動作確認手順
+
+1. **shellcheck**:
+   ```bash
+   shellcheck local-watcher/bin/issue-watcher.sh
+   ```
+   → 警告ゼロ
+2. **新規回帰テスト**:
+   ```bash
+   bash local-watcher/test/publish_terminal_failure_artifacts_test.sh
+   ```
+   → `PASS: 29, FAIL: 0`
+3. **既存テスト**:
+   ```bash
+   for t in local-watcher/test/*.sh; do bash "$t" >/dev/null 2>&1 && echo "OK: $t" || echo "FAIL: $t"; done
+   ```
+   → 全て OK（破壊なし）
+
+## 受入基準ごとのテスト対応表
+
+| AC | 担保 |
+|---|---|
+| 1.1 | Case 1（diagnostic commit push 経路）, Case 3（埋め込み fallback 経路） |
+| 1.2 | Case 2（重複保全なし） |
+| 1.3 | Case 1（untracked → commit + push）, Case 3（untracked → 本文埋め込み） |
+| 1.4 | Case 3（push 失敗 → 本文 fallback 埋め込み） |
+| 1.5 | Case 1〜6 全てで `mark_issue_failed` の 1 回呼出を assert |
+| 2.1 | Case 1（branch / local HEAD / origin HEAD / ahead / worktree path 全てコメント本文に含まれる） |
+| 2.2 | Case 1（artifact 単位の status: untracked → committed） / Case 2（tracked-pushed） |
+| 2.3 | Case 4（初回 push 前で「未 push」表記 + ahead local HEAD まで） |
+| 2.4 | Case 1〜6 で同一フォーマット（`### 診断 artifact / push 状態（Issue #306）`）を append |
+| 3.1, 3.2 | Reviewer / Debugger エージェント定義（`.claude/agents/reviewer.md` / `.claude/agents/debugger.md`）には触れていないことで担保 |
+| 3.3 | watcher 側（`publish_terminal_failure_artifacts`）が commit / push 責務を担うことで担保 |
+| 3.4 | コード grep で `git reset` / `git rebase` / `--force` を `publish_terminal_failure_artifacts` 内に含まないことを確認可能 |
+| 4.1 | 既存 `verify_pushed_or_retry` を変更せず（diff レベルで非干渉）、`verify_pushed_or_retry_test.sh` が引き続き pass することで担保 |
+| 4.2 | 本機能は `mark_issue_failed` を「呼ぶ前に extra_body を augment する」だけのラッパー設計のため、claude-failed ラベル付与経路は既存と同一（Case 1〜6 で `mark_issue_failed` の 1 回呼出を assert） |
+| 4.3 | 非 per-task terminal failure 経路（Stage A / Stage B / Stage C / design / triage）は `mark_issue_failed` 直接呼出のままで本機能の影響を受けない（diff 上でこれら経路の `mark_issue_failed` 呼出が変更されていないことを差分で確認） |
+| 5.1 | Case 1（review-notes.md / debugger-notes.md 両方を untracked にしてシナリオ再現） |
+| 5.2 | Case 1（diagnostic commit push 成功を bare repo に commit 数 2 で確認）／ Case 3（本文 marker `EMBED-MARKER-CASE3-CONTENT-XYZ` の埋め込みを確認） |
+| 5.3 | Case 1（branch / local HEAD ラベル / origin HEAD ラベル / ahead count ラベル / worktree path を全て assert） |
+
+## 確認事項（PR 本文 / レビュワー判断ポイント）
+
+1. **`pt_mark_diff_range_resolve_failed`（Issue #164）の per-task 失敗経路は今回の対象に
+   含めなかった**（requirements の terminal failure 5 経路に列挙されていないため）。
+   要件外の判断として確認していただきたい
+2. **`per-task-implementer-failed` 系（claude 非 0 exit / no-progress / debugger-blocked-but-invoked
+   / blocked-redo-failed / redo-failed / pp-failed / max-tasks-exceeded）も対象外**とした。
+   これらは Reviewer / Debugger が `review-notes.md` / `debugger-notes.md` を書き出す **前**
+   の段階での失敗であり、Req 1.1 の「Reviewer または Debugger が ... を書き出した後の
+   terminal failure」に該当しないため。要件解釈の妥当性を確認していただきたい
+3. **diagnostic commit のメッセージ規約**: `docs(spec): preserve terminal-failure
+   diagnostics (#<num> / stage=<stage>)` という Conventional Commits 準拠の subject を
+   採用したが、別 scope（例: `chore(watcher):` / `docs(watcher):`）が望ましい場合は
+   レビューで指摘されたい
+4. **要約モードの行数**: 先頭 80 行 + 末尾 80 行 + `(中略 / 全文 N 文字)` という固定で
+   実装した。多くの review-notes.md / debugger-notes.md でこの行数で十分と判断したが、
+   別の比率（例: 100 行 + 100 行 / 60 行 + 60 行）が好まれる場合は指摘されたい
+5. **`origin HEAD: 未 push` の固定表記**: 日本語表記を採用したが、英語固定表記が
+   望まれる場合は `origin HEAD: (not pushed yet)` 等に変更可能
+
+## 確認した規約整合
+
+- `.claude/agents/*.md` / `.claude/rules/*.md` は変更なし（Req 3.1, 3.2 の権限境界維持
+  と CLAUDE.md「root と repo-template の二重管理」規約を両立）
+- `diff -r .claude/agents repo-template/.claude/agents` および
+  `diff -r .claude/rules repo-template/.claude/rules` が空であることを確認済み
+- bash 規約: `set -euo pipefail` / `"$var"` クォート / `command -v` / `$HOME` 不使用
+  （本ヘルパーは `$HOME` を参照しない）/ silent fail を作らない（NFR 2.1, 2.2）
+
+STATUS: complete

--- a/docs/specs/306--bug-per-task-terminal-failure-reviewer/requirements.md
+++ b/docs/specs/306--bug-per-task-terminal-failure-reviewer/requirements.md
@@ -1,0 +1,150 @@
+# Requirements Document
+
+## Introduction
+
+per-task ループの terminal failure 経路（`per-task-reviewer-reject2` / `per-task-reviewer-reject3`
+/ `per-task-reviewer-error` / `per-task-reviewer-missing-file` / `debugger-notes-invalid` 等）では、
+Issue に投稿される失敗コメントが実装 branch と `review-notes.md` / `debugger-notes.md` を参照する
+にもかかわらず、watcher が push state を verify せず artifact 保全も行わないため、operator が
+remote branch を確認しても reviewer / debugger の診断成果物が見つからず、復旧起点を特定できない
+状況が発生している。本機能は、Reviewer / Debugger サブエージェントへの git 権限付与を禁じた
+まま、watcher 側が terminal failure 直前に push 状態を verify し、未追跡 / 未 push の診断
+artifact を Issue コメントまたは diagnostic commit として operator-visible に保全することで、
+失敗復旧の混乱を解消する。
+
+## Requirements
+
+### Requirement 1: per-task terminal failure 時の診断 artifact 保全
+
+**Objective:** As a 自動開発の運用者, I want per-task terminal failure 直後に reviewer / debugger
+の診断成果物に Issue コメントだけからアクセスできること, so that 失敗の根本原因調査と復旧判断を
+unpushed worktree に依存せず行える
+
+#### Acceptance Criteria
+
+1. When per-task ループが Reviewer または Debugger が `review-notes.md` / `debugger-notes.md` を
+   書き出した後の terminal failure（`per-task-reviewer-reject2` / `per-task-reviewer-reject3` /
+   `per-task-reviewer-error` / `per-task-reviewer-missing-file` / `debugger-notes-invalid` を含む）
+   で停止する場合, the watcher shall 同一 Issue に投稿する失敗コメントに `review-notes.md` /
+   `debugger-notes.md` の本文または要約を埋め込むか、もしくはそれらを含む diagnostic commit を
+   origin branch に push してから claude-failed ラベルを付与する
+2. If terminal failure 発生時点で `review-notes.md` または `debugger-notes.md` が worktree 上に
+   存在し、かつ tracked かつ pushed 済み（local HEAD と origin branch HEAD が一致）である,
+   the watcher shall artifact の重複保全（コメント埋め込みおよび diagnostic commit）を行わず
+   既存挙動と同じ失敗コメントを投稿する
+3. If terminal failure 発生時点で `review-notes.md` または `debugger-notes.md` が untracked
+   または未 commit である, the watcher shall それらの本文（または長文時は要約）を Issue コメント
+   に埋め込むか、watcher 自身が diagnostic commit を作成して origin に push する
+4. If watcher が diagnostic commit の push に失敗する, the watcher shall fallback として
+   `review-notes.md` / `debugger-notes.md` の本文または要約を Issue コメントに埋め込んで
+   claude-failed ラベルを付与する
+5. The watcher shall artifact 保全処理の失敗を理由に claude-failed ラベル付与と失敗コメント
+   投稿の責務を放棄しない
+
+### Requirement 2: terminal failure 時の push state 情報の可視化
+
+**Objective:** As a 自動開発の運用者, I want terminal failure 失敗コメントから現在の git push 状態
+を一目で把握できること, so that 復旧時に確認すべき branch / worktree / SHA をローカル調査せず
+特定できる
+
+#### Acceptance Criteria
+
+1. When per-task terminal failure が発生する, the watcher shall 失敗コメントに以下の項目を
+   すべて明記する: 実装 branch 名 / local HEAD SHA / origin branch HEAD SHA / ahead count
+   （local が origin より進んでいる commit 数）/ worktree 絶対パス
+2. When `review-notes.md` または `debugger-notes.md` を失敗コメント内で参照する, the watcher
+   shall それぞれの artifact が tracked か untracked か、pushed か unpushed か（ahead 状態を
+   含む）を artifact 単位で明示する
+3. If origin branch がまだ存在しない（初回 push 前である）, the watcher shall origin branch
+   HEAD SHA の欄を「未 push」相当の固定表記で埋め、ahead count を local HEAD までの commit 数
+   として算出する
+4. The watcher shall 上記 push state 情報を per-task terminal failure 全カテゴリで一貫した
+   フォーマットで出力する
+
+### Requirement 3: Reviewer / Debugger サブエージェントの git 権限境界の維持
+
+**Objective:** As a idd-claude メンテナ, I want Reviewer / Debugger サブエージェントが破壊的な
+git / gh 操作を行わない状態を維持できること, so that 役割逸脱と worktree の破壊リスクを増やさず
+本機能を導入できる
+
+#### Acceptance Criteria
+
+1. The Reviewer subagent shall `git add` / `git commit` / `git push` / `gh` を実行する権限を
+   付与されない
+2. The Debugger subagent shall `git add` / `git commit` / `git push` / `gh` を実行する権限を
+   付与されない
+3. When 診断 artifact の commit / push が必要になる, the watcher shall サブエージェントの
+   return 後に watcher / orchestrator プロセスがその責務を担う
+4. The watcher shall 診断 artifact 保全のために `git reset` / `git rebase` / force push を
+   実行しない
+
+### Requirement 4: terminal failure 経路間の push state verify 一貫性
+
+**Objective:** As a idd-claude メンテナ, I want per-task と非 per-task の terminal failure 経路で
+push state verify の意味論が乖離しないこと, so that 失敗時の挙動が経路に依らず予測可能になる
+
+#### Acceptance Criteria
+
+1. When per-task ループが terminal failure 分岐に入る, the watcher shall 既存の Stage A /
+   Stage B 経路で利用されている push リトライ機構と意味論的に整合する形で push state を
+   verify する（claude-failed ラベル付与の前に push state を確認する）
+2. If push リトライ機構の自動 push が失敗する, the watcher shall 既存 Stage A / Stage B の
+   失敗ハンドリングと同じく claude-failed ラベルを付与し失敗コメントを投稿する
+3. The watcher shall 既存の非 per-task terminal failure 経路の挙動を本機能導入前と同一に保つ
+
+### Requirement 5: 回帰テストによる挙動の固定
+
+**Objective:** As a idd-claude メンテナ, I want per-task terminal failure 時の artifact 保全挙動
+を回帰テストで固定できること, so that 将来のリファクタで silent regression が発生しても検知できる
+
+#### Acceptance Criteria
+
+1. The Test suite shall `per-task-reviewer-reject3` 形状の terminal failure を再現するシナリオを
+   含み、`review-notes.md` および `debugger-notes.md` が untracked な状態を入力として用意する
+2. The Test suite shall 上記シナリオで失敗コメントに artifact 本文／要約が埋め込まれること、
+   または diagnostic commit が push されたことのいずれかが成立することを assert する
+3. The Test suite shall 上記シナリオで失敗コメントに branch 名 / local HEAD SHA / origin
+   branch HEAD SHA / ahead count / worktree path が含まれることを assert する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The watcher shall 既に claude-failed 経路を通過した既存 Issue / 既存 cron 登録 / 既存 env var
+   名（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` 等）の意味を変更しない
+2. The watcher shall 本機能導入前に terminal failure コメントを生成していた経路の出力フォーマット
+   に対し、Requirement 2 で定める追加情報の append のみを行い、既存の必須項目（ログパス /
+   復旧ヒント / 手動復旧手順）を削除しない
+
+### NFR 2: 失敗時の堅牢性
+
+1. If artifact 保全処理（本文読み込み / 要約生成 / commit / push / コメント投稿）の途中で
+   想定外のエラーが発生する, the watcher shall claude-failed ラベルを付与する責務を最後まで
+   完遂する（silent fail を作らない）
+2. The watcher shall artifact 保全処理のエラーを `$LOG` に grep 可能な形で記録する
+
+### NFR 3: コメントサイズ上限
+
+1. When `review-notes.md` または `debugger-notes.md` の本文が GitHub Issue コメント本文の
+   実用上限（65,536 文字）を超える可能性がある, the watcher shall 本文をそのまま埋め込まず
+   要約または抜粋（先頭・末尾の固定行数）に切り替えて埋め込む
+
+## Out of Scope
+
+- Reviewer / Debugger サブエージェントへの `git add` / `git commit` / `git push` / `gh` 権限の付与
+- `git reset` / `git rebase` / force push の追加
+- 失敗コメントへの watcher 実行ログ全文の貼り付け
+- terminal failure の retry policy 変更（リトライ回数の増減 / 自動再起動の追加）
+- per-task 以外の terminal failure 経路（Stage A / Stage B / design / triage 等）の挙動変更
+- Reviewer / Debugger 起動回数制限の変更
+
+## Open Questions
+
+- 推奨方針（選択肢 1: コメント埋め込み / 選択肢 2: watcher diagnostic commit / 選択肢 3:
+  両方）のうちどれを採用するかは `design.md` で決定する。Requirement 1.1 はいずれの選択肢でも
+  満たせるよう「埋め込みまたは diagnostic commit」の OR で AC を記述しているため、設計段階で
+  選択肢 3（commit を試み失敗時にコメント fallback）を採る場合も追加要件は発生しない
+- artifact 本文の「要約」モードに切り替える閾値（NFR 3.1 の実用上限手前のどこで切るか）は
+  design 段階で決定する
+- 既存の `verify_pushed_or_retry` を per-task terminal failure 経路にも流用するか、新規ヘルパ
+  （Issue 本文の `publish_terminal_failure_artifacts` 風）を導入するかは design の責務

--- a/docs/specs/306--bug-per-task-terminal-failure-reviewer/review-notes.md
+++ b/docs/specs/306--bug-per-task-terminal-failure-reviewer/review-notes.md
@@ -1,0 +1,45 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-09T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-306-impl--bug-per-task-terminal-failure-reviewer
+- HEAD commit: a468b4fabc292b2a436a28cdb18b26b8a78a46d8
+- Compared to: main..HEAD
+
+## Verified Requirements
+
+- 1.1 — `publish_terminal_failure_artifacts` ヘルパー（`local-watcher/bin/issue-watcher.sh`）が 5 経路（reject2 / reject3 / reviewer-error / reviewer-missing-file / debugger-notes-invalid）で `mark_issue_failed` 直前に diagnostic commit 試行と本文埋め込みの両方を実施。テスト Case 1（commit push 成功） / Case 3（埋め込み fallback）で担保
+- 1.2 — tracked + pushed artifact 状態で `_need_commit` フラグが立たず diagnostic commit を実施しない。テスト Case 2 で bare repo の commit 数不変 + status `tracked-pushed` 表示を assert
+- 1.3 — `_ptfa_artifact_status` が untracked / modified / tracked-unpushed を検出して `_need_commit=1` を設定。テスト Case 1 / Case 3 で担保
+- 1.4 — `_commit_pushed != 1` 時の fallback ブロックが artifact 本文を `artifact_embed` に埋め込む。テスト Case 3 で push 失敗時の marker 埋め込みを assert
+- 1.5 — 全分岐の最後に必ず `mark_issue_failed "$stage" "$merged_body"` を呼ぶ。テスト Case 1〜6 全てで MARK_FAILED_CALL_COUNT=1 を assert
+- 2.1 — `push_state_block` が branch / local HEAD / origin HEAD / ahead count / worktree path を全て埋め込む。テスト Case 1 で全項目の存在を assert
+- 2.2 — artifact 毎に `_ptfa_artifact_status` の戻り値を `artifact_lines` として出力。テスト Case 1（untracked → committed） / Case 2（tracked-pushed）で担保
+- 2.3 — `origin_head="未 push"` 初期値と BASE_BRANCH..HEAD からの ahead count 算出。テスト Case 4 で `origin_head=未 push` の LOG 記録を assert
+- 2.4 — 同一 `publish_terminal_failure_artifacts` ヘルパーを 5 経路で共有することでフォーマット統一を構造的に担保
+- 3.1 / 3.2 — `.claude/agents/reviewer.md` / `.claude/agents/debugger.md` への変更なし（diff stat で確認済み）。git 権限付与なし
+- 3.3 — `publish_terminal_failure_artifacts` は watcher 側コードで、サブエージェント return 後に呼ばれる（call site は per-task ループ内）
+- 3.4 — diff 内に `git reset` / `git rebase` / `--force` の追加なし（コメント文の「使わない」記述のみ）
+- 4.1 — `verify_pushed_or_retry` を変更せず、新規ヘルパーで意味論を分離。`mark_issue_failed` 直前で push state を verify する一貫性を確保
+- 4.2 — push 失敗時も `mark_issue_failed` 呼び出しを完遂する設計（テスト Case 3 で担保）
+- 4.3 — 非 per-task 経路（Stage A / Stage B / design / triage）の `mark_issue_failed` 呼出は変更されていない（diff 確認）
+- 5.1 — `local-watcher/test/publish_terminal_failure_artifacts_test.sh` Case 1 で `per-task-reviewer-reject3` シナリオを再現し review-notes.md / debugger-notes.md を untracked 状態で投入
+- 5.2 — Case 1 で bare repo commit 数 2 件到達を assert、Case 3 で本文 marker `EMBED-MARKER-CASE3-CONTENT-XYZ` の埋め込みを assert
+- 5.3 — Case 1 で branch 名 / local HEAD ラベル / origin HEAD ラベル / ahead count ラベル / worktree path を全て assert
+- NFR 1.1 — `verify_pushed_or_retry` 既存 helper / 既存 env var 名（REPO / REPO_DIR / LOG_DIR / LOCK_FILE）に変更なし
+- NFR 1.2 — Case 1 で既存 extra_body 文言「per-task ループの Reviewer (task=...) reject」の保持を assert
+- NFR 2.1 — 例外時の最終 `mark_issue_failed` 呼出を全テストケースで担保
+- NFR 2.2 — `echo "[$(date '+%F %T')] terminal-failure-artifacts: ..." >> "$LOG"` の grep 可能なフォーマットで複数行記録。Case 1 で LOG 内容を assert
+- NFR 3.1 — `_max_chars=16384` 閾値超過時に先頭 80 行 + 末尾 80 行 + `(中略 / 全文 N 文字)` の抜粋モードに切替。Case 5 で 600 行入力時の `(中略` 含有と `TAIL-MARKER-CASE5-END` 含有を assert
+
+## Findings
+
+なし
+
+## Summary
+
+5 つの per-task terminal failure 経路（reject2 / reject3 / reviewer-error / reviewer-missing-file / debugger-notes-invalid）に対し新規ヘルパー `publish_terminal_failure_artifacts` を導入する設計で、Req 1-5 と NFR 1-3 を全てカバー。29 アサーションの新規回帰テストが全て pass し、既存テストへの破壊なし。Reviewer / Debugger サブエージェントへの git 権限付与を伴わず（`.claude/agents/` 無変更）、watcher 側で push state verify と diagnostic artifact 保全を完遂する設計が要件と整合している。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -3820,7 +3820,7 @@ run_per_task_loop() {
                   parsed3pt=$(parse_review_result "$REPO_DIR/$SPEC_DIR_REL/review-notes.md" 2>/dev/null || echo "")
                   cat3pt=$(echo "$parsed3pt" | cut -f2)
                   tgt3pt=$(echo "$parsed3pt" | cut -f3)
-                  mark_issue_failed "per-task-reviewer-reject3" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) も reject を出したため、自動 iteration を打ち切り人間判断に委ねます（Debugger は 1 task あたり 1 回のみ起動するため再起動しません / Req 3.5, 6.3）。
+                  publish_terminal_failure_artifacts "per-task-reviewer-reject3" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) も reject を出したため、自動 iteration を打ち切り人間判断に委ねます（Debugger は 1 task あたり 1 回のみ起動するため再起動しません / Req 3.5, 6.3）。
 
 - 対象 task ID: ${task_id}
 - 対象 requirement ID: ${tgt3pt:-(unknown)}
@@ -3846,13 +3846,13 @@ run_per_task_loop() {
                   # → `per-task-reviewer-missing-file` カテゴリで `claude-failed`（round=3 / Debugger 経由）。
                   dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=missing-file-after-retry" >> "$LOG"
                   echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) ファイル不在（リトライ後も未生成）→ claude-failed (per-task-reviewer-missing-file)" | tee -a "$LOG"
-                  mark_issue_failed "per-task-reviewer-missing-file" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+                  publish_terminal_failure_artifacts "per-task-reviewer-missing-file" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
                   return 1
                   ;;
                 *)
                   dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=error" >> "$LOG"
                   echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) 異常終了 → claude-failed" | tee -a "$LOG"
-                  mark_issue_failed "per-task-reviewer-error" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
+                  publish_terminal_failure_artifacts "per-task-reviewer-error" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
                   return 1
                   ;;
               esac
@@ -3866,7 +3866,7 @@ run_per_task_loop() {
               parsed2=$(parse_review_result "$REPO_DIR/$SPEC_DIR_REL/review-notes.md" 2>/dev/null || echo "")
               cat2=$(echo "$parsed2" | cut -f2)
               tgt2=$(echo "$parsed2" | cut -f3)
-              mark_issue_failed "per-task-reviewer-reject2" "per-task ループの Reviewer が task=\`${task_id}\` で 2 回連続 reject を出したため、残りの未完了 task の処理を停止し人間判断に委ねます。
+              publish_terminal_failure_artifacts "per-task-reviewer-reject2" "per-task ループの Reviewer が task=\`${task_id}\` で 2 回連続 reject を出したため、残りの未完了 task の処理を停止し人間判断に委ねます。
 
 - 対象 task ID: ${task_id}
 - 対象 requirement ID: ${tgt2:-(unknown)}
@@ -3890,12 +3890,12 @@ run_per_task_loop() {
             # Issue #296 Req 2.3 / Req 4.2 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
             # → `per-task-reviewer-missing-file` カテゴリで `claude-failed`（round=2）。
             echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) ファイル不在（リトライ後も未生成）→ claude-failed (per-task-reviewer-missing-file)" | tee -a "$LOG"
-            mark_issue_failed "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+            publish_terminal_failure_artifacts "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
             return 1
             ;;
           *)
             echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) 異常終了 → claude-failed" | tee -a "$LOG"
-            mark_issue_failed "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
+            publish_terminal_failure_artifacts "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
             return 1
             ;;
         esac
@@ -3910,13 +3910,13 @@ run_per_task_loop() {
         # Issue #296 Req 2.3 / Req 4.2 / NFR 2.2: ファイル不在 + 1 回限定リトライ後も生成されず
         # → `per-task-reviewer-missing-file` カテゴリで `claude-failed`（round=1）。
         echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) ファイル不在（リトライ後も未生成）→ claude-failed (per-task-reviewer-missing-file)" | tee -a "$LOG"
-        mark_issue_failed "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+        publish_terminal_failure_artifacts "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
         return 1
         ;;
       *)
         # round=1 reviewer error → claude-failed
         echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) 異常終了 → claude-failed" | tee -a "$LOG"
-        mark_issue_failed "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
+        publish_terminal_failure_artifacts "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
         return 1
         ;;
     esac
@@ -4366,7 +4366,7 @@ run_debugger_stage() {
   # debugger-notes.md の必須セクション verify
   if ! validate_debugger_notes "$notes_path" "$task_id"; then
     dbg_log "trigger=$trigger issue=#${NUMBER} task=${task_label} debugger-notes.md validation failed" >> "$LOG"
-    mark_issue_failed "debugger-notes-invalid" "Debugger が \`${SPEC_DIR_REL}/debugger-notes.md\` を期待形式で出力しませんでした（必須 4 セクション \`根本原因\` / \`修正手順\` / \`検証方法\` / \`関連参考資料\` のいずれかが欠落、もしくはファイル自体が不在）。\`$LOG\` の Debugger 実行ログを確認してください。"
+    publish_terminal_failure_artifacts "debugger-notes-invalid" "Debugger が \`${SPEC_DIR_REL}/debugger-notes.md\` を期待形式で出力しませんでした（必須 4 セクション \`根本原因\` / \`修正手順\` / \`検証方法\` / \`関連参考資料\` のいずれかが欠落、もしくはファイル自体が不在）。\`$LOG\` の Debugger 実行ログを確認してください。"
     return 1
   fi
   dbg_log "trigger=$trigger issue=#${NUMBER} task=${task_label} debugger-notes.md verified (sections=4)" >> "$LOG"
@@ -5060,6 +5060,311 @@ run_reviewer_stage() {
       return 2
       ;;
   esac
+}
+
+# ─── per-task terminal failure 時の診断 artifact 保全ヘルパー (Issue #306) ───
+#
+# per-task ループの terminal failure 経路（`per-task-reviewer-reject2` /
+# `per-task-reviewer-reject3` / `per-task-reviewer-error` /
+# `per-task-reviewer-missing-file` / `debugger-notes-invalid` 等）で
+# `mark_issue_failed` を呼び出す **直前** に経由するラッパー。Reviewer / Debugger
+# サブエージェントには git / gh 権限を付与しない設計（Req 3.1, 3.2, 3.3）のため、
+# watcher 側が以下を担う:
+#
+#   1. push state（branch / local HEAD / origin HEAD / ahead / worktree path）を
+#      失敗コメントに常時埋め込む（Req 2.1, 2.4 / NFR 1.2）
+#   2. `review-notes.md` / `debugger-notes.md` が untracked または未 commit / 未 push なら
+#      diagnostic commit を 1 件作成し origin branch に push する（Req 1.1, 1.3）
+#   3. diagnostic commit の commit / push が失敗したら artifact 本文（または長文時は
+#      先頭・末尾要約）を Issue コメント本文に埋め込んで fallback する（Req 1.4, NFR 3.1）
+#   4. 既に tracked かつ pushed 済みの artifact は重複保全しない（Req 1.2）
+#   5. 保全処理が失敗しても `mark_issue_failed` を必ず呼ぶ（Req 1.5, NFR 2.1）
+#
+# 本ヘルパーは `mark_issue_failed` の **ラッパー** として動作し、
+# 呼び出し側は `mark_issue_failed` の代わりに本関数を呼ぶだけで artifact 保全と
+# push state 可視化を行える（call site 変更最小化）。
+#
+# 引数:
+#   $1 = stage 識別子（既存 mark_issue_failed と同じ。例: per-task-reviewer-reject2）
+#   $2 = 既存 extra_body（call site が組み立てる失敗コメント追加情報）
+#
+# 戻り値: 0 always（best-effort、既存 mark_issue_failed と同方針）
+#
+# 副作用:
+#   - cwd が `$REPO_DIR`（slot worktree）であることを前提とする（_slot_run_issue が cd 済）
+#   - push state 情報と artifact 状態を $2 (extra_body) に append してから
+#     `mark_issue_failed` を呼び出す
+#   - diagnostic commit 作成 / push を試行する（必要時のみ）
+#   - 保全処理の各段階を `$LOG` に grep 可能な形で 1 行記録する（NFR 2.2）
+#   - `git reset` / `git rebase` / force push は **使わない**（Req 3.4）
+#
+# 設計判断:
+#   - 既存 `verify_pushed_or_retry` は ahead 数の verify と自動 push リトライに責務を
+#     絞っており、artifact の commit / 本文埋め込みまでは扱わない。本関数は
+#     **新規ヘルパー**として導入し、`verify_pushed_or_retry` の意味論は変更しない
+#     （Req 4.3 / NFR 1.1）
+#   - artifact 本文の埋め込み閾値は 16384 文字（NFR 3.1: GitHub Issue コメント 65,536
+#     文字制限の余裕を取った保守的しきい値）。超過時は先頭 80 行 + 末尾 80 行の抜粋に
+#     切り替える（Open Question の design 確定）
+#   - 既存 `verify_pushed_or_retry` 風の `timeout` 既存検出ロジックを踏襲し、
+#     `command -v timeout` で GNU coreutils の有無を判定（NFR 1.2）
+publish_terminal_failure_artifacts() {
+  local stage="$1"
+  local extra_body="$2"
+
+  # 防御: BRANCH / REPO_DIR / SPEC_DIR_REL が未設定でも処理を完遂する（Req 1.5 / NFR 2.1）
+  local branch="${BRANCH:-}"
+  local spec_dir_rel="${SPEC_DIR_REL:-}"
+  local repo_dir="${REPO_DIR:-}"
+
+  local _git_timeout=()
+  if command -v timeout >/dev/null 2>&1; then
+    _git_timeout=(timeout 30)
+  fi
+
+  # ── push state 収集（Req 2.1, 2.3, 2.4）──
+  # ahead 数 / origin HEAD SHA を取得。エラー時は安全側で "(unknown)" 等を埋める
+  local local_head="(unknown)" origin_head="未 push" ahead_count="(unknown)"
+  local worktree_path="${repo_dir:-(unknown)}"
+
+  local _lh
+  _lh=$("${_git_timeout[@]}" git rev-parse HEAD 2>/dev/null || true)
+  if [ -n "$_lh" ]; then
+    local_head="$_lh"
+  fi
+
+  # origin branch HEAD を取得する。fetch せず ls-remote で軽量に確認する（NFR 2.1）
+  local _origin_out _origin_rc=0
+  if [ -n "$branch" ]; then
+    _origin_out=$("${_git_timeout[@]}" git ls-remote origin "refs/heads/$branch" 2>/dev/null) || _origin_rc=$?
+    if [ "$_origin_rc" -eq 0 ] && [ -n "$_origin_out" ]; then
+      origin_head=$(echo "$_origin_out" | awk '{print $1}' | head -n 1)
+      if [ -z "$origin_head" ]; then
+        origin_head="未 push"
+      fi
+    fi
+  fi
+
+  # ahead count を算出
+  if [ "$origin_head" = "未 push" ]; then
+    # 初回 push 前: BASE_BRANCH..HEAD の commit 数を使う（Req 2.3）
+    local _base_ahead
+    _base_ahead=$("${_git_timeout[@]}" git rev-list --count "${BASE_BRANCH:-main}..HEAD" 2>/dev/null || true)
+    if [[ "$_base_ahead" =~ ^[0-9]+$ ]]; then
+      ahead_count="$_base_ahead"
+    fi
+  else
+    local _ah
+    _ah=$("${_git_timeout[@]}" git rev-list --count "${origin_head}..HEAD" 2>/dev/null || true)
+    if [[ "$_ah" =~ ^[0-9]+$ ]]; then
+      ahead_count="$_ah"
+    fi
+  fi
+
+  echo "[$(date '+%F %T')] terminal-failure-artifacts: stage=${stage} issue=#${NUMBER:-?} branch=${branch} local_head=${local_head} origin_head=${origin_head} ahead=${ahead_count}" >> "$LOG" 2>/dev/null || true
+
+  # ── artifact 単位の保全処理（Req 1.1, 1.2, 1.3）──
+  # artifact ごとに status を判定し、必要なら commit / push を試みる。失敗時は
+  # 本文を extra_body に埋め込んで fallback。各 artifact ごとに以下を保存:
+  #   <name> <status_token> <content_or_summary_or_empty>
+  # status_token: tracked-pushed | tracked-unpushed | untracked | absent | embedded | committed
+  local artifact_lines=""
+  local artifact_embed=""
+  local _need_commit=0
+
+  _ptfa_artifact_status() {
+    # echo "<status_token>" — file 状態を判定して返す
+    local rel_path="$1"
+    local abs_path="${repo_dir}/${rel_path}"
+    if [ ! -f "$abs_path" ]; then
+      echo "absent"
+      return 0
+    fi
+    # tracked check: ls-files で確認
+    local _tracked
+    _tracked=$("${_git_timeout[@]}" git ls-files --error-unmatch -- "$rel_path" 2>/dev/null || true)
+    if [ -z "$_tracked" ]; then
+      echo "untracked"
+      return 0
+    fi
+    # 変更が staged / unstaged に残っているか
+    local _status_out
+    _status_out=$("${_git_timeout[@]}" git status --porcelain -- "$rel_path" 2>/dev/null || true)
+    if [ -n "$_status_out" ]; then
+      echo "modified"
+      return 0
+    fi
+    # commit 済み: origin に到達しているか
+    if [ "$origin_head" = "未 push" ]; then
+      echo "tracked-unpushed"
+      return 0
+    fi
+    # 当該ファイルの最新 commit が origin に到達しているか:
+    # log <origin_head>..HEAD で当該ファイルを変更した commit が出れば unpushed
+    local _unpushed
+    _unpushed=$("${_git_timeout[@]}" git log --oneline "${origin_head}..HEAD" -- "$rel_path" 2>/dev/null || true)
+    if [ -n "$_unpushed" ]; then
+      echo "tracked-unpushed"
+      return 0
+    fi
+    echo "tracked-pushed"
+    return 0
+  }
+
+  # artifact 一覧（順序保証）
+  local _artifacts=("review-notes.md" "debugger-notes.md")
+  local artifact_rel artifact_status artifact_rel_full
+  local _need_save_list=()
+  for artifact_rel in "${_artifacts[@]}"; do
+    artifact_rel_full="${spec_dir_rel}/${artifact_rel}"
+    artifact_status=$(_ptfa_artifact_status "$artifact_rel_full")
+    artifact_lines="${artifact_lines}- \`${artifact_rel_full}\`: ${artifact_status}"$'\n'
+    echo "[$(date '+%F %T')] terminal-failure-artifacts: artifact=${artifact_rel_full} status=${artifact_status} stage=${stage} issue=#${NUMBER:-?}" >> "$LOG" 2>/dev/null || true
+    case "$artifact_status" in
+      untracked|modified|tracked-unpushed)
+        _need_commit=1
+        _need_save_list+=("$artifact_rel_full")
+        ;;
+      *) ;;
+    esac
+  done
+
+  # ── 保全が必要なら diagnostic commit を試みる（Req 1.1, 1.3）──
+  local _commit_pushed=0
+  if [ "$_need_commit" = "1" ] && [ -n "$branch" ] && [ -n "$spec_dir_rel" ]; then
+    local _add_rc=0 _commit_rc=0 _push_rc=0
+    local _commit_msg="docs(spec): preserve terminal-failure diagnostics (#${NUMBER:-?} / stage=${stage})"
+
+    # add: 対象 artifact のみ stage する
+    local _save_path
+    for _save_path in "${_need_save_list[@]}"; do
+      "${_git_timeout[@]}" git add -- "$_save_path" 2>/dev/null || _add_rc=$?
+    done
+
+    if [ "$_add_rc" -eq 0 ]; then
+      # commit を作成（user.email / user.name は cron 環境で global 設定済み前提）
+      "${_git_timeout[@]}" git -c commit.gpgsign=false commit -m "$_commit_msg" -- \
+        "${_need_save_list[@]}" >/dev/null 2>&1 || _commit_rc=$?
+      if [ "$_commit_rc" -eq 0 ]; then
+        "${_git_timeout[@]}" git push origin "$branch" >/dev/null 2>&1 || _push_rc=$?
+        if [ "$_push_rc" -eq 0 ]; then
+          _commit_pushed=1
+          echo "[$(date '+%F %T')] terminal-failure-artifacts: diagnostic-commit pushed branch=${branch} stage=${stage} issue=#${NUMBER:-?}" >> "$LOG" 2>/dev/null || true
+          # push 成功後の origin_head / ahead を更新（コメント上の情報を最新化）
+          local _new_origin
+          _new_origin=$("${_git_timeout[@]}" git ls-remote origin "refs/heads/$branch" 2>/dev/null | awk '{print $1}' | head -n 1)
+          if [ -n "$_new_origin" ]; then
+            origin_head="$_new_origin"
+          fi
+          local _new_local
+          _new_local=$("${_git_timeout[@]}" git rev-parse HEAD 2>/dev/null || true)
+          if [ -n "$_new_local" ]; then
+            local_head="$_new_local"
+          fi
+          ahead_count="0"
+          # artifact_lines を再生成（status を更新）
+          artifact_lines=""
+          for artifact_rel in "${_artifacts[@]}"; do
+            artifact_rel_full="${spec_dir_rel}/${artifact_rel}"
+            local _newst
+            _newst=$(_ptfa_artifact_status "$artifact_rel_full")
+            # commit/push 成功直後は committed として明示
+            case "$_newst" in
+              tracked-pushed) _newst="committed" ;;
+              *) ;;
+            esac
+            artifact_lines="${artifact_lines}- \`${artifact_rel_full}\`: ${_newst}"$'\n'
+          done
+        else
+          echo "[$(date '+%F %T')] terminal-failure-artifacts: WARN diagnostic-commit push 失敗 push_rc=${_push_rc} stage=${stage} issue=#${NUMBER:-?}" >> "$LOG" 2>/dev/null || true
+        fi
+      else
+        echo "[$(date '+%F %T')] terminal-failure-artifacts: WARN diagnostic-commit commit 失敗 commit_rc=${_commit_rc} stage=${stage} issue=#${NUMBER:-?}" >> "$LOG" 2>/dev/null || true
+      fi
+    else
+      echo "[$(date '+%F %T')] terminal-failure-artifacts: WARN diagnostic-commit add 失敗 add_rc=${_add_rc} stage=${stage} issue=#${NUMBER:-?}" >> "$LOG" 2>/dev/null || true
+    fi
+  fi
+
+  # ── push / commit が失敗（または skip）した場合の fallback 埋め込み（Req 1.3, 1.4, NFR 3.1）──
+  if [ "$_need_commit" = "1" ] && [ "$_commit_pushed" != "1" ]; then
+    local _save_path _abs _content _content_len
+    local _max_chars=16384  # 約 16KB 上限（GitHub Issue コメント 65,536 文字制限の余裕保守値）
+    for _save_path in "${_need_save_list[@]}"; do
+      _abs="${repo_dir}/${_save_path}"
+      if [ ! -f "$_abs" ]; then
+        continue
+      fi
+      _content=$(cat "$_abs" 2>/dev/null || true)
+      _content_len=${#_content}
+      if [ "$_content_len" -gt "$_max_chars" ]; then
+        # 長文時: 先頭 80 行 + 末尾 80 行に切り替える（NFR 3.1）
+        local _head_part _tail_part
+        _head_part=$(echo "$_content" | head -n 80)
+        _tail_part=$(echo "$_content" | tail -n 80)
+        artifact_embed="${artifact_embed}
+
+#### \`${_save_path}\` の内容（要約 / 長文のため先頭 80 行 + 末尾 80 行）
+
+\`\`\`
+${_head_part}
+
+… (中略 / 全文 ${_content_len} 文字) …
+
+${_tail_part}
+\`\`\`"
+      else
+        artifact_embed="${artifact_embed}
+
+#### \`${_save_path}\` の内容（全文）
+
+\`\`\`
+${_content}
+\`\`\`"
+      fi
+    done
+    echo "[$(date '+%F %T')] terminal-failure-artifacts: artifact 本文を Issue コメントに fallback 埋め込み stage=${stage} issue=#${NUMBER:-?}" >> "$LOG" 2>/dev/null || true
+  fi
+
+  # ── extra_body に append する情報ブロックを組み立て ──
+  local push_state_block
+  push_state_block="### 診断 artifact / push 状態（Issue #306）
+
+- 実装 branch: \`${branch:-(unknown)}\`
+- local HEAD : \`${local_head}\`
+- origin HEAD: \`${origin_head}\`
+- ahead count: ${ahead_count}
+- worktree  : \`${worktree_path}\`
+
+#### artifact 状態
+
+${artifact_lines}"
+
+  if [ "$_commit_pushed" = "1" ]; then
+    push_state_block="${push_state_block}
+> ℹ️ watcher が未 push の診断 artifact を検出し、diagnostic commit を作成して origin に push しました。
+> 上記 SHA / ahead 数は push 後の状態を反映しています。"
+  elif [ "$_need_commit" = "1" ]; then
+    push_state_block="${push_state_block}
+> ⚠️ watcher が未 push の診断 artifact を検出しましたが、diagnostic commit / push に失敗しました。
+> 下記の artifact 本文（または抜粋）が fallback として埋め込まれています。"
+  fi
+
+  local merged_body="$extra_body"
+  if [ -n "$merged_body" ]; then
+    merged_body="${merged_body}
+
+${push_state_block}"
+  else
+    merged_body="$push_state_block"
+  fi
+  if [ -n "$artifact_embed" ]; then
+    merged_body="${merged_body}${artifact_embed}"
+  fi
+
+  # ── 必ず claude-failed ラベルを付与する（Req 1.5, NFR 2.1）──
+  mark_issue_failed "$stage" "$merged_body"
+  return 0
 }
 
 # ─── Stage 完了直後の push 状態 verify ヘルパー (Issue #106) ───

--- a/local-watcher/test/publish_terminal_failure_artifacts_test.sh
+++ b/local-watcher/test/publish_terminal_failure_artifacts_test.sh
@@ -1,0 +1,434 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh の per-task terminal failure 経路で
+#       diagnostic artifact の保全と push state 可視化を行う
+#       publish_terminal_failure_artifacts ヘルパーを、ローカル bare repo を
+#       fake origin とした擬似環境で end-to-end 検証するスモークテスト。
+#       Issue #306 で導入。
+#
+#       検証観点（Req と対応付け）:
+#         - per-task-reviewer-reject3 シナリオで review-notes.md / debugger-notes.md
+#           が untracked のまま terminal failure に入った場合に、watcher が
+#           diagnostic commit を作って origin に push し、失敗コメント本文に
+#           push state（branch / local HEAD / origin HEAD / ahead / worktree path）と
+#           artifact 状態が埋め込まれる（Req 1.1, 1.3, 2.1, 2.4, 5.1, 5.2, 5.3）
+#         - 既に tracked かつ push 済みの artifact では diagnostic commit を作らず
+#           既存コメント情報の append のみ行う（Req 1.2）
+#         - diagnostic commit の push に失敗した場合、fallback として artifact 本文
+#           を Issue コメントに埋め込む（Req 1.4, NFR 3.1）
+#         - artifact 本文が長文の場合は先頭 + 末尾の抜粋に切り替える（NFR 3.1）
+#         - 初回 push 前（origin branch 不在）でも push state 欄に「未 push」と
+#           ahead count（local HEAD までの commit 数）を埋める（Req 2.3）
+#         - 保全処理の途中失敗でも claude-failed ラベル付与責務を放棄しない
+#           （Req 1.5, NFR 2.1）
+#
+# 配置先: local-watcher/test/publish_terminal_failure_artifacts_test.sh
+# 依存:   bash 4+, git, awk
+# 実行:   bash local-watcher/test/publish_terminal_failure_artifacts_test.sh
+# 前提:   外部ネットワークを使わない。fake origin は mktemp 配下の bare repo。
+#         GH_TOKEN は不要（gh コマンドを関数で stub する）。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# publish_terminal_failure_artifacts は内部で mark_issue_failed を呼ぶため、
+# 関数定義のみを抽出して current shell に load する。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "publish_terminal_failure_artifacts")"
+
+if ! declare -F publish_terminal_failure_artifacts >/dev/null; then
+  echo "ERROR: publish_terminal_failure_artifacts not loaded from issue-watcher.sh" >&2
+  exit 2
+fi
+
+# サニティ: 実装側の per-task terminal failure 経路が新ヘルパー名で呼んでいること
+# （関数差し替え漏れを検出 / Issue #306）
+if ! grep -q 'publish_terminal_failure_artifacts "per-task-reviewer-reject2"' "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh から publish_terminal_failure_artifacts per-task-reviewer-reject2 の呼出がない" >&2
+  exit 2
+fi
+if ! grep -q 'publish_terminal_failure_artifacts "per-task-reviewer-reject3"' "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh から publish_terminal_failure_artifacts per-task-reviewer-reject3 の呼出がない" >&2
+  exit 2
+fi
+if ! grep -q 'publish_terminal_failure_artifacts "per-task-reviewer-error"' "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh から publish_terminal_failure_artifacts per-task-reviewer-error の呼出がない" >&2
+  exit 2
+fi
+if ! grep -q 'publish_terminal_failure_artifacts "per-task-reviewer-missing-file"' "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh から publish_terminal_failure_artifacts per-task-reviewer-missing-file の呼出がない" >&2
+  exit 2
+fi
+if ! grep -q 'publish_terminal_failure_artifacts "debugger-notes-invalid"' "$WATCHER_SH"; then
+  echo "ERROR: issue-watcher.sh から publish_terminal_failure_artifacts debugger-notes-invalid の呼出がない" >&2
+  exit 2
+fi
+
+# ─── 一時環境（bare repo + work repo）構築ヘルパ ───
+TMPROOT=$(mktemp -d)
+cleanup() {
+  chmod -R u+rwX "$TMPROOT" 2>/dev/null || true
+  rm -rf "$TMPROOT" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# fake mark_issue_failed: 呼出を記録する
+LAST_MARK_FAILED_STAGE=""
+LAST_MARK_FAILED_BODY=""
+MARK_FAILED_CALL_COUNT=0
+mark_issue_failed() {
+  LAST_MARK_FAILED_STAGE="$1"
+  LAST_MARK_FAILED_BODY="$2"
+  MARK_FAILED_CALL_COUNT=$((MARK_FAILED_CALL_COUNT + 1))
+}
+
+# work / bare repo を作って初期 commit を push 済みにする
+setup_work_with_upstream() {
+  local case_id="$1"
+  local work="$TMPROOT/work-$case_id"
+  local bare="$TMPROOT/bare-$case_id.git"
+
+  git init --bare --quiet "$bare"
+  git init --quiet "$work"
+  (
+    cd "$work"
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git config commit.gpgsign false
+    git remote add origin "$bare"
+    mkdir -p docs/specs/306-test
+    echo "v0" > docs/specs/306-test/requirements.md
+    git add docs/specs/306-test/requirements.md
+    git commit --quiet -m "init"
+    git branch -m work-branch
+    git push --quiet -u origin work-branch
+  )
+  echo "$work"
+}
+
+# 初回 push 前の work repo（origin branch 不在）
+setup_work_without_upstream() {
+  local case_id="$1"
+  local work="$TMPROOT/work-$case_id"
+  local bare="$TMPROOT/bare-$case_id.git"
+
+  git init --bare --quiet "$bare"
+  git init --quiet "$work"
+  (
+    cd "$work"
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    git config commit.gpgsign false
+    git remote add origin "$bare"
+    mkdir -p docs/specs/306-test
+    echo "v0" > docs/specs/306-test/requirements.md
+    git add docs/specs/306-test/requirements.md
+    git commit --quiet -m "init"
+    git branch -m work-branch
+    # push しない
+  )
+  echo "$work"
+}
+
+# ─── アサーションヘルパ ───
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -Fq "$needle"; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  needle: $(printf '%q' "$needle")"
+    echo "  in (head): $(printf '%s' "$haystack" | head -c 800)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if printf '%s' "$haystack" | grep -Fq "$needle"; then
+    echo "FAIL: $label (needle found unexpectedly)"
+    echo "  needle: $(printf '%q' "$needle")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+reset_state() {
+  LAST_MARK_FAILED_STAGE=""
+  LAST_MARK_FAILED_BODY=""
+  MARK_FAILED_CALL_COUNT=0
+}
+
+# 共通 env vars
+LOG="$TMPROOT/test-watcher.log"
+: > "$LOG"
+export NUMBER REPO LOG SPEC_DIR_REL BASE_BRANCH BRANCH REPO_DIR
+NUMBER="306"
+REPO="owner/test"
+SPEC_DIR_REL="docs/specs/306-test"
+BASE_BRANCH="main"
+BRANCH="work-branch"
+
+echo "--- publish_terminal_failure_artifacts cases ---"
+
+# ─────────────────────────────────────────────────────────────────
+# Case 1: per-task-reviewer-reject3 シナリオ。review-notes.md / debugger-notes.md
+# が untracked な状態で terminal failure → diagnostic commit 作成 + push 成功
+# (Req 1.1, 1.3, 2.1, 2.4, 5.1, 5.2, 5.3)
+# ─────────────────────────────────────────────────────────────────
+WORK=$(setup_work_with_upstream "case1")
+REPO_DIR="$WORK"
+# untracked な review-notes.md / debugger-notes.md を作る
+echo "# Review notes (reject categories: missing-test)" > "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "RESULT: reject" >> "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "# Debugger fix plan" > "$WORK/$SPEC_DIR_REL/debugger-notes.md"
+echo "## 根本原因" >> "$WORK/$SPEC_DIR_REL/debugger-notes.md"
+
+reset_state
+: > "$LOG"
+pushd "$WORK" >/dev/null
+publish_terminal_failure_artifacts "per-task-reviewer-reject3" "per-task ループの Reviewer (task=\`1.1\`, round=3) reject (Req 3.5)"
+popd >/dev/null
+
+assert_eq "Case 1: mark_issue_failed が 1 回呼ばれた (Req 1.5)" "1" "$MARK_FAILED_CALL_COUNT"
+assert_eq "Case 1: stage 識別子が伝搬 (per-task-reviewer-reject3)" \
+  "per-task-reviewer-reject3" "$LAST_MARK_FAILED_STAGE"
+
+# Req 2.1: 失敗コメントに push state 必須項目
+assert_contains "Case 1: コメントに実装 branch 名 (Req 2.1)" \
+  "実装 branch: \`work-branch\`" "$LAST_MARK_FAILED_BODY"
+assert_contains "Case 1: コメントに worktree path (Req 2.1)" \
+  "worktree" "$LAST_MARK_FAILED_BODY"
+assert_contains "Case 1: コメントに local HEAD ラベル (Req 2.1)" \
+  "local HEAD" "$LAST_MARK_FAILED_BODY"
+assert_contains "Case 1: コメントに origin HEAD ラベル (Req 2.1)" \
+  "origin HEAD" "$LAST_MARK_FAILED_BODY"
+assert_contains "Case 1: コメントに ahead count ラベル (Req 2.1)" \
+  "ahead count" "$LAST_MARK_FAILED_BODY"
+
+# Req 2.2: artifact 単位の状態（review-notes.md / debugger-notes.md）が記載される
+assert_contains "Case 1: コメントに review-notes.md 行 (Req 2.2)" \
+  "review-notes.md" "$LAST_MARK_FAILED_BODY"
+assert_contains "Case 1: コメントに debugger-notes.md 行 (Req 2.2)" \
+  "debugger-notes.md" "$LAST_MARK_FAILED_BODY"
+
+# Req 1.1, 1.3, 5.2: diagnostic commit が origin に push されている
+BARE_COMMITS=$(git -C "$TMPROOT/bare-case1.git" rev-list --count work-branch)
+assert_eq "Case 1: bare 側に init + diagnostic commit の 2 件到達 (Req 1.1, 1.3)" \
+  "2" "$BARE_COMMITS"
+# Req 1.3 後: artifact が committed として表示される
+assert_contains "Case 1: artifact status が committed (Req 1.3)" \
+  "committed" "$LAST_MARK_FAILED_BODY"
+
+# 既存 extra_body 部分が保持される（NFR 1.2）
+assert_contains "Case 1: 既存 extra_body 文言が保持される (NFR 1.2)" \
+  "per-task ループの Reviewer (task=\`1.1\`, round=3) reject" "$LAST_MARK_FAILED_BODY"
+
+# NFR 2.2: $LOG に grep 可能な記録
+assert_contains "Case 1: \$LOG に terminal-failure-artifacts 記録 (NFR 2.2)" \
+  "terminal-failure-artifacts" "$(cat "$LOG")"
+assert_contains "Case 1: \$LOG に stage 識別子 (NFR 2.2)" \
+  "stage=per-task-reviewer-reject3" "$(cat "$LOG")"
+
+# ─────────────────────────────────────────────────────────────────
+# Case 2: artifact が既に tracked かつ pushed 済み → 重複保全しない (Req 1.2)
+# ─────────────────────────────────────────────────────────────────
+WORK=$(setup_work_with_upstream "case2")
+REPO_DIR="$WORK"
+# review-notes.md / debugger-notes.md を作成して commit + push 済みにする
+echo "# Already tracked" > "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "RESULT: reject" >> "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "# Already tracked debugger notes" > "$WORK/$SPEC_DIR_REL/debugger-notes.md"
+(
+  cd "$WORK"
+  git add docs/specs/306-test/review-notes.md docs/specs/306-test/debugger-notes.md
+  git commit --quiet -m "preexisting review + debugger artifacts"
+  git push --quiet origin work-branch
+)
+
+BARE_COMMITS_BEFORE=$(git -C "$TMPROOT/bare-case2.git" rev-list --count work-branch)
+
+reset_state
+: > "$LOG"
+pushd "$WORK" >/dev/null
+publish_terminal_failure_artifacts "per-task-reviewer-reject2" "per-task Reviewer reject2 (既存 tracked artifact)"
+popd >/dev/null
+
+assert_eq "Case 2: mark_issue_failed が 1 回呼ばれた (Req 1.5)" "1" "$MARK_FAILED_CALL_COUNT"
+
+# Req 1.2: 重複保全を行わない → bare 側に新規 commit が積まれていない
+BARE_COMMITS_AFTER=$(git -C "$TMPROOT/bare-case2.git" rev-list --count work-branch)
+assert_eq "Case 2: bare 側に新規 commit が追加されていない (Req 1.2)" \
+  "$BARE_COMMITS_BEFORE" "$BARE_COMMITS_AFTER"
+
+# Req 1.2: status が tracked-pushed と表示される
+assert_contains "Case 2: artifact status が tracked-pushed (Req 1.2)" \
+  "tracked-pushed" "$LAST_MARK_FAILED_BODY"
+
+# 既存挙動（push state 情報は常に append される / Req 2.4）
+assert_contains "Case 2: tracked かつ pushed でも push state 情報を append (Req 2.4)" \
+  "実装 branch: \`work-branch\`" "$LAST_MARK_FAILED_BODY"
+
+# ─────────────────────────────────────────────────────────────────
+# Case 3: diagnostic commit の push に失敗 → 本文を Issue コメントに fallback 埋め込み
+# (Req 1.4)
+# ─────────────────────────────────────────────────────────────────
+WORK=$(setup_work_with_upstream "case3")
+REPO_DIR="$WORK"
+# untracked artifact を用意
+EMBED_MARKER="EMBED-MARKER-CASE3-CONTENT-XYZ"
+echo "$EMBED_MARKER" > "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "RESULT: reject" >> "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "# Debugger" > "$WORK/$SPEC_DIR_REL/debugger-notes.md"
+
+# bare を壊して push を失敗させる
+chmod -R 000 "$TMPROOT/bare-case3.git/refs" 2>/dev/null || true
+
+reset_state
+: > "$LOG"
+pushd "$WORK" >/dev/null
+publish_terminal_failure_artifacts "per-task-reviewer-error" "per-task Reviewer error (commit push 失敗シナリオ)"
+popd >/dev/null
+
+chmod -R 755 "$TMPROOT/bare-case3.git/refs" 2>/dev/null || true
+
+assert_eq "Case 3: mark_issue_failed が 1 回呼ばれた (Req 1.5)" "1" "$MARK_FAILED_CALL_COUNT"
+
+# Req 1.4: artifact 本文がコメント本文に fallback 埋め込みされる
+assert_contains "Case 3: review-notes.md 本文の marker がコメントに埋め込まれた (Req 1.4)" \
+  "$EMBED_MARKER" "$LAST_MARK_FAILED_BODY"
+# 「全文」見出しが存在
+assert_contains "Case 3: fallback 埋め込みの見出しが存在 (Req 1.4)" \
+  "の内容（全文）" "$LAST_MARK_FAILED_BODY"
+
+# ─────────────────────────────────────────────────────────────────
+# Case 4: 初回 push 前（origin branch 不在）→ origin HEAD は「未 push」相当
+# (Req 2.3) かつ ahead は local HEAD までの commit 数として算出
+# ─────────────────────────────────────────────────────────────────
+WORK=$(setup_work_without_upstream "case4")
+REPO_DIR="$WORK"
+# untracked artifact
+echo "# Initial push 前 review-notes" > "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "RESULT: reject" >> "$WORK/$SPEC_DIR_REL/review-notes.md"
+
+reset_state
+: > "$LOG"
+pushd "$WORK" >/dev/null
+# 初回 push できる状態（bare に対する push 権限はある）にしておく
+publish_terminal_failure_artifacts "per-task-reviewer-reject2" "per-task Reviewer reject2 初回 push 前"
+popd >/dev/null
+
+assert_eq "Case 4: mark_issue_failed が 1 回呼ばれた (Req 1.5)" "1" "$MARK_FAILED_CALL_COUNT"
+
+# Req 2.3 の確認は「最初に push state を取得した段階」で origin が未 push だったことが
+# コメントに反映されること。watcher は commit 成功後に origin HEAD を更新するため、
+# ロジックとしては「origin HEAD: 未 push」が初期取得時に出力される実装。
+# 実際の挙動: 初回取得時の origin_head=未 push がそのまま埋まる場合もあるが、
+# commit/push 成功後に最新 SHA で上書きされるケースもある。
+# 安定的に検証できるのは「初回時点で未 push 経路を通った」ことの log 記録。
+assert_contains "Case 4: \$LOG に origin_head=未 push 記録 (Req 2.3)" \
+  "origin_head=未 push" "$(cat "$LOG")"
+
+# ─────────────────────────────────────────────────────────────────
+# Case 5: 長文 artifact (NFR 3.1) → 要約埋め込み（ただし commit が成功すれば fallback
+# 埋め込みは発生しないので、bare を壊して fallback 経路で評価する）
+# ─────────────────────────────────────────────────────────────────
+WORK=$(setup_work_with_upstream "case5")
+REPO_DIR="$WORK"
+# 長文 (16385 文字以上) の review-notes.md を作る
+{
+  i=0
+  while [ "$i" -lt 600 ]; do
+    printf 'long-line-marker-%04d aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n' "$i"
+    i=$((i + 1))
+  done
+} > "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "TAIL-MARKER-CASE5-END" >> "$WORK/$SPEC_DIR_REL/review-notes.md"
+echo "# Debugger" > "$WORK/$SPEC_DIR_REL/debugger-notes.md"
+
+# bare を壊して fallback 経路を通す
+chmod -R 000 "$TMPROOT/bare-case5.git/refs" 2>/dev/null || true
+
+reset_state
+: > "$LOG"
+pushd "$WORK" >/dev/null
+publish_terminal_failure_artifacts "per-task-reviewer-missing-file" "per-task Reviewer missing-file 長文"
+popd >/dev/null
+
+chmod -R 755 "$TMPROOT/bare-case5.git/refs" 2>/dev/null || true
+
+assert_eq "Case 5: mark_issue_failed が 1 回呼ばれた (Req 1.5)" "1" "$MARK_FAILED_CALL_COUNT"
+
+# NFR 3.1: 長文 → 要約埋め込み（「中略」を含む）
+assert_contains "Case 5: 要約モード（中略）が選択された (NFR 3.1)" \
+  "(中略" "$LAST_MARK_FAILED_BODY"
+assert_contains "Case 5: 要約モードの末尾 marker が含まれる (NFR 3.1)" \
+  "TAIL-MARKER-CASE5-END" "$LAST_MARK_FAILED_BODY"
+
+# ─────────────────────────────────────────────────────────────────
+# Case 6: review-notes.md / debugger-notes.md が両方 absent でも mark_issue_failed は
+# 必ず呼ばれる (Req 1.5, NFR 2.1)
+# ─────────────────────────────────────────────────────────────────
+WORK=$(setup_work_with_upstream "case6")
+REPO_DIR="$WORK"
+# 何も artifact を作らない
+
+reset_state
+: > "$LOG"
+pushd "$WORK" >/dev/null
+publish_terminal_failure_artifacts "debugger-notes-invalid" "Debugger notes 不正 / 不在"
+popd >/dev/null
+
+assert_eq "Case 6: artifact 不在でも mark_issue_failed が呼ばれる (Req 1.5)" \
+  "1" "$MARK_FAILED_CALL_COUNT"
+assert_eq "Case 6: stage 識別子が正しく伝搬" \
+  "debugger-notes-invalid" "$LAST_MARK_FAILED_STAGE"
+# absent 状態が status で出る
+assert_contains "Case 6: artifact 不在 status が absent (Req 1.5, NFR 2.1)" \
+  "absent" "$LAST_MARK_FAILED_BODY"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

per-task Implementer ループが terminal failure（Reviewer 二重 reject / Reviewer エラー /
Reviewer 成果物欠損 / Debugger 診断メモ不正）で停止したとき、`review-notes.md` /
`debugger-notes.md` が未 push のままで `claude-failed` 状態になり、運用者が診断成果物に
たどり着けない問題を修正する。

新規ヘルパー `publish_terminal_failure_artifacts` を `local-watcher/bin/issue-watcher.sh` に
導入し、5 種の terminal failure 経路で `mark_issue_failed` 呼出を同ヘルパー経由に差し替えた。
ヘルパーは diagnostic commit 試行（失敗時は Issue コメント本文への埋め込み fallback）と
push state 情報の可視化を行い、最後に必ず `claude-failed` ラベル付与を完遂する。

## 対応 Issue

Closes #306

## 関連 PR

- 設計 PR: なし（design モードを経由しない bug fix）

## 実装内容

- (Req 1.1 / Req 1.3) `publish_terminal_failure_artifacts` ヘルパー新規追加（約 250 行）。
  untracked / modified / tracked-unpushed な `review-notes.md` / `debugger-notes.md` を
  diagnostic commit で origin に push する
- (Req 1.4) diagnostic commit / push 失敗時は artifact 本文を Issue コメントに fallback 埋め込み
- (Req 1.5 / NFR 2.1) 保全処理の途中で例外が起きても最後に `mark_issue_failed` を呼んで
  `claude-failed` ラベル付与を完遂
- (Req 2.1〜2.4) 失敗コメントに branch 名 / local HEAD SHA / origin branch HEAD SHA /
  ahead count / worktree path を追記する push state ブロックを付与
- (Req 1.2) tracked かつ pushed 済みの artifact は重複保全しない
- (Req 3.1〜3.4) Reviewer / Debugger サブエージェントへの git 権限付与なし。
  `git reset` / `git rebase` / force push は使用しない
- (Req 5) `local-watcher/test/publish_terminal_failure_artifacts_test.sh` 新規追加
  （6 ケース / 29 アサーション）

## 受入基準チェック

- [x] Req 1.1: When terminal failure 後に artifact が存在 → diagnostic commit または埋め込みを実施
  ← Case 1（commit push）/ Case 3（埋め込み fallback）
- [x] Req 1.2: If already tracked + pushed → 重複保全なし ← Case 2
- [x] Req 1.3: If untracked / 未 commit → 保全する ← Case 1, Case 3
- [x] Req 1.4: If push 失敗 → fallback 埋め込み ← Case 3
- [x] Req 1.5: 保全失敗でも `claude-failed` を完遂 ← Case 1〜6 全てで assert
- [x] Req 2.1: 失敗コメントに branch / HEAD / ahead / worktree path ← Case 1
- [x] Req 2.2: artifact 単位の状態明示 ← Case 1（untracked→committed）/ Case 2（tracked-pushed）
- [x] Req 2.3: origin 不在時「未 push」固定表記 ← Case 4
- [x] Req 3.4: `git reset` / `git rebase` / force push を含まない ← diff 確認済み
- [x] Req 5.1〜5.3: 回帰テスト全 29 アサーション pass

## テスト結果

```
===========================================
PASS: 29, FAIL: 0
===========================================
（local-watcher/test/publish_terminal_failure_artifacts_test.sh）

全テストスイート:
OK: local-watcher/test/module_loader_missing_test.sh
OK: local-watcher/test/normalize_slug_test.sh
OK: local-watcher/test/parse_review_result_test.sh
OK: local-watcher/test/pi_detect_quota_soft_fail_test.sh
OK: local-watcher/test/pi_max_rounds_kind_test.sh
OK: local-watcher/test/po_apply_awaiting_slot_test.sh
OK: local-watcher/test/publish_terminal_failure_artifacts_test.sh
OK: local-watcher/test/qa_detect_rate_limit_test.sh
OK: local-watcher/test/qa_run_claude_stage_test.sh
OK: local-watcher/test/repo_prefix_log_test.sh
OK: local-watcher/test/slug_match_guard_test.sh
OK: local-watcher/test/stage_a_verify_round1_defer_test.sh
OK: local-watcher/test/stage_c_existing_pr_guard_test.sh
OK: local-watcher/test/stage_checkpoint_pending_tasks_test.sh
OK: local-watcher/test/stagec_pr_verify_fallback_test.sh
OK: local-watcher/test/stagec_pr_verify_retry_test.sh
OK: local-watcher/test/stagec_pr_verify_test.sh
OK: local-watcher/test/verify_pushed_or_retry_test.sh

shellcheck local-watcher/bin/issue-watcher.sh → 警告ゼロ
```

## 実装上の判断

`impl-notes.md`（`docs/specs/306--bug-per-task-terminal-failure-reviewer/impl-notes.md`）に
詳細な設計判断を記録済み。主要な判断は以下:

- 既存 `verify_pushed_or_retry` を変更せず新規ヘルパーとして追加（Req 4.3 / NFR 1.1 の
  後方互換を優先）
- 本文長 16,384 文字超で先頭 80 行 + 末尾 80 行 + `(中略 / 全文 N 文字)` の抜粋モードに
  切り替え（NFR 3.1）
- 対象経路は 5 種（reject2 / reject3 / reviewer-error / reviewer-missing-file /
  debugger-notes-invalid）。`per-task-implementer-failed` 系と `pt_mark_diff_range_resolve_failed`
  は Req 1.1 の定義（「Reviewer または Debugger が書き出した後の terminal failure」）に該当
  しないため対象外

## 確認事項 / レビュワーへの依頼

- Reviewer 判定: **approve**（`docs/specs/306--bug-per-task-terminal-failure-reviewer/review-notes.md` 参照）
- `pt_mark_diff_range_resolve_failed`（Issue #164）の per-task 失敗経路が今回の対象外であることの
  妥当性を確認されたい（requirements の terminal failure 5 経路に列挙されていないため除外した）
- `per-task-implementer-failed` 系（claude 非 0 exit / no-progress / debugger-blocked-but-invoked 等）
  も対象外とした。これらは Reviewer / Debugger が成果物を書き出す前の段階での失敗のため
- design-less impl: tasks.md 不在のため Closes を採用

---

base: main / baseRefName: main / OK

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #306 のコメントを参照してください。