### PR TITLE
feat(#304): per-task review range の marker truncation を検出して abort/extend する

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -390,6 +390,70 @@ fresh な Claude session** で本 Developer サブエージェントが起動さ
   ため、`diff-range-resolve-failed` を引き起こすリスクがある（watcher 側で fallback 解決は
   試行するが、canonical は単記分割のみ）。
 
+## Marker contract（marker は task の終端 commit）（Issue #304 / idd-codex #14 同型再発防止）
+
+per-task ループにおいて、`docs(tasks): mark <id> as done` marker commit は当該 task の
+**終端 commit**（task 完了時点で `${BASE_BRANCH}..HEAD` の最後尾に位置する commit）として
+扱う契約があります。本契約は watcher の `pt_resolve_diff_range` が当該 task の per-task
+Reviewer review range の **終端 SHA** を当該 marker commit に固定する前提に依拠しており、
+契約違反は **silent range truncation**（修正 commit が Reviewer の判定対象から漏れる事故）の
+原因になります。
+
+### marker 作成タイミングの契約（Req 1.1）
+
+- marker commit は、当該 task の **実装 commit・テスト commit・`impl-notes.md` への
+  learning 追記 commit** をすべて積み終えた **最後** に作成すること
+- 「実装途中で先に marker を打って後から修正を追加する」「learning 追記より先に marker を
+  打つ」等のフローは禁止。**「task の全成果物が積み終わった」状態でのみ marker を作る**
+- 本 attempt（Reviewer reject 後の retry も含む）の task-scope 作業がすべて完了した時点で
+  marker commit を作成する
+
+### retry 時の marker refresh 契約（Req 1.2）
+
+Reviewer reject や Debugger guidance による Implementer 再実行（round 2 / round 3）で
+修正 commit を追加する場合、**修正 commit を旧 marker より後ろに残してはならない**。
+旧 marker をそのままに修正 commit を marker 後ろに積むと、watcher の review range が
+旧 marker で固定されたまま修正 commit が漏れ、再 reject の根拠が実態と乖離します
+（idd-codex #14 で実際に発生した failure mode）。
+
+### 推奨 refresh 手順（順序付き）
+
+retry 時に marker を refresh する canonical 手順は以下です:
+
+1. **旧 marker commit の特定**: `git log --oneline ${BASE_BRANCH}..HEAD | grep "docs(tasks): mark <id> as done"` で
+   旧 marker の SHA を特定する
+2. **修正 commit を積む**: 実装 / テスト / learning 追記の修正 commit を通常通り積む（この
+   時点では旧 marker が中間位置に残っている状態）
+3. **旧 marker を剥がして新 marker を末尾に作り直す**: 以下のいずれかの方法で marker を
+   task 終端に移動する:
+   - **方法 A（推奨 / 単純）**: `git reset --soft <旧 marker の SHA>^` で旧 marker を含む
+     最近の commit を index に戻し、修正 commit を再 commit したうえで新 marker を末尾に
+     作成する
+   - **方法 B**: `git rebase -i ${BASE_BRANCH}` で旧 marker を tip に移動（reorder）し、
+     必要なら drop + 末尾で新 marker を作り直す
+4. **push して watcher の次サイクルへ**: refresh 後の HEAD（新 marker が終端）を push する。
+   watcher は次サイクルで新 marker を range_end として解決する
+
+### 禁止例
+
+以下のパターンは silent range truncation を引き起こすため **禁止**:
+
+- 旧 marker をそのままに修正 commit を marker **後ろに** 積む（marker が中間位置に残る）
+- 修正 commit と marker を別 attempt に分割し、marker のみを先行 attempt で push したまま
+  後続 attempt で修正 commit を push する
+- 旧 marker を残したまま「marker を打ち直す」つもりで `docs(tasks): mark <id> as done` を
+  もう 1 件追加する（同一 task ID の marker が複数存在する状態は watcher 側でも `1 commit
+  = 1 task ID` 規約に抵触する）
+
+### watcher 側 safety net との関係
+
+watcher は本契約違反を検出する safety net（`pt_detect_post_marker_commits` /
+`pt_handle_post_marker_commits` / `per-task-post-marker-commits-detected` カテゴリの
+claude-failed、env `POST_MARKER_RECOVERY_MODE`）を持ちますが、これは **Implementer 契約の
+代替ではなく defense-in-depth** です。default の `fail-with-diagnostic` モードでは
+silent truncation を顕在化させて claude-failed で停止するため、Implementer は本契約を
+遵守して safety net 発火を回避することが望まれます。
+
 ## learning 追記の責務（per-task ループの中核 / Req 4.1, 4.2, 4.4）
 
 - 完了時に `impl-notes.md` の `## Implementation Notes` セクション配下へ

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -300,6 +300,44 @@ git diff <range_start_sha>..<range_end_sha> -- <path>
 HEAD 全体（`<BASE_BRANCH>..HEAD`）は対象外です。全体観点は最終 Stage B Reviewer
 （per-task ループ完了後に別途起動される HEAD 全体レビュー）が担当します。
 
+### range 外 commit の判定対象外性（Issue #304 Req 3.2）
+
+prompt の `range_start_sha..range_end_sha` の **外側** にある commit（例: `range_end_sha` より
+後ろに HEAD が存在する場合の post-marker commit、または `range_start_sha` より前の commit）は、
+**本 Reviewer の判定対象外** です。Reviewer は以下を遵守してください:
+
+- range 外 commit を **`git diff` / `git log` の対象に含めない**（上記コマンド例の通り
+  `<range_start_sha>..<range_end_sha>` で範囲を限定して呼ぶ）
+- range 外 commit の内容を理由に **approve / reject を出さない**（範囲外で起きている問題は
+  本 Reviewer の責務外であり、HEAD 全体観点は Stage B Reviewer が担当する）
+- 「HEAD には range 外 commit がある」事実を観測しても、本 Reviewer の判定基準（AC 未カバー /
+  missing test / boundary 逸脱）に該当しなければそれを reject 理由にしない
+
+本制約は per-task ループ全体の役割分担（task 単位境界の検出 vs HEAD 全体 verify）を維持する
+ための前提です。range 外 commit を理由とした reject は Reviewer の責務逸脱として扱われます。
+
+### Extended range シグナルの解釈（Issue #304 Req 3.3）
+
+prompt の machine-parseable range block に `range_extended: true` シグナルが含まれる場合、
+watcher が marker 後の post-marker commit（task の終端 marker より後ろに積まれた未レビュー
+commit）を検出し、`POST_MARKER_RECOVERY_MODE=extend-range` 経路で **range_end を HEAD まで
+拡張済み**であることを示します。本シグナルの解釈は以下です:
+
+- **判定基準は変わらない**: extended 状態でも Reviewer の判定軸（AC 未カバー / missing test /
+  boundary 逸脱）は通常 review と同一。判定対象 SHA range の **終端が marker ではなく HEAD**
+  になっただけで、勘案する観点は変化しない
+- **range 内 commit のみを判定根拠とする**: extended であっても上記「range 外 commit の
+  判定対象外性」原則は変わらない。`range_start_sha..range_end_sha` 内の commit のみを
+  `git diff` / `git log` で参照する（`range_end_sha` は extended 状態では HEAD と一致する）
+- **Implementer 契約違反の事実を観察できる**: `range_extended: true` は Implementer が marker
+  contract（marker は task の終端 commit）を守らず、修正 commit を旧 marker 後ろに残した
+  ことを意味する。Reviewer はこの状況下でも当該 task の AC / 境界に対して通常通り判定を
+  出すこと（契約違反そのものは watcher 側のログ / 失敗カテゴリで観測される領分であり、
+  Reviewer の reject 理由にはしない）
+- **`range_extended: false` または欠落時は normal 経路**: 通常の per-task review は
+  `range_extended: false`（または当該行が prompt に存在しない）状態で起動される。この場合は
+  本節導入前と完全に同一の判定挙動。
+
 ## 判定 depth の絞り込み
 
 per-task ループの Reviewer は判定 depth が以下に絞り込まれます:

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -209,3 +209,57 @@ per-task ループの 1 タスクごとの learning を記録する。
     static rendering（heredoc 展開結果）の確認に留めた。実 Reviewer エージェントが
     machine-parseable block / Warning / Extended range 説明を正しく解釈することの確認は
     将来の dogfooding 観測で担保する。
+
+### Task 7
+
+- **採用方針**: `.claude/agents/developer.md` の「per-task ループ下での Implementer の責務」
+  節の「適用範囲」（`1 commit = 1 task ID` 記述で終わる）直後に新規 h2 subsection
+  `## Marker contract（marker は task の終端 commit）（Issue #304 / idd-codex #14 同型再発防止）`
+  を追加し、`.claude/agents/reviewer.md` の `## 判定対象 diff range の限定` subsection 末尾
+  （HEAD 全体観点を Stage B Reviewer に委ねる記述の直後）に h3 `### range 外 commit の
+  判定対象外性（Issue #304 Req 3.2）` と `### Extended range シグナルの解釈（Issue #304
+  Req 3.3）` を追加した。両ファイルとも root 系統のみで編集し、repo-template ミラーは
+  task 8 で同期する。
+- **重要な判断**:
+  - **subsection 階層の選び方**: developer.md の「per-task ループ下での Implementer の責務」
+    は h1（`#`）、配下既存 subsection（適用範囲 / learning 追記の責務 / task-test 境界整合
+    の責務 / 既存 learnings の利用）はすべて h2（`##`）。design.md の File Structure Plan
+    記載「`1 commit = 1 task ID` 記述直後に新たな subsection として配置」に従い、既存階層と
+    整合する h2 で `## Marker contract（marker は task の終端 commit）` を作成。reviewer.md
+    側は「判定対象 diff range の限定」が h2 のため、その配下に追記する Req 3.2 / Req 3.3 の
+    2 ブロックは h3（`###`）を選択（同階層に既存 h3 がないため新規導入だが、判定 depth
+    の絞り込み等の隣接 h2 と階層的に整合）。
+  - **文言の引用元**: 推奨 refresh 手順（旧 marker 特定 → 修正 commit → `git reset --soft`
+    or `git rebase -i` で剥がし新 marker 末尾作成 → push）は design.md `Components and
+    Interfaces` ＞ `developer.md` ＞「推奨 refresh 手順（順序付き）」の 4 ステップを
+    過不足なく転記。禁止例（marker 後ろに修正を残す / marker のみ先行 push /
+    同一 task ID の marker 重複）は design.md と tasks.md の文言を統合した 3 例を列挙。
+    Reviewer 側の「判定基準は変わらない / range 内 commit のみを判定根拠 / Implementer
+    契約違反の事実は観察できるが reject 理由にしない / `range_extended: false` または
+    欠落時は normal 経路」の 4 点は design.md `Components and Interfaces` ＞
+    `reviewer.md` の「extended range シグナル（Req 3.3）」と「range 外 commit の取扱い
+    （Req 3.2）」を吸収。
+  - **Req traceability**: Req 1.1（marker 作成タイミング）/ Req 1.2（retry 時の marker
+    refresh）/ Req 1.3（prompt に marker contract を明示）の 3 点を developer.md 側の
+    3 subsection（marker 作成タイミングの契約 / retry 時の marker refresh 契約 / 推奨
+    refresh 手順 + 禁止例）と watcher 側 safety net 説明で網羅。Req 3.2（range 外 commit
+    判定対象外）/ Req 3.3（extended range 解釈）は reviewer.md 側 2 ブロックに分離。
+    各 subsection 見出しに `Issue #304 Req X.Y` を明示し、将来の review-notes.md / Issue
+    遡及で AC traceability を即座に取れる形にした。
+  - **watcher 側 safety net への参照**: developer.md の marker contract 節末尾に
+    「`pt_detect_post_marker_commits` / `pt_handle_post_marker_commits` /
+    `per-task-post-marker-commits-detected` / env `POST_MARKER_RECOVERY_MODE`」の関数 / カテゴリ /
+    env 名を列挙し、Implementer 契約と watcher safety net が defense-in-depth として
+    両面で機能する設計思想を 1 段落で記述。task 2〜5 で導入済みの実装と prompt 文言の
+    対応関係を明文化することで、将来契約違反が発生した際の運用者の調査経路を短縮できる。
+- **残存課題**:
+  - **task 8 で repo-template ミラー反映が必要**: 本 task 完了時点で
+    `diff -r .claude/agents repo-template/.claude/agents` は **差分あり** の状態
+    （`developer.md` の Marker contract 節 / `reviewer.md` の range 外警告 + extended
+    range subsection が root 系統のみ）。CLAUDE.md「二重管理規約」に従い task 8 で
+    repo-template 系統に byte 一致で反映する責務が残る。
+  - **E2E 観測**: 本 task は agent prompt docs（markdown）の追記のみで、実 Implementer /
+    Reviewer エージェントが本契約・本解釈を正しく解釈するかの dogfooding は idd-claude
+    self-hosting 上で実際に marker contract 違反シナリオを通すことが必要。task 5 で
+    導入した watcher 側 safety net（`per-task-post-marker-commits-detected`）の発火と
+    本 task で追記した推奨 refresh 手順の妥当性は、将来運用観測で担保する。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -43,3 +43,33 @@ per-task ループの 1 タスクごとの learning を記録する。
 - **残存課題**: なし（task 3 で `pt_handle_post_marker_commits`、task 4 で
   `pt_mark_post_marker_commits_detected` を追加する際に本関数の rc 体系を前提として呼び出す
   予定。本関数自体の API / log 書式は確定）。
+
+### Task 3
+
+- **採用方針**: `pt_detect_post_marker_commits` 直後（2745 行付近）に
+  `pt_handle_post_marker_commits <task_id> <round> <range_start> <marker_sha> <post_marker_list>`
+  を追加。env `POST_MARKER_RECOVERY_MODE`（default=`fail-with-diagnostic`、不正値も default 化）で
+  `extend-range` / `fail-with-diagnostic` に case 分岐し、algorithm body は fixture 参照実装
+  line 139〜172 と byte 同期させた。env 宣言は `PER_TASK_LOOP_ENABLED` 直後（497〜506 行）に
+  `POST_MARKER_RECOVERY_MODE="${POST_MARKER_RECOVERY_MODE:-fail-with-diagnostic}"` を 1〜2 行
+  コメント付きで追加。
+- **重要な判断**:
+  - stderr ログは「NFR 2.1 メインイベントログ」と「warn ログ」を **書式分離** した。
+    メインログは fixture line 158 と同じ `[YYYY-MM-DD HH:MM:SS] per-task:
+    post-marker-commits-detected ...` 書式の単一行を直接 `echo` で出す（`pt_warn` の `WARN:`
+    接頭辞を **付けない** 設計）。一方、不正 env 値検知 / `git rev-parse HEAD` 失敗等の
+    abnormal 通知は `pt_warn`（`WARN:` 接頭辞付き）に置換した。Task 2 で確立した
+    「algorithm body は byte 同期 / stderr 表面文字列は対応許容」precedent を踏襲しつつ、
+    NFR 2.1 のメインイベントログは fixture と書式一致させる方針。
+  - `fail-with-diagnostic` 分岐は `pt_mark_post_marker_commits_detected`（task 4 で追加）を
+    呼ばず単に `return 5` で終わる設計とした。task 4 の関数追加後に `run_per_task_reviewer`
+    経路（task 5）または本関数の改修で `mark` 呼び出しを補完する。fixture 参照実装も
+    同じ設計（line 170〜171）であり前方参照を作らない。
+  - `extend-range` 経路で `git rev-parse HEAD` が失敗した場合は `extend-range` を諦めて
+    rc=5 を返す保守的設計とした（fixture line 162〜164 と同一）。HEAD が取れない状況での
+    range 拡張は意味を持たないため、`fail-with-diagnostic` 相当の rc に倒すことで
+    呼び出し側（task 5 で組み込む `run_per_task_reviewer`）の分岐を統一できる。
+- **残存課題**: なし（task 4 で `pt_mark_post_marker_commits_detected` を追加する際、本関数の
+  `fail-with-diagnostic` 分岐から呼び出す経路の組み込み判断が残る。design.md は
+  `run_per_task_reviewer`（task 5）側で呼ぶ設計に倒しているが、task 4 完了後に task 5 で
+  両者を接続するため、本関数自体は task 3 時点の signature / rc 体系で確定）。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -73,3 +73,36 @@ per-task ループの 1 タスクごとの learning を記録する。
   `fail-with-diagnostic` 分岐から呼び出す経路の組み込み判断が残る。design.md は
   `run_per_task_reviewer`（task 5）側で呼ぶ設計に倒しているが、task 4 完了後に task 5 で
   両者を接続するため、本関数自体は task 3 時点の signature / rc 体系で確定）。
+
+### Task 4
+
+- **採用方針**: `pt_mark_diff_range_resolve_failed`（3498 行〜）直後に
+  `pt_mark_post_marker_commits_detected <task_id> <round> <marker_sha> <post_marker_list>`
+  を追加。HTML marker `<!-- idd-claude:per-task-post-marker-commits-detected:#<issue>:<task> -->`
+  による重複コメント抑制、`gh issue edit` で `LABEL_CLAIMED` / `LABEL_PICKED` 除去 +
+  `LABEL_FAILED` 付与、復旧手順本文の組み立てまで既存 `pt_mark_diff_range_resolve_failed`
+  と byte レベルで対応する構造に揃えた。
+- **重要な判断**:
+  - 復旧手順は「reflog で push 前 commit を確認 → marker refresh（`git reset --soft <marker^>`
+    または `git rebase -i ${BASE_BRANCH}`）→ \`docs(tasks): mark ${task_id} as done\` が
+    \`${BASE_BRANCH}..HEAD\` の最終 commit になっているかを `git log --oneline` で確認」
+    という順序付きフローに固定した。design.md の `Components and Interfaces` ＞
+    `pt_mark_post_marker_commits_detected` 記載の「reflog で push 前 commit 確認 → marker
+    refresh 手順 → marker contract 再周知」を該当 subsection に過不足なくマップ。
+  - 切替 env (`POST_MARKER_RECOVERY_MODE`) の説明を末尾に追加し、運用者が
+    `fail-with-diagnostic`（default）/ `extend-range` の意味と推奨度（marker contract 違反を
+    黙って吸収する extend-range は通常変更不要）を Issue コメント内で判断できる形にした。
+    task 3 の env 命名 / 不正値の default 化と整合。
+  - post-marker SHA リストは CSV と bullet 表記の **両方** を本文に含める設計とした。CSV
+    は grep 用、bullet は人間レビュー用で、`pt_mark_diff_range_resolve_failed` よりも
+    情報密度を上げる方向に振った（marker contract 違反のような構造的失敗では運用者の
+    手動 rescue が重要になるため）。
+  - 本 commit 時点では本関数の呼び出し側は task 5 で `run_per_task_reviewer` の rc=5 経路
+    （または `pt_handle_post_marker_commits` 内）から組み込む予定。task 3 の
+    `pt_handle_post_marker_commits` は `return 5` のみで本関数を呼ばない設計のため、
+    現状コードベース上では unused-function 状態だが、これは task 3 ↔ task 4 ↔ task 5 の
+    順序依存（design.md `_Depends:_`）に従う中間状態。shellcheck warning は出ない
+    （関数定義は使われない状態でも警告対象外）。
+- **残存課題**: なし（task 5 で `run_per_task_reviewer` から本関数または
+  `pt_handle_post_marker_commits` 経由で本関数を呼ぶ経路を接続する責務が残る。本関数の
+  signature / 副作用は task 4 時点で確定）。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -106,3 +106,56 @@ per-task ループの 1 タスクごとの learning を記録する。
 - **残存課題**: なし（task 5 で `run_per_task_reviewer` から本関数または
   `pt_handle_post_marker_commits` 経由で本関数を呼ぶ経路を接続する責務が残る。本関数の
   signature / 副作用は task 4 時点で確定）。
+
+### Task 5
+
+- **採用方針**: `run_per_task_reviewer`（3350 行〜）の `pt_resolve_diff_range` 成功直後に
+  post-marker safety net を挿入し、`pt_detect_post_marker_commits "$range_end"` の rc に
+  応じて 3 分岐（rc=0 / rc=1 / rc=2）。検出時は `pt_handle_post_marker_commits` を呼び、
+  さらに rc=0 (extend-range) / rc=5 (fail-with-diagnostic) で分岐する 2 段 dispatcher
+  構造とした。fail-with-diagnostic と extend-range の失敗 fallback（HEAD 解決失敗 / 想定外
+  rc）の両方で `pt_mark_post_marker_commits_detected` を呼んで claude-failed を付与し、
+  `run_per_task_reviewer` 自身も rc=5 を返す。`run_per_task_loop` の round=1 / round=2
+  / round=3 (Debugger 経由) 各経路に `5)` ケースを既存 `diff-range-resolve-failed` (rc=3)
+  分岐と同じ位置に挿入。
+- **重要な判断**:
+  - **`pt_mark_post_marker_commits_detected` を呼ぶ場所の選択**: design.md は両方の選択肢
+    （`pt_handle_post_marker_commits` 内 / `run_per_task_reviewer` 内）を許容している
+    が、`run_per_task_reviewer` 側で呼ぶ方針を採用した。理由: (a) `pt_handle_post_marker_commits`
+    は fixture 参照実装と algorithm body の byte 同期責務を保持しており、ここに mark
+    呼び出しを追加すると fixture との差分が出る (task 3 impl-notes の precedent と整合)、
+    (b) `run_per_task_reviewer` は marker_sha (= range_end) / post_marker_list を自前で
+    保持しているため情報のプランビング上自然、(c) rc=3（`diff-range-resolve-failed`）の
+    既存 pattern と異なり、本経路は marker / post_marker SHA を含めた詳細復旧手順を要する
+    ため loop 側にデータを引き上げず本関数で完結させる方が plumbing が簡潔。
+  - **loop 側の `5)` ケースは追加投稿しない**: `run_per_task_reviewer` 内で
+    `pt_mark_post_marker_commits_detected` 済みのため、loop 側は stdout / log のみで停止
+    （`return 1`）。`publish_terminal_failure_artifacts` を重ねて呼ばない設計で、Issue
+    コメントの重複を防ぐ。rc=3 の `pt_mark_diff_range_resolve_failed` も loop 側で呼ぶ
+    pattern だが、こちらは `run_per_task_reviewer` 内で mark 済みなので分岐構造が違う。
+    loop 側のコメント欄で「`run_per_task_reviewer` 内で `pt_mark_post_marker_commits_detected`
+    済み」を明示して将来の読者が pattern 差を把握できるようにした。
+  - **fail-safe（NFR 1.3）の徹底**: rc=2（git エラー）/ rc=* (想定外 rc) は既存ルートで
+    fall-through する（既存挙動温存）。rc=0 経路内で `pt_handle_post_marker_commits` が
+    想定外 rc を返した場合（rc=0/5 以外）も `pt_mark_post_marker_commits_detected` を
+    呼んで rc=5 に倒す（安全側）。extend-range で stdout が空（HEAD 解決失敗等）の場合も
+    同様に fail-with-diagnostic 相当の停止に倒す。
+  - **`extended` ローカル変数の扱い**: task 6 で `build_per_task_reviewer_prompt` に
+    `extended` 引数を追加する責務のため、task 5 では `extended` を log 行に出すに留め、
+    prompt builder には渡さない。task 6 完了時に `build_per_task_reviewer_prompt` 呼び出し
+    位置で `"$extended"` を 6 番目の引数として渡すよう改修される予定。
+  - **rc=5 ドキュメント**: `run_per_task_reviewer` の戻り値コメント節を更新し、rc=5 の
+    意味（`post-marker commit を検出 + fail-with-diagnostic で停止`）と rc=3 との
+    使い分け（rc=3 は marker 不在 / rc=5 は marker は見つかったが後続に未レビュー commit）
+    を明示した。
+- **残存課題**:
+  - task 6（`build_per_task_reviewer_prompt` への `extended` 引数追加）で、`run_per_task_reviewer`
+    内 `prompt=$(build_per_task_reviewer_prompt ...)` 呼び出しに 6 番目の引数として
+    `"$extended"` を渡すよう改修する責務が残る。本 task 時点では `extended="false"`（normal
+    経路）/ `extended="true"`（extend-range 経路）の値が正しく分岐済みだが、prompt builder
+    側で消費する subsection 追加は task 6 の責務。
+  - task 7 / 8（agent prompt docs 更新と repo-template ミラー反映）も別 task として残る。
+  - rc=5 経路の E2E 観測は idd-claude self-hosting 上で marker contract 違反の test issue を
+    立てて挙動確認することが推奨だが、本 task では smoke test の case-3 / case-4 で
+    `pt_handle_post_marker_commits` 単体の rc / stdout を検証している。`run_per_task_reviewer`
+    の rc=5 全経路を smoke で検証するには `gh` mock が必要で本 fixture のスコープ外。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -24,3 +24,22 @@ per-task ループの 1 タスクごとの learning を記録する。
     fixture と同方針）。
 - **残存課題**: なし（task 2 以降で `issue-watcher.sh` に参照実装と同じシグネチャ・rc 体系で
   関数を追加する際に、本 fixture の参照実装と byte 一致させる責務が残る）。
+
+### Task 2
+
+- **採用方針**: `pt_resolve_diff_range`（2638 行付近）直後に `pt_detect_post_marker_commits
+  <marker_sha>` を追加し、`git log --format=%H <marker_sha>..HEAD` の結果で rc=0/1/2 を返す
+  最小実装に集約。algorithm body は fixture 参照実装と byte 同期し、stderr の log prefix のみ
+  既存 `pt_warn` を使うことで NFR 2.1 を満たす。
+- **重要な判断**:
+  - stderr 行の prefix は fixture 側 `[smoke] post-marker-commits-detect: ...` と本体側
+    `[YYYY-MM-DD HH:MM:SS] per-task: WARN: post-marker-commits-detect: ...` で差を許容した。
+    既存 #164 `test-pt-resolve.sh` ↔ `pt_resolve_diff_range` でも同じ差異が確立済みで、
+    fixture は smoke コンテキスト識別のために `[smoke]` prefix を使う precedent と整合する
+    （algorithm body のみ byte 同期、stderr 表面文字列は対応を許容）。
+  - git エラー時は `pt_warn` で stderr に出して rc=2 を返し、呼び出し側（task 5 で
+    `run_per_task_reviewer` に組み込む経路）が fail-safe で fall-through できるようにした
+    （NFR 1.3 と同方針）。
+- **残存課題**: なし（task 3 で `pt_handle_post_marker_commits`、task 4 で
+  `pt_mark_post_marker_commits_detected` を追加する際に本関数の rc 体系を前提として呼び出す
+  予定。本関数自体の API / log 書式は確定）。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -1,0 +1,26 @@
+# Implementation Notes
+
+per-task ループの 1 タスクごとの learning を記録する。
+
+## Implementation Notes
+
+### Task 1
+
+- **採用方針**: 既存 #164 fixture (`test-pt-resolve.sh`) と同じ「参照実装を本 script 内に
+  複製して assert を回す」形式で `test-post-marker-detect.sh` を新規作成。task 2〜4 で
+  追加する `pt_detect_post_marker_commits` / `pt_handle_post_marker_commits` を本 script に
+  先行ミラーすることで、watcher 本体実装と fixture を並行で書ける構造にした。
+- **重要な判断**:
+  - case-5 の「silent truncate を許容しない expectation（assert で fail にする）」は、
+    (a) `pt_resolve_diff_range` の range_end が marker と一致すること（silent truncate の証拠）、
+    (b) post-marker commit が `range_start..range_end` の外側にあること、(c) `pt_detect_post_marker_commits`
+    hook で当該 commit を検出できること、の 3 段構成で assert した。将来 hook が外された場合
+    (c) が fail し、本 test 全体が `SMOKE_RESULT: fail` で停止する。
+  - case-3 では env 明示設定（fail-with-diagnostic）／env 未設定／env 不正値の 3 パターンで
+    rc=5 になることを assert し、design.md 記載の「不正値も default 化」契約をテストでも
+    担保した。
+  - 参照実装の関数は task 2〜4 で `issue-watcher.sh` に追加する実装と byte 同期させる責務がある
+    （ヘッダコメントで明示）。乖離した場合は本体側を fixture に再同期する原則（既存 #164
+    fixture と同方針）。
+- **残存課題**: なし（task 2 以降で `issue-watcher.sh` に参照実装と同じシグネチャ・rc 体系で
+  関数を追加する際に、本 fixture の参照実装と byte 一致させる責務が残る）。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -159,3 +159,53 @@ per-task ループの 1 タスクごとの learning を記録する。
     立てて挙動確認することが推奨だが、本 task では smoke test の case-3 / case-4 で
     `pt_handle_post_marker_commits` 単体の rc / stdout を検証している。`run_per_task_reviewer`
     の rc=5 全経路を smoke で検証するには `gh` mock が必要で本 fixture のスコープ外。
+
+### Task 6
+
+- **採用方針**: `build_per_task_reviewer_prompt`（3188 行付近）に第 6 引数 `extended`
+  （省略時 "false"）を追加し、prompt 本文に (a) `## 判定対象 SHA range（machine-parseable）`
+  subsection、(b) range 外 commit 判定対象外の **Warning** block、(c) `extended=true` 時の
+  `### Extended range` 説明 block の 3 点を追加。`run_per_task_reviewer`（3459 行付近）の
+  prompt builder 呼び出しに 6 番目の引数として `"$extended"` を追加（task 5 で導入済みの
+  ローカル変数）。
+- **重要な判断**:
+  - **extended_explanation の差し込み方式**: heredoc 中で if/else 分岐すると bash 構文が
+    崩れるため、`extended=true` の場合のみ explanation 文字列をローカル変数
+    `extended_explanation` に組み立て、外側 heredoc 内で `${extended_explanation}` として
+    展開する方式を採用。normal 経路（extended="false"）では空文字列のまま外側 heredoc に
+    展開され、prompt 末尾に余分な空行が 1 行追加されるのみ（markdown レンダリング上は
+    無害で、Reviewer の解釈にも影響しない）。
+  - **quoted heredoc（`'EXTENDED_EOF'`）の使用**: extended_explanation は単独で組み立てた
+    後、外側 heredoc に **変数展開済みの文字列** として埋め込まれる。この入れ子構造で
+    内側を unquoted heredoc にすると `$` や バッククォートが二重 escape 必要になり可読性
+    が低下するため、内側を quoted heredoc にして markdown のバッククォートを literal で
+    保持する方針を採用（外側 heredoc で `${extended_explanation}` を展開する時点では
+    再度の変数展開・コマンド置換は走らないため安全）。
+  - **machine-parseable block の表記**: design.md `Components and Interfaces` ＞
+    `build_per_task_reviewer_prompt` の Service Interface に明示された通り、
+    `range_start_sha:` / `range_end_sha:` / `range_extended:` の 3 行構成で fenced code
+    block 内に配置。値の整列はラベル後の空白で揃え、Reviewer 側の正規表現
+    （例: `^range_extended:\s+(true|false)$`）でパース可能な形式とした。
+  - **Warning の配置位置**: 既存「reviewer は **本 range のみ** を判定対象としてください」
+    記述の直後（同 subsection 内）に blockquote（`> **Warning（Issue #304 Req 3.2）**:`）
+    として配置。design.md の `Components and Interfaces` 記述（Req 3.2 の警告強化）と
+    位置・文言を整合させた。
+  - **後方互換性**: 第 6 引数 `extended` は `local extended="${6:-false}"` で省略時
+    `"false"` にフォールバックするため、`build_per_task_reviewer_prompt` を 5 引数で呼ぶ
+    既存 / テスト経路（もしあれば）は破壊されない。`run_per_task_reviewer` 経由の唯一の
+    本番呼び出しでは task 5 で導入された `extended` ローカル変数を明示的に渡す。
+  - **smoke 検証**: bash 構文チェック（`bash -n`）、shellcheck 警告ゼロ、および
+    function を sed で切り出して default / extended=true 双方の出力を手動レンダリング
+    し、(a) machine-parseable block に SHA 値と extended 値が正しく差し込まれること、
+    (b) Warning が「本 range のみ」記述の直後に配置されること、(c) extended=true 時のみ
+    `### Extended range` block が出現し、normal 経路では出現しないこと、を確認した。
+- **残存課題**:
+  - task 7 / 8（agent prompt docs 更新と repo-template ミラー反映）が別 task として残る。
+    task 7 で reviewer.md の「判定対象 diff range の限定」 subsection に `range_extended:
+    true` シグナルの解釈と range 外 commit の判定対象外性の追記が予定されている。task 8
+    では root と repo-template/ の byte 一致を維持する。
+  - `build_per_task_reviewer_prompt` の prompt rendering の E2E 観測は idd-claude
+    self-hosting 上で post-marker recovery 経路を踏ませる必要があり、本 task では
+    static rendering（heredoc 展開結果）の確認に留めた。実 Reviewer エージェントが
+    machine-parseable block / Warning / Extended range 説明を正しく解釈することの確認は
+    将来の dogfooding 観測で担保する。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
@@ -263,3 +263,24 @@ per-task ループの 1 タスクごとの learning を記録する。
     self-hosting 上で実際に marker contract 違反シナリオを通すことが必要。task 5 で
     導入した watcher 側 safety net（`per-task-post-marker-commits-detected`）の発火と
     本 task で追記した推奨 refresh 手順の妥当性は、将来運用観測で担保する。
+
+### Task 8
+
+- **採用方針**: `cp .claude/agents/developer.md repo-template/.claude/agents/developer.md` /
+  `cp .claude/agents/reviewer.md repo-template/.claude/agents/reviewer.md` の単純コピーで
+  task 7 の root 系統追記を repo-template 系統に **byte 一致** で反映。Edit による部分
+  パッチ適用ではなく丸ごとコピーを選んだ理由は、CLAUDE.md「二重管理規約」の検証点が
+  `diff -r .claude/agents repo-template/.claude/agents` の空集合一致であり、丸ごとコピー
+  なら手動 patch 順序ミス（subsection 位置ずれ等）が原理的に発生しないため。
+- **重要な判断**:
+  - **rules 側は無変更**: tasks.md 記載の通り本 Issue では `.claude/rules/` 側の変更は
+    行わない。`diff -r .claude/rules repo-template/.claude/rules` は task 7 以前の状態と
+    同様に空（変更前後で同じ状態を維持）であることを verify ブロックで確認した。
+  - **stage-a-verify 全項目を実行**: 単に diff だけでなく shellcheck（task 2〜5 の
+    watcher 変更）、`test-post-marker-detect.sh`（task 1 fixture、14/14 pass）、
+    `test-pt-resolve.sh`（#164 fixture、19/19 pass 非回帰）を含む構造化 verify ブロックを
+    手元で連結実行し、`SMOKE_RESULT: pass` を 2 件確認。NFR 1.1（既存挙動非回帰）を本 task
+    完了直前にも担保した。
+- **残存課題**: なし（本 task で Issue #304 の per-task ループ marker contract 強化と
+  repo-template ミラーが完了。後続は Reviewer / PjM 起動による per-task review と
+  PR 作成 stage に渡される）。

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/review-notes.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/review-notes.md
@@ -1,0 +1,88 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-09T19:03:18Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-304-impl--bug-per-task-commit-task-marker-review
+- HEAD commit: 94fb95aa5a3087286c8b491d47375f2fc8c2fc48
+- Compared to: main..HEAD（実質 merge-base 2d6cce6..HEAD。main は本ブランチ作成後に
+  #311 等が merge され進行しているため、`main..HEAD` 差分には branch 自身が触れていない
+  削除ファイルが見かけ上含まれる。実際の本 branch 変更は merge-base 2d6cce6..HEAD で
+  確認した 9 ファイル / +1373 / -15 のみ）
+
+## Verified Requirements
+
+- 1.1 — `.claude/agents/developer.md` 「marker 作成タイミングの契約」subsection（root +
+  repo-template、byte 一致）。task-scope の全成果物完了後に marker を作る契約を明文化
+- 1.2 — `.claude/agents/developer.md` 「retry 時の marker refresh 契約」subsection。
+  旧 marker 後ろに修正 commit を残してはならないことと推奨 refresh 手順を明文化
+- 1.3 — developer.md の per-task ループ責務節配下に「Marker contract」h2 subsection を配置。
+  Implementer が commit 追加前に読む位置（per-task ループ責務節内）に契約が文書化されている
+- 2.1 — `local-watcher/bin/issue-watcher.sh` `pt_detect_post_marker_commits`（新規関数）+
+  `run_per_task_reviewer` への組込み（`pt_resolve_diff_range` 成功直後）で marker 後の
+  commit を検出。silent truncation を防ぐ
+- 2.2 — `pt_handle_post_marker_commits`（新規関数）で
+  `POST_MARKER_RECOVERY_MODE=extend-range`（include 経路）/ `=fail-with-diagnostic`
+  （abort 経路）を分岐。env 不正値は default の fail-with-diagnostic にフォールバック
+- 2.3 — `pt_mark_post_marker_commits_detected`（新規関数）が
+  `per-task-post-marker-commits-detected` カテゴリで `claude-failed` ラベル付与 + 復旧手順
+  付き Issue コメント投稿。既存 per-task failure path（`pt_mark_diff_range_resolve_failed`）
+  と同パターンで実装
+- 3.1 — `build_per_task_reviewer_prompt` の prompt 本文に
+  `## 判定対象 SHA range（machine-parseable）` subsection を追加。fenced code block 内に
+  `range_start_sha:` / `range_end_sha:` / `range_extended:` の 3 行を machine-parseable
+  形式で配置
+- 3.2 — prompt 本文に「reviewer は **本 range のみ** を判定対象としてください」記述の
+  直後に blockquote `> **Warning（Issue #304 Req 3.2）**:` を配置。
+  `.claude/agents/reviewer.md`「range 外 commit の判定対象外性」h3 subsection も併せて追記
+- 3.3 — `build_per_task_reviewer_prompt` 第 6 引数 `extended`（省略時 "false"）を追加し、
+  `extended="true"` 時のみ prompt 末尾に `### Extended range` 説明 block を出力。
+  `run_per_task_reviewer` の extend-range 経路で `"$extended"` を実際に渡す経路を組込済。
+  `.claude/agents/reviewer.md`「Extended range シグナルの解釈」h3 subsection も追記
+- 4.1 / 4.2 — `diff -r .claude/agents repo-template/.claude/agents` および
+  `diff -r .claude/rules repo-template/.claude/rules` がいずれも exit 0（差分なし）。
+  task 7 の root 系統変更が task 8 で repo-template/ にも byte 一致で反映されている
+- 5.1 — `docs/specs/304--.../test-fixtures/test-post-marker-detect.sh` の case-2（marker +
+  修正 commit 2 件）が idd-codex #14 同型の commit shape を一時 git repo で構築
+- 5.2 — 同 fixture の case-3（fail-with-diagnostic で rc=5）と case-4（extend-range で
+  rc=0 + 新 range pair）が abort / include の両経路を assert で検証
+- 5.3 — case-5(a)(b)(c) が silent truncate の証拠（range_end == marker / post-marker
+  commit が range 外）と検出 hook の発火（rc=0）を 3 段構成で assert。hook が外れた場合
+  (c) が fail し SMOKE_RESULT: fail で停止する設計
+- NFR 1.1 — 既存 rc=0/1/2/3/4/99 の意味は不変、rc=5 は新規追加（additive）。
+  `POST_MARKER_RECOVERY_MODE` は新規 env で既存 env 名に影響なし。
+  `test-pt-resolve.sh`（#164 fixture）が 19/19 pass で非回帰確認
+- NFR 1.2 — marker commit message format `docs(tasks): mark <id> as done` の変更なし
+- NFR 1.3 — post-marker 0 件のとき `pt_detect_post_marker_commits` が rc=1 を返し、
+  `run_per_task_reviewer` の case 分岐 `1)` で既存ルートに fall-through。git エラー
+  （rc=2）も fail-safe で fall-through
+- NFR 2.1 — `pt_handle_post_marker_commits` が
+  `[YYYY-MM-DD HH:MM:SS] per-task: post-marker-commits-detected task_id=<id> round=<n>
+  marker=<sha> post_marker_shas=<csv> recovery=<mode>` の単一行ログを stderr に出力。
+  fixture と書式整合
+
+## Verification 補足
+
+- 構造化 verify ブロック（tasks.md `## Verify`）を実行確認:
+  - `shellcheck local-watcher/bin/issue-watcher.sh` 警告ゼロ
+  - `diff -r .claude/agents repo-template/.claude/agents` exit 0
+  - `diff -r .claude/rules repo-template/.claude/rules` exit 0
+  - `test-post-marker-detect.sh` → 14 PASSED / 0 FAILED / SMOKE_RESULT: pass
+  - `test-pt-resolve.sh`（#164 fixture）→ 19 PASSED / 0 FAILED / SMOKE_RESULT: pass
+- tasks.md の 8 件のタスクすべてが `- [x]` で marker commit 済み
+- 境界違反なし: 差分は per-task ループ関連の watcher 関数追加、Reviewer prompt 拡張、
+  agent docs（developer.md / reviewer.md）の subsection 追記、spec 配下 fixture / impl-notes /
+  tasks.md のみ。他の Issue 領域 / 他コンポーネントへの侵食なし
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #304 の AC（Req 1.1〜1.3 / 2.1〜2.3 / 3.1〜3.3 / 4.1〜4.2 / 5.1〜5.3 / NFR 1.1〜1.3 /
+NFR 2.1）はすべて diff 内の実装・テスト・ドキュメントで観測可能にカバーされている。
+構造化 verify（shellcheck / diff -r / 2 件の smoke）はいずれも pass。境界逸脱なし。
+
+RESULT: approve

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -84,7 +84,7 @@
   - _Requirements: 3.1, 3.2, 3.3_
   - _Depends: 5_
 
-- [ ] 7. developer.md / reviewer.md への marker contract 節と range 警告追記（root 系統）
+- [x] 7. developer.md / reviewer.md への marker contract 節と range 警告追記（root 系統）
   - `.claude/agents/developer.md` の「per-task ループ下での Implementer の責務」節（369 行以降）
     に新 subsection `## Marker contract（marker は task の終端 commit）` を追加
     - 1.1: marker は task 終端 commit である契約

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -97,7 +97,7 @@
     （Req 3.3）を追記
   - _Requirements: 1.1, 1.2, 1.3, 3.2, 3.3_
 
-- [ ] 8. developer.md / reviewer.md の repo-template ミラー反映（byte 一致）
+- [x] 8. developer.md / reviewer.md の repo-template ミラー反映（byte 一致）
   - タスク 7 で root 系統に加えた変更を、`repo-template/.claude/agents/developer.md` /
     `repo-template/.claude/agents/reviewer.md` に **byte 一致** で適用する
   - 反映後に `diff -r .claude/agents repo-template/.claude/agents` が空であることを確認

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -27,7 +27,7 @@
   - 単体動作確認: `test-post-marker-detect.sh` の case-1, case-2 が pass
   - _Requirements: 2.1, NFR 1.3, NFR 2.1_
 
-- [ ] 3. watcher への recovery dispatcher の追加（`pt_handle_post_marker_commits`）
+- [x] 3. watcher への recovery dispatcher の追加（`pt_handle_post_marker_commits`）
   - `local-watcher/bin/issue-watcher.sh` の `pt_detect_post_marker_commits` 直後に
     `pt_handle_post_marker_commits <task_id> <round> <range_start> <marker_sha> <post_marker_list>` を追加
   - env `POST_MARKER_RECOVERY_MODE` を読み（default=`fail-with-diagnostic`、不正値も default 化）、

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -1,6 +1,6 @@
 # Implementation Plan
 
-- [ ] 1. 回帰テスト fixture の追加（idd-codex #14 同型 commit shape）
+- [x] 1. 回帰テスト fixture の追加（idd-codex #14 同型 commit shape）
   - `docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/test-post-marker-detect.sh`
     を新規作成し、以下 5 ケースを assert で検証する
     - case-1: marker 後に commit 無し → 検出 0 件で既存挙動温存

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -70,7 +70,7 @@
   - _Requirements: 2.1, 2.2, 2.3, NFR 1.1, NFR 1.3_
   - _Depends: 4_
 
-- [ ] 6. Reviewer prompt への range 明示と extended フラグ対応
+- [x] 6. Reviewer prompt への range 明示と extended フラグ対応
   - `build_per_task_reviewer_prompt`（3060 行付近）の signature に第 6 引数 `extended`
     （"true"/"false"、省略時 "false"）を追加
   - prompt 本文に `## 判定対象 SHA range（machine-parseable）` subsection を追加し、

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -17,7 +17,7 @@
   - 末尾で `SMOKE_RESULT: pass` / `fail` を出力
   - _Requirements: 5.1, 5.2, 5.3_
 
-- [ ] 2. watcher への post-marker 検出関数の追加（`pt_detect_post_marker_commits`）
+- [x] 2. watcher への post-marker 検出関数の追加（`pt_detect_post_marker_commits`）
   - `local-watcher/bin/issue-watcher.sh` の `pt_resolve_diff_range`（2638 行付近）直後に
     新規関数 `pt_detect_post_marker_commits <marker_sha>` を追加
   - `git log --format=%H <marker_sha>..HEAD` で post-marker commit を列挙

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -55,7 +55,7 @@
   - _Requirements: 2.3, NFR 2.1_
   - _Depends: 3_
 
-- [ ] 5. `run_per_task_reviewer` への post-marker hook 組込みと rc=5 対応
+- [x] 5. `run_per_task_reviewer` への post-marker hook 組込みと rc=5 対応
   - `run_per_task_reviewer`（3226 行付近）内、`pt_resolve_diff_range` 成功直後に
     `pt_detect_post_marker_commits "$range_end"` を呼ぶ
   - 検出 0 件（rc=1）または git エラー（rc=2）: 既存ルートで Reviewer 起動（NFR 1.3 fail-safe）

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/tasks.md
@@ -41,7 +41,7 @@
   - _Requirements: 2.2, 2.3, 3.3, NFR 1.1, NFR 2.1_
   - _Depends: 2_
 
-- [ ] 4. 失敗カテゴリ通知関数の追加（`pt_mark_post_marker_commits_detected`）
+- [x] 4. 失敗カテゴリ通知関数の追加（`pt_mark_post_marker_commits_detected`）
   - `local-watcher/bin/issue-watcher.sh` の `pt_mark_diff_range_resolve_failed`（3374 行付近）と
     同セクション末尾に新規関数 `pt_mark_post_marker_commits_detected <task_id> <round> <marker_sha> <post_marker_list>` を追加
   - HTML marker `<!-- idd-claude:per-task-post-marker-commits-detected:#<issue>:<task> -->` で

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/README.md
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/README.md
@@ -1,0 +1,77 @@
+# test-fixtures — Issue #304 回帰テスト
+
+Issue #304（per-task ループの marker commit / Reviewer review range 整合性）で導入する
+post-marker commit 検出 hook の挙動を、idd-codex #14 と同型の commit shape を持つ
+一時 git repo fixture で検証する smoke script 群。
+
+## 概要
+
+per-task Implementer ループでは、各タスクの完了時に
+`docs(tasks): mark <id> as done` marker commit を積み、watcher はその marker を
+per-task Reviewer の review range の終端として利用する。Reviewer reject /
+Debugger guidance 後に Implementer が修正 commit を旧 marker より後ろに残すと、
+`pt_resolve_diff_range` の range_end が marker で止まり、修正 commit が
+Reviewer の判定対象から漏れる（silent range truncation）。
+
+本 fixture は以下を検証する:
+
+- watcher 側に追加する `pt_detect_post_marker_commits` が marker..HEAD の
+  post-marker commit を正しく列挙する
+- `pt_handle_post_marker_commits` の `extend-range` / `fail-with-diagnostic` 両
+  recovery mode が決定論的な rc / stdout / stderr を返す
+- silent truncate が起きうるシナリオで、hook が無ければ commit が漏れる事実を
+  明示的に assert し、hook 併用で検出できることを担保する
+
+## 実行方法
+
+```sh
+bash docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/test-post-marker-detect.sh
+```
+
+`SMOKE_RESULT: pass` が出力されれば全 assertion が通っている。`SMOKE_RESULT: fail`
+の場合、参照実装と本 fixture の参照実装ミラーが乖離している、または
+post-marker 検出 hook の挙動が期待値からずれている。
+
+shellcheck も合わせて実行することを推奨:
+
+```sh
+shellcheck docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/test-post-marker-detect.sh
+```
+
+## 検証対象 case 一覧
+
+| Case | シナリオ | 検証する関数 | 対応 Requirement |
+|------|---------|--------------|------------------|
+| case-1 | marker 後に commit 無し（既存挙動温存） | `pt_detect_post_marker_commits` rc=1 / stdout 空 | 5.2, NFR 1.3 |
+| case-2 | marker + 修正 commit 2 件（idd-codex #14 同型） | `pt_detect_post_marker_commits` rc=0 / SHA list 出力 | 5.1, 5.2 |
+| case-3 | `POST_MARKER_RECOVERY_MODE=fail-with-diagnostic` | `pt_handle_post_marker_commits` rc=5 / 範囲非出力。env 未設定 / 不正値も default 化されて rc=5 | 5.2, 2.2 |
+| case-4 | `POST_MARKER_RECOVERY_MODE=extend-range` | `pt_handle_post_marker_commits` rc=0 / 新 range pair `<range_start>\t<HEAD>` 出力 | 5.2, 2.2 |
+| case-5 | silent truncate 不許容（hook が無いと commit が漏れる証拠 + hook で検出できることの担保） | `pt_resolve_diff_range` の range_end が marker で止まり、post-marker commit が `range_start..range_end` の外に置かれることを assert + `pt_detect_post_marker_commits` で当該 commit を検出 | 5.3 |
+
+## 参照実装ミラー方針
+
+本 fixture は `pt_resolve_diff_range` / `pt_detect_post_marker_commits` /
+`pt_handle_post_marker_commits` の **参照実装**を本 script 内に複製する形式を
+取る（既存 `docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/test-pt-resolve.sh`
+と同形式）。これは:
+
+- watcher 本体 (`local-watcher/bin/issue-watcher.sh`) を起動せずに smoke 単体で
+  挙動を検証可能にする
+- task 2〜4 の `issue-watcher.sh` 関数追加と本 fixture を **並行で書ける**
+  （本 fixture を task 1 で先に書き、task 2〜4 で同期の取れた実装を入れる）
+
+ためである。fixture と本体実装が乖離した場合、本 fixture は **本体実装側を
+fixture に再同期する** ことを原則とする（既存 fixture と同じ方針）。
+
+## 関連参照
+
+- 要件: `../requirements.md`（Req 5.1〜5.3 が本 fixture の責務範囲）
+- 設計: `../design.md`「Testing Strategy / Components and Interfaces」節
+- 既存 fixture（同形式の先例）:
+  `docs/specs/164-bug-watcher-per-task-reviewer-task-id-ma/test-pt-resolve.sh`
+- 本体実装（task 2〜4 で追加予定）:
+  `local-watcher/bin/issue-watcher.sh` の以下関数
+  - `pt_detect_post_marker_commits`（`pt_resolve_diff_range` 直後）
+  - `pt_handle_post_marker_commits`（`pt_detect_post_marker_commits` 直後）
+  - `pt_mark_post_marker_commits_detected`（`pt_mark_diff_range_resolve_failed`
+    と同セクション）

--- a/docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/test-post-marker-detect.sh
+++ b/docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/test-post-marker-detect.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #304 で導入する `pt_detect_post_marker_commits` /
+#       `pt_handle_post_marker_commits` の挙動を、idd-codex #14 と同型の
+#       「marker + 後続修正 commit」shape を持つ一時 git repo で検証するスモーク
+#       スクリプト。silent range truncation（marker で range_end を止めると
+#       post-marker commit が Reviewer から見えなくなる挙動）の予防策が
+#       期待どおり機能することを assert で確認する。
+# 配置: docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/
+#       test-post-marker-detect.sh
+# 依存: bash 4+, git
+# セットアップ参照先:
+#   docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md
+#
+# 実行:
+#   ./docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/test-post-marker-detect.sh
+# 出力:
+#   各ケース: `[OK]` / `[NG]` の prefix で 1 行レポート
+#   末尾: `SMOKE_RESULT: pass` / `SMOKE_RESULT: fail`
+# 副作用:
+#   /tmp/post-marker-smoke-XXXX/ に一時 git repo を作成し、終了時に削除する
+
+set -euo pipefail
+
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+# ─── pt_resolve_diff_range の参照実装（既存 #164 fixture と同一実装） ─────────
+# silent truncate 不許容 case (case-5) の前提として、本関数のみでは marker で
+# range_end が止まることを示すために必要。本関数は
+# local-watcher/bin/issue-watcher.sh の pt_resolve_diff_range と同一実装で
+# なければならない（既存 #164 fixture と byte 一致）。
+pt_resolve_diff_range() {
+  local task_id="$1"
+  local base="${BASE_BRANCH:-main}"
+
+  local all_pairs
+  all_pairs=$(git log --grep="^docs(tasks): mark " --format='%H%x09%s' --reverse "${base}..HEAD" 2>/dev/null || true)
+  if [ -z "$all_pairs" ]; then
+    return 1
+  fi
+
+  local current_mark="" via="" sha subject id_list tok found
+  while IFS=$'\t' read -r sha subject; do
+    [ -n "$sha" ] || continue
+    if [ "$subject" = "docs(tasks): mark ${task_id} as done" ]; then
+      current_mark="$sha"
+      via="single-id-marker"
+    fi
+  done <<<"$all_pairs"
+
+  if [ -z "$current_mark" ]; then
+    while IFS=$'\t' read -r sha subject; do
+      [ -n "$sha" ] || continue
+      id_list=$(printf '%s' "$subject" | sed -nE 's/^docs\(tasks\): mark (.+) as done$/\1/p')
+      [ -n "$id_list" ] || continue
+      found=false
+      for tok in $(printf '%s' "$id_list" | tr '/,' '  '); do
+        if [ "$tok" = "$task_id" ]; then
+          found=true
+          break
+        fi
+      done
+      if [ "$found" = "true" ]; then
+        current_mark="$sha"
+        via="multi-id-marker"
+      fi
+    done <<<"$all_pairs"
+  fi
+
+  if [ -z "$current_mark" ]; then
+    return 1
+  fi
+
+  local prev_mark=""
+  while IFS=$'\t' read -r sha subject; do
+    [ -n "$sha" ] || continue
+    if [ "$sha" = "$current_mark" ]; then
+      break
+    fi
+    prev_mark="$sha"
+  done <<<"$all_pairs"
+
+  local range_start
+  if [ -n "$prev_mark" ]; then
+    range_start="$prev_mark"
+  else
+    range_start=$(git rev-parse "$base" 2>/dev/null || true)
+    if [ -z "$range_start" ]; then
+      return 1
+    fi
+  fi
+
+  if [ "$via" = "multi-id-marker" ]; then
+    echo "[smoke] diff-range resolved via=multi-id-marker task_id=${task_id} sha=${current_mark}" >&2
+  fi
+
+  printf '%s\t%s\n' "$range_start" "$current_mark"
+  return 0
+}
+
+# ─── pt_detect_post_marker_commits の参照実装 ───────────────────────────────
+# 本関数は task 2 で local-watcher/bin/issue-watcher.sh に追加される実装と
+# 同一実装でなければならない。差分が出た場合は impl 側を本 fixture に再同期
+# すること（既存 #164 fixture と同じ参照実装ミラー方針）。
+#
+# Contract:
+#   引数: <marker_sha>
+#   stdout: post-marker SHA list（newline 区切り、空の場合は出力なし）
+#   stderr: 警告ログ（NFR 2.1 / git エラー時）
+#   rc=0: 1 件以上検出
+#   rc=1: 0 件（fall-through OK）
+#   rc=2: git エラー（fail-safe）
+pt_detect_post_marker_commits() {
+  local marker_sha="$1"
+  local post_list
+  if ! post_list=$(git log --format=%H "${marker_sha}..HEAD" 2>/dev/null); then
+    echo "[smoke] post-marker-commits-detect: git log error marker=${marker_sha}" >&2
+    return 2
+  fi
+  if [ -z "$post_list" ]; then
+    return 1
+  fi
+  printf '%s\n' "$post_list"
+  return 0
+}
+
+# ─── pt_handle_post_marker_commits の参照実装 ───────────────────────────────
+# 本関数は task 3 で local-watcher/bin/issue-watcher.sh に追加される実装と
+# 同一実装でなければならない。差分が出た場合は impl 側を本 fixture に再同期
+# すること。
+#
+# Contract:
+#   引数: <task_id> <round> <range_start> <marker_sha> <post_marker_list>
+#   env: POST_MARKER_RECOVERY_MODE (default=fail-with-diagnostic, 不正値も default 化)
+#   stdout: extend-range 時のみ <new_range_start>\t<new_range_end>（HEAD まで拡張）
+#   stderr: NFR 2.1 準拠の単一行ログ
+#   rc=0: extend-range で続行
+#   rc=5: fail-with-diagnostic で停止
+pt_handle_post_marker_commits() {
+  local task_id="$1"
+  local round="$2"
+  local range_start="$3"
+  local marker_sha="$4"
+  local post_marker_list="$5"
+
+  local mode="${POST_MARKER_RECOVERY_MODE:-fail-with-diagnostic}"
+  case "$mode" in
+    extend-range|fail-with-diagnostic) ;;
+    *)
+      echo "[smoke] post-marker-commits-detect: invalid POST_MARKER_RECOVERY_MODE='${mode}', falling back to fail-with-diagnostic" >&2
+      mode="fail-with-diagnostic"
+      ;;
+  esac
+
+  local ts post_csv
+  ts=$(date '+%Y-%m-%d %H:%M:%S')
+  post_csv=$(printf '%s' "$post_marker_list" | tr '\n' ',' | sed 's/,$//')
+  echo "[${ts}] per-task: post-marker-commits-detected task_id=${task_id} round=${round} marker=${marker_sha} post_marker_shas=${post_csv} recovery=${mode}" >&2
+
+  if [ "$mode" = "extend-range" ]; then
+    local head_sha
+    if ! head_sha=$(git rev-parse HEAD 2>/dev/null); then
+      echo "[smoke] post-marker-commits-detect: git rev-parse HEAD failed (range_start=${range_start})" >&2
+      return 5
+    fi
+    printf '%s\t%s\n' "$range_start" "$head_sha"
+    return 0
+  fi
+
+  # fail-with-diagnostic
+  return 5
+}
+
+# ─── テストハーネス ─────────────────────────────────────────────────────────
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "[OK]   ${label} (expected=${expected}, actual=${actual})"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "[NG]   ${label} (expected=${expected}, actual=${actual})" >&2
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_rc() {
+  local label="$1" expected_rc="$2" actual_rc="$3"
+  if [ "$expected_rc" = "$actual_rc" ]; then
+    echo "[OK]   ${label} (rc=${actual_rc} as expected)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "[NG]   ${label} (expected rc=${expected_rc} but got rc=${actual_rc})" >&2
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+assert_fail() {
+  local label="$1" rc="$2"
+  if [ "$rc" -ne 0 ]; then
+    echo "[OK]   ${label} (rc=${rc} as expected non-zero)"
+    TESTS_PASSED=$((TESTS_PASSED + 1))
+  else
+    echo "[NG]   ${label} (expected non-zero rc but got 0)" >&2
+    TESTS_FAILED=$((TESTS_FAILED + 1))
+  fi
+}
+
+# ─── fixture セットアップ ─────────────────────────────────────────────────
+TMPDIR=$(mktemp -d /tmp/post-marker-smoke-XXXX)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cd "$TMPDIR"
+git init -q -b main
+git config user.email smoke@example.com
+git config user.name smoke
+
+echo init > README.md
+git add README.md
+git commit -q -m "initial commit"
+MAIN_SHA=$(git rev-parse main)
+
+# ─── case-1: marker 後に commit 無し（既存挙動温存 / NFR 1.3 / Req 5.2 normal） ───
+git checkout -q -b case1-no-post-marker
+echo a > task1.txt && git add task1.txt && git commit -q -m "feat: task 1 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 1 as done"
+C1_MARKER=$(git rev-parse HEAD)
+
+# pt_detect_post_marker_commits は rc=1（0 件）、stdout 空を返すべき
+DETECT_OUT=""
+DETECT_RC=0
+DETECT_OUT=$(pt_detect_post_marker_commits "$C1_MARKER" 2>/dev/null) || DETECT_RC=$?
+assert_rc "case-1: pt_detect_post_marker_commits rc (no post-marker)" "1" "$DETECT_RC"
+assert_eq "case-1: pt_detect_post_marker_commits stdout (empty)" "" "$DETECT_OUT"
+
+# ─── case-2: idd-codex #14 同型 commit shape ────────────────────────────────
+# marker commit + 修正 commit 2 件（push 後の Reviewer reject → Implementer 再実行で
+# 修正 commit を marker 後ろに残してしまったケース）
+git checkout -q main
+git checkout -q -b case2-codex-14-shape
+echo a > task2.txt && git add task2.txt && git commit -q -m "feat: task 2 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 2 as done"
+C2_MARKER=$(git rev-parse HEAD)
+# Reviewer reject 後の修正 commit 2 件（marker 後ろに残置）
+echo fix1 > fix1.txt && git add fix1.txt && git commit -q -m "fix: address reviewer round 1 feedback"
+C2_FIX1=$(git rev-parse HEAD)
+echo fix2 > fix2.txt && git add fix2.txt && git commit -q -m "test: add regression for case found in review"
+C2_FIX2=$(git rev-parse HEAD)
+
+DETECT_OUT=$(pt_detect_post_marker_commits "$C2_MARKER")
+DETECT_RC=$?
+assert_rc "case-2: pt_detect_post_marker_commits rc (2 post-marker)" "0" "$DETECT_RC"
+# git log は新しい順（HEAD 側が先頭）
+EXPECTED_POST=$(printf '%s\n%s' "$C2_FIX2" "$C2_FIX1")
+assert_eq "case-2: pt_detect_post_marker_commits stdout (2 SHA, newest first)" "$EXPECTED_POST" "$DETECT_OUT"
+
+# ─── case-3: fail-with-diagnostic で rc=5 (abort) ───────────────────────────
+# case-2 と同じリポジトリ状態をそのまま流用（同 branch / 同 HEAD）。
+HANDLE_RC=0
+POST_LIST_CASE3="$DETECT_OUT"
+RANGE_START_CASE3="$MAIN_SHA"
+# default 値（env 未設定）でも fail-with-diagnostic にフォールバックする想定。
+# 明示設定でも同じ rc になることを確認するため明示する。
+HANDLE_STDOUT=$(POST_MARKER_RECOVERY_MODE=fail-with-diagnostic \
+  pt_handle_post_marker_commits "2" "1" "$RANGE_START_CASE3" "$C2_MARKER" "$POST_LIST_CASE3" \
+  2>/dev/null) || HANDLE_RC=$?
+assert_rc "case-3: pt_handle_post_marker_commits rc (fail-with-diagnostic)" "5" "$HANDLE_RC"
+assert_eq "case-3: pt_handle_post_marker_commits stdout (no range emitted on abort)" "" "$HANDLE_STDOUT"
+
+# default 値での挙動も同じ rc=5 であることを確認（env 未設定 / 不正値の default 化）
+HANDLE_RC=0
+HANDLE_STDOUT=$(unset POST_MARKER_RECOVERY_MODE; \
+  pt_handle_post_marker_commits "2" "1" "$RANGE_START_CASE3" "$C2_MARKER" "$POST_LIST_CASE3" \
+  2>/dev/null) || HANDLE_RC=$?
+assert_rc "case-3: pt_handle_post_marker_commits rc (env unset → default fail-with-diagnostic)" "5" "$HANDLE_RC"
+
+HANDLE_RC=0
+HANDLE_STDOUT=$(POST_MARKER_RECOVERY_MODE=garbage-value \
+  pt_handle_post_marker_commits "2" "1" "$RANGE_START_CASE3" "$C2_MARKER" "$POST_LIST_CASE3" \
+  2>/dev/null) || HANDLE_RC=$?
+assert_rc "case-3: pt_handle_post_marker_commits rc (invalid env → default fail-with-diagnostic)" "5" "$HANDLE_RC"
+
+# ─── case-4: extend-range で rc=0 + 新 range pair ───────────────────────────
+HANDLE_RC=0
+HANDLE_STDOUT=$(POST_MARKER_RECOVERY_MODE=extend-range \
+  pt_handle_post_marker_commits "2" "1" "$RANGE_START_CASE3" "$C2_MARKER" "$POST_LIST_CASE3" \
+  2>/dev/null) || HANDLE_RC=$?
+assert_rc "case-4: pt_handle_post_marker_commits rc (extend-range)" "0" "$HANDLE_RC"
+# 新 range = <range_start>\t<HEAD>（HEAD = C2_FIX2）
+EXPECTED_RANGE_CASE4=$(printf '%s\t%s' "$RANGE_START_CASE3" "$C2_FIX2")
+assert_eq "case-4: pt_handle_post_marker_commits stdout (new range = range_start TAB HEAD)" \
+  "$EXPECTED_RANGE_CASE4" "$HANDLE_STDOUT"
+
+# ─── case-5: silent truncate を許容しない expectation ───────────────────────
+# Req 5.3: pt_resolve_diff_range のみで stop した場合、post-marker commit は
+# range_end の外に置かれる（silent truncate 状態）。本 case は以下を assert
+# として明示することで、将来 hook が外された場合に test が fail するように
+# 設計されている:
+#   (a) pt_resolve_diff_range の range_end が marker と一致すること
+#       （silent truncate の証拠）
+#   (b) post-marker commit が `range_start..range_end` の外側にあること
+#       （hook なしでは漏れていた）
+#   (c) pt_detect_post_marker_commits hook を併用すれば post-marker commit を
+#       検出できること（rc=0 + SHA list 返却）
+# (a) と (b) は「silent truncate が起きうる証拠」であり、(c) で hook が
+# 検出することを assert する。hook が将来外されると (c) が fail し、本 test
+# 全体が SMOKE_RESULT: fail で終了する。
+git checkout -q main
+git checkout -q -b case5-silent-truncate-guard
+echo a > task5.txt && git add task5.txt && git commit -q -m "feat: task 5 impl"
+git commit -q --allow-empty -m "docs(tasks): mark 5 as done"
+C5_MARKER=$(git rev-parse HEAD)
+echo fix > fix5.txt && git add fix5.txt && git commit -q -m "fix: late correction not covered by marker"
+C5_LATE=$(git rev-parse HEAD)
+
+# (a) pt_resolve_diff_range の range_end が marker と一致（silent truncate の証拠）
+RESOLVED=$(pt_resolve_diff_range "5")
+RESOLVED_END=$(printf '%s' "$RESOLVED" | cut -f2)
+assert_eq "case-5(a): pt_resolve_diff_range range_end == marker (silent truncate evidence)" \
+  "$C5_MARKER" "$RESOLVED_END"
+
+# (b) post-marker commit (C5_LATE) は range_start..range_end の外にある
+#     git log で range 内に C5_LATE が含まれないことを確認
+RESOLVED_START=$(printf '%s' "$RESOLVED" | cut -f1)
+RANGE_CONTENTS=$(git log --format=%H "${RESOLVED_START}..${RESOLVED_END}" 2>/dev/null)
+CONTAINS_LATE=no
+if printf '%s\n' "$RANGE_CONTENTS" | grep -qx "$C5_LATE"; then
+  CONTAINS_LATE=yes
+fi
+assert_eq "case-5(b): C5_LATE is NOT in range_start..range_end (would be silently truncated)" \
+  "no" "$CONTAINS_LATE"
+
+# (c) pt_detect_post_marker_commits hook を使えば C5_LATE を検出できる
+DETECT_OUT=$(pt_detect_post_marker_commits "$C5_MARKER")
+DETECT_RC=$?
+assert_rc "case-5(c): pt_detect_post_marker_commits detects post-marker commit (rc=0)" "0" "$DETECT_RC"
+assert_eq "case-5(c): pt_detect_post_marker_commits stdout == C5_LATE (single post-marker)" \
+  "$C5_LATE" "$DETECT_OUT"
+
+# ─── 結果集計 ───────────────────────────────────────────────────────────────
+echo ""
+echo "============================================="
+echo " PASSED: ${TESTS_PASSED}"
+echo " FAILED: ${TESTS_FAILED}"
+echo "============================================="
+if [ "$TESTS_FAILED" -eq 0 ]; then
+  echo "SMOKE_RESULT: pass"
+  exit 0
+else
+  echo "SMOKE_RESULT: fail"
+  exit 1
+fi

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -2717,6 +2717,45 @@ pt_resolve_diff_range() {
   return 0
 }
 
+# ─── pt_detect_post_marker_commits <marker_sha> ───
+#
+# 指定 marker SHA より後ろ（`<marker_sha>..HEAD`）に存在する commit を列挙する safety net。
+# per-task Reviewer reject 後の Implementer 再実行で、修正 commit が古い marker より後ろに
+# 積まれた場合（idd-codex #14 と同型）に silent range truncation を防ぐための検出 hook。
+#
+# Contract（design.md「pt_detect_post_marker_commits」節 / Req 2.1, NFR 1.3, NFR 2.1）:
+#   引数: <marker_sha>
+#   stdout: post-marker SHA list（newline 区切り、git log と同じ「新しい順」/ HEAD 側が先頭）
+#   stderr: 警告ログ（NFR 2.1 / git エラー時のみ）
+#   rc=0: 1 件以上検出
+#   rc=1: 0 件（fall-through OK / NFR 1.3 既存挙動温存）
+#   rc=2: git エラー（fail-safe / 呼び出し側は rc=1 と同様に扱える）
+#
+# 後方互換性（NFR 1.3）:
+#   - post-marker commit が 0 件のケース（典型シナリオ）では rc=1 / stdout 空となるため、
+#     呼び出し側は既存ルートを温存できる
+#
+# 参照実装:
+#   - 本関数は `docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/
+#     test-post-marker-detect.sh` 内の参照実装と algorithm body を byte 同期させる責務がある
+#     （stderr 行の prefix のみ `[smoke]` ↔ `[YYYY-MM-DD HH:MM:SS] per-task:` で差を許容、
+#     既存 #164 fixture と同方針）
+#
+# Requirements: 2.1, NFR 1.3, NFR 2.1
+pt_detect_post_marker_commits() {
+  local marker_sha="$1"
+  local post_list
+  if ! post_list=$(git log --format=%H "${marker_sha}..HEAD" 2>/dev/null); then
+    pt_warn "post-marker-commits-detect: git log error marker=${marker_sha}"
+    return 2
+  fi
+  if [ -z "$post_list" ]; then
+    return 1
+  fi
+  printf '%s\n' "$post_list"
+  return 0
+}
+
 # ─── pt_has_subtasks <tasks_md_path> <task_id> ───
 #
 # tasks.md 上で指定 task_id を numeric 階層 prefix とする子タスク行が 1 件以上存在するか

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -2835,9 +2835,13 @@ pt_handle_post_marker_commits() {
     return 0
   fi
 
-  # fail-with-diagnostic: task 4 で `pt_mark_post_marker_commits_detected` 追加後に
-  # `run_per_task_reviewer` 経路（task 5）または本関数の改修でここから mark を呼ぶ。
-  # 本 task 3 時点では rc=5 を返すのみで終わる（fixture 参照実装も同様）。
+  # fail-with-diagnostic: task 3 時点では rc=5 を返すのみで終わる設計とし、
+  # `pt_mark_post_marker_commits_detected`（task 4 で追加）を呼ぶ責務は
+  # `run_per_task_reviewer`（task 5）側に倒した。本関数は fixture 参照実装
+  # （`test-post-marker-detect.sh` line 139〜172）と algorithm body を byte 同期させる
+  # 責務を保持しているため、ここで mark 呼び出しを追加すると fixture との同期が崩れる。
+  # `run_per_task_reviewer` 側は rc=5 を受領した際に必要な marker_sha / post_marker_list を
+  # 自前で保持しているため、そちらから mark を呼べる（Issue #304 task 5 で接続）。
   return 5
 }
 
@@ -3333,9 +3337,11 @@ run_per_task_implementer() {
 #   2  = 異常終了（claude crash / parse 失敗 = 装飾起因 parse 失敗）
 #   3  = diff range 解決失敗（marker commit が単記でも連記でも見つからない / Issue #164）
 #   4  = ファイル不在で 1 回限定リトライ後も生成されず（Issue #296 Req 2 / Req 4.2 で導入）
+#   5  = post-marker commit を marker 後に検出 + POST_MARKER_RECOVERY_MODE=fail-with-diagnostic
+#        （default）で停止（idd-codex #14 同型 commit shape / Issue #304 Req 2.1, 2.2, 2.3）
 #   99 = quota 超過
 #
-# 戻り値 2 / 3 / 4 の使い分け:
+# 戻り値 2 / 3 / 4 / 5 の使い分け:
 #   - rc=2: claude プロセスが起動した後の異常終了（claude crash / RESULT 行欠落 = 装飾起因 parse 失敗）。
 #     呼び出し側は既存の `per-task-reviewer-error` カテゴリで `claude-failed` 付与。
 #   - rc=3: claude プロセス起動前に diff range が解決できなかった（marker 不在 / Issue #164 Req 4）。
@@ -3345,8 +3351,15 @@ run_per_task_implementer() {
 #   - rc=4: review-notes.md がファイル不在で 1 回限定リトライ後も生成されず（Issue #296 Req 2.3 /
 #     Req 4.2）。呼び出し側は `per-task-reviewer-missing-file` カテゴリで `claude-failed` 付与し、
 #     NFR 2.2 に従い装飾起因 parse 失敗（rc=2）と grep で区別可能な reason を出力する。
+#   - rc=5: claude プロセス起動前に marker 後の未レビュー commit を検出した（Issue #304）。
+#     `pt_mark_post_marker_commits_detected` で `per-task-post-marker-commits-detected` カテゴリの
+#     `claude-failed` を本関数内で付与済みのため、呼び出し側は Issue コメント投稿を重ねずに
+#     即停止（既存 rc=3 のように `pt_mark_diff_range_resolve_failed` を loop 側で呼ぶ pattern
+#     と異なり、本経路は marker_sha / post_marker_list を本関数内で保持済みなため loop 側に
+#     データを引き上げず本関数で完結させる）。
 #
-# Requirements: 3.1, 3.2, 3.3, NFR 2.1, NFR 2.2, NFR 2.3, Issue #164 Req 4.1, 4.2, 4.3, NFR 2.2
+# Requirements: 3.1, 3.2, 3.3, NFR 2.1, NFR 2.2, NFR 2.3, Issue #164 Req 4.1, 4.2, 4.3, NFR 2.2,
+#               Issue #304 Req 2.1, 2.2, 2.3, NFR 1.1, NFR 1.3
 run_per_task_reviewer() {
   local task_id="$1"
   local round="$2"
@@ -3365,6 +3378,71 @@ run_per_task_reviewer() {
     return 3
   fi
 
+  # ─── Issue #304: post-marker commit の safety net ──────────────────────────
+  # `pt_resolve_diff_range` で得た range_end（= 当該 task の marker commit）より後ろに
+  # 未レビュー commit が積まれていないかを `pt_detect_post_marker_commits` で確認する。
+  # idd-codex #14 同型の Implementer 契約違反（Reviewer reject 後の再実行で修正 commit を
+  # 旧 marker 後ろに残置）を検出して silent range truncation を防ぐ。
+  #
+  # 後方互換性（NFR 1.1, 1.3）:
+  #   - 検出 0 件（rc=1）: post-marker commit が無い典型シナリオ → 既存ルートで Reviewer 起動
+  #   - git エラー（rc=2）: fail-safe で既存ルート fall-through（NFR 1.3 と同方針）
+  #   - 検出 1 件以上（rc=0）: `pt_handle_post_marker_commits` で recovery dispatch
+  #     - extend-range（rc=0）: 新 range で Reviewer を起動（range_end を HEAD まで拡張）
+  #     - fail-with-diagnostic（rc=5）: `pt_mark_post_marker_commits_detected` を呼んで
+  #       claude-failed を付与した上で rc=5 を呼び出し側に返す
+  local post_marker_list pt_detect_rc=0 extended="false"
+  post_marker_list=$(pt_detect_post_marker_commits "$range_end") || pt_detect_rc=$?
+  case "$pt_detect_rc" in
+    0)
+      # 1 件以上検出 → recovery dispatcher を起動
+      local pt_handle_out pt_handle_rc=0
+      pt_handle_out=$(pt_handle_post_marker_commits "$task_id" "$round" "$range_start" "$range_end" "$post_marker_list") || pt_handle_rc=$?
+      case "$pt_handle_rc" in
+        0)
+          # extend-range: 新 range を採用して Reviewer を起動
+          local new_range_start new_range_end
+          new_range_start=$(printf '%s' "$pt_handle_out" | cut -f1)
+          new_range_end=$(printf '%s' "$pt_handle_out" | cut -f2)
+          if [ -z "$new_range_start" ] || [ -z "$new_range_end" ]; then
+            pt_log "task=$task_id reviewer start round=$round result=error reason=post-marker-extend-range-empty detail=handle-returned-empty-pair" >> "$LOG"
+            # fail-safe: extend-range 結果が空なら fail-with-diagnostic と同等扱いで停止
+            pt_mark_post_marker_commits_detected "$task_id" "$round" "$range_end" "$post_marker_list" || true
+            return 5
+          fi
+          pt_log "task=$task_id reviewer start round=$round post-marker-commits-detected recovery=extend-range old_range_end=${range_end:0:7} new_range_end=${new_range_end:0:7}" >> "$LOG"
+          range_start="$new_range_start"
+          range_end="$new_range_end"
+          extended="true"
+          ;;
+        5)
+          # fail-with-diagnostic: claude-failed を付与して rc=5 を返す
+          pt_log "task=$task_id reviewer start round=$round result=error reason=per-task-post-marker-commits-detected marker=${range_end:0:7}" >> "$LOG"
+          pt_mark_post_marker_commits_detected "$task_id" "$round" "$range_end" "$post_marker_list" || true
+          return 5
+          ;;
+        *)
+          # 想定外の rc: 安全側に倒して fail-with-diagnostic 相当の停止
+          pt_log "task=$task_id reviewer start round=$round result=error reason=post-marker-handle-unexpected-rc rc=$pt_handle_rc marker=${range_end:0:7}" >> "$LOG"
+          pt_mark_post_marker_commits_detected "$task_id" "$round" "$range_end" "$post_marker_list" || true
+          return 5
+          ;;
+      esac
+      ;;
+    1)
+      # 0 件 → 既存ルート（NFR 1.3 既存挙動温存）
+      :
+      ;;
+    2)
+      # git エラー → fail-safe で既存ルート fall-through（NFR 1.3 同方針）
+      pt_log "task=$task_id reviewer start round=$round post-marker-commits-detect-git-error marker=${range_end:0:7} (fall-through to existing route)" >> "$LOG"
+      ;;
+    *)
+      # 想定外の rc → fail-safe で既存ルート fall-through
+      pt_log "task=$task_id reviewer start round=$round post-marker-commits-detect-unexpected-rc rc=$pt_detect_rc marker=${range_end:0:7} (fall-through to existing route)" >> "$LOG"
+      ;;
+  esac
+
   # prev_result（round=2 のみ意味あり）
   local prev_result="(none)"
   local notes_path="$REPO_DIR/$SPEC_DIR_REL/review-notes.md"
@@ -3375,7 +3453,7 @@ run_per_task_reviewer() {
     fi
   fi
 
-  pt_log "task=$task_id reviewer start round=$round model=$REVIEWER_MODEL max-turns=$REVIEWER_MAX_TURNS range=${range_start:0:7}..${range_end:0:7}" >> "$LOG"
+  pt_log "task=$task_id reviewer start round=$round model=$REVIEWER_MODEL max-turns=$REVIEWER_MAX_TURNS range=${range_start:0:7}..${range_end:0:7} extended=${extended}" >> "$LOG"
 
   local prompt
   prompt=$(build_per_task_reviewer_prompt "$task_id" "$range_start" "$range_end" "$round" "$prev_result")
@@ -4133,6 +4211,14 @@ run_per_task_loop() {
                   publish_terminal_failure_artifacts "per-task-reviewer-missing-file" "per-task ループの Debugger 経由 Reviewer (task=\`${task_id}\`, round=3) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
                   return 1
                   ;;
+                5)
+                  # per-task-post-marker-commits-detected (Issue #304) → marker 後の未レビュー
+                  # commit を検出し fail-with-diagnostic で停止（Debugger 経由 round=3）。
+                  # `run_per_task_reviewer` 内で `pt_mark_post_marker_commits_detected` 済み。
+                  dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=per-task-post-marker-commits-detected" >> "$LOG"
+                  echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) marker 後の未レビュー commit を検出 → claude-failed (per-task-post-marker-commits-detected)" | tee -a "$LOG"
+                  return 1
+                  ;;
                 *)
                   dbg_log "trigger=round2-reject issue=#${NUMBER} task=${task_id} round3 result=error" >> "$LOG"
                   echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=3) 異常終了 → claude-failed" | tee -a "$LOG"
@@ -4177,6 +4263,13 @@ run_per_task_loop() {
             publish_terminal_failure_artifacts "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
             return 1
             ;;
+          5)
+            # per-task-post-marker-commits-detected (Issue #304) → marker 後の未レビュー commit
+            # を検出し fail-with-diagnostic で停止。`run_per_task_reviewer` 内で
+            # `pt_mark_post_marker_commits_detected` 済みのため追加の Issue コメントは行わない。
+            echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) marker 後の未レビュー commit を検出 → claude-failed (per-task-post-marker-commits-detected)" | tee -a "$LOG"
+            return 1
+            ;;
           *)
             echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=2) 異常終了 → claude-failed" | tee -a "$LOG"
             publish_terminal_failure_artifacts "per-task-reviewer-error" "per-task ループの Reviewer (task=\`${task_id}\`, round=2) が異常終了しました（claude crash / parse 失敗）。\`$LOG\` を確認してください。"
@@ -4195,6 +4288,14 @@ run_per_task_loop() {
         # → `per-task-reviewer-missing-file` カテゴリで `claude-failed`（round=1）。
         echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) ファイル不在（リトライ後も未生成）→ claude-failed (per-task-reviewer-missing-file)" | tee -a "$LOG"
         publish_terminal_failure_artifacts "per-task-reviewer-missing-file" "per-task ループの Reviewer (task=\`${task_id}\`, round=1) が rc=0 で終了しましたが、\`${SPEC_DIR_REL}/review-notes.md\` が同一 round 内の 1 回限定リトライ後も生成されませんでした（Issue #296 ファイル不在経路）。Reviewer subagent の Write 漏れが疑われます。\`$LOG\` を確認してください。"
+        return 1
+        ;;
+      5)
+        # per-task-post-marker-commits-detected (Issue #304) → marker 後の未レビュー commit
+        # を検出し、`POST_MARKER_RECOVERY_MODE=fail-with-diagnostic`（default）で停止。
+        # `run_per_task_reviewer` 内で `pt_mark_post_marker_commits_detected` 済みのため、
+        # ここでは追加の Issue コメント投稿は行わず、stdout / log 出力のみで停止する。
+        echo "❌ #$NUMBER: per-task Reviewer (task=$task_id, round=1) marker 後の未レビュー commit を検出 → claude-failed (per-task-post-marker-commits-detected)" | tee -a "$LOG"
         return 1
         ;;
       *)

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -3596,6 +3596,166 @@ EOF
   gh issue comment "$NUMBER" --repo "$REPO" --body "$body" || true
 }
 
+# ─── pt_mark_post_marker_commits_detected <task_id> <round> <marker_sha> <post_marker_list> ───
+#
+# `per-task-post-marker-commits-detected` カテゴリで `claude-failed` を付与し、復旧手順付き
+# Issue コメントを投稿する専用ヘルパー（Issue #304 Req 2.3, NFR 2.1）。
+#
+# 通常の `per-task-reviewer-error` 経路（claude crash / parse 失敗等）および
+# `diff-range-resolve-failed`（marker 不在）との違い:
+#   - marker commit は見つかったが、その後ろに未レビュー commit が積まれた状態を検出した
+#     ケース（idd-codex #14 同型 / Implementer 契約違反: marker を task の終端 commit として
+#     refresh せずに修正 commit を旧 marker 後ろに残置）
+#   - silent range truncation（marker で range_end を止めて post-marker commit を見逃す）を
+#     防ぐため、`POST_MARKER_RECOVERY_MODE=fail-with-diagnostic`（default）経路で
+#     `run_per_task_reviewer` 起動を中止し、本ヘルパーで運用者向けの復旧手順を提示する
+#
+# 重複コメント抑制:
+#   - HTML コメント marker `<!-- idd-claude:per-task-post-marker-commits-detected:#<issue>:<task> -->`
+#     を本文末尾に埋め込み、当該 Issue に同一 marker のコメントが既存なら新規投稿を skip
+#     して既存コメントに「追記」する形式の単発コメントのみ追加する
+#     （`pt_mark_diff_range_resolve_failed` と同パターン）
+#
+# Args:
+#   $1 = task_id (例: `1.2`)
+#   $2 = round (1 / 2 / 3 のいずれか / どの round で検出したかを Issue に明示するため)
+#   $3 = marker_sha (検出時の対象 marker commit SHA)
+#   $4 = post_marker_list (改行区切りの post-marker SHA 列。`git log --format=%H` 由来 /
+#        新しい順 / 0 件の状態では本関数は呼ばれない想定だが空文字を許容する)
+#
+# 副作用:
+#   1. claude-claimed / claude-picked-up を除去し claude-failed を付与
+#   2. 復旧手順付き Issue コメントを 1 件投稿（既存があれば追記コメント）
+#
+# Requirements: Issue #304 Req 2.3, NFR 2.1
+pt_mark_post_marker_commits_detected() {
+  local task_id="$1"
+  local round="$2"
+  local marker_sha="$3"
+  local post_marker_list="$4"
+  local hostname_val
+  hostname_val=$(hostname)
+  local marker="<!-- idd-claude:per-task-post-marker-commits-detected:#${NUMBER}:${task_id} -->"
+
+  # post-marker SHA を CSV / bullet 表記に整形（NFR 2.1: 観測可能性）
+  local post_csv post_bullets
+  post_csv=$(printf '%s' "$post_marker_list" | tr '\n' ',' | sed 's/,$//')
+  post_bullets=$(printf '%s\n' "$post_marker_list" | sed '/^$/d' | sed 's/^/  - `/' | sed 's/$/`/')
+
+  # 重複コメント抑制のため既存 marker を gh API で検索
+  local comments_json existing_count=0
+  if comments_json=$(gh issue view "$NUMBER" --repo "$REPO" --json comments 2>/dev/null); then
+    existing_count=$(echo "$comments_json" | jq -r --arg marker "$marker" '
+      (.comments // []) | map(select(.body | contains($marker))) | length
+    ' 2>/dev/null || echo "0")
+    [ -n "$existing_count" ] || existing_count=0
+  fi
+
+  # ラベル付け替え（既存 mark_issue_failed / pt_mark_diff_range_resolve_failed と同方針 /
+  # 1 コマンド原子的に発行）
+  gh issue edit "$NUMBER" --repo "$REPO" \
+    --remove-label "$LABEL_CLAIMED" --remove-label "$LABEL_PICKED" --add-label "$LABEL_FAILED" || true
+
+  local body_header
+  if [ "$existing_count" -gt 0 ]; then
+    body_header="⚠️ 自動開発が失敗しました（${hostname_val} / モード: $MODE / 失敗 stage: per-task-post-marker-commits-detected / round=${round}）— **追記コメント**
+
+本 Issue には同一カテゴリ (\`per-task-post-marker-commits-detected\` / task=\`${task_id}\`) の失敗コメントが既に存在します。
+本コメントは状況が再発生したことを示す追記です。詳細な復旧手順は既存コメントを参照してください。"
+  else
+    body_header="⚠️ 自動開発が失敗しました（${hostname_val} / モード: $MODE / 失敗 stage: per-task-post-marker-commits-detected / round=${round}）"
+  fi
+
+  local body
+  body=$(cat <<EOF
+${body_header}
+
+## 失敗カテゴリ
+- カテゴリ: \`per-task-post-marker-commits-detected\`
+- 対象 task ID: \`${task_id}\`
+- 失敗 round: ${round}
+- 対象 marker SHA: \`${marker_sha}\`
+- post-marker SHA リスト（新しい順 / CSV）: \`${post_csv}\`
+- post-marker SHA リスト（詳細）:
+${post_bullets}
+- ログ: \`$LOG\`
+
+## 原因
+per-task Reviewer 起動前の safety net (\`pt_detect_post_marker_commits\`) が、当該 task の
+\`docs(tasks): mark ${task_id} as done\` marker commit (\`${marker_sha}\`) より後ろに、未レビューの
+commit が積まれている状態を検出しました。このまま Reviewer を起動すると range_end が marker
+で止まり、post-marker commit が判定対象から漏れる **silent range truncation** を引き起こすため、
+\`POST_MARKER_RECOVERY_MODE=fail-with-diagnostic\`（default）に従って Reviewer 起動前に停止しました
+（idd-codex #14 同型の failure mode 予防 / Issue #304）。
+
+Implementer 側で以下のいずれかに該当した可能性があります:
+
+- Reviewer reject / Debugger guidance 後の再実行で、修正 commit を旧 marker 後ろに積んだまま
+  marker を refresh しなかった
+- marker contract（marker は task の終端 commit / retry 時に refresh）に違反した順序で
+  marker commit を作成した
+
+## 復旧手順（重要 / データ損失リスク回避）
+
+**【重要】次サイクルで本ブランチの worktree が reset される可能性があります。**
+push 前の Developer commit が残っていれば、次サイクル前に必ず以下を実施してください:
+
+1. **push 前 commit の有無と現状の commit 列を確認**:
+   \`\`\`bash
+   cd <worktree-or-repo-dir>
+   git reflog --date=iso | head -50
+   git log --oneline ${BASE_BRANCH}..HEAD
+   git status
+   \`\`\`
+2. **push 前 commit がある場合は手動で push して保護**:
+   \`\`\`bash
+   git push origin <current-branch>
+   \`\`\`
+   または、reflog から拾い直して別ブランチに退避:
+   \`\`\`bash
+   git branch <rescue-branch-name> <reflog-sha>
+   git push origin <rescue-branch-name>
+   \`\`\`
+3. **marker commit を refresh**（marker を task の終端 commit に戻す）:
+   - 推奨 (a): 旧 marker を \`git reset --soft <marker^>\` で剥がし、修正 commit を含めた状態で
+     新 marker を末尾に作り直す
+   - 推奨 (b): \`git rebase -i ${BASE_BRANCH}\` で marker commit を tip に移動し、続けて
+     marker SHA を更新する
+   - いずれの場合も「\`docs(tasks): mark ${task_id} as done\` commit が \`${BASE_BRANCH}..HEAD\` の
+     最終 commit」になっていることを \`git log --oneline ${BASE_BRANCH}..HEAD\` で確認すること
+4. **修正完了後**: 修正 push を実施し、\`claude-failed\` ラベルを外すと watcher が次サイクルで
+   再 pickup する
+
+## Marker contract（再周知）
+
+per-task Implementer は以下の contract を厳守してください（詳細は
+\`repo-template/.claude/agents/developer.md\` の「per-task ループ下での Implementer の責務」節
+「Marker contract」subsection を参照）:
+
+- \`docs(tasks): mark <id> as done\` marker commit は、当該 task の **終端 commit**。
+  実装・テスト・learning 追記が完了した時点でのみ作成する
+- Reviewer reject / Debugger guidance 後の再実行では、修正 commit を旧 marker 後ろに残してはならない。
+  必要なら旧 marker を剥がして新 marker を末尾に積み直す（marker refresh）
+- 1 commit = 1 task ID（連記 \`mark 1 / 1.1 as done\` を作らない / 親 task 完了昇格は別 commit）
+
+## 切替 env（運用者向け / 通常は変更不要）
+
+- \`POST_MARKER_RECOVERY_MODE=fail-with-diagnostic\`（**default**）: 本コメントのような失敗扱いで停止
+- \`POST_MARKER_RECOVERY_MODE=extend-range\`: marker を捨てて HEAD まで range を拡張して
+  Reviewer を起動（marker contract 違反を黙って吸収するため、Implementer 側の修正契約が
+  弱くなる点に注意）
+
+${marker}
+EOF
+)
+
+  body="${body}
+
+問題を解決してから \`claude-failed\` ラベルを外してください。"
+
+  gh issue comment "$NUMBER" --repo "$REPO" --body "$body" || true
+}
+
 # ─── run_per_task_loop ───
 #
 # Stage A の代替実体。未完了 task を numeric ID 順に 1 件ずつ Implementer + Reviewer で

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -494,6 +494,17 @@ PATH_OVERLAP_BUSY_WAIT_THRESHOLD="${PATH_OVERLAP_BUSY_WAIT_THRESHOLD:-5}"
 PER_TASK_LOOP_ENABLED="${PER_TASK_LOOP_ENABLED:-false}"
 PER_TASK_MAX_TASKS="${PER_TASK_MAX_TASKS:-0}"
 
+# ─── #304: per-task post-marker commit recovery mode ───
+# per-task Reviewer 起動前の `pt_detect_post_marker_commits` で marker 後の未レビュー commit
+# が検出されたときの復旧モードを切り替える env（Req 2.2, 2.3）。idd-codex #14 と同型の
+# silent range truncation（修正 commit が古い marker 後ろに積まれ Reviewer から漏れる）を
+# 防ぐ safety net の挙動を運用者が制御できる。
+#
+# - POST_MARKER_RECOVERY_MODE: 既定 `fail-with-diagnostic`。明示的 `extend-range` で opt-in
+#   切替。不正値・未設定はすべて default の `fail-with-diagnostic` にフォールバックする
+#   （安全側に倒す / Req 2.2 abort 経路の決定論性）。
+POST_MARKER_RECOVERY_MODE="${POST_MARKER_RECOVERY_MODE:-fail-with-diagnostic}"
+
 # LOG_DIR と LOCK_FILE は REPO_SLUG を挟むことで repo ごとに分離。
 # 環境変数で明示上書きもできる。
 LOG_DIR="${LOG_DIR:-$HOME/.issue-watcher/logs/$REPO_SLUG}"
@@ -2754,6 +2765,80 @@ pt_detect_post_marker_commits() {
   fi
   printf '%s\n' "$post_list"
   return 0
+}
+
+# ─── pt_handle_post_marker_commits <task_id> <round> <range_start> <marker_sha> <post_marker_list> ───
+#
+# `pt_detect_post_marker_commits` で marker 後の未レビュー commit が検出された場合の
+# recovery dispatcher。env `POST_MARKER_RECOVERY_MODE` に応じて以下のいずれかに分岐する:
+#
+#   - `extend-range`: stdout に新 `<range_start>\t<HEAD_SHA>` を出力し rc=0 を返す。
+#     呼び出し側は marker を捨てて HEAD まで range を拡張し、`extended=true` で
+#     Reviewer prompt を組み立てる
+#   - `fail-with-diagnostic` (default): 後続タスク（#304 task 4）で追加される
+#     `pt_mark_post_marker_commits_detected` を呼んで claude-failed を付与した上で rc=5
+#     を返す。本 task 3 時点では当該関数が未実装のため、本実装は rc=5 を返すまでに留め、
+#     `run_per_task_reviewer` 経路の組み込み（task 5）または `pt_mark_post_marker_commits_detected`
+#     追加（task 4）で `mark` 呼び出しを補完する
+#
+# 不正値 / 未設定はすべて default の `fail-with-diagnostic` にフォールバックする
+# （安全側に倒す / Req 2.2）。
+#
+# Contract（design.md「pt_handle_post_marker_commits」節 / Req 2.2, 2.3, 3.3, NFR 1.1, NFR 2.1）:
+#   引数: <task_id> <round> <range_start> <marker_sha> <post_marker_list>
+#   env:  POST_MARKER_RECOVERY_MODE (default=fail-with-diagnostic, 不正値も default 化)
+#   stdout: extend-range 時のみ <new_range_start>\t<new_range_end>（HEAD まで拡張済み）
+#   stderr: NFR 2.1 準拠の単一行イベントログ（後述）
+#   rc=0: extend-range で続行（呼び出し側は新しい range で Reviewer 起動）
+#   rc=5: fail-with-diagnostic で停止（後段で claude-failed を付与）
+#
+# NFR 2.1 ログ書式（fixture 参照実装 line 158 と同一書式 / `pt_warn` の WARN: 接頭辞を付けない
+# 単一行イベントログとして出力する）:
+#   `[YYYY-MM-DD HH:MM:SS] per-task: post-marker-commits-detected task_id=<id> round=<n>
+#    marker=<sha> post_marker_shas=<csv> recovery=<mode>`
+#
+# 参照実装:
+#   - 本関数は `docs/specs/304--bug-per-task-commit-task-marker-review/test-fixtures/
+#     test-post-marker-detect.sh` 内の参照実装と algorithm body を byte 同期させる責務がある
+#     （stderr 行の `[smoke]` warn prefix のみ `pt_warn` で置換、NFR 2.1 メインログは
+#     fixture と同一書式を保つ / 既存 #164 fixture と同方針）
+#
+# Requirements: 2.2, 2.3, 3.3, NFR 1.1, NFR 2.1
+pt_handle_post_marker_commits() {
+  local task_id="$1"
+  local round="$2"
+  local range_start="$3"
+  local marker_sha="$4"
+  local post_marker_list="$5"
+
+  local mode="${POST_MARKER_RECOVERY_MODE:-fail-with-diagnostic}"
+  case "$mode" in
+    extend-range|fail-with-diagnostic) ;;
+    *)
+      pt_warn "post-marker-commits-detect: invalid POST_MARKER_RECOVERY_MODE='${mode}', falling back to fail-with-diagnostic"
+      mode="fail-with-diagnostic"
+      ;;
+  esac
+
+  local ts post_csv
+  ts=$(date '+%F %T')
+  post_csv=$(printf '%s' "$post_marker_list" | tr '\n' ',' | sed 's/,$//')
+  echo "[${ts}] per-task: post-marker-commits-detected task_id=${task_id} round=${round} marker=${marker_sha} post_marker_shas=${post_csv} recovery=${mode}" >&2
+
+  if [ "$mode" = "extend-range" ]; then
+    local head_sha
+    if ! head_sha=$(git rev-parse HEAD 2>/dev/null); then
+      pt_warn "post-marker-commits-detect: git rev-parse HEAD failed (range_start=${range_start})"
+      return 5
+    fi
+    printf '%s\t%s\n' "$range_start" "$head_sha"
+    return 0
+  fi
+
+  # fail-with-diagnostic: task 4 で `pt_mark_post_marker_commits_detected` 追加後に
+  # `run_per_task_reviewer` 経路（task 5）または本関数の改修でここから mark を呼ぶ。
+  # 本 task 3 時点では rc=5 を返すのみで終わる（fixture 参照実装も同様）。
+  return 5
 }
 
 # ─── pt_has_subtasks <tasks_md_path> <task_id> ───

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -3173,7 +3173,7 @@ ${learnings_block}
 EOF
 }
 
-# ─── build_per_task_reviewer_prompt <task_id> <range_start_sha> <range_end_sha> <round> <prev_result> ───
+# ─── build_per_task_reviewer_prompt <task_id> <range_start_sha> <range_end_sha> <round> <prev_result> [<extended>] ───
 #
 # per-task Reviewer 用の prompt を heredoc で組み立てて stdout に出力。
 # 既存 `build_reviewer_prompt` の形式を踏襲しつつ、以下を明示する:
@@ -3183,6 +3183,8 @@ EOF
 #   - `_Boundary:_` 違反は depth に関わらず常に reject 対象
 #   - 既存 reviewer.md の 3 カテゴリ（AC 未カバー / missing test / boundary 逸脱）と
 #     RESULT 行 / review-notes.md 出力契約を流用
+#   - 第 6 引数 `extended`（"true"/"false"、省略時 "false"）: watcher が marker 後の
+#     post-marker commit を検出して HEAD ベースに range を拡張したか否か（Issue #304 Req 3.3）
 #
 # Requirements: 3.1, 3.2, 3.3
 build_per_task_reviewer_prompt() {
@@ -3191,6 +3193,34 @@ build_per_task_reviewer_prompt() {
   local range_end="$3"
   local round="$4"
   local prev_result="$5"
+  # Issue #304 Req 3.3: 第 6 引数 `extended` は省略時 "false"（既存呼び出し互換）。
+  # watcher が post-marker commit を検出して range を HEAD まで拡張した場合のみ "true" が
+  # 渡される。値は prompt 本文の `range_extended:` 行と extended-range 説明文に反映される。
+  local extended="${6:-false}"
+
+  # Issue #304 Req 3.3: extended=true 時の追加説明 block（normal 経路では空文字列）。
+  # heredoc 中で条件分岐すると bash 構文が崩れるため、変数で差し込む方式を採用。
+  # 変数の中身は外側の `cat <<EOF` で変数展開された後の最終 prompt にそのまま埋め込まれる。
+  # quoted heredoc（'EXTENDED_EOF'）を使うことで $ / ` / \ が一切解釈されず、markdown の
+  # バッククォートも literal で保持される（外側 heredoc の二重 escape 不要）。
+  local extended_explanation=""
+  if [ "$extended" = "true" ]; then
+    extended_explanation=$(cat <<'EXTENDED_EOF'
+
+### Extended range（watcher による range 拡張通知）
+
+watcher が当該 task の `docs(tasks): mark` marker commit より後ろに **未レビューの
+post-marker commit** を検出したため、env `POST_MARKER_RECOVERY_MODE=extend-range` の
+recovery 経路により range_end を marker SHA ではなく **HEAD まで拡張** しています
+（Issue #304 Req 3.3）。
+
+上記 `range_end_sha` は marker commit ではなく **HEAD の SHA** であり、上記
+`range_start_sha..range_end_sha` の範囲には marker 後に積まれた修正 commit も含まれます。
+extended 状態でも本 Reviewer の判定基準は変わりません（range 内 commit のみを判定根拠と
+してください）。
+EXTENDED_EOF
+)
+  fi
 
   cat <<EOF
 あなたはこのリポジトリの Claude Code オーケストレーターです。
@@ -3214,10 +3244,29 @@ build_per_task_reviewer_prompt() {
 
 - **対象 task ID**: \`${task_id}\`
 - **range_start_sha**: \`${range_start}\` （= 直前の \`docs(tasks): mark\` commit、または初回時は \`${BASE_BRANCH}\` の SHA）
-- **range_end_sha**:   \`${range_end}\`   （= 当該 task の \`docs(tasks): mark ${task_id} as done\` commit）
+- **range_end_sha**:   \`${range_end}\`   （= 当該 task の \`docs(tasks): mark ${task_id} as done\` commit、ただし extended=true の場合は HEAD）
 
 reviewer は **本 range のみ** を判定対象としてください。HEAD 全体は対象外（全体観点は
 最終 Stage B Reviewer が別途担当します）。
+
+> **Warning（Issue #304 Req 3.2）**: 上記 \`range_start_sha..range_end_sha\` の **外側** に
+> ある commit（HEAD が range_end より後ろにある場合等）は本 Reviewer の **判定対象外** です。
+> range 外 commit の内容を理由に approve / reject を出してはいけません。HEAD 全体観点は
+> 最終 Stage B Reviewer が担当します。本 Reviewer は \`range_start_sha..range_end_sha\` 内
+> commit のみを判定根拠としてください。
+
+## 判定対象 SHA range（machine-parseable）
+
+以下は watcher → Reviewer 間の range 引き継ぎを機械パース可能な形で再掲した block です
+（Issue #304 Req 3.1）。Reviewer は本 block の値を判定対象 SHA range の正本として扱って
+ください。
+
+\`\`\`
+range_start_sha: ${range_start}
+range_end_sha:   ${range_end}
+range_extended:  ${extended}
+\`\`\`
+${extended_explanation}
 
 ## 必読ファイル
 
@@ -3456,7 +3505,10 @@ run_per_task_reviewer() {
   pt_log "task=$task_id reviewer start round=$round model=$REVIEWER_MODEL max-turns=$REVIEWER_MAX_TURNS range=${range_start:0:7}..${range_end:0:7} extended=${extended}" >> "$LOG"
 
   local prompt
-  prompt=$(build_per_task_reviewer_prompt "$task_id" "$range_start" "$range_end" "$round" "$prev_result")
+  # Issue #304 Req 3.3: post-marker recovery で extend-range 経路に入った場合は extended="true"。
+  # normal 経路では extended="false"（task 5 で初期化済み）。`build_per_task_reviewer_prompt`
+  # の 6 番目の引数として渡し、prompt の `range_extended:` 行と extended-range 説明文に反映。
+  prompt=$(build_per_task_reviewer_prompt "$task_id" "$range_start" "$range_end" "$round" "$prev_result" "$extended")
 
   # Issue #296 Req 2.4 / NFR 3.1 / Req 4.2: per-task 経路でもファイル不在起因の再起動は
   # 同一 round 内で最大 1 回まで（単発経路 run_reviewer_stage と対称）。

--- a/repo-template/.claude/agents/developer.md
+++ b/repo-template/.claude/agents/developer.md
@@ -390,6 +390,70 @@ fresh な Claude session** で本 Developer サブエージェントが起動さ
   ため、`diff-range-resolve-failed` を引き起こすリスクがある（watcher 側で fallback 解決は
   試行するが、canonical は単記分割のみ）。
 
+## Marker contract（marker は task の終端 commit）（Issue #304 / idd-codex #14 同型再発防止）
+
+per-task ループにおいて、`docs(tasks): mark <id> as done` marker commit は当該 task の
+**終端 commit**（task 完了時点で `${BASE_BRANCH}..HEAD` の最後尾に位置する commit）として
+扱う契約があります。本契約は watcher の `pt_resolve_diff_range` が当該 task の per-task
+Reviewer review range の **終端 SHA** を当該 marker commit に固定する前提に依拠しており、
+契約違反は **silent range truncation**（修正 commit が Reviewer の判定対象から漏れる事故）の
+原因になります。
+
+### marker 作成タイミングの契約（Req 1.1）
+
+- marker commit は、当該 task の **実装 commit・テスト commit・`impl-notes.md` への
+  learning 追記 commit** をすべて積み終えた **最後** に作成すること
+- 「実装途中で先に marker を打って後から修正を追加する」「learning 追記より先に marker を
+  打つ」等のフローは禁止。**「task の全成果物が積み終わった」状態でのみ marker を作る**
+- 本 attempt（Reviewer reject 後の retry も含む）の task-scope 作業がすべて完了した時点で
+  marker commit を作成する
+
+### retry 時の marker refresh 契約（Req 1.2）
+
+Reviewer reject や Debugger guidance による Implementer 再実行（round 2 / round 3）で
+修正 commit を追加する場合、**修正 commit を旧 marker より後ろに残してはならない**。
+旧 marker をそのままに修正 commit を marker 後ろに積むと、watcher の review range が
+旧 marker で固定されたまま修正 commit が漏れ、再 reject の根拠が実態と乖離します
+（idd-codex #14 で実際に発生した failure mode）。
+
+### 推奨 refresh 手順（順序付き）
+
+retry 時に marker を refresh する canonical 手順は以下です:
+
+1. **旧 marker commit の特定**: `git log --oneline ${BASE_BRANCH}..HEAD | grep "docs(tasks): mark <id> as done"` で
+   旧 marker の SHA を特定する
+2. **修正 commit を積む**: 実装 / テスト / learning 追記の修正 commit を通常通り積む（この
+   時点では旧 marker が中間位置に残っている状態）
+3. **旧 marker を剥がして新 marker を末尾に作り直す**: 以下のいずれかの方法で marker を
+   task 終端に移動する:
+   - **方法 A（推奨 / 単純）**: `git reset --soft <旧 marker の SHA>^` で旧 marker を含む
+     最近の commit を index に戻し、修正 commit を再 commit したうえで新 marker を末尾に
+     作成する
+   - **方法 B**: `git rebase -i ${BASE_BRANCH}` で旧 marker を tip に移動（reorder）し、
+     必要なら drop + 末尾で新 marker を作り直す
+4. **push して watcher の次サイクルへ**: refresh 後の HEAD（新 marker が終端）を push する。
+   watcher は次サイクルで新 marker を range_end として解決する
+
+### 禁止例
+
+以下のパターンは silent range truncation を引き起こすため **禁止**:
+
+- 旧 marker をそのままに修正 commit を marker **後ろに** 積む（marker が中間位置に残る）
+- 修正 commit と marker を別 attempt に分割し、marker のみを先行 attempt で push したまま
+  後続 attempt で修正 commit を push する
+- 旧 marker を残したまま「marker を打ち直す」つもりで `docs(tasks): mark <id> as done` を
+  もう 1 件追加する（同一 task ID の marker が複数存在する状態は watcher 側でも `1 commit
+  = 1 task ID` 規約に抵触する）
+
+### watcher 側 safety net との関係
+
+watcher は本契約違反を検出する safety net（`pt_detect_post_marker_commits` /
+`pt_handle_post_marker_commits` / `per-task-post-marker-commits-detected` カテゴリの
+claude-failed、env `POST_MARKER_RECOVERY_MODE`）を持ちますが、これは **Implementer 契約の
+代替ではなく defense-in-depth** です。default の `fail-with-diagnostic` モードでは
+silent truncation を顕在化させて claude-failed で停止するため、Implementer は本契約を
+遵守して safety net 発火を回避することが望まれます。
+
 ## learning 追記の責務（per-task ループの中核 / Req 4.1, 4.2, 4.4）
 
 - 完了時に `impl-notes.md` の `## Implementation Notes` セクション配下へ

--- a/repo-template/.claude/agents/reviewer.md
+++ b/repo-template/.claude/agents/reviewer.md
@@ -300,6 +300,44 @@ git diff <range_start_sha>..<range_end_sha> -- <path>
 HEAD 全体（`<BASE_BRANCH>..HEAD`）は対象外です。全体観点は最終 Stage B Reviewer
 （per-task ループ完了後に別途起動される HEAD 全体レビュー）が担当します。
 
+### range 外 commit の判定対象外性（Issue #304 Req 3.2）
+
+prompt の `range_start_sha..range_end_sha` の **外側** にある commit（例: `range_end_sha` より
+後ろに HEAD が存在する場合の post-marker commit、または `range_start_sha` より前の commit）は、
+**本 Reviewer の判定対象外** です。Reviewer は以下を遵守してください:
+
+- range 外 commit を **`git diff` / `git log` の対象に含めない**（上記コマンド例の通り
+  `<range_start_sha>..<range_end_sha>` で範囲を限定して呼ぶ）
+- range 外 commit の内容を理由に **approve / reject を出さない**（範囲外で起きている問題は
+  本 Reviewer の責務外であり、HEAD 全体観点は Stage B Reviewer が担当する）
+- 「HEAD には range 外 commit がある」事実を観測しても、本 Reviewer の判定基準（AC 未カバー /
+  missing test / boundary 逸脱）に該当しなければそれを reject 理由にしない
+
+本制約は per-task ループ全体の役割分担（task 単位境界の検出 vs HEAD 全体 verify）を維持する
+ための前提です。range 外 commit を理由とした reject は Reviewer の責務逸脱として扱われます。
+
+### Extended range シグナルの解釈（Issue #304 Req 3.3）
+
+prompt の machine-parseable range block に `range_extended: true` シグナルが含まれる場合、
+watcher が marker 後の post-marker commit（task の終端 marker より後ろに積まれた未レビュー
+commit）を検出し、`POST_MARKER_RECOVERY_MODE=extend-range` 経路で **range_end を HEAD まで
+拡張済み**であることを示します。本シグナルの解釈は以下です:
+
+- **判定基準は変わらない**: extended 状態でも Reviewer の判定軸（AC 未カバー / missing test /
+  boundary 逸脱）は通常 review と同一。判定対象 SHA range の **終端が marker ではなく HEAD**
+  になっただけで、勘案する観点は変化しない
+- **range 内 commit のみを判定根拠とする**: extended であっても上記「range 外 commit の
+  判定対象外性」原則は変わらない。`range_start_sha..range_end_sha` 内の commit のみを
+  `git diff` / `git log` で参照する（`range_end_sha` は extended 状態では HEAD と一致する）
+- **Implementer 契約違反の事実を観察できる**: `range_extended: true` は Implementer が marker
+  contract（marker は task の終端 commit）を守らず、修正 commit を旧 marker 後ろに残した
+  ことを意味する。Reviewer はこの状況下でも当該 task の AC / 境界に対して通常通り判定を
+  出すこと（契約違反そのものは watcher 側のログ / 失敗カテゴリで観測される領分であり、
+  Reviewer の reject 理由にはしない）
+- **`range_extended: false` または欠落時は normal 経路**: 通常の per-task review は
+  `range_extended: false`（または当該行が prompt に存在しない）状態で起動される。この場合は
+  本節導入前と完全に同一の判定挙動。
+
 ## 判定 depth の絞り込み
 
 per-task ループの Reviewer は判定 depth が以下に絞り込まれます:


### PR DESCRIPTION
## 概要

per-task Reviewer ループにおいて、Implementer の retry 修正 commit が task marker（`docs(tasks): mark <id> as done`）の後ろに積まれた場合、watcher の review range 解決（`pt_resolve_diff_range`）が marker で打ち切られ、修正 commit が Reviewer の判定から漏れる silent truncation バグを修正する。

idd-codex #14 で実際に発生した failure mode（retry 後の修正が妥当にもかかわらず古い range のみが再評価され `codex-failed` 終了）を idd-claude 側でも再現し、watcher の検出 + prompt の明文化の両面で予防策を実装した。

## 対応 Issue

Closes #304

## 関連 PR

- 設計 PR: #307（merged）

## 実装内容

- (Req 2.1 / Task 2) `pt_detect_post_marker_commits`: marker 後の commit を `git log <marker>..HEAD` で検出。rc=0（1 件以上）/ rc=1（0 件）/ rc=2（git エラー）を返す
- (Req 2.2 / Task 3) `pt_handle_post_marker_commits`: `POST_MARKER_RECOVERY_MODE` env で `extend-range`（range 拡張、rc=0）/ `fail-with-diagnostic`（abort、rc=5、default）を分岐
- (Req 2.3 / Task 4) `pt_mark_post_marker_commits_detected`: `per-task-post-marker-commits-detected` カテゴリで `claude-failed` ラベル付与 + 復旧手順付き Issue コメント投稿（既存 `pt_mark_diff_range_resolve_failed` と同パターン）
- (Req 2.1〜2.3 / Task 5) `run_per_task_reviewer` への post-marker hook 組込み: `pt_resolve_diff_range` 成功直後に 2 段 dispatcher を挿入。`run_per_task_loop` の round=1/2/3 各経路に rc=5 捕捉を追加
- (Req 3.1〜3.3 / Task 6) `build_per_task_reviewer_prompt` に第 6 引数 `extended` を追加。prompt に `## 判定対象 SHA range（machine-parseable）` fenced block（`range_start_sha:` / `range_end_sha:` / `range_extended:`）と range 外 commit の判定対象外 Warning、および `extended=true` 時の `### Extended range` 説明 block を出力
- (Req 1.1〜1.3 / Task 7) `.claude/agents/developer.md` に「Marker contract（marker は task の終端 commit）」subsection 追加。`.claude/agents/reviewer.md` に「range 外 commit の判定対象外性」「Extended range シグナルの解釈」h3 追加（root 系統）
- (Req 4.1〜4.2 / Task 8) root と `repo-template/` の両系統を byte 一致で同期。`diff -r .claude/agents repo-template/.claude/agents` exit 0 を確認
- (Req 5.1〜5.3 / Task 1) `docs/specs/304-.../test-fixtures/test-post-marker-detect.sh`: idd-codex #14 同型 commit shape の回帰 fixture。case-1〜5（検出 0 件 / 検出 2 件 / fail-with-diagnostic rc=5 / extend-range rc=0 / silent truncation 証拠 3 段）で assert

## 受入基準チェック

- [x] Req 1.1: marker は task の終端 commit である契約 ← `.claude/agents/developer.md` 「marker 作成タイミングの契約」subsection
- [x] Req 1.2: retry 時に旧 marker 後ろに修正を残さない契約 ← developer.md 「retry 時の marker refresh 契約」subsection
- [x] Req 1.3: marker contract が Implementer が読む位置に文書化 ← per-task ループ責務節配下の「Marker contract」h2
- [x] Req 2.1: silent truncation を許容しない ← `pt_detect_post_marker_commits` + `run_per_task_reviewer` hook
- [x] Req 2.2: post-marker commit を include または abort ← `pt_handle_post_marker_commits` の extend-range / fail-with-diagnostic 分岐
- [x] Req 2.3: abort 時に既存 failure path で診断を surface ← `pt_mark_post_marker_commits_detected` で `claude-failed` + Issue コメント
- [x] Req 3.1: Reviewer prompt に SHA range を machine-parseable 形式で明示 ← `## 判定対象 SHA range` fenced block
- [x] Req 3.2: range 外 commit が判定対象外である Warning ← blockquote Warning + reviewer.md 追記
- [x] Req 3.3: extend-range 時に拡張 range を prompt に反映 ← `extended=true` 時の `### Extended range` block
- [x] Req 4.1 / 4.2: root と repo-template の byte 一致 ← `diff -r .claude/agents repo-template/.claude/agents` exit 0
- [x] Req 5.1〜5.3: 回帰 fixture が post-marker commit を検出しない場合に fail ← case-5(c) assert
- [x] NFR 1.1: 既存 rc=0/1/2/3/4/99 の意味不変、rc=5 は additive ← `test-pt-resolve.sh` 19/19 pass
- [x] NFR 1.2: marker commit message format 変更なし
- [x] NFR 1.3: post-marker 0 件時は既存ルートに fall-through

## テスト結果

```
# test-post-marker-detect.sh（idd-codex #14 同型回帰 fixture）
14 PASSED / 0 FAILED / SMOKE_RESULT: pass

# test-pt-resolve.sh（#164 非回帰 fixture）
19 PASSED / 0 FAILED / SMOKE_RESULT: pass

# shellcheck local-watcher/bin/issue-watcher.sh
警告ゼロ

# diff -r .claude/agents repo-template/.claude/agents
exit 0（差分なし）

# diff -r .claude/rules repo-template/.claude/rules
exit 0（差分なし）
```

## 実装上の判断

主要な判断を `docs/specs/304--bug-per-task-commit-task-marker-review/impl-notes.md` に記録。

主なポイント:
- `pt_mark_post_marker_commits_detected` の呼び出し場所を `run_per_task_reviewer` 内とした（`pt_handle_post_marker_commits` 内でなく）。fixture 参照実装との byte 同期責務と plumbing の自然さから
- `extended_explanation` の差し込みは heredoc ネスト回避のためローカル変数化。normal 経路では空文字列展開のみで Reviewer 解釈に影響なし
- rc=5 と既存 rc=3（`diff-range-resolve-failed`）の使い分け: rc=3 は marker 不在 / rc=5 は marker は見つかったが後続に未レビュー commit が存在
- fail-safe（NFR 1.3）の徹底: rc=2（git エラー）/ 想定外 rc は既存ルートで fall-through

## 確認事項 / レビュワーへの依頼

- `POST_MARKER_RECOVERY_MODE=extend-range` は marker contract 違反を黙って吸収するため、通常は default（`fail-with-diagnostic`）推奨。詳細は impl-notes.md Task 4 参照
- rc=5 の E2E 観測（idd-claude self-hosting 上で marker contract 違反の test issue を立てる）は本 PR スコープ外。dogfooding での確認を推奨
- 最終 PR: tasks.md 全 8 件完了（`- [x]`）のため Closes を採用
- `docs/specs/304--bug-per-task-commit-task-marker-review/review-notes.md` の Reviewer 判定 `RESULT: approve`（findings なし）を参照

base: main / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #304 のコメントを参照してください。
