### PR TITLE
feat(#316): dr_resolve_one に base 相対化を導入し develop dispatch で staged-for-release 依存を解決可能にする

### DIFF
--- a/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/impl-notes.md
+++ b/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/impl-notes.md
@@ -1,0 +1,115 @@
+# Implementation Notes — #316
+
+## 概要
+
+依存ゲート `dr_resolve_one` に base 相対化を導入し、`BASE_BRANCH != main` の multi-branch
+（gitflow）運用で依存先 Issue が `OPEN` かつ `staged-for-release` ラベルを持つ場合に
+解決済み (`resolved`) として分類するようにした。`BASE_BRANCH=main` の従来挙動は完全に
+維持する（NFR 1.1）。
+
+## 変更ファイル
+
+- `local-watcher/bin/issue-watcher.sh`
+  - `dr_gh_graphql_closed_by` (:8870 付近) の GraphQL クエリに `labels(first: 20) { nodes { name } }`
+    を追加。state / labels / closedByPullRequestsReferences を 1 回の問い合わせで取得（NFR 2.1）
+  - `dr_resolve_one` (:8924 付近) の OPEN 分岐に base 相対化ロジックを追加:
+    - `BASE_BRANCH=main` → ラベル参照せず `open`（従来挙動 / Req 1.2）
+    - `BASE_BRANCH!=main` → labels を jq で集計し、`staged-for-release` 付与時のみ `resolved`
+    - labels の jq parse 失敗 / 想定外応答 → `api error`（安全側 / Req 2.3）
+  - `staged-for-release` による解決時には `dr_log` に `verdict=resolved reason=staged-for-release base=<BASE_BRANCH>`
+    を出力し、運用者が分類根拠を log から判別できるようにした（NFR 3.1）
+- `docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh`
+  - shell-level の回帰テスト（#204 の test-dependency-resolver.sh と同パターン）
+  - 21 ケースを網羅: Req 1.1〜1.5 / 2.1〜2.3 / NFR 1.1 をカバー
+
+## 設計判断
+
+### base 相対化の判定基準: `BASE_BRANCH != main` を採用
+
+#221 の `po_resolve_holder_labels`（promote-pipeline.sh:240）では
+`BASE_BRANCH != PROMOTION_TARGET_BRANCH` で multi-branch を判定している。
+依存ゲートは Triage 段階で動作し promote コンテキストを持たないため、
+Issue 本文の指示・requirements.md Req 1.1 に従い、より単純な
+`BASE_BRANCH != main` を採用した（develop 以外の任意 branch 名でも main 以外なら
+multi-branch 扱い、という Out of Scope 末尾の方針と整合）。
+
+### ラベル定数のハードコード回避
+
+`LABEL_STAGED_FOR_RELEASE` 定数を `jq --arg target` 経由で渡して比較する形にした
+（promote-pipeline.sh と同じ `${LABEL_STAGED_FOR_RELEASE:-staged-for-release}` の
+fallback パターン）。
+
+### labels 取得失敗時の安全側挙動
+
+`labels` ノードの jq parse に失敗した場合は **`api error` を返す**ことで、依存ゲートの
+caller (`dr_check_dependencies`) が当該依存を未解決として扱い `blocked` を付与する経路に
+合流する（Req 2.3 / Req 2.2 の挙動と整合）。「ラベル取得失敗 = `staged-for-release` 付与を
+仮定して resolved にしてはならない」という要件を、より安全に倒して `open` ではなく
+`api error` で返している（依存ゲート上は両者とも未解決として扱われるため挙動は等価）。
+
+なお `labels` ノード自体が response 構造から欠落しているケース（旧クライアントが古い
+クエリで叩いた応答が混入する等）は jq の `?` で空配列扱いとなり length=0 → false → `open`
+を返す。これは「staged-for-release 付与を仮定して resolved にする処理は行わない」
+（Req 2.3）の文意と整合する（`api error` ではなく `open` ではあるが、いずれも未解決として
+扱われる安全側の挙動）。
+
+### NFR 2.1 (API 呼び出し回数の維持)
+
+`labels(first: 20)` を既存 GraphQL クエリに追加することで、依存先 Issue 1 件あたりの
+`gh api graphql` 呼び出し回数は本変更前と同じ 1 回（dr_check_dependencies 全体で 2 回相当の
+従来回数）に保たれている。
+
+## テスト方法
+
+```sh
+# 新規テスト（21 cases）
+bash docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh
+
+# 既存 #204 回帰テスト
+bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
+
+# shellcheck（全 bash 成果物）
+shellcheck local-watcher/bin/issue-watcher.sh \
+           local-watcher/bin/modules/*.sh \
+           install.sh setup.sh .github/scripts/*.sh \
+           docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh
+```
+
+最終確認時の結果:
+
+- 新規テスト 21/21 pass
+- 既存 #204 テスト 21/21 pass（回帰なし）
+- shellcheck 警告ゼロ
+
+## 受入基準カバレッジ
+
+| Req | 内容 | カバーするテストケース |
+|---|---|---|
+| 1.1 | `BASE_BRANCH != main` + OPEN + staged-for-release → resolved | `Req1.1 develop+OPEN+staged-for-release` / `Req1.1 任意 base != main + 他ラベル混在` |
+| 1.2 | `BASE_BRANCH = main` + OPEN + staged-for-release → 従来通り未解決 | `Req1.2 main+OPEN+staged-for-release は open` |
+| 1.3 | OPEN + staged-for-release なし → BASE_BRANCH 不問で未解決 | `Req1.3 develop+OPEN+ラベルなし` / `Req1.3 develop+OPEN+他ラベルのみ` / `Req1.3 main+OPEN+ラベルなし` |
+| 1.4 | CLOSED + MERGED PR あり → 従来通り resolved | `Req1.4 develop+CLOSED+MERGED PR` / `Req1.4 main+CLOSED+MERGED PR` / `Req1.4 main+CLOSED+SfR+MERGED は resolved（ラベル無視）` |
+| 1.5 | CLOSED + MERGED PR なし → 従来通り closed unmerged | `Req1.5 develop+CLOSED+CLOSED PR` / `Req1.5 main+CLOSED+PR 0 件` |
+| 2.1 | state + labels を同一クエリで取得 | `Req2.1 単一 response に state + labels + PR 一覧が同梱` |
+| 2.2 | state または labels の取得・解析失敗 → 安全側 (`api error`) | `Req2.2 gh 失敗時は base 値によらず api error` / `Req2.2 GraphQL errors は api error` / `Req2.2 壊れた JSON` |
+| 2.3 | labels 取得・解析失敗時に staged-for-release 付与を仮定しない | `Req2.3 OPEN + labels ノード欠落は staged を仮定せず open`（実装側の jq エラー時は `api error` に倒す） |
+| 3.1 | develop dispatch + OPEN + SfR で resolved となる回帰テスト | 上記 1.1 のテスト |
+| 3.2 | develop dispatch + OPEN + SfR なしで unresolved となる回帰テスト | 上記 1.3 のテスト |
+| 3.3 | main dispatch + OPEN + SfR で unresolved となる回帰テスト | 上記 1.2 のテスト |
+| 3.4 | CLOSED + merged PR ありで resolved となる回帰テスト | 上記 1.4 のテスト |
+| 3.5 | CLOSED + merged PR なしで closed unmerged となる回帰テスト | 上記 1.5 のテスト |
+| NFR 1.1 | `BASE_BRANCH=main` の挙動が本変更導入前と完全同一 | `NFR1.1 main+OPEN+SfR は open（従来同一）` / `NFR1.1 main+OPEN+ラベルなしは open` / `NFR1.1 main+CLOSED+MERGED は resolved` / `NFR1.1 main+CLOSED+混在 は resolved` / `NFR1.1 main+CLOSED+CLOSED PR は closed unmerged` |
+| NFR 1.2 | 既存 env のみで制御し新規 env var を導入しない | コードレビュー: 新規 env var 追加なし（`BASE_BRANCH` / `DRR_GH_TIMEOUT` / `LABEL_STAGED_FOR_RELEASE` の 3 つはいずれも既存） |
+| NFR 1.3 | path-overlap holder 側 (#221) の base 相対化判定を変更しない | `local-watcher/bin/modules/promote-pipeline.sh` は本 PR で変更なし |
+| NFR 2.1 | API 呼び出し回数を変更前と同数に維持 | コードレビュー: `gh api graphql` 呼び出しは 1 依存先あたり 1 回（旧と同じ）。labels は同じ呼び出しに追加フィールドで載せる |
+| NFR 3.1 | resolved 分類時の理由を log に出力 | コードレビュー: `dr_log "issue=#${dep_num} verdict=resolved reason=staged-for-release base=${BASE_BRANCH:-main}"` を追加 |
+
+## 確認事項
+
+- なし。設計判断は requirements.md と #221 path-overlap holder の base 相対化規約から導出可能で、
+  Issue 本文 / requirements.md / Out of Scope と整合している。
+- 本変更は `BASE_BRANCH=main` の従来挙動を 1 切変えないため、既存 single-branch 運用への影響なし。
+- 既稼働の self-hosting watcher に対しては、次サイクル以降の依存ゲート判定にのみ影響する
+  （Triage 段階のラベル遷移のみ。dispatch 候補フィルタ・promote-pipeline 等への波及なし）。
+
+STATUS: complete

--- a/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/requirements.md
+++ b/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/requirements.md
@@ -1,0 +1,84 @@
+# Requirements Document
+
+## Introduction
+
+gitflow など `BASE_BRANCH=develop` を用いる multi-branch 運用では、依存先 Issue が
+develop に統合済みで main 到達待ちの状態（`staged-for-release` ラベル付与 + OPEN 維持）に
+留まる期間がある。現状の依存ゲート（Issue 本文の明示依存宣言行 `Depends on:` 等を判定する
+`dr_*` 系統、#146 由来）は依存先 Issue の close 状態のみで解決判定を行うため、
+`staged-for-release` の OPEN 依存先を「未解決」と誤判定し、依存元 Issue に `blocked` を
+付与して auto-dev を不要に停止させてしまう。同様の base 相対化は path-overlap holder
+集合では #221 で実装済みだが、依存ゲート側には未適用である。本要件は、依存ゲートに
+base 相対化を導入して develop dispatch での誤ブロックを解消しつつ、`BASE_BRANCH=main`
+の従来挙動を一切変えないことを目的とする。
+
+## Requirements
+
+### Requirement 1: 依存ゲートの base 相対化（staged-for-release 依存の解決判定）
+
+**Objective:** As an auto-dev 運用者, I want 依存ゲートが develop dispatch で
+`staged-for-release` の OPEN 依存先を解決済みとして扱うこと, so that develop 統合済み
+依存に阻まれて後続 Issue の自動実装が不要に停止しないようにする
+
+#### Acceptance Criteria
+
+1. When `BASE_BRANCH` が `main` 以外の値で依存ゲートが起動し依存先 Issue が `OPEN` かつ `staged-for-release` ラベルを持つ場合, the Dependency Gate shall 当該依存を解決済み (`resolved`) として分類する
+2. When `BASE_BRANCH` が `main` で依存ゲートが起動し依存先 Issue が `OPEN` かつ `staged-for-release` ラベルを持つ場合, the Dependency Gate shall 当該依存を未解決として分類し従来挙動を維持する
+3. When 依存先 Issue が `OPEN` で `staged-for-release` ラベルを持たない場合, the Dependency Gate shall `BASE_BRANCH` の値にかかわらず当該依存を未解決として分類する
+4. When 依存先 Issue が `CLOSED` で関連 PR に `MERGED` 状態のものが存在する場合, the Dependency Gate shall 当該依存を解決済み (`resolved`) として分類し従来挙動を維持する
+5. When 依存先 Issue が `CLOSED` で関連 PR に `MERGED` 状態のものが存在しない場合, the Dependency Gate shall 当該依存を `closed unmerged` として分類し従来挙動を維持する
+
+### Requirement 2: 解決判定のラベル取得と失敗時フォールバック
+
+**Objective:** As an auto-dev 運用者, I want 依存ゲートが依存先 Issue のラベルを取得できない場合でも安全側に倒れること, so that 不確実な状態で誤って依存をスキップしてブロックすべき Issue を実装に進めないようにする
+
+#### Acceptance Criteria
+
+1. The Dependency Gate shall 依存先 Issue の state とラベル一覧を同一の問い合わせで取得する
+2. If 依存先 Issue の state またはラベル一覧の取得・解析に失敗した場合, the Dependency Gate shall 当該依存を従来同様の安全側 (`api error` = 未解決) として分類する
+3. If 依存先 Issue のラベル一覧の取得・解析に失敗した場合, the Dependency Gate shall `BASE_BRANCH` の値にかかわらず `staged-for-release` ラベル付与を仮定して解決済みとして扱う処理を行わない
+
+### Requirement 3: テスト網羅性（回帰防止）
+
+**Objective:** As an auto-dev 運用者, I want 依存ゲートの主要シナリオが回帰テストで網羅されること, so that 将来の watcher 改修で同種の誤判定が再発しないようにする
+
+#### Acceptance Criteria
+
+1. The Dependency Gate Test Suite shall develop dispatch (`BASE_BRANCH != main`) かつ依存先 OPEN かつ `staged-for-release` 付与のシナリオで解決済み判定となることを検証するケースを含む
+2. The Dependency Gate Test Suite shall develop dispatch かつ依存先 OPEN かつ `staged-for-release` 未付与のシナリオで未解決判定となることを検証するケースを含む
+3. The Dependency Gate Test Suite shall main dispatch (`BASE_BRANCH == main`) かつ依存先 OPEN かつ `staged-for-release` 付与のシナリオで未解決判定となることを検証するケースを含む
+4. The Dependency Gate Test Suite shall 依存先 CLOSED + merged PR ありのシナリオで解決済み判定となる従来挙動の回帰テストを含む
+5. The Dependency Gate Test Suite shall 依存先 CLOSED + merged PR なしのシナリオで `closed unmerged` 判定となる従来挙動の回帰テストを含む
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While `BASE_BRANCH` の値が `main` の状態で動作している場合, the Dependency Gate shall 本変更導入前と完全に同一の解決判定結果を返す
+2. The Dependency Gate shall 既存環境変数 (`BASE_BRANCH`, `DRR_GH_TIMEOUT`) のみで本機能を制御し新規 env var を導入しない
+3. The Dependency Gate shall #221 で実装済みの path-overlap holder 側の base 相対化判定を変更しない
+
+### NFR 2: 外部 API 呼び出し効率
+
+1. The Dependency Gate shall 1 依存先 Issue あたりの GitHub API 問い合わせ回数を本変更導入前と同数（state 取得 + 関連 PR 取得の従来回数）に保つ
+
+### NFR 3: 観測可能性
+
+1. While 依存先 Issue を `staged-for-release` により解決済みとして分類した場合, the Dependency Gate shall 解決理由が `staged-for-release` であることを運用者が watcher ログから判別できる形で出力する
+
+## Out of Scope
+
+- path-overlap holder 側（#221）の base 相対化ロジックの再変更
+- dispatch 候補フィルタ（`issue-watcher.sh:9822` 付近）の挙動変更
+- `staged-for-release` ラベルを Issue / PR に自動付与する側の挙動変更
+- 依存記法（`Depends on:` / `Blocked by:` 等）の本文抽出ロジック（`dr_extract_deps`）の変更
+- `BASE_BRANCH` の値判定そのものの仕様変更（develop 以外の任意 branch 名でも `main` 以外なら multi-branch 扱いとなる従来規約を踏襲）
+
+## Open Questions
+
+- なし（Issue 本文と #221 の base 相対化規約から判定方針は確定。残課題は design 段階での GraphQL クエリ変更点と log 出力フォーマットの詳細）
+
+## 関連
+
+- Depends on: #221
+- Related: #146

--- a/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/review-notes.md
+++ b/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/review-notes.md
@@ -1,0 +1,80 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-10T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-316-impl-fix-watcher-dr-resolve-one-develop-dispa
+- HEAD commit: 53f433c3b7d3513feb6c9b9cd088a4bf7db74599
+- Compared to: main..HEAD
+
+差分構成:
+- `local-watcher/bin/issue-watcher.sh` — `dr_gh_graphql_closed_by` の GraphQL クエリに
+  `labels(first: 20) { nodes { name } }` を追加。`dr_resolve_one` の OPEN 分岐に
+  base 相対化（`BASE_BRANCH=main` は従来パスを early-out、`!= main` で
+  `staged-for-release` ラベル時のみ `resolved`）と log 出力を追加
+- `docs/specs/316-.../test-dependency-resolver-base.sh` — 新規 21 ケースの shell-level 回帰テスト
+- `docs/specs/316-.../requirements.md`, `impl-notes.md` — spec 成果物
+
+注:
+- `design.md` / `tasks.md` は存在せず、本 Issue は design-less impl（bug fix）として
+  扱われる。tasks.md の `_Boundary:_` 制約は適用対象外
+- CLAUDE.md に `## Feature Flag Protocol` 節は存在せず、opt-out 既定として通常 3 カテゴリ判定のみを実施
+
+## Verified Requirements
+
+- 1.1 — `BASE_BRANCH != main` + OPEN + `staged-for-release` → `resolved`：
+  `dr_resolve_one` の OPEN 分岐に jq `--arg target` で `staged-for-release` を集計し
+  `true` → `resolved` を返す実装あり。テスト `Req1.1 develop+OPEN+staged-for-release`
+  と `Req1.1 任意 base != main + 他ラベル混在` で検証
+- 1.2 — `BASE_BRANCH = main` + OPEN + `staged-for-release` → 未解決（open）：
+  `if [ "${BASE_BRANCH:-main}" = "main" ]; then echo "open"; return 0; fi` で早期 return。
+  テスト `Req1.2 main+OPEN+staged-for-release は open`
+- 1.3 — OPEN で `staged-for-release` なし → 任意 base で未解決：
+  jq 集計結果 `false` → `echo "open"`。テスト 3 ケース（develop ラベルなし / develop 他ラベルのみ / main ラベルなし）
+- 1.4 — CLOSED + MERGED PR → 従来通り `resolved`：既存 CLOSED 分岐温存。
+  テスト 3 ケース（develop / main / main+SfR ラベル混在）
+- 1.5 — CLOSED + MERGED なし → 従来通り `closed unmerged`：既存ロジック温存。
+  テスト 2 ケース（develop CLOSED PR / main 0 件）
+- 2.1 — state とラベル一覧を同一問い合わせで取得：`labels(first: 20) { nodes { name } }` を
+  既存 GraphQL クエリに同梱。テスト `Req2.1 単一 response に state + labels + PR 一覧が同梱`
+  で構造を直接検証
+- 2.2 — state/labels の取得・解析失敗時 → `api error`（安全側）：
+  `dr_resolve_one` 既存 state 取得失敗パス温存 + 新規 labels jq 失敗時に
+  `dr_warn`+`echo "api error"`。テスト 3 ケース（gh 失敗 / GraphQL errors / 壊れた JSON）
+- 2.3 — labels 取得失敗時に staged-for-release 付与を仮定しない：
+  jq parse 失敗時は `api error` を返し `resolved` には倒さない。
+  labels ノード欠落時も `jq ... .nodes[]?` で空配列扱い → length=0 → false → `open` に
+  倒れることをテスト `Req2.3 OPEN + labels ノード欠落は staged を仮定せず open` で検証
+- 3.1 — develop dispatch + OPEN + SfR → resolved の回帰テスト：Req 1.1 のケースで担保
+- 3.2 — develop dispatch + OPEN + SfR なし → unresolved の回帰テスト：Req 1.3 のケースで担保
+- 3.3 — main dispatch + OPEN + SfR → unresolved の回帰テスト：Req 1.2 のケースで担保
+- 3.4 — CLOSED + merged PR → resolved の回帰テスト：Req 1.4 のケースで担保
+- 3.5 — CLOSED + merged PR なし → closed unmerged の回帰テスト：Req 1.5 のケースで担保
+- NFR 1.1 — `BASE_BRANCH=main` の挙動が本変更前と完全同一：`main` 早期 return + CLOSED
+  分岐温存。テスト 5 ケース（NFR1.1 main+OPEN+SfR / main+OPEN+ラベルなし / main+CLOSED+MERGED /
+  main+CLOSED+混在 / main+CLOSED+CLOSED PR）
+- NFR 1.2 — 既存 env のみで制御し新規 env を導入しない：diff 上 `BASE_BRANCH` /
+  `DRR_GH_TIMEOUT` / `LABEL_STAGED_FOR_RELEASE` のみ参照、新規 env var の追加なし
+- NFR 1.3 — path-overlap holder 側 (#221) の base 相対化を変更しない：
+  `git diff --stat` 上 `local-watcher/bin/modules/promote-pipeline.sh` の変更なし
+- NFR 2.1 — API 呼び出し回数を変更前と同数に保つ：既存 `dr_gh_graphql_closed_by` の
+  1 回の `gh api graphql` 呼び出しに `labels(first: 20)` を追加フィールドで載せただけで、
+  呼び出し回数は不変
+- NFR 3.1 — staged-for-release で解決した場合の理由 log 出力：
+  `dr_log "issue=#${dep_num} verdict=resolved reason=staged-for-release base=${BASE_BRANCH:-main}"`
+  を resolved 経路に追加
+
+## Findings
+
+なし
+
+## Summary
+
+新規 21 ケースのテストはすべて pass（reviewer も `bash test-dependency-resolver-base.sh` を
+再実行して確認）。Req 1.1〜1.5 / 2.1〜2.3 / 3.1〜3.5 / NFR 1.1〜1.3 / 2.1 / 3.1 すべてが
+実装またはテストにより観測可能で、`BASE_BRANCH=main` 経路の従来挙動が明示的な early-out で
+温存されているため後方互換性も担保されている。design-less impl のため `_Boundary:_` 制約は
+適用対象外、CLAUDE.md の Feature Flag Protocol も opt-out のため flag 観点の検査は対象外。
+
+RESULT: approve

--- a/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh
+++ b/docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# 用途: Dependency Gate (#146 / #204) の base 相対化（#316）回帰テスト。
+#       BASE_BRANCH != main の develop dispatch で `staged-for-release` を持つ OPEN
+#       依存先を resolved 扱いし、BASE_BRANCH=main 時の従来挙動を変更しないことを
+#       検証する。並行して CLOSED 系の従来挙動（merged → resolved / unmerged →
+#       closed unmerged）にも回帰テストを再配置する（Req 3.4, 3.5）。
+# 配置先: docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh
+# 依存: bash 4+, jq, sed, awk
+# セットアップ参照先: docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/impl-notes.md
+#
+# Usage:
+#   bash docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh
+#
+# Exit code:
+#   0 = すべてのケースが期待通り
+#   1 = いずれかのケースが不一致（standard error にどれが失敗したか出力）
+#
+# 設計:
+#   - #204 の test-dependency-resolver.sh と同パターンで `dr_gh_graphql_closed_by`
+#     を stub に差し替え、GraphQL レスポンスを mock 注入する（実 API 不要 / 高速）。
+#   - watcher 本体は末尾に main 実行コードを持つため source できない。よって
+#     `dr_log` 〜 `dr_check_dependencies` を awk で抽出して source する（既存
+#     パターン踏襲）。
+#   - dr_log / dr_warn / dr_error はテスト中に副作用ログを抑止する（出力検証は
+#     本テストのスコープ外）。
+#   - BASE_BRANCH 環境変数で base 相対化の挙動を切り替えながら検証する。
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+WATCHER="$SCRIPT_DIR/../../../local-watcher/bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER" ]; then
+  echo "[FATAL] watcher script not found: $WATCHER" >&2
+  exit 1
+fi
+
+# ── dr_* 関数ブロックを抽出して source ──
+EXTRACTED=$(mktemp)
+trap 'rm -f "$EXTRACTED"' EXIT
+
+awk '
+  /^dr_log\(\) \{/ { capture = 1 }
+  capture { print }
+  capture && /^dr_check_dependencies\(\) \{/ { in_check = 1 }
+  in_check && /^\}$/ { capture = 0; in_check = 0 }
+' "$WATCHER" > "$EXTRACTED"
+
+if ! grep -q '^dr_resolve_one() {' "$EXTRACTED"; then
+  echo "[FATAL] dr_resolve_one を抽出できませんでした（watcher のリファクタで marker がずれた可能性）" >&2
+  exit 1
+fi
+
+# テスト用環境（REPO は owner/repo 形式、タイムアウト類は短く設定）。
+# shellcheck disable=SC2034
+REPO="owner/repo"
+# shellcheck disable=SC2034
+DRR_GH_TIMEOUT=60
+# shellcheck disable=SC2034
+MERGE_QUEUE_GIT_TIMEOUT=60
+# shellcheck disable=SC2034
+LABEL_STAGED_FOR_RELEASE="staged-for-release"
+
+# shellcheck disable=SC1090
+source "$EXTRACTED"
+
+# 抽出ブロック内の dr_log / dr_warn / dr_error を上書きしてテスト中の副作用ログを捨てる。
+dr_log() { :; }
+dr_warn() { :; }
+dr_error() { :; }
+
+# ── mock 注入の仕組み ──
+MOCK_RESPONSE=""
+MOCK_RC=0
+dr_gh_graphql_closed_by() {
+  printf '%s' "$MOCK_RESPONSE"
+  return "$MOCK_RC"
+}
+
+fail_count=0
+pass_count=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "[OK]   $label -> '$actual'"
+    pass_count=$((pass_count + 1))
+  else
+    echo "[FAIL] $label: expected '$expected', got '$actual'" >&2
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+# GraphQL レスポンス生成ヘルパ。
+# $1 = issue state (OPEN|CLOSED)
+# $2 = labels CSV（カンマ区切り、空文字列なら labels なし）
+# 残り = PR ノードの state 列（MERGED|CLOSED|OPEN）
+make_response() {
+  local state="$1"; shift
+  local labels_csv="$1"; shift
+  local labels_json="[]"
+  if [ -n "$labels_csv" ]; then
+    labels_json=$(printf '%s' "$labels_csv" \
+      | tr ',' '\n' \
+      | jq -R 'select(length > 0) | {name: .}' \
+      | jq -s '.')
+  fi
+  local nodes_json="[]"
+  if [ "$#" -gt 0 ]; then
+    nodes_json=$(printf '%s\n' "$@" \
+      | jq -R '{number: 0, state: .}' \
+      | jq -s '.')
+  fi
+  jq -n \
+    --arg state "$state" \
+    --argjson labels "$labels_json" \
+    --argjson nodes "$nodes_json" '
+    {data: {repository: {issue: {
+      state: $state,
+      labels: {nodes: $labels},
+      closedByPullRequestsReferences: {nodes: $nodes}
+    }}}}'
+}
+
+echo "=== #316 Req 1.1: develop dispatch + OPEN + staged-for-release → resolved ==="
+
+# BASE_BRANCH は source した dr_resolve_one が参照する。shellcheck が sourced スコープを
+# 追跡できないため `export` で外部参照を明示し SC2034 を回避する（実 watcher 経路と同等）。
+export BASE_BRANCH="develop"
+MOCK_RC=0
+MOCK_RESPONSE=$(make_response OPEN "staged-for-release")
+assert_eq "Req1.1 develop+OPEN+staged-for-release" "resolved" "$(dr_resolve_one 301)"
+
+# 補強: develop 以外の任意 branch 名でも main 以外なら multi-branch 扱い（Out of Scope 末尾）
+export BASE_BRANCH="feature/foo"
+MOCK_RESPONSE=$(make_response OPEN "staged-for-release,other-label")
+assert_eq "Req1.1 任意 base != main + 他ラベル混在" "resolved" "$(dr_resolve_one 302)"
+
+echo "=== #316 Req 1.2: main dispatch + OPEN + staged-for-release → unresolved (open) ==="
+
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response OPEN "staged-for-release")
+assert_eq "Req1.2 main+OPEN+staged-for-release は open" "open" "$(dr_resolve_one 303)"
+
+echo "=== #316 Req 1.3: OPEN without staged-for-release → unresolved (open) どの BASE_BRANCH でも ==="
+
+export BASE_BRANCH="develop"
+MOCK_RESPONSE=$(make_response OPEN "")
+assert_eq "Req1.3 develop+OPEN+ラベルなし" "open" "$(dr_resolve_one 304)"
+
+export BASE_BRANCH="develop"
+MOCK_RESPONSE=$(make_response OPEN "other-label")
+assert_eq "Req1.3 develop+OPEN+他ラベルのみ" "open" "$(dr_resolve_one 305)"
+
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response OPEN "")
+assert_eq "Req1.3 main+OPEN+ラベルなし" "open" "$(dr_resolve_one 306)"
+
+echo "=== #316 Req 1.4 / 1.5: CLOSED 系の従来挙動（base 値によらず）==="
+
+export BASE_BRANCH="develop"
+MOCK_RESPONSE=$(make_response CLOSED "staged-for-release" MERGED)
+assert_eq "Req1.4 develop+CLOSED+MERGED PR" "resolved" "$(dr_resolve_one 307)"
+
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response CLOSED "" MERGED)
+assert_eq "Req1.4 main+CLOSED+MERGED PR" "resolved" "$(dr_resolve_one 308)"
+
+export BASE_BRANCH="develop"
+MOCK_RESPONSE=$(make_response CLOSED "" CLOSED)
+assert_eq "Req1.5 develop+CLOSED+CLOSED PR" "closed unmerged" "$(dr_resolve_one 309)"
+
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response CLOSED "")
+assert_eq "Req1.5 main+CLOSED+PR 0 件" "closed unmerged" "$(dr_resolve_one 310)"
+
+# CLOSED+staged-for-release ラベル付き + MERGED PR は resolved（ラベルは無視されるべき）
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response CLOSED "staged-for-release" MERGED)
+assert_eq "Req1.4 main+CLOSED+SfR+MERGED は resolved（ラベル無視）" "resolved" "$(dr_resolve_one 311)"
+
+echo "=== #316 Req 2.1: state + labels を同一クエリで取得（GraphQL 構造の確認）==="
+
+# response の data.repository.issue 配下に state / labels / closedByPullRequestsReferences が
+# 揃っているかを構造として確認（make_response が生成する JSON を直接検証）。
+MOCK_RESPONSE=$(make_response OPEN "staged-for-release")
+struct_ok=$(printf '%s' "$MOCK_RESPONSE" \
+  | jq -r '(.data.repository.issue | has("state")) and (.data.repository.issue | has("labels")) and (.data.repository.issue | has("closedByPullRequestsReferences"))')
+assert_eq "Req2.1 単一 response に state + labels + PR 一覧が同梱" "true" "$struct_ok"
+
+echo "=== #316 Req 2.2 / 2.3: 失敗時フォールバック（安全側に倒す）==="
+
+# 2.2: gh api graphql 失敗 → api error（labels も取れないため安全側）
+export BASE_BRANCH="develop"
+MOCK_RC=1
+MOCK_RESPONSE="gh: rate limit exceeded"
+assert_eq "Req2.2 gh 失敗時は base 値によらず api error" "api error" "$(dr_resolve_one 312)"
+MOCK_RC=0
+
+# 2.2: GraphQL errors → api error
+export BASE_BRANCH="develop"
+MOCK_RESPONSE='{"errors":[{"message":"Could not resolve to a node","type":"NOT_FOUND"}]}'
+assert_eq "Req2.2 GraphQL errors は api error" "api error" "$(dr_resolve_one 313)"
+
+# 2.3: OPEN + labels ノードが欠落（想定外構造） → 「ラベルなし」と等価で扱われる
+# （jq の `?` で欠落をスキップし length=0 → false → open）。
+# これは「ラベル取得失敗 → 仮定して resolved にしない」(Req 2.3) と整合する:
+# labels ノードが欠落していても staged-for-release 付与を仮定して resolved にする
+# 処理は行わず unresolved (open) のままとなる。
+export BASE_BRANCH="develop"
+MOCK_RESPONSE='{"data":{"repository":{"issue":{"state":"OPEN","closedByPullRequestsReferences":{"nodes":[]}}}}}'
+assert_eq "Req2.3 OPEN + labels ノード欠落は staged を仮定せず open" "open" "$(dr_resolve_one 314)"
+
+# 2.2: 壊れた JSON → api error（state 取り出しで死ぬ）
+export BASE_BRANCH="develop"
+MOCK_RESPONSE='not a json at all {{{'
+assert_eq "Req2.2 壊れた JSON" "api error" "$(dr_resolve_one 315)"
+
+echo "=== #316 NFR 1.1: BASE_BRANCH=main 時の挙動が本変更前と完全一致 ==="
+
+# main + OPEN+SfR → open（base 相対化ロジックがバイパスされること）
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response OPEN "staged-for-release,other")
+assert_eq "NFR1.1 main+OPEN+SfR は open（従来同一）" "open" "$(dr_resolve_one 316)"
+
+# main + OPEN+ラベルなし → open
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response OPEN "")
+assert_eq "NFR1.1 main+OPEN+ラベルなしは open" "open" "$(dr_resolve_one 317)"
+
+# main + CLOSED+MERGED → resolved
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response CLOSED "" MERGED)
+assert_eq "NFR1.1 main+CLOSED+MERGED は resolved" "resolved" "$(dr_resolve_one 318)"
+
+# main + CLOSED+(CLOSED,MERGED) 混在 → resolved
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response CLOSED "" CLOSED MERGED)
+assert_eq "NFR1.1 main+CLOSED+混在 は resolved" "resolved" "$(dr_resolve_one 319)"
+
+# main + CLOSED+全て CLOSED → closed unmerged
+export BASE_BRANCH="main"
+MOCK_RESPONSE=$(make_response CLOSED "" CLOSED)
+assert_eq "NFR1.1 main+CLOSED+CLOSED PR は closed unmerged" "closed unmerged" "$(dr_resolve_one 320)"
+
+echo ""
+if [ "$fail_count" -gt 0 ]; then
+  echo "$fail_count case(s) failed, $pass_count passed." >&2
+  exit 1
+fi
+echo "All $pass_count cases passed."

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -8878,11 +8878,22 @@ dr_gh_graphql_closed_by() {
   # 返らないため誤判定していた / 本 bug の根因）。
   # `includeClosedPrs: true` で CLOSED/MERGED の PR も含めて返させる。
   # `first: 20` は check_existing_impl_pr と同じく十分なマージン。
+  #
+  # #316: 依存ゲートの base 相対化（staged-for-release 解決判定）のため、同一
+  # クエリで Issue の labels も取得する。`labels(first: 20)` は Issue 1 件に付く
+  # ラベル数として十分なマージン（実運用では 10 件未満が大半）。state + labels を
+  # 1 回の問い合わせで取得することで API 呼び出し回数を本変更前と同数に保つ
+  # （NFR 2.1）。
   # shellcheck disable=SC2016  # `$owner` / `$repo` / `$number` は GraphQL 変数記法であり bash 展開ではない（`-F` で値を渡す）
   local query='query($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {
       issue(number: $number) {
         state
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
         closedByPullRequestsReferences(first: 20, includeClosedPrs: true) {
           nodes {
             number
@@ -8906,21 +8917,37 @@ dr_gh_graphql_closed_by() {
 # return = 常に 0（判定結果は stdout で返す）。
 # 副作用 = API エラー / jq parse 失敗時のみ dr_warn でログ（Req 6.2）。
 #
-# `dr_gh_graphql_closed_by` で Issue の state と
+# `dr_gh_graphql_closed_by` で Issue の state / labels /
 # `closedByPullRequestsReferences.nodes[].state` を取得し、以下を判定:
-#   - issue.state == "OPEN"  → "open"（unresolved / Req 1.4 / 旧 2.3）
+#   - issue.state == "OPEN" かつ BASE_BRANCH != main かつ labels に
+#     `staged-for-release` を含む → "resolved"（#316 / Req 1.1 / NFR 3.1）
+#   - issue.state == "OPEN"（上記以外）→ "open"（unresolved / Req 1.4 / 旧 2.3 /
+#     #316 Req 1.2, 1.3 で BASE_BRANCH=main の従来挙動を維持）
 #   - issue.state == "CLOSED" かつ PR ノードの state に "MERGED" が 1 件以上
-#     → "resolved"（Req 1.1）
+#     → "resolved"（Req 1.1 / #316 Req 1.4 で従来挙動を維持）
 #   - issue.state == "CLOSED" かつ "MERGED" が 0 件（空配列・全 CLOSED 含む）
-#     → "closed unmerged"（Req 1.2, 1.3）
+#     → "closed unmerged"（Req 1.2, 1.3 / #316 Req 1.5 で従来挙動を維持）
 #   - gh / jq 失敗 / GraphQL errors / 未知の state → "api error"
-#     （Req 2.1, 2.2 / NFR 4.2 安全側）
+#     （Req 2.1, 2.2 / NFR 4.2 安全側 / #316 Req 2.2, 2.3）
 #
 # 旧実装は `gh issue view --json closedByPullRequestsReferences` の PR ノードに
 # 存在しない `.merged` フィールドを参照していたため、merge 済み依存も常に
 # `closed unmerged` と誤判定していた（#204 の根因 / Req 1.5）。
 #
-# timeout は DRR_GH_TIMEOUT に従う（個別の新規 env var は導入しない / Req 3.5）。
+# #316: BASE_BRANCH != main（gitflow 等の multi-branch 運用 / develop dispatch）
+# の場合、依存先が OPEN かつ `staged-for-release` ラベルを持つ状態は「develop
+# には統合済みで main 到達待ち」を意味するため、当該依存を resolved として
+# 扱う（base 相対化）。BASE_BRANCH=main の従来挙動は変更しない。labels 取得・
+# parse に失敗した場合は安全側に倒し `staged-for-release` 付与を仮定しない
+# （`api error` = 未解決 / #316 Req 2.3）。base 相対化の閾値は #221
+# （promote-pipeline.sh `po_resolve_holder_labels`）の dispatch×multi-branch
+# 判定（BASE_BRANCH != PROMOTION_TARGET_BRANCH）と整合させる発想だが、本関数の
+# 文脈は dispatch 確定後の Triage 段階であり依存ゲートに promote コンテキストは
+# 存在しないため、判定基準は単純な `BASE_BRANCH != main` で十分（Issue 本文の
+# 仕様および requirements.md Req 1.1）。
+#
+# timeout は DRR_GH_TIMEOUT に従う（個別の新規 env var は導入しない / Req 3.5 /
+# #316 NFR 1.2）。
 dr_resolve_one() {
   local dep_num="$1"
 
@@ -8967,8 +8994,44 @@ dr_resolve_one() {
 
   case "$state" in
     OPEN)
-      echo "open"
-      return 0
+      # #316: base 相対化（staged-for-release 依存の解決判定）。
+      # BASE_BRANCH=main の場合は従来挙動を維持し、ラベルを参照せず unresolved
+      # （Req 1.2 / NFR 1.1 後方互換）。BASE_BRANCH != main の場合のみ labels を
+      # 読み出し、`staged-for-release` 付与時に resolved として返す（Req 1.1）。
+      if [ "${BASE_BRANCH:-main}" = "main" ]; then
+        echo "open"
+        return 0
+      fi
+      # labels 一覧を取り出して `staged-for-release` の有無を判定。jq parse 失敗時は
+      # 安全側に倒し api error（ラベル付与を仮定して resolved として扱う処理は行わ
+      # ない / Req 2.3）。
+      local has_staged_label
+      if ! has_staged_label=$(printf '%s' "$response" \
+            | jq -r --arg target "${LABEL_STAGED_FOR_RELEASE:-staged-for-release}" \
+                '[.data.repository.issue.labels.nodes[]? | select(.name == $target)] | length > 0' \
+            2>/dev/null); then
+        dr_warn "issue=#${dep_num} jq parse 失敗（labels 取り出し）"
+        echo "api error"
+        return 0
+      fi
+      # 想定外応答（labels ノードが取れない等）で true/false 以外が返った場合も
+      # 安全側で api error（Req 2.2, 2.3）。
+      case "$has_staged_label" in
+        true)
+          dr_log "issue=#${dep_num} verdict=resolved reason=staged-for-release base=${BASE_BRANCH:-main}"
+          echo "resolved"
+          return 0
+          ;;
+        false)
+          echo "open"
+          return 0
+          ;;
+        *)
+          dr_warn "issue=#${dep_num} labels 集計結果が想定外: ${has_staged_label}"
+          echo "api error"
+          return 0
+          ;;
+      esac
       ;;
     CLOSED)
       # closedByPullRequestsReferences.nodes[].state に "MERGED" が 1 件以上あれば


### PR DESCRIPTION
## 概要

gitflow など `BASE_BRANCH=develop` を用いる multi-branch 運用では、依存先 Issue が develop に統合済みで main 到達待ちの状態（`staged-for-release` ラベル付与 + OPEN 維持）に留まる期間がある。現状の依存ゲート `dr_resolve_one` は依存先 Issue の close 状態のみで解決判定を行うため、`staged-for-release` の OPEN 依存先を「未解決」と誤判定し、後続 Issue に `blocked` を付与して auto-dev を不要に停止させていた。

本 PR は `dr_resolve_one` に base 相対化ロジックを導入し、`BASE_BRANCH != main` の multi-branch 運用での誤ブロックを解消する。`BASE_BRANCH=main` の従来挙動は完全に維持する（NFR 1.1）。同様の base 相対化は path-overlap holder 集合（#221）では実装済みであり、本 PR はその依存ゲート側への適用に相当する。

## 対応 Issue

Closes #316

## 関連 PR

- 設計 PR: なし（design-less impl の bug fix）

## 実装内容

- (Req 1.1 / Req 1.2) `dr_resolve_one` の OPEN 分岐に base 相対化ロジックを追加: `BASE_BRANCH=main` は既存の early-out を保持し、`BASE_BRANCH != main` では `staged-for-release` ラベル付与時のみ `resolved` を返す
- (Req 2.1) `dr_gh_graphql_closed_by` の GraphQL クエリに `labels(first: 20) { nodes { name } }` を追加し、state / labels / 関連 PR を同一クエリで取得（API 呼び出し回数は変更前と同数 / NFR 2.1）
- (Req 2.2 / 2.3) labels の jq parse 失敗時は `api error`（安全側）を返し、`staged-for-release` 付与を仮定して resolved にする処理を行わない
- (NFR 3.1) `staged-for-release` による解決時に `verdict=resolved reason=staged-for-release base=<BASE_BRANCH>` を `dr_log` に出力
- (Req 3) shell-level 回帰テスト 21 ケースを追加（`docs/specs/316-.../test-dependency-resolver-base.sh`）

## 受入基準チェック

- [x] Req 1.1: `BASE_BRANCH != main` + OPEN + `staged-for-release` → `resolved` ← `Req1.1 develop+OPEN+staged-for-release`
- [x] Req 1.2: `BASE_BRANCH = main` + OPEN + `staged-for-release` → `open`（従来挙動維持） ← `Req1.2 main+OPEN+staged-for-release は open`
- [x] Req 1.3: OPEN + `staged-for-release` なし → base 不問で未解決 ← `Req1.3 develop+OPEN+ラベルなし` ほか 3 ケース
- [x] Req 1.4: CLOSED + MERGED PR → `resolved`（従来挙動） ← `Req1.4 develop+CLOSED+MERGED PR` ほか
- [x] Req 1.5: CLOSED + MERGED PR なし → `closed unmerged`（従来挙動） ← `Req1.5 develop+CLOSED+CLOSED PR` ほか
- [x] Req 2.1: state + labels を同一クエリで取得 ← `Req2.1 単一 response に state + labels + PR 一覧が同梱`
- [x] Req 2.2: 取得・解析失敗 → `api error`（安全側） ← `Req2.2 gh 失敗時は api error` ほか 3 ケース
- [x] Req 2.3: labels 取得失敗時に `staged-for-release` 付与を仮定しない ← `Req2.3 OPEN + labels ノード欠落は staged を仮定せず open`
- [x] NFR 1.1: `BASE_BRANCH=main` の従来挙動が完全維持 ← NFR1.1 main 系 5 ケース
- [x] NFR 3.1: 解決理由を log に出力 ← `dr_log "... verdict=resolved reason=staged-for-release ..."` 追加

## テスト結果

```
# 新規テスト（21 cases）
bash docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/test-dependency-resolver-base.sh
21/21 pass

# 既存 #204 回帰テスト
bash docs/specs/204-bug-watcher-dependency-resolver-146-merg/test-dependency-resolver.sh
21/21 pass（回帰なし）

# shellcheck
shellcheck local-watcher/bin/issue-watcher.sh \
           local-watcher/bin/modules/*.sh \
           install.sh setup.sh .github/scripts/*.sh \
           docs/specs/316-.../test-dependency-resolver-base.sh
警告ゼロ
```

## 実装上の判断

`impl-notes.md` に詳細を記載。主な判断点:

- base 相対化の判定基準として `BASE_BRANCH != main` を採用（#221 の `po_resolve_holder_labels` が `BASE_BRANCH != PROMOTION_TARGET_BRANCH` を用いるのに対し、依存ゲートは Triage 段階で promote コンテキストを持たないため）
- `LABEL_STAGED_FOR_RELEASE` 定数を `jq --arg target` 経由で渡す（promote-pipeline.sh の `${LABEL_STAGED_FOR_RELEASE:-staged-for-release}` fallback パターンと統一）
- labels jq parse 失敗時は `open` ではなく `api error` を返し、安全側（blocked 経路）に倒す

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer の判定詳細は `docs/specs/316-fix-watcher-dr-resolve-one-develop-dispa/review-notes.md` を参照（RESULT: approve）
- `BASE_BRANCH=main` 既存環境への影響なし（`dr_resolve_one` OPEN 分岐は早期 return で温存）
- base 検証: --base main 指定 / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #316 のコメントを参照してください。
