### PR TITLE
fix(security): 未信頼 GitHub 入力に対する hardening（#318）

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -62,7 +62,11 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write   # Bedrock / Vertex OIDC 利用時に必要
+  # id-token: write は Bedrock / Vertex の OIDC 認証を使う場合にのみ必要。
+  # 既定の ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN 認証では不要なため、
+  # 最小権限の原則に従い既定では付与しない（プロンプトインジェクション時の
+  # OIDC トークン窃取の踏み台化を防ぐ）。OIDC を使う場合のみ次行を有効化する:
+  # id-token: write
 
 jobs:
   claude-team-dev:
@@ -150,11 +154,18 @@ jobs:
       # ─────────────────────────────────────────────────────────────
       - name: Create working branch from base
         id: branch
+        # step output / Issue 番号は env 経由で shell へ渡す（`${{ }}` を run: スクリプト
+        # 本体へ直接展開しない GitHub 公式 hardening パターン）。slug の sanitize が将来
+        # 緩んでも shell injection に発展しないようにする防御層。
+        env:
+          DETECT_MODE: ${{ steps.detect.outputs.mode }}
+          DETECT_SLUG: ${{ steps.detect.outputs.slug }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          if [ "${{ steps.detect.outputs.mode }}" = "impl-resume" ]; then
-            BRANCH="claude/issue-${{ github.event.issue.number }}-impl-${{ steps.detect.outputs.slug }}"
+          if [ "$DETECT_MODE" = "impl-resume" ]; then
+            BRANCH="claude/issue-${ISSUE_NUMBER}-impl-${DETECT_SLUG}"
           else
-            BRANCH="claude/issue-${{ github.event.issue.number }}-${{ steps.detect.outputs.slug }}"
+            BRANCH="claude/issue-${ISSUE_NUMBER}-${DETECT_SLUG}"
           fi
           # Checkout step が ref=$BASE_BRANCH で fetch しているため、HEAD は既に
           # base branch の先端。ここでは作業ブランチを派生させて push するだけ。

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -9412,7 +9412,15 @@ _slot_run_issue() {
     local TRIAGE_FILE="/tmp/triage-${REPO_SLUG}-${NUMBER}-${TS}.json"
     rm -f "$TRIAGE_FILE"
 
-    local TITLE_SAFE="${TITLE//|/\\|}"
+    # sed 置換文字列で特別扱いされる文字を網羅エスケープする（未信頼の Issue タイトル由来）。
+    # `\`（エスケープ導入）→ `&`（被マッチ展開）→ 区切り `|` の順で処理する
+    # （`\` を先に処理しないと後続で挿入した `\&` / `\|` が二重エスケープされる）。
+    # 末尾が `\` のタイトルで sed 式が malformed 化する事故、および `&` による
+    # `{{TITLE}}` 逐語混入を防ぐ。
+    local TITLE_SAFE="$TITLE"
+    TITLE_SAFE="${TITLE_SAFE//\\/\\\\}"
+    TITLE_SAFE="${TITLE_SAFE//&/\\&}"
+    TITLE_SAFE="${TITLE_SAFE//|/\\|}"
     local TRIAGE_PROMPT
     TRIAGE_PROMPT=$(sed \
       -e "s|{{NUMBER}}|${NUMBER}|g" \

--- a/local-watcher/bin/modules/pr-reviewer.sh
+++ b/local-watcher/bin/modules/pr-reviewer.sh
@@ -577,7 +577,9 @@ pr_detect_iteration_keyword() {
   local pattern="${PR_REVIEWER_ITERATION_PATTERN}"
 
   local count
-  count=$(printf '%s' "$review_text" | grep -E -i -c "$pattern" 2>/dev/null || true)
+  # `--` でパターン以降をオプション解釈から切り離し、`-f...` 等によるフラグ注入を防ぐ
+  # （`PR_REVIEWER_ITERATION_PATTERN` は operator 設定だが安価な hardening）。
+  count=$(printf '%s' "$review_text" | grep -E -i -c -- "$pattern" 2>/dev/null || true)
   count="${count:-0}"
 
   pr_log "PR #${pr_number}: iteration keyword 検出 matches=${count} pattern='${pattern}'" >&2

--- a/local-watcher/bin/modules/promote-pipeline.sh
+++ b/local-watcher/bin/modules/promote-pipeline.sh
@@ -1166,7 +1166,10 @@ pp_resolve_merge_sha() {
     merge_sha=$(timeout "$PROMOTE_GIT_TIMEOUT" \
       gh pr view "$pr_number" --repo "$REPO" \
         --json mergeCommit --jq '.mergeCommit.oid // ""' 2>/dev/null) || continue
-    if [ -n "$merge_sha" ] && [ "$merge_sha" != "null" ]; then
+    # SHA40（git full object name）を厳格検証してから返す。下流の
+    # `git revert "$merge_sha"`（先頭 `-` 引数注入）/ `gh api .../commits/$merge_sha/...`
+    # （`../` path 横断）へ不正値が流れるのを防ぐ。不正値は未解決として次候補へ。
+    if [[ "$merge_sha" =~ ^[0-9a-f]{40}$ ]]; then
       echo "$merge_sha"
       return 0
     fi

--- a/repo-template/.github/scripts/idd-claude-labels.sh
+++ b/repo-template/.github/scripts/idd-claude-labels.sh
@@ -74,6 +74,7 @@ LABELS=(
   "awaiting-slot|c5def5|【Issue 用】 hot file 競合予防で同サイクル dispatch を見送り中（Phase E Path Overlap Checker が付与・除去）"
   "blocked|b60205|【Issue 用】 依存 Issue 未 merge により auto-dev 進行不能"
   "hotfix|d93f0b|hotfix 優先処理対象（Dispatcher が非 hotfix より先に投入）"
+  "needs-security-fix|d73a4a|【PR 用】 Security Review strict モード（#281）で severity 閾値以上の検出により付与される。手動剥がしで override 可"
 )
 
 echo "📌 idd-claude ラベルを作成します"

--- a/repo-template/.github/workflows/issue-to-pr.yml
+++ b/repo-template/.github/workflows/issue-to-pr.yml
@@ -62,7 +62,11 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  id-token: write   # Bedrock / Vertex OIDC 利用時に必要
+  # id-token: write は Bedrock / Vertex の OIDC 認証を使う場合にのみ必要。
+  # 既定の ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN 認証では不要なため、
+  # 最小権限の原則に従い既定では付与しない（プロンプトインジェクション時の
+  # OIDC トークン窃取の踏み台化を防ぐ）。OIDC を使う場合のみ次行を有効化する:
+  # id-token: write
 
 jobs:
   claude-team-dev:
@@ -150,11 +154,18 @@ jobs:
       # ─────────────────────────────────────────────────────────────
       - name: Create working branch from base
         id: branch
+        # step output / Issue 番号は env 経由で shell へ渡す（`${{ }}` を run: スクリプト
+        # 本体へ直接展開しない GitHub 公式 hardening パターン）。slug の sanitize が将来
+        # 緩んでも shell injection に発展しないようにする防御層。
+        env:
+          DETECT_MODE: ${{ steps.detect.outputs.mode }}
+          DETECT_SLUG: ${{ steps.detect.outputs.slug }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          if [ "${{ steps.detect.outputs.mode }}" = "impl-resume" ]; then
-            BRANCH="claude/issue-${{ github.event.issue.number }}-impl-${{ steps.detect.outputs.slug }}"
+          if [ "$DETECT_MODE" = "impl-resume" ]; then
+            BRANCH="claude/issue-${ISSUE_NUMBER}-impl-${DETECT_SLUG}"
           else
-            BRANCH="claude/issue-${{ github.event.issue.number }}-${{ steps.detect.outputs.slug }}"
+            BRANCH="claude/issue-${ISSUE_NUMBER}-${DETECT_SLUG}"
           fi
           # Checkout step が ref=$BASE_BRANCH で fetch しているため、HEAD は既に
           # base branch の先端。ここでは作業ブランチを派生させて push するだけ。


### PR DESCRIPTION
## 概要

Issue #318 のセキュリティ監査結果のうち、**後方互換を保ったまま安全に適用できる hardening** を実装する。リポジトリ全体（watcher 本体 + 全モジュール + installer + GitHub Actions workflow）を 8 並列の読み取り専用エージェントで監査し、本体で検証・トリアージした上で、実在する hardening 対象に限定して対応した。

> 脅威モデル: watcher はメンテナのローカルマシン上で、メンテナが `auto-dev` を付与した Issue にのみ稼働する。LLM プロンプトインジェクション（Issue 本文が bypassPermissions エージェントへ逐語的に渡る点）は idd-claude の動作原理そのものであり、本 PR の対象外（Issue #318 に受容リスクとして文書化）。

## 変更内容

### GitHub Actions hardening（`fix(workflow)`）
- `id-token: write` を既定 permissions から除外（コメントアウト + 再有効化手順を明記）。既定の `ANTHROPIC_API_KEY` / OAuth 認証では不要で、Bedrock / Vertex の OIDC 利用時のみ必要。最小権限化。
- "Create working branch from base" step の step output / Issue 番号を `env:` 経由で shell へ渡す（GitHub 公式 hardening パターン）。slug sanitize が将来緩んでも run: への shell injection に発展しない防御層。
- root / repo-template の両ワークフローに **byte 一致**で適用。

### watcher 入力 hardening（`fix(watcher)`）
- **triage プロンプトの sed 置換エスケープ網羅化**（`issue-watcher.sh` `_slot_run_issue`）。従来 `TITLE_SAFE` は `|` のみエスケープで、**末尾が `\` の Issue タイトルで sed 式が malformed 化し triage プロンプトが破損**する不具合があった。`\` / `&` / `|` を網羅エスケープ。
- `pr_detect_iteration_keyword` の `grep -E -i -c` に `--` を追加（フラグ注入防止）。
- `pp_resolve_merge_sha` の戻り値を `^[0-9a-f]{40}$` で厳格検証（下流の `git revert` 先頭 `-` 引数注入 / `gh api` の `../` path 横断を防ぐ）。

### ラベル drift 解消（`fix(labels)`）
- Security Review モジュールが付与する `needs-security-fix` を repo-template のラベル script に追加（consumer 配布ギャップの解消）。

## Test plan（手動スモークテスト）
- `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/pr-reviewer.sh local-watcher/bin/modules/promote-pipeline.sh repo-template/.github/scripts/idd-claude-labels.sh` → 警告ゼロ
- `actionlint .github/workflows/issue-to-pr.yml repo-template/.github/workflows/issue-to-pr.yml` → エラーゼロ
- `bash -n` 構文チェック（編集 3 ファイル）→ OK
- 既存テスト `local-watcher/test/*_test.sh` → 20/21 PASS。残り 1（`qa_run_claude_stage_test.sh`）は **本 PR 変更前の clean main でも失敗する既存事象**（私が touch していない `qa_run_claude_stage` のテスト。回帰ではない）。
- **TITLE_SAFE 実証**: 末尾 `\` タイトルで旧コードは `sed: unterminated 's' command`（rc=1, プロンプト破損）→ 修正後は `&` / `|` / `\` / 複合すべて rc=0 で正しく逐語展開。
- **merge_sha 検証実証**: 正規 SHA40 のみ ACCEPT、空 / `null` / `-m` / `../...` / 大文字 / 短長 / 非 hex はすべて reject。
- `diff -r .claude/agents repo-template/.claude/agents` / `diff -r .claude/rules repo-template/.claude/rules` → IN SYNC（本 PR は agents/rules 未変更）
- 両ワークフローの security 変更が byte 一致であることを diff で確認（新規 drift なし）

## 確認事項（レビュワー判断ポイント）
1. **`id-token: write` のコメントアウト**: 既定無効化が方針として妥当か（OIDC 利用者は 1 行 uncomment で復帰）。本ワークフローは `IDD_CLAUDE_USE_ACTIONS=true` opt-in かつ既定無効のため影響は限定的。
2. **意図的に対象外としたもの**:
   - stage-a-verify 構造化ブロックの `bash -c` 実行（`stage-a-verify.sh:801`）→ Developer エージェントが既に bypassPermissions で任意コマンドを実行できる既存信頼境界の内側。allowlist 化は正当な verify コマンドを壊すため挙動変更しない。
   - `/tmp` の予測可能な LOCK_FILE / 一時ファイル（symlink TOCTOU）→ `LOCK_FILE` 既定パス変更は稼働中 watcher の二重起動リスクがあるため本 PR では変更せず Issue #318 に記録。
   - GitHub Actions `prompt:` フィールドへの Issue title/body 展開 → action 入力でありシェルではないため LLM プロンプトインジェクション（設計上の受容リスク）。`run:` ブロックの env 間接化のみ本 PR で対応。
3. **workflow 既存 drift**（base-branch 明示プロンプトが repo-template に欠落）は本 PR のスコープ外（別途対応）。本 PR は新たな drift を増やしていない。

Closes #318
