### PR TITLE
refactor(promote-pipeline): sticky comment の URL/ID パース純粋関数を抽出 (#320)

### DIFF
--- a/local-watcher/bin/modules/promote-pipeline.sh
+++ b/local-watcher/bin/modules/promote-pipeline.sh
@@ -48,6 +48,41 @@ po_warn() {
   echo "[$(date '+%F %T')] [$REPO] path-overlap: WARN: $*" >&2
 }
 
+# ─── sticky comment 共通ヘルパー（#320 三重化解消 / 副作用なしの純粋関数） ───
+# po_persist_edit_paths / po_apply_awaiting_slot / po_apply_busy_wait_signal の
+# 3 箇所で同一だった URL/ID パースと marker 検索を共通化する。本ヘルパーは
+# gh / git を呼ばず状態も変更しない（各 call site の取得・PATCH/create・error
+# 分岐の制御フローは不変。差分等価）。
+
+# `gh ... --json comments` の `.url`（末尾 `#issuecomment-<numeric-id>`）から
+# REST API の数値 comment ID を抽出する。`.comments[].id` は GraphQL の base64 id で
+# REST PATCH には使えないため URL 末尾から取り出す。
+#
+# Args: $1 = comment URL（空文字可）
+# Stdout: 数値 comment ID（マッチしない場合は空文字）
+# Return: 0 always
+po_extract_comment_id_from_url() {
+  local url="$1"
+  [ -n "$url" ] || return 0
+  printf '%s' "$url" | sed -nE 's/.*#issuecomment-([0-9]+)$/\1/p'
+}
+
+# `gh issue view --json comments` の JSON から、本文に marker を含む最初のコメントの
+# URL を取り出す。jq 失敗・該当なしはいずれも空文字を返す fail-safe。
+#
+# Args: $1 = comments JSON（`{"comments":[...]}`）, $2 = marker 文字列
+# Stdout: 該当コメントの URL（該当なし / 失敗時は空文字）
+# Return: 0 always
+po_find_sticky_comment_url() {
+  local comments_json="$1"
+  local marker="$2"
+  printf '%s' "$comments_json" | jq -r --arg marker "$marker" '
+    (.comments // [])
+    | map(select(.body | contains($marker)))
+    | .[0].url // ""
+  ' 2>/dev/null || echo ""
+}
+
 # ─── Phase E: Triage Edit-Paths Parser (#18 Req 2.4 / 2.5) ───
 # Triage 結果 JSON から edit_paths 配列を fail-safe に抽出する。
 # - key 不在 / null / 非配列 / 要素に文字列以外混入はすべて空配列にフォールバック
@@ -135,17 +170,9 @@ EOF
   if ! comments_json=$(gh issue view "$issue_number" --repo "$REPO" --json comments 2>/dev/null); then
     return 1
   fi
-  local existing_url
-  existing_url=$(echo "$comments_json" | jq -r '
-    (.comments // [])
-    | map(select(.body | contains("<!-- idd-claude:edit-paths:v1 -->")))
-    | .[0].url // ""
-  ' 2>/dev/null || echo "")
-  local existing_comment_id=""
-  if [ -n "$existing_url" ]; then
-    existing_comment_id=$(printf '%s' "$existing_url" \
-      | sed -nE 's/.*#issuecomment-([0-9]+)$/\1/p')
-  fi
+  local existing_url existing_comment_id
+  existing_url=$(po_find_sticky_comment_url "$comments_json" "<!-- idd-claude:edit-paths:v1 -->")
+  existing_comment_id=$(po_extract_comment_id_from_url "$existing_url")
 
   if [ -n "$existing_comment_id" ]; then
     # 既存 sticky comment を PATCH で上書き（Req 3.3）
@@ -581,17 +608,9 @@ EOF
     gh issue comment "$issue_number" --repo "$REPO" --body "$body" >/dev/null 2>&1 || true
     return 0
   fi
-  local existing_url
-  existing_url=$(echo "$comments_json" | jq -r '
-    (.comments // [])
-    | map(select(.body | contains("<!-- idd-claude:awaiting-slot:v1 -->")))
-    | .[0].url // ""
-  ' 2>/dev/null || echo "")
-  local existing_comment_id=""
-  if [ -n "$existing_url" ]; then
-    existing_comment_id=$(printf '%s' "$existing_url" \
-      | sed -nE 's/.*#issuecomment-([0-9]+)$/\1/p')
-  fi
+  local existing_url existing_comment_id
+  existing_url=$(po_find_sticky_comment_url "$comments_json" "<!-- idd-claude:awaiting-slot:v1 -->")
+  existing_comment_id=$(po_extract_comment_id_from_url "$existing_url")
   if [ -n "$existing_comment_id" ]; then
     gh api -X PATCH "/repos/${REPO}/issues/comments/${existing_comment_id}" \
       -f body="$body" >/dev/null 2>&1 || true
@@ -723,17 +742,9 @@ EOF
     gh issue comment "$issue_number" --repo "$REPO" --body "$body" >/dev/null 2>&1 || true
     return 0
   fi
-  local existing_url
-  existing_url=$(echo "$comments_json" | jq -r '
-    (.comments // [])
-    | map(select(.body | contains("<!-- idd-claude:busy-wait:v1 -->")))
-    | .[0].url // ""
-  ' 2>/dev/null || echo "")
-  local existing_comment_id=""
-  if [ -n "$existing_url" ]; then
-    existing_comment_id=$(printf '%s' "$existing_url" \
-      | sed -nE 's/.*#issuecomment-([0-9]+)$/\1/p')
-  fi
+  local existing_url existing_comment_id
+  existing_url=$(po_find_sticky_comment_url "$comments_json" "<!-- idd-claude:busy-wait:v1 -->")
+  existing_comment_id=$(po_extract_comment_id_from_url "$existing_url")
   if [ -n "$existing_comment_id" ]; then
     gh api -X PATCH "/repos/${REPO}/issues/comments/${existing_comment_id}" \
       -f body="$body" >/dev/null 2>&1 || true

--- a/local-watcher/test/po_apply_awaiting_slot_test.sh
+++ b/local-watcher/test/po_apply_awaiting_slot_test.sh
@@ -43,10 +43,16 @@ extract_function() {
 }
 
 # 対象関数 + 本文整形ヘルパー（po_format_holders_table_md）を実物で読み込む。
+# #320: po_apply_awaiting_slot が呼ぶ sticky comment 共通ヘルパー 2 つも実物で読み込む
+# （extract_function は単一関数を隔離抽出するため、依存ヘルパーは明示的に読み込む必要がある）。
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_apply_awaiting_slot")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_format_holders_table_md")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_find_sticky_comment_url")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_extract_comment_id_from_url")"
 
 if ! declare -F po_apply_awaiting_slot >/dev/null; then
   echo "ERROR: po_apply_awaiting_slot not loaded" >&2
@@ -54,6 +60,14 @@ if ! declare -F po_apply_awaiting_slot >/dev/null; then
 fi
 if ! declare -F po_format_holders_table_md >/dev/null; then
   echo "ERROR: po_format_holders_table_md not loaded" >&2
+  exit 2
+fi
+if ! declare -F po_find_sticky_comment_url >/dev/null; then
+  echo "ERROR: po_find_sticky_comment_url not loaded" >&2
+  exit 2
+fi
+if ! declare -F po_extract_comment_id_from_url >/dev/null; then
+  echo "ERROR: po_extract_comment_id_from_url not loaded" >&2
   exit 2
 fi
 

--- a/local-watcher/test/po_sticky_comment_helpers_test.sh
+++ b/local-watcher/test/po_sticky_comment_helpers_test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/promote-pipeline.sh の #320（sticky comment の
+#       URL/ID パース純粋関数抽出）で新設した 2 ヘルパーを fixture で検証する
+#       スモークテスト。
+#
+#       対象関数:
+#         - po_extract_comment_id_from_url（URL 末尾 #issuecomment-<id> から数値 ID 抽出）
+#         - po_find_sticky_comment_url（comments JSON から marker 一致コメントの URL 抽出）
+#
+#       両者は副作用のない純粋関数（gh / git を呼ばず状態を変更しない）。抽出前に
+#       3 箇所（po_persist_edit_paths / po_apply_awaiting_slot / po_apply_busy_wait_signal）
+#       で同一だったロジックを共通化したため、入出力の差分等価を本テストで固定する。
+#
+# 配置先: local-watcher/test/po_sticky_comment_helpers_test.sh
+# 依存:   bash 4+, awk, jq
+# 実行:   bash local-watcher/test/po_sticky_comment_helpers_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROMOTE_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/promote-pipeline.sh"
+
+if [ ! -f "$PROMOTE_PIPELINE_SH" ]; then
+  echo "ERROR: cannot find promote-pipeline.sh at $PROMOTE_PIPELINE_SH" >&2
+  exit 2
+fi
+
+# 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
+# eval で読み込む。トップレベル副作用は回避する。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_extract_comment_id_from_url")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PROMOTE_PIPELINE_SH" "po_find_sticky_comment_url")"
+
+if ! declare -F po_extract_comment_id_from_url >/dev/null; then
+  echo "ERROR: po_extract_comment_id_from_url not loaded" >&2
+  exit 2
+fi
+if ! declare -F po_find_sticky_comment_url >/dev/null; then
+  echo "ERROR: po_find_sticky_comment_url not loaded" >&2
+  exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+echo "--- po_extract_comment_id_from_url cases ---"
+
+# 正常系: GitHub の issue comment URL 末尾から数値 ID を抽出
+assert_eq "末尾 #issuecomment-<id> から数値 ID を抽出する" \
+  "123456789" \
+  "$(po_extract_comment_id_from_url "https://github.com/owner/repo/issues/42#issuecomment-123456789")"
+
+# 異常系: 空入力 → 空文字（return 0）
+assert_eq "空 URL のとき空文字を返す" \
+  "" \
+  "$(po_extract_comment_id_from_url "")"
+
+# 異常系: marker パターンを含まない URL → 空文字
+assert_eq "#issuecomment- を含まない URL のとき空文字を返す" \
+  "" \
+  "$(po_extract_comment_id_from_url "https://github.com/owner/repo/issues/42")"
+
+# 境界値: 末尾が数値で終わらない（#issuecomment-abc）→ 空文字（数値のみ許容）
+assert_eq "#issuecomment- の後が非数値のとき空文字を返す" \
+  "" \
+  "$(po_extract_comment_id_from_url "https://github.com/owner/repo/issues/42#issuecomment-abc")"
+
+echo "--- po_find_sticky_comment_url cases ---"
+
+MARKER="<!-- idd-claude:awaiting-slot:v1 -->"
+
+# 正常系: marker を含む最初のコメントの URL を返す
+JSON_HIT='{"comments":[{"body":"無関係","url":"https://x/issues/1#issuecomment-1"},{"body":"待機中\n<!-- idd-claude:awaiting-slot:v1 -->","url":"https://x/issues/1#issuecomment-222"}]}'
+assert_eq "marker 一致コメントの URL を返す" \
+  "https://x/issues/1#issuecomment-222" \
+  "$(po_find_sticky_comment_url "$JSON_HIT" "$MARKER")"
+
+# 異常系: marker 不在 → 空文字
+JSON_MISS='{"comments":[{"body":"無関係","url":"https://x/issues/1#issuecomment-1"}]}'
+assert_eq "marker 不在のとき空文字を返す" \
+  "" \
+  "$(po_find_sticky_comment_url "$JSON_MISS" "$MARKER")"
+
+# 境界値: comments が空配列 → 空文字
+assert_eq "comments 空配列のとき空文字を返す" \
+  "" \
+  "$(po_find_sticky_comment_url '{"comments":[]}' "$MARKER")"
+
+# 異常系: comments キー不在 → 空文字（fail-safe）
+assert_eq "comments キー不在のとき空文字を返す" \
+  "" \
+  "$(po_find_sticky_comment_url '{}' "$MARKER")"
+
+# 異常系: 不正 JSON → 空文字（jq 失敗 fail-safe）
+assert_eq "不正 JSON 入力のとき空文字を返す（jq 失敗 fail-safe）" \
+  "" \
+  "$(po_find_sticky_comment_url 'not-json' "$MARKER")"
+
+# 複数 marker 一致時は最初の 1 件のみ
+JSON_MULTI='{"comments":[{"body":"a <!-- idd-claude:awaiting-slot:v1 -->","url":"https://x#issuecomment-10"},{"body":"b <!-- idd-claude:awaiting-slot:v1 -->","url":"https://x#issuecomment-20"}]}'
+assert_eq "複数 marker 一致のとき最初の 1 件の URL を返す" \
+  "https://x#issuecomment-10" \
+  "$(po_find_sticky_comment_url "$JSON_MULTI" "$MARKER")"
+
+echo ""
+echo "================================"
+echo "PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "================================"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## 概要

`local-watcher/bin/modules/promote-pipeline.sh` の sticky comment upsert 3 箇所
（`po_persist_edit_paths` / `po_apply_awaiting_slot` / `po_apply_busy_wait_signal`）で
完全に同一コードだった**副作用のない純粋パース処理**を共通ヘルパーに抽出し、三重化を解消する。

## 変更内容

新設した純粋関数 2 つ（ロガー直後に配置）:

| 関数 | 役割 |
|---|---|
| `po_extract_comment_id_from_url <url>` | `#issuecomment-<id>` URL から数値 comment ID を抽出（不一致は空文字） |
| `po_find_sticky_comment_url <comments_json> <marker>` | comments JSON から marker 一致コメントの URL を抽出（不在 / jq 失敗は空文字 fail-safe） |

3 箇所の inline ブロック（jq + sed）をヘルパー呼び出しに置換。`po_find_sticky_comment_url` の jq は
literal marker を `--arg` 化（等価かつ JSON インジェクション安全側）。

## 意図的にスコープ外（挙動変更リスク回避）

- 3 箇所で異なる **error 意味論**（`po_persist_edit_paths` は失敗時 `return 1`、他 2 つは best-effort `|| true`）と、`gh issue view` 取得・PATCH・create の制御フローには一切触れない。これらを内包する `po_upsert_sticky_comment` 化は error 差異の吸収が必要で挙動変更リスクがあるため見送る。
- 抽出は純粋関数に限定し、各 call site の戻り値・error 分岐は不変（**差分等価**）。

## Test plan
- `bash -n local-watcher/bin/modules/promote-pipeline.sh` → OK
- `shellcheck local-watcher/bin/modules/promote-pipeline.sh local-watcher/test/po_*helpers_test.sh local-watcher/test/po_apply_awaiting_slot_test.sh` → 警告ゼロ
- **新規** `local-watcher/test/po_sticky_comment_helpers_test.sh` → 10/10 PASS（正常 / 空入力 / marker 不在 / 不正 JSON / 複数一致境界）
- **既存** `local-watcher/test/po_apply_awaiting_slot_test.sh` → 19/19 PASS（helper 抽出に追随。「ラベル成功 + 既存 marker 有りなら PATCH 1 回」が実 jq でヘルパーを通過して通る = 差分等価の確認）
- 全テストスイート（`local-watcher/test/*_test.sh`）: 21 PASS / 1 FAIL。残り 1（`qa_run_claude_stage_test.sh`）は **本 PR 変更前の clean main でも失敗する既存事象**（本 PR は `issue-watcher.sh` を触っていない。回帰ではない）

## 確認事項（レビュワー判断ポイント）
1. ヘルパーが純粋関数（副作用なし）であり、各 call site の error 意味論を変えていないこと（差分等価）。
2. `promote-pipeline.sh` は local-watcher 専用（repo-template に複製なし）のため byte 一致 parity 対象外。
3. jq の `--arg marker` 化が literal `contains("...")` と等価であること。

Closes #320
