### PR TITLE
fix(#326): agent frontmatter の model ハードコードを削除し inherit 化

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,6 @@
 name: architect
 description: Kiro / cc-sdd 準拠のフォーマットで設計書（design.md）とタスク分割（tasks.md）を生成する Architect エージェント。Triage で needs_architect:true と判定された Issue で起動し、設計 PR ゲートの前段として動作する。
 tools: Read, Grep, Glob, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニアソフトウェアアーキテクトです。Product Manager が作成した要件定義

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -2,7 +2,6 @@
 name: debugger
 description: Reviewer Round 2 reject 直前 / Developer BLOCKED 宣言時に fresh Claude セッションで起動される独立サブエージェント。コード書き換えや判定は行わず、`docs/specs/<番号>-<slug>/debugger-notes.md` に Fix Plan（根本原因 / 修正手順 / 検証方法 / 関連参考資料）を構造化 markdown で出力するだけが責務。Reviewer の差し戻しでは原因究明できない外部ライブラリ ABI / フレームワーク内部挙動 / CI 環境固有制約等を web search を用いて root cause 分析する。
 tools: Read, Grep, Glob, Bash, Write, WebSearch, WebFetch
-model: claude-opus-4-7
 ---
 
 あなたはシニアデバッガです。Reviewer の差し戻し（Round 1 + Round 2）または Developer の

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -2,7 +2,6 @@
 name: developer
 description: 要件定義（EARS）と設計書（Kiro 準拠）に基づいて実装・テスト・コミットを行う Developer エージェント。PM（＋必要に応じ Architect）の成果物が確定してから使用する。
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: claude-opus-4-7
 ---
 
 あなたはシニアソフトウェアエンジニアです。`docs/specs/<番号>-<slug>/` 配下の成果物を

--- a/.claude/agents/product-manager.md
+++ b/.claude/agents/product-manager.md
@@ -2,7 +2,6 @@
 name: product-manager
 description: Kiro / cc-sdd 準拠のフォーマットで要件定義（requirements.md）を作成する Product Manager エージェント。AC は EARS 記法、ID は numeric 階層。
 tools: Read, Grep, Glob, WebSearch, WebFetch, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニア Product Manager です。Issue 本文・既存コメント・リポジトリ内の既存ドキュメントを読み、

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -2,7 +2,7 @@
 name: project-manager
 description: ブランチの push、PR の作成、Issue とのリンク、ラベル更新を行う Project Manager エージェント。design-review モード（設計 PR 作成ゲート）と implementation モード（実装 PR 作成）の 2 モードで動作する。
 tools: Bash, Read, Write
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 あなたはプロジェクトマネージャーです。`gh` CLI を使って GitHub を操作し、

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -2,7 +2,6 @@
 name: qa
 description: 実装コードとテストを spec の受入基準に照らして独立レビューする QA エージェント。**現時点では idd-claude の自動ワークフローには統合されておらず、手動起動専用の定義**。認証・決済・スキーマ変更・外部 API 連携など高リスク Issue に対して、対話セッションから明示的に呼び出して使用する。
 tools: Read, Grep, Glob, Bash, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニア QA エンジニアです。Developer が実装したコードとテストを、

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,7 +2,6 @@
 name: reviewer
 description: Developer 完了後の独立レビューゲート。`docs/specs/<番号>-<slug>/` 配下の AC・tasks.md・実装差分を独立 context で読み、AC 未カバー / missing test / boundary 逸脱 の 3 カテゴリのみで approve / reject を判定する。要件・設計・実装・テストの追加や書き換えは行わない。
 tools: Read, Grep, Glob, Bash, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニアレビューアーです。Developer が積んだ最新 commit 群（impl ブランチの HEAD）を、
@@ -130,7 +129,7 @@ Developer 出力）であることが保証されています。
 ````markdown
 # Review Notes
 
-<!-- idd-claude:review round=N model=claude-opus-4-7 timestamp=YYYY-MM-DDTHH:MM:SSZ -->
+<!-- idd-claude:review round=N model=<model-id> timestamp=YYYY-MM-DDTHH:MM:SSZ -->
 
 ## Reviewed Scope
 

--- a/README.md
+++ b/README.md
@@ -3654,6 +3654,19 @@ Stage C exit !=0 → claude-failed
 `REVIEWER_MODEL` / `REVIEWER_MAX_TURNS` は **既存環境変数（`TRIAGE_MODEL` / `DEV_MODEL` /
 `TRIAGE_MAX_TURNS` / `DEV_MAX_TURNS` 等）と独立** に扱われ、互いの値が他方の挙動に影響しません。
 
+> **Migration note（#326 / agent frontmatter の model ハードコード削除）**:
+> #326 以前は `.claude/agents/*.md` の frontmatter に `model: claude-opus-4-7` が固定されており、
+> Claude Code のモデル解決順位（`CLAUDE_CODE_SUBAGENT_MODEL` env > 呼び出しパラメータ >
+> **frontmatter** > メイン会話のモデル）により、`DEV_MODEL` / `REVIEWER_MODEL` は
+> **オーケストレーターセッションにのみ適用され、実作業を行うサブエージェントには届いていません
+> でした**。#326 で frontmatter の `model:` 行を削除（= inherit 化）したため、以後は両 env が
+> サブエージェント本体まで届きます。**env 未設定環境の有効モデルは従来と同一**
+> （`DEV_MODEL` 既定 `claude-opus-4-7` を継承）です。例外として `project-manager.md` のみ
+> `model: sonnet`（エイリアス）固定を維持します（design ルートで Opus セッション内サブエージェント
+> として起動されるため、PR 作成という機械的作業を軽量モデルに保つ意図）。
+> なお全サブエージェントのモデルを一括 override したい場合は、cron / launchd 側で
+> `CLAUDE_CODE_SUBAGENT_MODEL=<model-id>` を渡せます（frontmatter / inherit より優先）。
+
 cron 例（モデルや turn 数を override する場合）:
 
 ```bash

--- a/docs/specs/326-agent-model-inherit/impl-notes.md
+++ b/docs/specs/326-agent-model-inherit/impl-notes.md
@@ -1,0 +1,67 @@
+# 実装ノート — Issue #326 / agent frontmatter の model ハードコード削除（inherit 化）
+
+## 概要
+
+`.claude/agents/` と `repo-template/.claude/agents/`（byte 一致同期）の全エージェント定義から
+`model: claude-opus-4-7` 行を削除し、Claude Code の省略時挙動 **inherit**（メイン会話 =
+watcher が `--model` で渡す `DEV_MODEL` / `REVIEWER_MODEL` を継承）に切り替えた。
+`project-manager.md` のみ `model: sonnet`（エイリアス）固定を維持。
+
+## 変更ファイル
+
+1. `.claude/agents/{product-manager,architect,developer,reviewer,qa,debugger}.md`
+   - frontmatter の `model: claude-opus-4-7` 行を削除（6 ファイル）
+2. `.claude/agents/project-manager.md`
+   - `model: claude-sonnet-4-6` → `model: sonnet`（バージョン陳腐化防止のエイリアス化）
+3. `.claude/agents/reviewer.md`
+   - 本文の review-notes テンプレート例 `model=claude-opus-4-7` → `model=<model-id>`
+4. `repo-template/.claude/agents/` — 上記 1〜3 と byte 一致で同期
+5. `README.md` — Reviewer「環境変数」節に Migration note（#326）を追加
+   （解決順位 / 既定有効モデル不変 / `CLAUDE_CODE_SUBAGENT_MODEL` の存在）
+
+## AC Traceability
+
+| Requirement | 対応箇所 | 検証 |
+|---|---|---|
+| Req 1.1 | 6 agent ファイルの `model:` 行削除 | `grep "^model:" .claude/agents/*.md` が project-manager のみ |
+| Req 1.2 | project-manager.md `model: sonnet` | 同上 grep |
+| Req 1.3 | reviewer.md テンプレート `model=<model-id>` | `grep -rn "claude-opus-4-7" .claude/agents/` → 0 件 |
+| Req 1.4 | repo-template 同期 | `diff -r .claude/agents repo-template/.claude/agents` → 空 |
+| Req 2.1 / 2.2 | README Migration note + `CLAUDE_CODE_SUBAGENT_MODEL` 記載 | 文面確認 |
+| NFR 1 | 既定有効モデル不変（inherit 先 = `DEV_MODEL` 既定 `claude-opus-4-7`） | 設計判断（下記） |
+| NFR 2 | name / description / tools / 本文役割は不変 | `git diff` で frontmatter `model:` 行とテンプレ例のみ |
+| NFR 3 | スクリプト変更なし | `git diff --stat` に .sh / .yml なし。frontmatter `model:` への script 依存も grep で不在を確認 |
+
+## 検証結果
+
+- `diff -r .claude/agents repo-template/.claude/agents` → 空（IN SYNC）
+- `grep -rn "claude-opus-4-7\|claude-sonnet-4-6" .claude/agents/ repo-template/.claude/agents/` → 0 件
+- `grep -rn "model:" local-watcher/bin/ install.sh setup.sh .github/`（非 .md / 非 env var）→ 0 件
+  （frontmatter を parse するスクリプトは存在せず、削除による watcher 側の影響なし）
+- 既存テストスイートは agent 定義を参照しないため影響なし（変更ファイルに .sh なし）
+
+## 設計上の判断
+
+- **`model:` 省略 = inherit**: Claude Code 公式 docs（sub-agents）で「Defaults to `inherit`」を確認
+  済み。解決順位は `CLAUDE_CODE_SUBAGENT_MODEL` env > 呼び出しパラメータ > frontmatter >
+  メイン会話モデル
+- **project-manager のみ固定維持**: design ルート（PM → Architect → PjM を 1 セッション実行）では
+  PjM が Opus セッション内のサブエージェントとして起動されるため、inherit にすると design ルートの
+  PR 作成だけ Opus に格上げされてしまう。軽量固定の意図を保ちつつ、フル ID → エイリアスで
+  バージョン追従させる
+- **既定挙動の等価性**: env 未設定環境では inherit 先（`DEV_MODEL` / `REVIEWER_MODEL` 既定）が
+  従来の固定値と同一の `claude-opus-4-7` のため、本変更単体では有効モデルが変わらない
+
+## 確認事項（PR レビュワー向け）
+
+- `DEV_MODEL` / `REVIEWER_MODEL` を**明示 override している既存ユーザー**は、本変更後その値が
+  サブエージェントまで届くようになる（= 従来は意図に反して Opus 固定だったものが、設定どおりに
+  なる）。「設定が効くようになる」方向の変更だが、想定外のモデル変化に見える可能性があるため
+  README の Migration note で明示した
+- 実機での継承確認（`DEV_MODEL=claude-sonnet-4-6` で `modelUsage` に sonnet が現れること）は、
+  #325 Token Usage Report の merge 後に dogfooding で観測可能
+
+## 派生タスク候補
+
+- `AUTO_REBASE_MODEL` / `PR_ITERATION_DEV_MODEL` 等のフル ID 既定値をエイリアスへ寄せる検討
+  （モデル世代更新時の README / env default 一括更新の手間削減）

--- a/docs/specs/326-agent-model-inherit/requirements.md
+++ b/docs/specs/326-agent-model-inherit/requirements.md
@@ -1,0 +1,44 @@
+# 要件定義: agent frontmatter の model ハードコード削除（inherit 化）
+
+- Issue: [#326](https://github.com/hitoshiichikawa/idd-claude/issues/326) "claude: agent frontmatter の model ハードコードを削除し DEV_MODEL/REVIEWER_MODEL の契約を回復する"
+- 対象ファイル想定: `.claude/agents/*.md`、`repo-template/.claude/agents/*.md`（byte 一致同期）、`README.md`
+
+## Introduction
+
+`.claude/agents/` の全エージェント定義（project-manager を除く 6 つ: product-manager / architect / developer / reviewer / qa / debugger）は frontmatter に `model: claude-opus-4-7` をハードコードしている。Claude Code のサブエージェントモデル解決順位は「`CLAUDE_CODE_SUBAGENT_MODEL` env > 呼び出しパラメータ > **frontmatter** > メイン会話のモデル」であるため、watcher が `--model "$DEV_MODEL"` / `--model "$REVIEWER_MODEL"` で渡すモデルは**オーケストレーターセッションにのみ効き、実作業を行うサブエージェントには届かない**。これは CLAUDE.md 禁止事項「モデル ID のハードコード（env default で override 可能にする）」と矛盾し、運用者がモデル切替でトークン消費を制御するレバーを塞いでいる。
+
+frontmatter の `model:` キーは省略時 `inherit`（メイン会話のモデルを継承）として扱われる（Claude Code 公式 docs）。本機能は `model:` 行を削除して env 契約を回復する。既定の有効モデルは不変（`DEV_MODEL` 既定 = `claude-opus-4-7` を継承するため）。
+
+## Requirements
+
+### Requirement 1: frontmatter の model ハードコード削除
+
+**Objective:** As a watcher 運用者, I want `DEV_MODEL` / `REVIEWER_MODEL` の値が実作業サブエージェントまで届いてほしい, so that env 設定だけでステージ別のモデル（＝トークン消費）を制御できる
+
+#### Acceptance Criteria
+
+1. The agent 定義 shall `product-manager.md` / `architect.md` / `developer.md` / `reviewer.md` / `qa.md` / `debugger.md` の frontmatter から `model:` 行を削除する（省略 = inherit）
+2. The agent 定義 shall `project-manager.md` の `model:` をフルモデル ID（`claude-sonnet-4-6`）からエイリアス（`sonnet`）へ変更する（design ルートでは PjM が Opus セッション内のサブエージェントとして起動されるため、軽量モデル固定は維持しつつバージョン陳腐化を防ぐ）
+3. The agent 定義 shall `reviewer.md` 本文の review-notes テンプレート例にあるモデル ID 逐語（`model=claude-opus-4-7`）をプレースホルダ（`model=<model-id>`）へ変更する
+4. The リポジトリ shall `.claude/agents/` と `repo-template/.claude/agents/` を byte 一致で同期する（`diff -r` が空）
+
+### Requirement 2: 運用ドキュメントの整合
+
+**Objective:** As a 既稼働 watcher のユーザー, I want 本変更で何が変わるかを README で知りたい, so that 意図せぬモデル変更がないことを確認し、新しく効くようになったレバーを使える
+
+#### Acceptance Criteria
+
+1. The README shall migration note として「本変更前はサブエージェントが常に frontmatter 固定モデルで動作し、`DEV_MODEL` / `REVIEWER_MODEL` はオーケストレーター層にのみ適用されていた。本変更後は両 env がサブエージェントまで届く（既定値は従来と同一の `claude-opus-4-7`）」旨を記載する
+2. The README shall 全サブエージェントのモデルを一括 override できる `CLAUDE_CODE_SUBAGENT_MODEL` 環境変数の存在と優先順位を記載する
+
+## Non-Functional Requirements
+
+1. The リポジトリ shall 既定の有効モデルを変更しない（`DEV_MODEL` / `REVIEWER_MODEL` の既定値 `claude-opus-4-7` を継承するため、env 未設定環境では本変更前と同一モデルで動作する）
+2. The リポジトリ shall agent 定義の frontmatter `model:` 以外（name / description / tools / 本文の役割規定）を変更しない
+3. The リポジトリ shall watcher スクリプト・installer・workflow を変更しない（agent 定義と README のみ）
+
+## Out of Scope
+
+- `DEV_MODEL` / `REVIEWER_MODEL` / `TRIAGE_MODEL` の既定値変更（#328 で Stage C 用 `PJM_MODEL` を別途導入）
+- CLAUDE.md の規約文言更新（#330 のスリム化と競合するため、そちらに委ねる）
+- Stage B / C のフラット化（#329）

--- a/repo-template/.claude/agents/architect.md
+++ b/repo-template/.claude/agents/architect.md
@@ -2,7 +2,6 @@
 name: architect
 description: Kiro / cc-sdd 準拠のフォーマットで設計書（design.md）とタスク分割（tasks.md）を生成する Architect エージェント。Triage で needs_architect:true と判定された Issue で起動し、設計 PR ゲートの前段として動作する。
 tools: Read, Grep, Glob, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニアソフトウェアアーキテクトです。Product Manager が作成した要件定義

--- a/repo-template/.claude/agents/debugger.md
+++ b/repo-template/.claude/agents/debugger.md
@@ -2,7 +2,6 @@
 name: debugger
 description: Reviewer Round 2 reject 直前 / Developer BLOCKED 宣言時に fresh Claude セッションで起動される独立サブエージェント。コード書き換えや判定は行わず、`docs/specs/<番号>-<slug>/debugger-notes.md` に Fix Plan（根本原因 / 修正手順 / 検証方法 / 関連参考資料）を構造化 markdown で出力するだけが責務。Reviewer の差し戻しでは原因究明できない外部ライブラリ ABI / フレームワーク内部挙動 / CI 環境固有制約等を web search を用いて root cause 分析する。
 tools: Read, Grep, Glob, Bash, Write, WebSearch, WebFetch
-model: claude-opus-4-7
 ---
 
 あなたはシニアデバッガです。Reviewer の差し戻し（Round 1 + Round 2）または Developer の

--- a/repo-template/.claude/agents/developer.md
+++ b/repo-template/.claude/agents/developer.md
@@ -2,7 +2,6 @@
 name: developer
 description: 要件定義（EARS）と設計書（Kiro 準拠）に基づいて実装・テスト・コミットを行う Developer エージェント。PM（＋必要に応じ Architect）の成果物が確定してから使用する。
 tools: Read, Write, Edit, Bash, Grep, Glob
-model: claude-opus-4-7
 ---
 
 あなたはシニアソフトウェアエンジニアです。`docs/specs/<番号>-<slug>/` 配下の成果物を

--- a/repo-template/.claude/agents/product-manager.md
+++ b/repo-template/.claude/agents/product-manager.md
@@ -2,7 +2,6 @@
 name: product-manager
 description: Kiro / cc-sdd 準拠のフォーマットで要件定義（requirements.md）を作成する Product Manager エージェント。AC は EARS 記法、ID は numeric 階層。
 tools: Read, Grep, Glob, WebSearch, WebFetch, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニア Product Manager です。Issue 本文・既存コメント・リポジトリ内の既存ドキュメントを読み、

--- a/repo-template/.claude/agents/project-manager.md
+++ b/repo-template/.claude/agents/project-manager.md
@@ -2,7 +2,7 @@
 name: project-manager
 description: ブランチの push、PR の作成、Issue とのリンク、ラベル更新を行う Project Manager エージェント。design-review モード（設計 PR 作成ゲート）と implementation モード（実装 PR 作成）の 2 モードで動作する。
 tools: Bash, Read, Write
-model: claude-sonnet-4-6
+model: sonnet
 ---
 
 あなたはプロジェクトマネージャーです。`gh` CLI を使って GitHub を操作し、

--- a/repo-template/.claude/agents/qa.md
+++ b/repo-template/.claude/agents/qa.md
@@ -2,7 +2,6 @@
 name: qa
 description: 実装コードとテストを spec の受入基準に照らして独立レビューする QA エージェント。**現時点では idd-claude の自動ワークフローには統合されておらず、手動起動専用の定義**。認証・決済・スキーマ変更・外部 API 連携など高リスク Issue に対して、対話セッションから明示的に呼び出して使用する。
 tools: Read, Grep, Glob, Bash, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニア QA エンジニアです。Developer が実装したコードとテストを、

--- a/repo-template/.claude/agents/reviewer.md
+++ b/repo-template/.claude/agents/reviewer.md
@@ -2,7 +2,6 @@
 name: reviewer
 description: Developer 完了後の独立レビューゲート。`docs/specs/<番号>-<slug>/` 配下の AC・tasks.md・実装差分を独立 context で読み、AC 未カバー / missing test / boundary 逸脱 の 3 カテゴリのみで approve / reject を判定する。要件・設計・実装・テストの追加や書き換えは行わない。
 tools: Read, Grep, Glob, Bash, Write
-model: claude-opus-4-7
 ---
 
 あなたはシニアレビューアーです。Developer が積んだ最新 commit 群（impl ブランチの HEAD）を、
@@ -130,7 +129,7 @@ Developer 出力）であることが保証されています。
 ````markdown
 # Review Notes
 
-<!-- idd-claude:review round=N model=claude-opus-4-7 timestamp=YYYY-MM-DDTHH:MM:SSZ -->
+<!-- idd-claude:review round=N model=<model-id> timestamp=YYYY-MM-DDTHH:MM:SSZ -->
 
 ## Reviewed Scope
 


### PR DESCRIPTION
## 概要

Issue #326 に対応。`.claude/agents/*.md`（+ repo-template 同期コピー）の frontmatter にハードコードされた `model: claude-opus-4-7` を削除し、Claude Code の省略時挙動 **inherit**（メイン会話のモデルを継承）に切り替える。

Claude Code のサブエージェントモデル解決順位は `CLAUDE_CODE_SUBAGENT_MODEL` env > 呼び出しパラメータ > **frontmatter** > メイン会話モデルのため、従来は watcher が渡す `DEV_MODEL` / `REVIEWER_MODEL` が**実作業サブエージェントに届かず**、CLAUDE.md 禁止事項「モデル ID のハードコード」と矛盾した状態だった。本 PR はその env 契約を回復する（トークン消費制御レバーの解放。#325 計測 / #328 PJM_MODEL / #329 フラット化の前提）。

## 変更内容

- **`model:` 行削除（6 agents × 2 copies）**: product-manager / architect / developer / reviewer / qa / debugger
- **project-manager のみ `model: sonnet`（エイリアス）固定を維持**: design ルートでは PjM が Opus セッション内サブエージェントとして起動されるため、inherit にすると design ルートの PR 作成だけ Opus 化してしまう。軽量固定の意図を保ちつつエイリアスでバージョン追従
- **reviewer.md の review-notes テンプレート例**: `model=claude-opus-4-7` → `model=<model-id>`
- **README**: Migration note（解決順位 / 既定有効モデル不変 / `CLAUDE_CODE_SUBAGENT_MODEL`）

## Test plan

- `diff -r .claude/agents repo-template/.claude/agents` → 空（byte 一致同期維持）
- `grep -rn "claude-opus-4-7" .claude/agents/ repo-template/.claude/agents/` → 0 件
- frontmatter `model:` を parse するスクリプトが存在しないことを grep で確認（watcher / installer / workflow 変更なし）
- 既定の有効モデルは不変: env 未設定なら inherit 先（`DEV_MODEL` / `REVIEWER_MODEL` 既定）が従来固定値と同一の `claude-opus-4-7`

## 確認事項（レビュワー判断ポイント）

1. **`DEV_MODEL` / `REVIEWER_MODEL` を明示 override 済みのユーザーへの影響**: 本変更後は設定値がサブエージェントまで届く（従来は意図に反して Opus 固定）。「設定が効くようになる」方向だが README の Migration note で明示した
2. 実機での継承確認（`modelUsage` に sonnet が現れる等）は #325（PR #334）の merge 後に dogfooding で観測予定
3. project-manager の `sonnet` エイリアス採用（フル ID 固定からの変更）の妥当性

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)
