### PR TITLE
refactor(#327): .claude/rules に paths: スコープを導入し条件ロード化

### DIFF
--- a/.claude/rules/design-principles.md
+++ b/.claude/rules/design-principles.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/design.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/.claude/rules/design-review-gate.md
+++ b/.claude/rules/design-review-gate.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/design.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/.claude/rules/ears-format.md
+++ b/.claude/rules/ears-format.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/requirements.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/.claude/rules/feature-flag.md
+++ b/.claude/rules/feature-flag.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - ".claude/rules/feature-flag.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 # Feature Flag Protocol（規約詳細）
 
 > **このファイルは opt-in 宣言したプロジェクトでのみエージェントが Read します。**

--- a/.claude/rules/issue-dependency.md
+++ b/.claude/rules/issue-dependency.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - ".claude/rules/issue-dependency.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 # Issue 間依存関係ガイド
 
 idd-claude では tasks.md 内のタスク間依存（`_Depends:_`）は

--- a/.claude/rules/requirements-review-gate.md
+++ b/.claude/rules/requirements-review-gate.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/requirements.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/.claude/rules/tasks-generation.md
+++ b/.claude/rules/tasks-generation.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "docs/specs/**/tasks.md"
+  - "docs/specs/**/design.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,16 @@ rm CLAUDE.md.org
 > 指定時のみ従来の上書き挙動（`.bak` once-only 退避＋ template で上書き）に切り替わります。
 > 詳細は本節先頭の「`CLAUDE.md` の `.org` 並置 (#87)」を参照してください。
 
+> **Migration note（#327 / `.claude/rules/` の条件ロード化）**: Claude Code は
+> `.claude/rules/*.md` を全セッション・全サブエージェントの context に自動注入しますが、
+> #327 で各ルールに YAML frontmatter `paths:`（glob）を付与し、**該当パスのファイルに触れる
+> セッションにのみ付与される条件ロード**へ切り替えました（例: `ears-format.md` は
+> `docs/specs/**/requirements.md` を扱うセッションのみ）。ロール特化ルールが Triage / PjM 等の
+> 無関係コンテキストへ毎回載る固定トークン費を削減します。agent 定義内の明示 Read 指示は
+> 従来どおり機能し（新規ファイル作成時の主経路）、`feature-flag.md` / `issue-dependency.md` は
+> 自己参照スコープ（明示 Read 時のみ）です。挙動を従来に戻したい場合は frontmatter の
+> `paths:` ブロックを削除してください（ファイル先頭の注意コメント参照）。
+
 #### `--dry-run` モード
 
 `--dry-run` を付けると、ファイルシステムを変更せずに**予定操作のみを列挙**します。出力例:

--- a/docs/specs/327-rules-paths-scope/impl-notes.md
+++ b/docs/specs/327-rules-paths-scope/impl-notes.md
@@ -1,0 +1,70 @@
+# 実装ノート — Issue #327 / .claude/rules への paths: スコープ導入
+
+## 概要
+
+全 7 ルールファイル（`.claude/rules/` + `repo-template/.claude/rules/` の byte 一致同期）に
+YAML frontmatter `paths:` を付与し、Claude Code のルール自動ロードを「全コンテキスト常時」から
+「該当パスに触れるセッションのみ」の条件ロードへ切り替えた。本文（SPDX ヘッダ含む）は不変。
+
+## 変更ファイル
+
+1. `.claude/rules/{ears-format,requirements-review-gate}.md` → `paths: docs/specs/**/requirements.md`
+2. `.claude/rules/{design-principles,design-review-gate}.md` → `paths: docs/specs/**/design.md`
+3. `.claude/rules/tasks-generation.md` → `paths: docs/specs/**/tasks.md, docs/specs/**/design.md`
+4. `.claude/rules/feature-flag.md` → `paths: .claude/rules/feature-flag.md`（自己参照 = 明示 Read 時のみ）
+5. `.claude/rules/issue-dependency.md` → `paths: .claude/rules/issue-dependency.md`（同上）
+6. `repo-template/.claude/rules/` — 上記と byte 一致同期
+7. `README.md` — install 節（rules safe-overwrite の説明近傍）に Migration note を追加
+
+各ファイルの frontmatter 直後に「条件ロード（#327）」の 1 行注意コメントを置き、将来の編集で
+frontmatter が誤削除されないようにした（Req 1.4）。
+
+## AC Traceability
+
+| Requirement | 対応箇所 | 検証 |
+|---|---|---|
+| Req 1.1 | 7 ファイル × 2 コピーの frontmatter | `head` 目視 + 下記 grep |
+| Req 1.2 | 既存本文は cat 連結のみ（変更なし） | `git diff` が各ファイル先頭への追記のみであること |
+| Req 1.3 | repo-template 同期 | `diff -r .claude/rules repo-template/.claude/rules` → 空 |
+| Req 1.4 | frontmatter 直後の注意コメント | 各ファイル 6 行目 |
+| Req 2.1 | agent 定義は不変 | `git diff --stat` に `.claude/agents` なし |
+| Req 2.2 | triage-prompt.tmpl は不変 | 同上 |
+| Req 3.1 | README Migration note | 文面確認 |
+| NFR 1 | スクリプト変更なし | `git diff --stat` に .sh / .yml なし |
+| NFR 2 | ルール本文セマンティクス不変（正準 regex を含む節は無変更） | 本文 diff なし |
+
+## 検証結果
+
+- `diff -r .claude/rules repo-template/.claude/rules` → 空（IN SYNC）
+- 各ルールの消費者到達経路を棚卸し（スコープ化で孤児にならないことの確認）:
+  - ears-format / requirements-review-gate → PM が明示 Read（product-manager.md）+ requirements.md に触れるセッションで自動付与
+  - design-principles / design-review-gate → Architect が明示 Read（architect.md）+ design.md に触れる Developer / Reviewer で自動付与
+  - tasks-generation → Architect 明示 Read + tasks.md / design.md に触れる Developer / Reviewer で自動付与
+  - feature-flag → developer.md / reviewer.md の opt-in 条件付き明示 Read（本来の設計意図どおりに復帰）
+  - issue-dependency → product-manager.md の明示参照 + triage-prompt.tmpl がパス記載とエイリアス要約をインライン保持（Triage は必要時に Read 可能）
+  - ハーネス側の参照（`tc_count_tasks` / `design-review-gate` regex mirror 等）はコメントによる正準参照のみで、実行時にルールファイルを読まない（grep 確認）
+
+## 設計上の判断
+
+- **明示 Read を主経路として維持**: `paths` トリガーは「該当ファイルを読んだとき」に発火するため、
+  新規に requirements.md / design.md を**作成**するセッション（PM / Architect の初回）では発火しない
+  可能性がある。agent 定義の「必ず先に読む」指示を不変とすることで到達を保証し、`paths` は
+  Developer / Reviewer 等の後段ロールへの自動付与として機能させる
+- **自己参照スコープ（feature-flag / issue-dependency）**: 通常のファイル操作では発火せず、
+  明示 Read したセッションにのみ付与される。Read のツール結果と二重になる軽微な重複は許容
+  （対象は当該 1 セッションのみで、従来の「全コンテキスト常時」より大幅に小さい）
+- **サブエージェントへの paths 適用**: 公式 docs はサブエージェントが「CLAUDE.md と rules を
+  ロードする」と記すが、`paths` フィルタの適用有無は明記がない。フィルタが適用されない場合でも
+  挙動は従来（常時ロード）と同じであり安全側
+
+## 確認事項（PR レビュワー向け）
+
+- 旧バージョンの Claude Code（`paths` 非対応）では frontmatter が無視され常時ロードが継続する
+  可能性がある（劣化ではなく従来挙動の維持）。frontmatter ブロック自体が context に混入しても
+  数行のため影響は無視できる
+- 削減効果の実測は #325（Token Usage Report / PR #334）の merge 後、Triage / Stage C の
+  `in=` / `cache_read=` の before/after で観測可能
+
+## 派生タスク候補
+
+- CLAUDE.md「エージェントが参照する共通ルール」表への条件ロード列の追記（#330 スリム化に内包予定）

--- a/docs/specs/327-rules-paths-scope/requirements.md
+++ b/docs/specs/327-rules-paths-scope/requirements.md
@@ -1,0 +1,54 @@
+# 要件定義: .claude/rules への paths: スコープ導入（常時自動ロードの解消）
+
+- Issue: [#327](https://github.com/hitoshiichikawa/idd-claude/issues/327) "claude: .claude/rules に paths: スコープを導入して全コンテキスト常時ロードを解消する"
+- 対象ファイル想定: `.claude/rules/*.md`（7 ファイル）、`repo-template/.claude/rules/*.md`（byte 一致同期）、`README.md`
+
+## Introduction
+
+Claude Code 2.x は `.claude/rules/*.md` を CLAUDE.md と同格のプロジェクト指示として、**全セッションおよび全サブエージェント**（Explore / Plan を除く）の context に自動注入する。本リポジトリのルール 7 ファイル（合計約 30K 字）はロール特化（ears-format は要件定義時のみ、design-principles は設計時のみ等）だが、現状 Triage / Developer / Reviewer / PjM を含む全コンテキストに毎回載っており、watcher の 1 Issue 処理（8〜12 コンテキスト）あたり推定数万〜十数万トークンの固定費になっている。`feature-flag.md` は「opt-in 宣言したプロジェクトでのみ Read される」という自身の前提が崩れている。
+
+Claude Code のルールは YAML frontmatter の `paths` キー（glob）で**条件ロード**（該当パスのファイルに触れたセッションにのみ付与）に切り替えられる。本機能は各ルールに役割対応の `paths` を付与し、明示 Read 指示（agent 定義側に既存）を主経路として維持したまま、無関係コンテキストへの常時注入を解消する。
+
+## Requirements
+
+### Requirement 1: ルールファイルへの paths frontmatter 付与
+
+**Objective:** As a watcher 運用者, I want ロール特化ルールが関係するコンテキストにだけロードされてほしい, so that 全 stage に載る固定トークン費を削減できる
+
+#### Acceptance Criteria
+
+1. The ルールファイル shall 以下の対応で YAML frontmatter `paths:` をファイル先頭に持つ:
+   - `ears-format.md` / `requirements-review-gate.md` → `docs/specs/**/requirements.md`
+   - `design-principles.md` / `design-review-gate.md` → `docs/specs/**/design.md`
+   - `tasks-generation.md` → `docs/specs/**/tasks.md` と `docs/specs/**/design.md`
+   - `feature-flag.md` → `.claude/rules/feature-flag.md`（明示 Read 時のみ付与される自己参照スコープ）
+   - `issue-dependency.md` → `.claude/rules/issue-dependency.md`（同上）
+2. The ルールファイル shall frontmatter 以下の本文（SPDX ヘッダ含む既存内容）を変更しない
+3. The リポジトリ shall `.claude/rules/` と `repo-template/.claude/rules/` を byte 一致で同期する（`diff -r` が空）
+4. The ルールファイル shall frontmatter 直後に条件ロードの旨を示す 1 行コメントを持つ（将来の編集者が誤って frontmatter を削除しないため）
+
+### Requirement 2: 明示 Read 経路の維持（ルールが必要なロールへの到達保証）
+
+**Objective:** As a PM / Architect / Developer / Reviewer エージェント, I want 自分の作業に必要なルールへ確実に到達したい, so that 記法・ゲートの一貫性が劣化しない
+
+#### Acceptance Criteria
+
+1. The リポジトリ shall agent 定義（`.claude/agents/*.md`）内の既存の明示 Read 指示・ルール参照を変更しない（新規ファイル作成時は paths トリガーが発火しないため、明示 Read が主経路）
+2. The リポジトリ shall Triage prompt template 内の `issue-dependency.md` への参照（パス記載 + エイリアス要約のインライン記述）を変更しない（Triage は必要時に当該パスを Read できる）
+
+### Requirement 3: 運用ドキュメント
+
+#### Acceptance Criteria
+
+1. The README shall ルールの条件ロード化（#327）の migration note を記載する（挙動: 該当ファイルに触れないセッションにはルールが注入されなくなる / 明示 Read は従来どおり機能する）
+
+## Non-Functional Requirements
+
+1. The リポジトリ shall watcher スクリプト・installer・workflow を変更しない
+2. The リポジトリ shall ルール本文のセマンティクス（EARS 記法・ゲート手順・正準 regex）を変更しない（ハーネス側 mirror regex との整合に影響しない）
+
+## Out of Scope
+
+- CLAUDE.md のルール表更新（#330 スリム化と競合するため、そちらで実施）
+- ルール本文の分量削減（#331）
+- `paths` 非対応の旧 Claude Code バージョンでの挙動最適化（frontmatter は無害に無視またはルール全文ロードのまま）

--- a/repo-template/.claude/rules/design-principles.md
+++ b/repo-template/.claude/rules/design-principles.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/design.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/repo-template/.claude/rules/design-review-gate.md
+++ b/repo-template/.claude/rules/design-review-gate.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/design.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/repo-template/.claude/rules/ears-format.md
+++ b/repo-template/.claude/rules/ears-format.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/requirements.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/repo-template/.claude/rules/feature-flag.md
+++ b/repo-template/.claude/rules/feature-flag.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - ".claude/rules/feature-flag.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 # Feature Flag Protocol（規約詳細）
 
 > **このファイルは opt-in 宣言したプロジェクトでのみエージェントが Read します。**

--- a/repo-template/.claude/rules/issue-dependency.md
+++ b/repo-template/.claude/rules/issue-dependency.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - ".claude/rules/issue-dependency.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 # Issue 間依存関係ガイド
 
 idd-claude では tasks.md 内のタスク間依存（`_Depends:_`）は

--- a/repo-template/.claude/rules/requirements-review-gate.md
+++ b/repo-template/.claude/rules/requirements-review-gate.md
@@ -1,3 +1,9 @@
+---
+paths:
+  - "docs/specs/**/requirements.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 

--- a/repo-template/.claude/rules/tasks-generation.md
+++ b/repo-template/.claude/rules/tasks-generation.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "docs/specs/**/tasks.md"
+  - "docs/specs/**/design.md"
+---
+<!-- 条件ロード（#327）: 上記 paths に触れるセッションにのみ自動付与される。frontmatter を削除すると全コンテキスト常時ロードに戻るため注意。 -->
+
 <!-- SPDX-License-Identifier: MIT -->
 <!-- Adapted from cc-sdd (https://github.com/gotalab/cc-sdd), MIT License, Copyright (c) gotalab -->
 


### PR DESCRIPTION
## 概要

Issue #327 に対応。Claude Code 2.x は `.claude/rules/*.md` を**全セッション・全サブエージェント**の context に自動注入する。本リポジトリのルール 7 ファイル（約 30K 字）はロール特化だが、Triage / Developer / Reviewer / PjM を含む全コンテキストに毎回載っており、1 Issue 処理（8〜12 コンテキスト）あたりの大きな固定トークン費になっていた。

本 PR は各ルールに YAML frontmatter `paths:`（glob）を付与し、**該当パスのファイルに触れるセッションにのみ付与される条件ロード**へ切り替える（Claude Code 公式機能）。agent 定義の明示 Read 指示は不変のまま主経路として維持する。

## 変更内容

| ルール | paths スコープ |
|---|---|
| `ears-format.md` / `requirements-review-gate.md` | `docs/specs/**/requirements.md` |
| `design-principles.md` / `design-review-gate.md` | `docs/specs/**/design.md` |
| `tasks-generation.md` | `docs/specs/**/tasks.md` + `docs/specs/**/design.md` |
| `feature-flag.md` / `issue-dependency.md` | 自己参照（明示 Read 時のみ。feature-flag は「opt-in 時のみ Read」という本来の設計意図に復帰） |

- 各ファイル frontmatter 直後に誤削除防止の 1 行注意コメント
- `repo-template/.claude/rules/` と byte 一致同期
- README に Migration note（戻し方含む）

## Test plan

- `diff -r .claude/rules repo-template/.claude/rules` → 空（IN SYNC）
- 本文 diff なし（各ファイル先頭への追記のみ）。正準 regex 節（tasks-generation / design-review-gate ↔ ハーネス mirror）に影響なし
- 全ルールの消費者到達経路を棚卸し（impl-notes 参照）: 各ルールに明示 Read 経路が存在し、スコープ化で孤児になるロールがないことを確認
- スクリプト・agent 定義・triage template は不変（`git diff --stat` に .sh / .yml / agents なし）

## 確認事項（レビュワー判断ポイント）

1. **新規ファイル作成時の非発火**: `paths` トリガーは「読んだとき」発火のため、requirements.md を新規作成する PM の初回には発火しない可能性がある → agent 定義の「必ず先に読む」明示指示を主経路として不変維持（Req 2.1）
2. **サブエージェントへの paths 適用有無**は公式 docs に明記なし。適用されない場合でも従来挙動（常時ロード）と同じで安全側
3. 旧 Claude Code バージョン（paths 非対応）では従来どおり常時ロードが継続（劣化なし）
4. 削減効果の実測は #325（PR #334）merge 後に `token-usage:` 行の before/after で観測予定

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)
