### PR TITLE
feat(#333): docs-only 差分で Reviewer ステージをスキップする opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -3650,6 +3650,7 @@ Stage C exit !=0 → claude-failed
 |---|---|---|---|
 | `REVIEWER_MODEL` | `claude-opus-4-7` | `DEV_MODEL` と揃える運用が無難 | Reviewer サブエージェント用 Claude モデル ID |
 | `REVIEWER_MAX_TURNS` | `30` | turn 不足で parse 失敗が出る場合のみ増やす | Reviewer 1 起動あたりの Claude 実行 turn 数上限（NFR 1.1） |
+| `REVIEWER_SKIP_PATTERN` | （空 = 無効） | アプリ系 repo の docs-only 変更向け（例 `'^docs/'`）。**idd-claude 自身では有効化しない**（markdown が成果物本体のため） | **opt-in（#333）**: 全変更ファイルが本 POSIX ERE に一致する場合のみ Stage B（独立 Reviewer）をスキップし、自動 approve の review-notes.md（hidden marker `idd-claude:reviewer-skip:v1` 付き）を生成。1 件でも不一致 / diff 空 / git 失敗はスキップしない（fail-safe）。スキップ時は run-summary に Stage B を記録しない |
 
 `REVIEWER_MODEL` / `REVIEWER_MAX_TURNS` は **既存環境変数（`TRIAGE_MODEL` / `DEV_MODEL` /
 `TRIAGE_MAX_TURNS` / `DEV_MAX_TURNS` 等）と独立** に扱われ、互いの値が他方の挙動に影響しません。

--- a/docs/specs/333-reviewer-skip-pattern/impl-notes.md
+++ b/docs/specs/333-reviewer-skip-pattern/impl-notes.md
@@ -1,0 +1,58 @@
+# 実装ノート — Issue #333 / REVIEWER_SKIP_PATTERN（Stage B 条件スキップ）
+
+## 概要
+
+opt-in env `REVIEWER_SKIP_PATTERN`（POSIX ERE、既定 空 = 無効）を導入。`run_impl_pipeline` の
+Stage B（round=1）入口で `_reviewer_skip_check` を評価し、全変更ファイルがパターンに一致する
+場合のみ Reviewer の claude 起動をスキップして自動 approve の review-notes.md を生成する。
+不一致 / diff 空 / git 失敗 / パターン空はすべて従来経路（fail-safe）。
+
+## 変更ファイル
+
+1. `local-watcher/bin/issue-watcher.sh`
+   - config: `REVIEWER_SKIP_PATTERN="${REVIEWER_SKIP_PATTERN:-}"`（Reviewer 設定ブロック）
+   - `reviewer_skip_files_match`（純粋判定関数。`grep -Eq --` でフラグ注入防止 / #318 同方針）
+   - `_reviewer_skip_check`（評価本体 + 自動 approve notes 生成 + rv_log）
+   - Stage B round=1 入口の配線（スキップ時は `rs_record_stage B` を記録しない）
+2. `local-watcher/test/reviewer_skip_files_match_test.sh`（新規 7 ケース）
+3. `README.md` — Reviewer「環境変数」表に行を追加
+
+## AC Traceability
+
+| Requirement | 対応箇所 | 検証 |
+|---|---|---|
+| 1.1 | config ブロック | grep |
+| 1.2 / 1.3 | `_reviewer_skip_check` + round=1 入口の if 分岐 | 文面確認 |
+| 1.4 | 4 条件すべて return 1（fail-safe） | テスト（関数）+ 文面確認（git 失敗 / 空） |
+| 1.5 | 配線は round=1 の `run_reviewer_stage 1` 呼び出し前のみ（round=2/3 は不変） | `git diff` |
+| 2.1 | heredoc の review-notes.md（marker + `RESULT: approve` 最終行） | parse_review_result 互換は既存テストの抽出規則で担保 |
+| 2.2 | `rv_log "round=1 result=approve reason=skip-pattern ..."` | 文面確認 |
+| 2.3 | スキップ分岐では rs_record_stage B を呼ばない | 文面確認 |
+| 2.4 | notes 本文に省略の旨と人間レビュー委任を明記 | 文面確認 |
+| 3.1 | 新規テスト 7 ケース | 7/7 PASS |
+| 3.2 | README 行（fail-safe 条件 / idd-claude 非適用を含む） | 文面確認 |
+| NFR 1 | 既定 空 → `_reviewer_skip_check` が即 return 1 → 従来コードパス | 文面確認 + スイート green |
+| NFR 2 / 3 | shellcheck / スイート | 検証結果 |
+
+## 検証結果
+
+- 新規テスト 7/7 PASS / 既存スイート **全 PASS**（基準環境 = system bash + util-linux flock）
+- `shellcheck` 新規警告ゼロ（既存 SC2329 info 6 件のみ）/ bash 5.3 `bash -n` syntax OK
+
+## 設計上の判断
+
+- **スキップ時に run-summary へ Stage B を記録しない**: `stages=A,C` が実行実態。`reviewer=` は
+  `n/a` のままとなるが、専用ログ行（`reason=skip-pattern`）と review-notes の hidden marker で
+  外形観測できる
+- **review-notes.md を生成する（省略しない）**: `parse_review_result` / Stage C の commit 手順 /
+  Stage Checkpoint（review-notes 存在 = Stage B 完了）との契約互換を保つため
+- **round=1 入口のみ**: reject 差し戻し後（round=2/3）は是正確認が目的のため対象外
+- **heredoc への env 展開**: `REVIEWER_SKIP_PATTERN` は operator 設定（cron / launchd）であり
+  未信頼入力ではない（config コメントに明記）。grep には `--` を適用（#318 と同方針）
+
+## 確認事項（PR レビュワー向け）
+
+- スキップは「独立レビューの省略」であり品質ゲートの弱化を伴う。opt-in 既定無効・全ファイル
+  一致条件・fail-safe の 3 段で限定し、README で idd-claude 自身への適用を禁止した
+- `origin/<BASE_BRANCH>..HEAD` の比較は reviewer プロンプトの diff 取得（`<BASE_BRANCH>..HEAD`）
+  より厳密（worktree は origin 起点 reset のため通常等価）

--- a/docs/specs/333-reviewer-skip-pattern/requirements.md
+++ b/docs/specs/333-reviewer-skip-pattern/requirements.md
@@ -1,0 +1,48 @@
+# 要件定義: docs-only 差分での Reviewer ステージスキップ（REVIEWER_SKIP_PATTERN, opt-in）
+
+- Issue: [#333](https://github.com/hitoshiichikawa/idd-claude/issues/333)
+- 対象ファイル想定: `local-watcher/bin/issue-watcher.sh`、`local-watcher/test/reviewer_skip_files_match_test.sh`（新規）、`README.md`
+
+## Introduction
+
+Reviewer ゲート（既定 Opus、最大 2 round + per-task 経路）は全 impl Issue で必ず起動するが、ドキュメントのみの変更では AC カバレッジ判定の費用対効果が低い。アプリ系 consumer repo（feedman / altpocket / keynest 等）の docs-only 差分に限定して Stage B をスキップできる opt-in env `REVIEWER_SKIP_PATTERN` を導入する。idd-claude 自身は markdown が成果物本体のため有効化しない（README に明記）。
+
+## Requirements
+
+### Requirement 1: スキップ判定（fail-safe）
+
+#### Acceptance Criteria
+
+1. The watcher shall `REVIEWER_SKIP_PATTERN`（POSIX ERE、既定 空 = 無効）を持つ
+2. While `REVIEWER_SKIP_PATTERN` が非空であるとき, when Stage B（round=1）へ進む直前, the watcher shall `git diff --name-only origin/<BASE_BRANCH>..HEAD` の全ファイルがパターンに一致するかを判定する
+3. If 全変更ファイル（1 件以上）がパターンに一致した場合, the watcher shall Stage B（独立 Reviewer の claude 起動）をスキップし approve 経路に進む
+4. If 1 ファイルでも不一致 / 変更ファイル 0 件 / git diff 失敗 / パターン空 のいずれかの場合, the watcher shall スキップせず従来どおり Reviewer を起動する（fail-safe）
+5. The watcher shall round=2 以降（reject 差し戻し後）にはスキップ判定を適用しない（round=1 入口のみ）
+
+### Requirement 2: スキップ時の成果物・観測性
+
+#### Acceptance Criteria
+
+1. When スキップが適用されたとき, the watcher shall hidden marker `<!-- idd-claude:reviewer-skip:v1 ... -->` と最終行 `RESULT: approve` を含む review-notes.md を生成する（`parse_review_result` / Stage C の commit 契約 / Stage Checkpoint と互換）
+2. When スキップが適用されたとき, the watcher shall `reviewer: round=1 result=approve reason=skip-pattern ...` 形式のログを出力する
+3. While スキップが適用されたとき, the watcher shall run-summary の `stages` に B を記録しない（実行実態との一致）
+4. The review-notes.md shall 独立レビューが省略された旨と人間レビューへの委任を明記する
+
+### Requirement 3: テスト・ドキュメント
+
+#### Acceptance Criteria
+
+1. The build pipeline shall 判定純粋関数のテスト（全一致 / 部分不一致 / 空リスト / 空パターン / `-` 始まり path のフラグ注入耐性 / 代替 ERE）を持つ
+2. The README shall env の用途・fail-safe 条件・idd-claude 自身では有効化しない旨を記載する
+
+## Non-Functional Requirements
+
+1. While `REVIEWER_SKIP_PATTERN` が空（既定）であるとき, the watcher shall 本機能導入前と完全に同一の挙動を保つ
+2. When `shellcheck` を実行したとき, the build pipeline shall 新規警告 0 件にする
+3. The build pipeline shall 既存テストスイートを全 PASS のまま維持する
+
+## Out of Scope
+
+- 軽量モデルでのレビュー継続（スキップでなく `REVIEWER_MODEL` 切替で代替可能）
+- per-task Reviewer 経路への適用（別経路。単発経路での運用実績後に検討）
+- idd-claude 自身での有効化

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -536,6 +536,14 @@ DEV_MAX_TURNS="${DEV_MAX_TURNS:-60}"
 # Reviewer サブエージェント用の env。既存の TRIAGE_* / DEV_* と独立に扱う。
 REVIEWER_MODEL="${REVIEWER_MODEL:-claude-opus-4-7}"
 REVIEWER_MAX_TURNS="${REVIEWER_MAX_TURNS:-30}"
+# Reviewer ステージの条件スキップ (#333, opt-in)。POSIX ERE。空（既定）で無効。
+# 全変更ファイルが本パターンに一致する場合のみ Stage B（独立 Reviewer）をスキップし、
+# 自動 approve の review-notes.md（hidden marker 付き）を生成する。1 ファイルでも不一致 /
+# diff 空 / git 失敗時はスキップせず通常どおり Reviewer を起動する（fail-safe）。
+# アプリ系 consumer repo の docs-only 変更向け（例: REVIEWER_SKIP_PATTERN='^docs/'）。
+# idd-claude 自身は markdown が成果物本体のため有効化しないこと（README 参照）。
+# 値は operator 設定（cron / launchd）であり未信頼入力ではない。
+REVIEWER_SKIP_PATTERN="${REVIEWER_SKIP_PATTERN:-}"
 
 # ─── Debugger subagent 設定 (#22 Phase 3) ───
 # 新規 opt-in 機能。明示的に `=true` を指定したときだけ Reviewer Round 2 reject 直前 /
@@ -6005,6 +6013,94 @@ parse_review_result() {
   return 0
 }
 
+# ─── reviewer_skip_files_match <pattern> ───
+#
+# stdin の変更ファイル一覧（1 行 1 path）が「1 件以上あり、かつ全行が pattern（POSIX ERE）に
+# 一致する」かを判定する純粋関数（#333）。`--` でパターン以降をオプション解釈から切り離す
+# （`-` 始まりの path / pattern によるフラグ注入防止。#318 hardening と同方針）。
+#
+# 戻り値:
+#   0 = スキップ適用可（非空リスト + 全行一致）
+#   1 = それ以外（pattern 空 / リスト空 / 1 行でも不一致）
+reviewer_skip_files_match() {
+  local pattern="$1"
+  [ -n "$pattern" ] || return 1
+  local line
+  local seen=1
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    seen=0
+    if ! printf '%s\n' "$line" | grep -Eq -- "$pattern"; then
+      return 1
+    fi
+  done
+  [ "$seen" -eq 0 ]
+}
+
+# ─── _reviewer_skip_check ───
+#
+# REVIEWER_SKIP_PATTERN（opt-in）の評価本体（#333）。スキップ適用時のみ 0 を返し、副作用として
+# 自動 approve の review-notes.md（hidden marker `idd-claude:reviewer-skip:v1` 付き）生成と
+# rv_log 出力を行う。以下はすべて「スキップしない」（fail-safe / 戻り値 1）:
+#   - REVIEWER_SKIP_PATTERN 未設定・空（既定）
+#   - git diff 失敗 / 変更ファイル 0 件
+#   - 1 ファイルでもパターン不一致
+#
+# 入力 (環境変数経由): REVIEWER_SKIP_PATTERN, BASE_BRANCH, BRANCH, NUMBER, REPO_DIR,
+#                      SPEC_DIR_REL, LOG
+# 副作用: $REPO_DIR/$SPEC_DIR_REL/review-notes.md の生成（commit は Stage C の責務 / 既存契約）
+_reviewer_skip_check() {
+  [ -n "${REVIEWER_SKIP_PATTERN:-}" ] || return 1
+
+  local files
+  if ! files=$(git diff --name-only "origin/${BASE_BRANCH}..HEAD" 2>/dev/null); then
+    rv_log "skip-pattern: git diff 失敗 → 通常 Reviewer 起動（fail-safe）" >> "$LOG"
+    return 1
+  fi
+  if [ -z "$files" ]; then
+    rv_log "skip-pattern: 変更ファイル 0 件 → 通常 Reviewer 起動（fail-safe）" >> "$LOG"
+    return 1
+  fi
+  if ! reviewer_skip_files_match "$REVIEWER_SKIP_PATTERN" <<< "$files"; then
+    return 1
+  fi
+
+  local notes_path="$REPO_DIR/$SPEC_DIR_REL/review-notes.md"
+  local head_sha file_count
+  head_sha=$(git rev-parse HEAD 2>/dev/null || echo "(unknown)")
+  file_count=$(printf '%s\n' "$files" | grep -c . || true)
+  mkdir -p "$REPO_DIR/$SPEC_DIR_REL"
+  cat > "$notes_path" <<EOF
+# Review Notes
+
+<!-- idd-claude:reviewer-skip:v1 pattern=${REVIEWER_SKIP_PATTERN} files=${file_count} -->
+
+## Reviewed Scope
+
+- Branch: ${BRANCH}
+- HEAD commit: ${head_sha}
+- Compared to: ${BASE_BRANCH}..HEAD
+
+## Verified Requirements
+
+（独立 Reviewer はスキップされました: 変更ファイル ${file_count} 件すべてが
+REVIEWER_SKIP_PATTERN（\`${REVIEWER_SKIP_PATTERN}\`）に一致 / #333 opt-in）
+
+## Findings
+
+なし（自動 approve。内容レビューは PR 上の人間レビューで実施してください）
+
+## Summary
+
+REVIEWER_SKIP_PATTERN による Stage B スキップ（自動 approve / #333）。
+
+RESULT: approve
+EOF
+  rv_log "round=1 result=approve reason=skip-pattern pattern='${REVIEWER_SKIP_PATTERN}' files=${file_count}" >> "$LOG"
+  echo "⏭️  #$NUMBER: Reviewer スキップ（REVIEWER_SKIP_PATTERN 全一致 → 自動 approve）" | tee -a "$LOG"
+  return 0
+}
+
 # ─── run_reviewer_stage <round> ───
 #
 # Reviewer サブエージェントを 1 回起動し、review-notes.md の最終 RESULT 行を抽出して
@@ -7394,11 +7490,19 @@ run_impl_pipeline() {
   case "$START_STAGE" in
     A|B)
       rev_rc=0
-      run_reviewer_stage 1 || rev_rc=$?
-      # run サマリ: Stage B（Reviewer round=1）実行を記録し degraded 兆候を反映（Req 2.1, 6.x）。
-      # Reviewer verdict / round の記録は task 6 の責務。ここは stage 記録のみ。
-      rs_record_stage B
-      rs_scan_degraded_log "$LOG"
+      # #333: REVIEWER_SKIP_PATTERN（opt-in）— 全変更ファイルがパターンに一致する場合のみ
+      # Stage B をスキップして自動 approve に倒す（_reviewer_skip_check が自動 approve の
+      # review-notes.md 生成とログ出力まで実施済み）。スキップ時は Reviewer が実行されて
+      # いないため rs_record_stage B は記録しない（run-summary の実行実態と一致させる）。
+      if _reviewer_skip_check; then
+        rev_rc=0
+      else
+        run_reviewer_stage 1 || rev_rc=$?
+        # run サマリ: Stage B（Reviewer round=1）実行を記録し degraded 兆候を反映（Req 2.1, 6.x）。
+        # Reviewer verdict / round の記録は task 6 の責務。ここは stage 記録のみ。
+        rs_record_stage B
+        rs_scan_degraded_log "$LOG"
+      fi
       case $rev_rc in
         0)
           # Issue #106 Req 3: Stage B (Reviewer round=1 approve) 完了直後に push 状態 verify。

--- a/local-watcher/test/reviewer_skip_files_match_test.sh
+++ b/local-watcher/test/reviewer_skip_files_match_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh の reviewer_skip_files_match（#333
+#       REVIEWER_SKIP_PATTERN による Stage B 条件スキップの純粋判定関数）を
+#       fixture で検証するスモークテスト。
+#
+#       判定契約: stdin の変更ファイル一覧が「1 件以上 かつ 全行が POSIX ERE に一致」の
+#       ときのみ rc=0（スキップ適用可）。pattern 空 / リスト空 / 1 行でも不一致は rc=1。
+#
+# 配置先: local-watcher/test/reviewer_skip_files_match_test.sh
+# 依存:   bash 4+, awk, grep
+# 実行:   bash local-watcher/test/reviewer_skip_files_match_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "reviewer_skip_files_match")"
+if ! declare -F reviewer_skip_files_match >/dev/null; then
+  echo "ERROR: reviewer_skip_files_match not loaded" >&2
+  exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_rc() {
+  local label="$1"
+  local expected_rc="$2"
+  shift 2
+  local actual_rc=0
+  reviewer_skip_files_match "$@" || actual_rc=$?
+  if [ "$expected_rc" -eq "$actual_rc" ]; then
+    echo "PASS: $label (rc=$actual_rc)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected rc: $expected_rc / actual rc: $actual_rc"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# 正常系: 全行一致 → 0
+assert_rc "全ファイルが ^docs/ に一致なら 0" 0 '^docs/' <<'EOF'
+docs/specs/1-foo/requirements.md
+docs/README.md
+EOF
+
+# 異常系: 1 行でも不一致 → 1
+assert_rc "1 ファイルでも不一致なら 1" 1 '^docs/' <<'EOF'
+docs/specs/1-foo/requirements.md
+local-watcher/bin/issue-watcher.sh
+EOF
+
+# 境界値: リスト空 → 1（fail-safe）
+assert_rc "リスト空なら 1" 1 '^docs/' < /dev/null
+
+# 境界値: 空行のみ → 1（実質空リスト）
+assert_rc "空行のみなら 1" 1 '^docs/' <<'EOF'
+
+EOF
+
+# 異常系: pattern 空 → 1（無効）
+assert_rc "pattern 空なら 1" 1 '' <<'EOF'
+docs/a.md
+EOF
+
+# hardening: `-` 始まりの path / pattern でもフラグ注入されない（grep -- 区切り）
+assert_rc "ハイフン始まり path + ハイフン始まり pattern でも判定可能" 0 '^-' <<'EOF'
+-leading-dash.md
+EOF
+
+# 複合 ERE: 代替（|）パターン
+assert_rc "代替 ERE（docs か *.md）全一致で 0" 0 '^docs/|\.md$' <<'EOF'
+docs/a.txt
+README.md
+EOF
+
+echo ""
+echo "================================"
+echo "PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "================================"
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## 概要

Issue #333 に対応。Reviewer ゲート（既定 Opus）は全 impl Issue で必ず起動するが、docs-only 変更では費用対効果が低い。opt-in env `REVIEWER_SKIP_PATTERN`（POSIX ERE、既定 空 = 無効）を導入し、**全変更ファイルがパターンに一致する場合のみ** Stage B をスキップして自動 approve に倒す。アプリ系 consumer repo（feedman / altpocket / keynest 等）向けで、**idd-claude 自身では有効化しない**（markdown が成果物本体のため。README 明記）。

## 変更内容

- `REVIEWER_SKIP_PATTERN` 追加（Reviewer 設定ブロック）
- `reviewer_skip_files_match`（純粋判定）+ `_reviewer_skip_check`（評価 + 自動 approve の review-notes.md 生成 + ログ）
- Stage B round=1 入口に配線。**fail-safe**: 1 件でも不一致 / diff 空 / git 失敗 / パターン空 → 従来どおり Reviewer 起動。round=2/3（reject 差し戻し後）は対象外
- review-notes.md は hidden marker `idd-claude:reviewer-skip:v1` + 最終行 `RESULT: approve` で生成（`parse_review_result` / Stage C commit / Stage Checkpoint と契約互換）
- スキップ時は `rs_record_stage B` を記録しない（run-summary の実行実態と一致）
- テスト 7 ケース新規（全一致 / 部分不一致 / 空リスト / 空パターン / `-` 始まりのフラグ注入耐性（`grep --`、#318 同方針）/ 代替 ERE）
- README: Reviewer 環境変数表に行を追加

## Test plan

- 新規テスト 7/7 PASS、既存スイート**全 PASS**（基準環境 = system bash + flock）
- `shellcheck` 新規警告ゼロ / bash 5.3 `bash -n` OK
- 既定（空）では `_reviewer_skip_check` が即 return 1 → 導入前と完全同一のコードパス

## 確認事項（レビュワー判断ポイント）

1. **品質ゲートの意図的な弱化**を opt-in・全ファイル一致・fail-safe の 3 段で限定する設計の妥当性
2. スキップ時の run-summary は `stages=A,C` / `reviewer=n/a` となる（専用ログ行と marker で観測可能）
3. 有効化判断は #325 の `token-usage:` 実測で docs-only Issue の Stage B コストを確認してから

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)
