### PR TITLE
feat(#356): per-task post-marker docs-only commit を auto-refresh で許容 + Developer 契約強化

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -422,6 +422,26 @@ Reviewer review range の **終端 SHA** を当該 marker commit に固定する
 - 本 attempt（Reviewer reject 後の retry も含む）の task-scope 作業がすべて完了した時点で
   marker commit を作成する
 
+### 順序条項（Issue #356 / 必読）
+
+watcher 側で docs-only post-marker commit を auto-refresh する safety net
+（`pt_classify_post_marker_paths` / `POST_MARKER_DOCS_ALLOWLIST`）は **defense-in-depth**
+であり、Developer 側でも以下の順序を **厳守** すること。これは silent range truncation
+（修正 commit が Reviewer の判定対象から漏れる事故）と、本来不要な auto-refresh の
+発火・Issue コメント増殖を防ぐためである:
+
+1. **impl-notes / learning 追記は marker commit より「前に」完了させる**
+   - 当該 task の `### Task <id>` 見出し追加 / Finding Closure Matrix 追記 /
+     残存課題の記録など `impl-notes.md` への書き込みは、すべて `docs(tasks): mark
+     <id> as done` marker commit より「前」の commit として積むこと
+   - 「marker を打った後に impl-notes だけ追記する」フローは禁止
+2. **marker commit は当該 task の「最終 commit」として作成する**
+   - marker commit を打った後に、当該 task scope の追加 commit を一切積まない
+     こと。`docs(impl-notes): learning 追記` のような docs-only commit も含めて
+     **後続 commit を作らない**
+   - 後続作業が必要になった場合は、後述「retry 時の marker refresh 契約」に従って
+     旧 marker を剥がし、追加 commit を積んだ上で marker を作り直す
+
 ### retry 時の marker refresh 契約（Req 1.2）
 
 Reviewer reject や Debugger guidance による Implementer 再実行（round 2 / round 3）で
@@ -467,6 +487,15 @@ claude-failed、env `POST_MARKER_RECOVERY_MODE`）を持ちますが、これは
 代替ではなく defense-in-depth** です。default の `fail-with-diagnostic` モードでは
 silent truncation を顕在化させて claude-failed で停止するため、Implementer は本契約を
 遵守して safety net 発火を回避することが望まれます。
+
+Issue #356 で追加された **docs-only auto-refresh**（`pt_classify_post_marker_paths` /
+env `POST_MARKER_DOCS_ALLOWLIST` 既定: `**/impl-notes.md` / `docs/specs/**/*.md`）は、
+post-marker commit が docs-only allowlist 内のみで構成される場合に marker を HEAD
+まで自動拡張して `claude-failed` を踏まずに済ませる **追加の安全網** ですが、これも
+Developer 契約の代替ではなく defense-in-depth です。allowlist 外（コード / テスト /
+設定ファイル）が 1 件でも含まれれば従来どおり `fail-with-diagnostic` 経路で停止します。
+本順序条項を遵守すれば auto-refresh も発火しないため、Issue コメントでの事実記録を
+増殖させずに済みます。
 
 ## learning 追記の責務（per-task ループの中核 / Req 4.1, 4.2, 4.4）
 

--- a/README.md
+++ b/README.md
@@ -5237,6 +5237,38 @@ reject 時のログには `categories=` / `targets=` が含まれ、対応 requi
 [YYYY-MM-DD HH:MM:SS] per-task: task=1.2 reviewer end round=1 result=reject categories=AC未カバー targets=1.2
 ```
 
+### Post-marker commit safety net（#304 / #356）
+
+per-task Reviewer 起動前に `pt_detect_post_marker_commits` が `docs(tasks): mark <id> as done`
+marker commit より後ろに **未レビュー commit** が積まれていないかをチェックし、idd-codex #14
+同型の **silent range truncation**（修正 commit が Reviewer の判定対象から漏れる事故）を
+防ぎます（#304）。`POST_MARKER_RECOVERY_MODE` で挙動を切り替えられます:
+
+| 値 | 挙動 |
+|---|---|
+| `fail-with-diagnostic` (既定) | post-marker commit を検出したら `claude-failed` を付与して停止し、復旧手順付き Issue コメントを投稿 |
+| `extend-range` | post-marker commit の内容に関わらず range を HEAD まで拡張して Reviewer を続行（既存 escape hatch） |
+
+#### docs-only auto-refresh（#356）
+
+post-marker commit が **docs-only**（`docs(impl-notes): learning 追記` のような無害な
+文書追記のみ）のときは、`fail-with-diagnostic` であっても `claude-failed` を踏まずに marker を
+HEAD まで auto-refresh して Reviewer を続行します。発火条件は env `POST_MARKER_DOCS_ALLOWLIST`
+の glob パターン（既定: `**/impl-notes.md,docs/specs/**/*.md`）に **全ての** post-marker 変更
+ファイルが閉じていることです。コード / テスト / 設定ファイルが 1 件でも混在すれば、従来どおり
+`fail-with-diagnostic` 経路で停止します。
+
+- 発火時のログ行（grep 抽出可能 / NFR 2.2）:
+  ```
+  [YYYY-MM-DD HH:MM:SS] per-task: post-marker-commits-detected task_id=1.2 round=1 marker=<sha> post_marker_shas=<csv> recovery=docs-only-auto-refresh
+  ```
+- 発火時、当該 Issue に 1 件のみ事実記録コメントが投稿されます（同一 task の再発火は
+  重複抑制マーカーで抑止）
+- `POST_MARKER_RECOVERY_MODE=extend-range` を明示している repo では、本判定はオーバーライド
+  されず既存 extend-range 挙動が温存されます（#356 Req 3.3）
+- Developer 契約として `impl-notes` 追記を marker より「前」に積む順序を遵守すれば、本
+  auto-refresh は発火せず Issue コメントも増えません（[`developer.md` の Marker contract 順序条項](repo-template/.claude/agents/developer.md) 参照）
+
 ### 累積コスト警告（重要）
 
 ⚠️ **per-task ループ有効化により Claude CLI 起動回数は task 件数に比例して増加します。**

--- a/docs/specs/356-fix-watcher-per-task-post-marker-commit/impl-notes.md
+++ b/docs/specs/356-fix-watcher-per-task-post-marker-commit/impl-notes.md
@@ -1,0 +1,117 @@
+# Implementation Notes — Issue #356
+
+## 概要
+
+per-task Reviewer 起動前の post-marker commit safety net (`pt_detect_post_marker_commits` /
+`pt_handle_post_marker_commits`) を、docs-only post-marker commit に対しては fail させずに
+marker を auto-refresh して続行する形に拡張した（Fix A）。併せて Developer agent の Marker
+contract に「impl-notes / learning 追記は marker より前、marker は task の最終 commit」
+順序条項を追記し、そもそも docs-only post-marker commit を生まない契約強化を行った（Fix B）。
+
+## Fix A: watcher 側 docs-only auto-refresh
+
+### 変更ファイル
+- `local-watcher/bin/issue-watcher.sh` — env `POST_MARKER_DOCS_ALLOWLIST` 追加 /
+  `pt_classify_post_marker_paths` 新設 / `pt_handle_post_marker_commits` への docs-only
+  判定前段の組み込み / `pt_post_docs_only_auto_refresh_comment` 新設 / `run_per_task_reviewer`
+  の recovery 種別ログ分岐
+- `local-watcher/test/pt_post_marker_classify_test.sh` — 単体 8 ケース + 統合 5 ケース +
+  境界 3 ケースの計 39 アサーション
+
+### 設計判断
+
+- **docs allowlist の決定根拠**: 要件 Req 1.1 / 1.5 が「impl-notes.md / docs/specs/**/*.md
+  相当の運用者観点で文書のみと判別できるパス集合」と抽象化していたため、Open Question
+  「README.md / CLAUDE.md / .claude/** ルール類の扱い」は **既定では含めず最小集合**
+  （`**/impl-notes.md,docs/specs/**/*.md`）に倒した。理由: docs-only 発火の主用途は
+  `docs(impl-notes): learning 追記` 救済であり、`CLAUDE.md` / `README.md` 等のドキュメント変更
+  は Developer 契約上 marker と分離した別 task で扱うべきもの。allowlist は env 経由で運用者
+  が拡張可能（カンマ区切り glob パターン）にしているため、必要に応じて override できる。
+- **mode dispatch との関係**: docs-only 判定を mode dispatch の **前段**（`extend-range`
+  以外のときのみ）に置くことで、Req 3.3「`extend-range` は docs-only にオーバーライドされない」
+  を満たした。`extend-range` mode 時は本判定を完全に skip して既存挙動を温存する。不正値
+  正規化（`fail-with-diagnostic` への fallback）は判定後に適用されるが、判定対象は
+  `extend-range` 以外なので不正値 → fallback → docs-only auto-refresh の経路も正常に動く
+  （test Case E で確認）。
+- **auto-refresh 手段（marker を tip に進める操作）の具体**: 「marker commit を物理的に
+  rebase で末尾移動する」のではなく、**Reviewer の review range を HEAD まで拡張する**
+  形（`pt_handle_post_marker_commits` 返却値を `<range_start>\t<HEAD_SHA>` にする）で実現。
+  この方式は既存の `extend-range` mode と同じ仕組みであり、git 操作（reset/rebase）を
+  行わないため副作用ゼロ。実装上は `pt_handle_post_marker_commits` の rc=0 経路を 2 種類
+  （`extend-range` と `docs-only-auto-refresh`）共有しつつ、`run_per_task_reviewer` で
+  `POST_MARKER_RECOVERY_MODE` の正規化値を見て recovery 種別を判別する。
+- **Issue コメントの重複抑制**: `pt_post_docs_only_auto_refresh_comment` は
+  `pt_mark_post_marker_commits_detected` と同じ HTML コメントマーカー方式で重複抑制
+  （`<!-- idd-claude:per-task-post-marker-docs-only-auto-refresh:#<issue>:<task> -->`）。
+  ただし「追記コメント」モードは持たず、同一 task で auto-refresh が複数回発火しても 1 件
+  のみ投稿する設計（Issue コメント増殖を抑制 / NFR 1.3）。
+
+## Fix B: Developer agent Marker contract 強化
+
+### 変更ファイル
+- `.claude/agents/developer.md` — Marker contract 節に「順序条項（Issue #356 / 必読）」
+  サブセクション追加 + 「watcher 側 safety net との関係」に docs-only auto-refresh の説明追加
+- `repo-template/.claude/agents/developer.md` — root と byte 一致で同期
+
+### 設計判断
+- 既存 Marker contract 節の「marker 作成タイミングの契約」は順序を暗黙化していたため、
+  Req 4.1 が要求する明示性を満たすには専用サブセクション「順序条項」を新設するのが妥当
+  と判断した。既存サブセクション（「retry 時の marker refresh 契約」「推奨 refresh 手順」
+  「禁止例」「watcher 側 safety net との関係」）は構造を保ったまま順序条項を挿入。
+- 「watcher 側 safety net との関係」に docs-only auto-refresh も defense-in-depth として
+  追記し、Developer から見て両 safety net（fail-with-diagnostic / docs-only auto-refresh）
+  の存在意義が一貫して理解できるようにした（Req 4.4: Developer 単体で読んだとき自己完結）。
+
+## 検証結果
+
+- `bash -n local-watcher/bin/issue-watcher.sh` / 全テスト sh ファイル → OK
+- `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/test/pt_post_marker_classify_test.sh
+  local-watcher/bin/modules/*.sh` → 警告ゼロ
+- `bash local-watcher/test/pt_post_marker_classify_test.sh` → PASS: 39, FAIL: 0
+- 既存隣接テスト 4 件回帰確認（`pt_check_fail_fast_test.sh` 18 PASS /
+  `pt_extract_findings_block_test.sh` 20 PASS / `pt_extract_debugger_section_test.sh`
+  24 PASS / `normalize_slug_test.sh` 12 PASS）
+- `diff -r .claude/agents repo-template/.claude/agents` → 空
+- `diff -r .claude/rules repo-template/.claude/rules` → 空
+
+## AC Traceability
+
+| Req | テスト / 実装での担保 |
+|---|---|
+| 1.1 | test Case A（docs-only + default → rc=0 auto-refresh）+ `pt_classify_post_marker_paths` Case 1-2 |
+| 1.2 | test Case A（stderr に `recovery=docs-only-auto-refresh` / `task_id` / `post_marker_shas` 含む） |
+| 1.3 | `pt_post_docs_only_auto_refresh_comment` 新設（重複抑制マーカー付き 1 件投稿） |
+| 1.4 | test Case A（rc=0 = 続行可能）+ Case B との挙動差で間接的に担保 |
+| 1.5 | env `POST_MARKER_DOCS_ALLOWLIST` 既定値の README 明示 + watcher 内コメント |
+| 2.1 | test Case 3-4（code/test 含む → mixed） |
+| 2.2 | test Case B（mixed + default → rc=5）+ Case 5-7（allowlist 空 / 0 件 / fail-safe） |
+| 2.3 | `pt_handle_post_marker_commits` 内の `pt_mark_post_marker_commits_detected` 経路維持 |
+| 2.4 | test Case 5（git diff エラー → fail-safe mixed → 上位 fail-with-diagnostic） |
+| 3.1 | test Case F（post-marker 0 件 → rc=1） |
+| 3.2 | `POST_MARKER_RECOVERY_MODE` の case 文を変更せず（既存 2 値解釈温存） |
+| 3.3 | test Case C / D（extend-range は docs-only にオーバーライドされない） |
+| 3.4 | test Case E（不正値 → default fallback → docs-only 判定適用 → auto-refresh） |
+| 3.5 | env var 名 / ラベル / exit code 意味を変更せず（既存コードベース確認） |
+| 4.1-4.4 | `.claude/agents/developer.md` に「順序条項」サブセクション追記（Fix B） |
+| NFR 1.1 | README に docs-only auto-refresh 節追記 |
+| NFR 1.2 | `diff -r .claude/agents repo-template/.claude/agents` → 空 |
+| NFR 1.3 | docs-only auto-refresh / fail-with-diagnostic / extend-range それぞれ単一行ログ |
+| NFR 2.1 | 本ノート末尾の merge 後運用 follow-up 参照 |
+| NFR 2.2 | `recovery=docs-only-auto-refresh` の単一行 tag を grep 可能 |
+| NFR 3.1 | 3 系統 39 アサーションのテスト追加 |
+| NFR 3.2 | shellcheck 警告ゼロ / bash -n OK |
+
+## 確認事項
+
+- **allowlist 既定値の妥当性**: Open Questions「`README.md` / `CLAUDE.md` / `.claude/**` の扱い」は
+  最小集合（`**/impl-notes.md,docs/specs/**/*.md`）に倒した。運用拡張は env `POST_MARKER_DOCS_ALLOWLIST` で可能。
+- **glob `**/impl-notes.md` の挙動**: bash `[[ ]]` 内では `**` は `*` と同等。test Case 8 で root 直下 `impl-notes.md`
+  が match しないことを観測。運用上は `docs/specs/<番号>-<slug>/` 配下しかないため実害なし。
+
+## merge 後の運用 follow-up
+
+- **idd-claude watcher cron の暫定 `POST_MARKER_RECOVERY_MODE=extend-range` を撤去できる**。
+  本 PR merge 後は default の `fail-with-diagnostic` で動かしても docs-only post-marker commit
+  は auto-refresh で救済されるため、暫定運用を維持する必要なし。
+
+STATUS: complete

--- a/docs/specs/356-fix-watcher-per-task-post-marker-commit/review-notes.md
+++ b/docs/specs/356-fix-watcher-per-task-post-marker-commit/review-notes.md
@@ -1,0 +1,54 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-22T15:25:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-356-impl-fix-watcher-per-task-post-marker-commit
+- HEAD commit: 7885959a3e3ffbbf0ebe53fc4fe4bc7ea434b5db
+- Compared to: main..HEAD
+- 構成: 5 commits / 6 files / +866 -3
+  - `feat(watcher)`: docs-only post-marker auto-refresh 本体
+  - `test(watcher)`: 近接テスト 39 アサーション
+  - `docs(agents)`: developer.md Marker contract 順序条項
+  - `docs(readme)`: post-marker docs-only auto-refresh 節
+  - `docs(impl-notes)`: 実装ノート
+- 備考: 本 spec は `tasks.md` / `design.md` を持たない単一実装パス（Architect 起動なし）。`_Boundary:_` アノテーションは存在しないため、boundary 逸脱は変更ファイル群と Req スコープの整合で判定した。
+
+## Verified Requirements
+
+- 1.1 — `pt_classify_post_marker_paths` 新設 + `pt_handle_post_marker_commits` 前段ブロックで mode != extend-range 時の docs-only auto-refresh を実装。`pt_post_marker_classify_test.sh` Case 1/2/A で観測可能（rc=0 + `<range_start>\tHEAD_SHA` 返却）
+- 1.2 — `pt_handle_post_marker_commits` の `echo "[${ts}] per-task: post-marker-commits-detected task_id=... round=... marker=... post_marker_shas=... recovery=docs-only-auto-refresh"` 行（issue-watcher.sh:3432）。Case A で stderr に `recovery=docs-only-auto-refresh` / `task_id=1.2` / `post_marker_shas=post001,post002` を assert
+- 1.3 — `pt_post_docs_only_auto_refresh_comment` 新設（issue-watcher.sh:4791〜）。`run_per_task_reviewer` の rc=0 経路で `_recovery_kind = "docs-only-auto-refresh"` のときのみ呼ばれる（issue-watcher.sh:4341〜4343）。HTML コメントマーカーで重複抑制
+- 1.4 — auto-refresh 経路（rc=0）は `pt_mark_post_marker_commits_detected` を呼ばないため `claude-failed` が付かない（issue-watcher.sh:4317〜4348 case 0 で確認）。Case A test の rc=0 + Case B test との挙動差で間接担保
+- 1.5 — `POST_MARKER_DOCS_ALLOWLIST` 既定値 `**/impl-notes.md,docs/specs/**/*.md` を env var 宣言コメント（issue-watcher.sh:595〜610）と README（「docs-only auto-refresh」節）の両方で明示
+- 2.1 — `pt_classify_post_marker_paths` の allowlist 外 1 件で `mixed` 判定（first_unmatched 返却）。Case 3/4 test で code/test ファイル含む → rc=1 + verdict=mixed を assert
+- 2.2 — mixed / allowlist 空 / 変更 0 件はすべて保守的に mixed に倒し fail-with-diagnostic 経路（rc=5）に fall through。Case 6/7/B test で確認
+- 2.3 — `pt_mark_post_marker_commits_detected` 経路は変更しておらず、`run_per_task_reviewer` 側 case 5 で従来どおり呼ばれる（issue-watcher.sh:4349〜4353）。claude-failed 付与 + diagnostic コメントの既存挙動を温存
+- 2.4 — `pt_classify_post_marker_paths` rc=2（git エラー）は `_classify_reason="classify-git-error"` でログを残しつつ `if classify_rc=0 && verdict=docs-only` 条件を満たさないため mode dispatch（fail-with-diagnostic）に倒れる。Case 5 test で git diff エラー時の挙動確認
+- 3.1 — `pt_detect_post_marker_commits` 0 件時の rc=1 は変更なし。`run_per_task_reviewer` の case 1 で `:` no-op として既存 fall-through を維持。Case F test で確認
+- 3.2 — `POST_MARKER_RECOVERY_MODE` の `case` 文（issue-watcher.sh:3393〜3399）は変更なし。既存 2 値解釈温存
+- 3.3 — `if [ "$mode" != "extend-range" ]` ガード（issue-watcher.sh:3417）で extend-range mode 時は docs-only 判定を完全 skip。Case C/D test で確認
+- 3.4 — 不正値は既存 case 文で fail-with-diagnostic に正規化された後、本ガードを通過して docs-only 判定が適用される。Case E test で `bogus-mode-value` + docs-only → auto-refresh rc=0 を確認
+- 3.5 — env var 名（`POST_MARKER_RECOVERY_MODE`）/ ラベル名（`claude-failed`）/ exit code（rc=5）/ cron 登録文字列 / ログ出力先はいずれも変更なし
+- 4.1 — `.claude/agents/developer.md` の Marker contract 節に「順序条項（Issue #356 / 必読）」サブセクションを新設し、(1) impl-notes/learning を marker より前に積む、(2) marker は task の最終 commit、の 2 条項を明示
+- 4.2 — `diff -r .claude/agents repo-template/.claude/agents` 実行結果が空（byte 一致確認済み）
+- 4.3 — 同節内で「後続作業が必要になった場合は『retry 時の marker refresh 契約』に従って旧 marker を剥がし、追加 commit を積んだ上で marker を作り直す」と明示。既存 retry セクションを参照する形で順序保持
+- 4.4 — 「watcher 側 safety net との関係」末尾に docs-only auto-refresh の defense-in-depth 説明を追加し、Developer 単体で読んだとき auto-refresh 機構の存在意義と発火条件が自己完結
+- NFR 1.1 — README 「Post-marker commit safety net (#304 / #356)」節を全面追加。`POST_MARKER_RECOVERY_MODE` の値表 + 「docs-only auto-refresh」サブ節で発火条件・allowlist・ログ書式・既存運用との関係を明示
+- NFR 1.2 — `diff -r .claude/agents repo-template/.claude/agents` 空 / `diff -r .claude/rules repo-template/.claude/rules` 空（手元で再確認）
+- NFR 1.3 — docs-only-auto-refresh / fail-with-diagnostic / extend-range のいずれも single-line stderr ログ（`[ts] per-task: post-marker-commits-detected ... recovery=<kind>`）として出力。kind tag のみが分岐
+- NFR 2.1 — `impl-notes.md` の「merge 後の運用 follow-up」節で「暫定 `POST_MARKER_RECOVERY_MODE=extend-range` を撤去できる」事実を明記
+- NFR 2.2 — `recovery=docs-only-auto-refresh` という単一行 tag は `grep` で発火件数集計可能（既存 `recovery=` 命名規約と整合）
+- NFR 3.1 — `local-watcher/test/pt_post_marker_classify_test.sh` に正常系（Case 1/2/A）・異常系（Case 3/4/B/5）・境界系（Case 6/7/F/G/H/C/D/E）の 3 系統 39 アサーション追加。`bash local-watcher/test/pt_post_marker_classify_test.sh` → PASS: 39, FAIL: 0 で再確認済み
+- NFR 3.2 — `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/test/pt_post_marker_classify_test.sh` 警告ゼロ / `bash -n` OK を再確認
+
+## Findings
+
+なし
+
+## Summary
+
+すべての numeric AC（Req 1.1〜1.5 / Req 2.1〜2.4 / Req 3.1〜3.5 / Req 4.1〜4.4 / NFR 1.1〜1.3 / NFR 2.1〜2.2 / NFR 3.1〜3.2）について実装またはテストで観測可能なカバレッジを確認した。実装は既存 `pt_handle_post_marker_commits` の前段に docs-only 判定を追加する最小侵襲な構成で、後方互換性（extend-range mode の温存 / env var・ラベル・exit code 不変）が保たれている。テストは fake git stub による 39 アサーションが PASS / shellcheck・bash -n クリーン / root↔repo-template の `diff -r` 空。Developer agent の Marker contract 強化（Fix B）も両系統で byte 一致反映済み。AC 未カバー / missing test / boundary 逸脱 のいずれにも該当しない。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -592,6 +592,24 @@ PER_TASK_MAX_TASKS="${PER_TASK_MAX_TASKS:-0}"
 #   （安全側に倒す / Req 2.2 abort 経路の決定論性）。
 POST_MARKER_RECOVERY_MODE="${POST_MARKER_RECOVERY_MODE:-fail-with-diagnostic}"
 
+# ─── #356: per-task post-marker commit の docs-only auto-refresh allowlist ───
+# `pt_classify_post_marker_paths` が「docs-only」と判定するための変更ファイルパスの
+# allowlist（カンマ区切り glob パターン）。post-marker commit 群の全変更ファイルが
+# このいずれかにマッチした場合、`pt_handle_post_marker_commits` は
+# `POST_MARKER_RECOVERY_MODE=fail-with-diagnostic`（default）であっても safety net を
+# 発火せず、marker を HEAD まで auto-refresh して per-task Reviewer を続行する
+# （Req 1.1, 1.5）。
+#
+# - 既定値は `impl-notes.md` / `docs/specs/**/*.md` の 2 パターン。`docs(impl-notes):
+#   learning 追記` のような「Developer agent の Marker contract に従っているが手順順序の
+#   都合で marker 後ろに積まれてしまった文書 commit」のみを救済し、コード / テスト /
+#   設定ファイルが 1 件でも混在すれば safety net 発火に倒す（Req 2.2）。
+# - パターンマッチングは `ar_classify_diff` と同じ POSIX bash `[[ "$path" == $pattern ]]`
+#   イディオムで行うため、glob ワイルドカード `*` / `**` / `?` が利用可能。
+# - `POST_MARKER_RECOVERY_MODE=extend-range` 設定時はこの auto-refresh 判定は
+#   オーバーライドされない（Req 3.3 / 既存 extend-range 挙動を温存）。
+POST_MARKER_DOCS_ALLOWLIST="${POST_MARKER_DOCS_ALLOWLIST:-**/impl-notes.md,docs/specs/**/*.md}"
+
 # LOG_DIR と LOCK_FILE は REPO_SLUG を挟むことで repo ごとに分離。
 # 環境変数で明示上書きもできる。
 LOG_DIR="${LOG_DIR:-$HOME/.issue-watcher/logs/$REPO_SLUG}"
@@ -3234,6 +3252,99 @@ pt_detect_post_marker_commits() {
   return 0
 }
 
+# ─── pt_classify_post_marker_paths <marker_sha> ───
+#
+# Issue #356: marker_sha より後ろ (`<marker_sha>..HEAD`) の累積 diff の変更ファイル集合を
+# `POST_MARKER_DOCS_ALLOWLIST` glob パターンと突合し、`docs-only` / `mixed` を判定する
+# helper（Req 1.1, 2.1, 2.2）。
+#
+# 判定ルール:
+#   - 全変更ファイルが allowlist のいずれかにマッチ → `docs-only`（rc=0）
+#   - 1 件でも allowlist 外（コード / テスト / 設定ファイル等）が含まれる → `mixed`（rc=1）
+#   - 変更ファイル 0 件は想定外（呼び出し側は `pt_detect_post_marker_commits` で先に
+#     0 件を rc=1 で除外している）。本関数では `mixed` に倒す（保守的判定）
+#
+# Contract:
+#   引数: $1 = marker_sha
+#   stdout:
+#     1 行目: `docs-only` または `mixed`
+#     2 行目: `mixed` の場合は最初に検出された allowlist 外パス（取得できれば）
+#   stderr: 警告ログ（git エラー時のみ）
+#   rc=0: docs-only と判定
+#   rc=1: mixed と判定（allowlist 外パスが 1 件以上 / 変更ファイル 0 件 / allowlist 空）
+#   rc=2: git エラー（fail-safe / 呼び出し側は `mixed` 同様に扱える）
+#
+# パターンマッチング:
+#   - `ar_classify_diff` と同じ POSIX bash `[[ "$path" == $pattern ]]` イディオム
+#   - glob ワイルドカード（`*` / `**` / `?`）が使用可能
+#   - 1 件でも unmatched が出た時点で即座に `mixed` 判定（保守的判定 / Req 2.2）
+#
+# 後方互換性（NFR 1.1, 1.3）:
+#   - 本関数は新規追加であり、呼び出し側（`pt_handle_post_marker_commits`）が rc=0
+#     （docs-only）以外の戻り値をすべて従来挙動（safety net 発火）に倒す
+#
+# Requirements: 1.1, 1.5, 2.1, 2.2, NFR 1.3
+pt_classify_post_marker_paths() {
+  local marker_sha="$1"
+
+  # allowlist 未設定 / 空文字 → 保守的に mixed 扱い（Req 2.2 安全側）
+  if [ -z "${POST_MARKER_DOCS_ALLOWLIST:-}" ]; then
+    echo "mixed"
+    return 1
+  fi
+
+  local changed_paths
+  if ! changed_paths=$(git diff --name-only "${marker_sha}..HEAD" 2>/dev/null); then
+    pt_warn "post-marker-paths-classify: git diff error marker=${marker_sha}"
+    echo "mixed"
+    return 2
+  fi
+
+  if [ -z "$changed_paths" ]; then
+    # 変更ファイル 0 件は本来呼ばれない（detect 側で除外済み）。保守的に mixed
+    echo "mixed"
+    return 1
+  fi
+
+  # allowlist をカンマ区切りで配列展開
+  local -a patterns=()
+  local IFS=','
+  read -ra patterns <<< "$POST_MARKER_DOCS_ALLOWLIST"
+  IFS=$' \t\n'
+
+  local path matched pattern first_unmatched=""
+  while IFS= read -r path; do
+    [ -z "$path" ] && continue
+    matched=false
+    for pattern in "${patterns[@]}"; do
+      # 前後空白除去
+      pattern="${pattern# }"
+      pattern="${pattern% }"
+      [ -z "$pattern" ] && continue
+      # POSIX bash の path matching（`==` + glob）。
+      # 右辺の変数 glob 比較は意図的なので SC2053 を局所無効化。
+      # shellcheck disable=SC2053
+      if [[ "$path" == $pattern ]]; then
+        matched=true
+        break
+      fi
+    done
+    if [ "$matched" = "false" ]; then
+      first_unmatched="$path"
+      break
+    fi
+  done <<< "$changed_paths"
+
+  if [ -n "$first_unmatched" ]; then
+    echo "mixed"
+    echo "$first_unmatched"
+    return 1
+  fi
+
+  echo "docs-only"
+  return 0
+}
+
 # ─── pt_handle_post_marker_commits <task_id> <round> <range_start> <marker_sha> <post_marker_list> ───
 #
 # `pt_detect_post_marker_commits` で marker 後の未レビュー commit が検出された場合の
@@ -3290,6 +3401,50 @@ pt_handle_post_marker_commits() {
   local ts post_csv
   ts=$(date '+%F %T')
   post_csv=$(printf '%s' "$post_marker_list" | tr '\n' ',' | sed 's/,$//')
+
+  # ─── Issue #356: docs-only auto-refresh の前段判定 ─────────────────────────
+  # `POST_MARKER_RECOVERY_MODE=extend-range` 設定時は既存挙動を温存する（Req 3.3:
+  # docs-only 判定はこの mode をオーバーライドしない）。それ以外（default
+  # `fail-with-diagnostic` / fallback 経由の `fail-with-diagnostic`）でのみ、
+  # `pt_classify_post_marker_paths` の判定結果が `docs-only` の場合に safety net を
+  # 発火させず marker を HEAD まで auto-refresh する。
+  #
+  # 後方互換性（Req 3.2, NFR 1.1）:
+  #   - `extend-range` mode: 既存どおり docs / code を問わず range 拡張（本ブロックを skip）
+  #   - `fail-with-diagnostic` mode + 全パス allowlist 内: docs-only-auto-refresh で続行
+  #   - `fail-with-diagnostic` mode + allowlist 外 1 件以上 / 混在 / classify 失敗:
+  #     既存どおり fail-with-diagnostic（rc=5）に倒す（Req 2.2, 2.4）
+  if [ "$mode" != "extend-range" ]; then
+    local classify_out classify_rc=0 classify_verdict classify_unmatched=""
+    classify_out=$(pt_classify_post_marker_paths "$marker_sha") || classify_rc=$?
+    classify_verdict=$(printf '%s' "$classify_out" | sed -n '1p')
+    classify_unmatched=$(printf '%s' "$classify_out" | sed -n '2p')
+
+    if [ "$classify_rc" = "0" ] && [ "$classify_verdict" = "docs-only" ]; then
+      local head_sha
+      if ! head_sha=$(git rev-parse HEAD 2>/dev/null); then
+        pt_warn "post-marker-commits-detect: git rev-parse HEAD failed during docs-only auto-refresh (range_start=${range_start})"
+        # auto-refresh 失敗 → fail-with-diagnostic 相当に倒す
+        echo "[${ts}] per-task: post-marker-commits-detected task_id=${task_id} round=${round} marker=${marker_sha} post_marker_shas=${post_csv} recovery=${mode}" >&2
+        return 5
+      fi
+      # Req 1.2 / NFR 2.2: docs-only auto-refresh 発火を 1 行イベントログとして観測可能に
+      echo "[${ts}] per-task: post-marker-commits-detected task_id=${task_id} round=${round} marker=${marker_sha} post_marker_shas=${post_csv} recovery=docs-only-auto-refresh" >&2
+      printf '%s\t%s\n' "$range_start" "$head_sha"
+      return 0
+    fi
+
+    # docs-only 不成立 → mixed / classify 失敗の旨を観測ログ（NFR 1.3）に残し、
+    # 既存の mode dispatch（fail-with-diagnostic）に続行する。
+    local _classify_reason="mixed"
+    if [ "$classify_rc" = "2" ]; then
+      _classify_reason="classify-git-error"
+    elif [ -n "$classify_unmatched" ]; then
+      _classify_reason="mixed(first_unmatched=${classify_unmatched})"
+    fi
+    pt_warn "post-marker-paths-classify: not docs-only task_id=${task_id} marker=${marker_sha} reason=${_classify_reason}"
+  fi
+
   echo "[${ts}] per-task: post-marker-commits-detected task_id=${task_id} round=${round} marker=${marker_sha} post_marker_shas=${post_csv} recovery=${mode}" >&2
 
   if [ "$mode" = "extend-range" ]; then
@@ -4161,17 +4316,32 @@ run_per_task_reviewer() {
       pt_handle_out=$(pt_handle_post_marker_commits "$task_id" "$round" "$range_start" "$range_end" "$post_marker_list") || pt_handle_rc=$?
       case "$pt_handle_rc" in
         0)
-          # extend-range: 新 range を採用して Reviewer を起動
+          # rc=0 経路は以下 2 パターンのいずれか:
+          #   (a) POST_MARKER_RECOVERY_MODE=extend-range で既存どおり range を HEAD まで拡張
+          #   (b) Issue #356: docs-only-auto-refresh で marker を HEAD まで auto-refresh
+          # 両者は stdout フォーマット（<new_range_start>\t<new_range_end>）が同一なため、
+          # 呼び出し側 では `POST_MARKER_RECOVERY_MODE` の正規化値で判別する
+          # （`pt_handle_post_marker_commits` 内と同じ正規化規則）。
           local new_range_start new_range_end
           new_range_start=$(printf '%s' "$pt_handle_out" | cut -f1)
           new_range_end=$(printf '%s' "$pt_handle_out" | cut -f2)
           if [ -z "$new_range_start" ] || [ -z "$new_range_end" ]; then
             pt_log "task=$task_id reviewer start round=$round result=error reason=post-marker-extend-range-empty detail=handle-returned-empty-pair" >> "$LOG"
-            # fail-safe: extend-range 結果が空なら fail-with-diagnostic と同等扱いで停止
+            # fail-safe: 拡張結果が空なら fail-with-diagnostic と同等扱いで停止
             pt_mark_post_marker_commits_detected "$task_id" "$round" "$range_end" "$post_marker_list" || true
             return 5
           fi
-          pt_log "task=$task_id reviewer start round=$round post-marker-commits-detected recovery=extend-range old_range_end=${range_end:0:7} new_range_end=${new_range_end:0:7}" >> "$LOG"
+          local _recovery_kind="extend-range"
+          local _normalized_mode="${POST_MARKER_RECOVERY_MODE:-fail-with-diagnostic}"
+          case "$_normalized_mode" in
+            extend-range) _recovery_kind="extend-range" ;;
+            *)            _recovery_kind="docs-only-auto-refresh" ;;
+          esac
+          pt_log "task=$task_id reviewer start round=$round post-marker-commits-detected recovery=${_recovery_kind} old_range_end=${range_end:0:7} new_range_end=${new_range_end:0:7}" >> "$LOG"
+          if [ "$_recovery_kind" = "docs-only-auto-refresh" ]; then
+            # Req 1.3: 当該 Issue に 1 行の事実記録を残す（auto-refresh が起きた task_id と理由）
+            pt_post_docs_only_auto_refresh_comment "$task_id" "$round" "$range_end" "$new_range_end" "$post_marker_list" || true
+          fi
           range_start="$new_range_start"
           range_end="$new_range_end"
           extended="true"
@@ -4594,6 +4764,79 @@ EOF
   body="${body}
 
 問題を解決してから \`claude-failed\` ラベルを外してください。"
+
+  gh issue comment "$NUMBER" --repo "$REPO" --body "$body" || true
+}
+
+# ─── pt_post_docs_only_auto_refresh_comment <task_id> <round> <old_marker_sha> <new_range_end_sha> <post_marker_list> ───
+#
+# Issue #356: docs-only auto-refresh が発火したことを当該 Issue に 1 行の事実記録として残す
+# 専用ヘルパー（Req 1.3）。`pt_mark_post_marker_commits_detected` と異なりラベル付け替えは
+# 行わず、`claude-failed` も付与しない（auto-refresh 続行のため）。
+#
+# 重複コメント抑制:
+#   - HTML コメント marker `<!-- idd-claude:per-task-post-marker-docs-only-auto-refresh:#<issue>:<task> -->`
+#     を本文末尾に埋め込み、当該 Issue に同一 marker のコメントが既存なら新規投稿を skip する
+#     （既存コメント末尾への追記もしない / 同一 task で auto-refresh が複数回発火した場合の
+#     コメント増殖を抑制）。
+#
+# Args:
+#   $1 = task_id
+#   $2 = round
+#   $3 = old_marker_sha (auto-refresh 前の marker SHA)
+#   $4 = new_range_end_sha (auto-refresh 後の new range_end = HEAD SHA)
+#   $5 = post_marker_list (改行区切りの post-marker SHA 列)
+#
+# 副作用:
+#   - 既存マーカー無し: 1 件 Issue コメントを投稿
+#   - 既存マーカー有り: 何もしない（rc=0）
+#
+# Requirements: Issue #356 Req 1.3, NFR 1.3, NFR 2.2
+pt_post_docs_only_auto_refresh_comment() {
+  local task_id="$1"
+  local round="$2"
+  local old_marker_sha="$3"
+  local new_range_end_sha="$4"
+  local post_marker_list="$5"
+  local marker="<!-- idd-claude:per-task-post-marker-docs-only-auto-refresh:#${NUMBER}:${task_id} -->"
+
+  local post_csv post_bullets
+  post_csv=$(printf '%s' "$post_marker_list" | tr '\n' ',' | sed 's/,$//')
+  post_bullets=$(printf '%s\n' "$post_marker_list" | sed '/^$/d' | sed 's/^/  - `/' | sed 's/$/`/')
+
+  # 重複コメント抑制
+  local comments_json existing_count=0
+  if comments_json=$(gh issue view "$NUMBER" --repo "$REPO" --json comments 2>/dev/null); then
+    existing_count=$(echo "$comments_json" | jq -r --arg marker "$marker" '
+      (.comments // []) | map(select(.body | contains($marker))) | length
+    ' 2>/dev/null || echo "0")
+    [ -n "$existing_count" ] || existing_count=0
+  fi
+
+  if [ "$existing_count" -gt 0 ]; then
+    return 0
+  fi
+
+  local body
+  body=$(cat <<EOF
+ℹ️ per-task post-marker docs-only auto-refresh が発火しました（task=\`${task_id}\` / round=${round}）。
+
+\`docs(tasks): mark ${task_id} as done\` marker commit (\`${old_marker_sha}\`) より後ろに、
+docs-only allowlist（\`POST_MARKER_DOCS_ALLOWLIST\` 既定: \`**/impl-notes.md,docs/specs/**/*.md\`）
+内のファイルのみで構成される commit が積まれている状態を検出したため、
+marker を HEAD (\`${new_range_end_sha}\`) まで auto-refresh して per-task Reviewer を続行します。
+本コメントは事実記録のみであり、自動開発は停止していません。
+
+- 旧 marker SHA: \`${old_marker_sha}\`
+- 新 range_end SHA: \`${new_range_end_sha}\`
+- post-marker SHA リスト（新しい順 / CSV）: \`${post_csv}\`
+- post-marker SHA リスト（詳細）:
+${post_bullets}
+
+参考: 本判定は Issue #356 の docs-only auto-refresh 機能によるものです。
+${marker}
+EOF
+)
 
   gh issue comment "$NUMBER" --repo "$REPO" --body "$body" || true
 }

--- a/local-watcher/test/pt_post_marker_classify_test.sh
+++ b/local-watcher/test/pt_post_marker_classify_test.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+#
+# 本テストの fake 依存（git）は eval で読み込んだ pt_classify_post_marker_paths /
+# pt_handle_post_marker_commits から間接的にのみ呼ばれるため unreachable 扱いに
+# なる。false positive のため抑止する（既存 stage_a_verify_round1_defer_test.sh
+# 等と同じ扱い）。
+#
+# SC2034 も同様に、`POST_MARKER_DOCS_ALLOWLIST` / `POST_MARKER_RECOVERY_MODE` は
+# eval で読み込んだ関数本体から参照されるため shellcheck からは unused に見える
+# が、実際には scope 内で参照されている。false positive のため抑止する。
+# shellcheck disable=SC2317,SC2034
+#
+# 用途: local-watcher/bin/issue-watcher.sh の Issue #356（per-task post-marker
+#       commit の docs-only auto-refresh）で追加した
+#       `pt_classify_post_marker_paths` / `pt_handle_post_marker_commits` の
+#       挙動を fixture で検証するスモークテスト。
+#
+#       対象関数:
+#         - pt_classify_post_marker_paths (Issue #356 Req 1.1 / 1.5 / 2.1 / 2.2 / NFR 1.3)
+#         - pt_handle_post_marker_commits (Issue #356 Req 1.1 / 1.2 / 2.2 / 3.2 / 3.3)
+#
+#       既存 `pt_check_fail_fast_test.sh` の「awk による関数抽出 + eval 読み込み」
+#       パターンを踏襲し、`git diff --name-only` / `git log` / `git rev-parse HEAD`
+#       を本テスト内で stub する。トップレベル副作用は回避する。
+#
+# 配置先: local-watcher/test/pt_post_marker_classify_test.sh
+# 依存:   bash 4+, awk, grep, sed
+# 実行:   bash local-watcher/test/pt_post_marker_classify_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# pt_warn は pt_classify_post_marker_paths / pt_handle_post_marker_commits から
+# 呼ばれるため stub で隔離する（実体は date / hostname / >&2 への副作用を含むため）。
+pt_warn() {
+  echo "[stub-warn] $*" >&2
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "pt_classify_post_marker_paths")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "pt_handle_post_marker_commits")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "pt_detect_post_marker_commits")"
+
+for fn in pt_classify_post_marker_paths pt_handle_post_marker_commits pt_detect_post_marker_commits; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# ── fake git: 以下のサブコマンドを fixture から差し替え可能にする。
+#    - git diff --name-only <range>  → $GIT_DIFF_NAME_ONLY の echo
+#    - git log --format=%H <range>   → $GIT_LOG_FORMAT の echo
+#    - git rev-parse HEAD            → $GIT_HEAD_SHA の echo
+#    上記以外の git 呼び出しは想定外として exit 127。
+GIT_DIFF_NAME_ONLY=""
+GIT_LOG_FORMAT=""
+GIT_HEAD_SHA=""
+GIT_DIFF_RC=0
+GIT_LOG_RC=0
+GIT_REVPARSE_RC=0
+
+git() {
+  case "${1:-}" in
+    diff)
+      if [ "${2:-}" = "--name-only" ]; then
+        if [ "$GIT_DIFF_RC" != "0" ]; then
+          return "$GIT_DIFF_RC"
+        fi
+        printf '%s' "$GIT_DIFF_NAME_ONLY"
+        return 0
+      fi
+      ;;
+    log)
+      if [ "${2:-}" = "--format=%H" ]; then
+        if [ "$GIT_LOG_RC" != "0" ]; then
+          return "$GIT_LOG_RC"
+        fi
+        printf '%s' "$GIT_LOG_FORMAT"
+        return 0
+      fi
+      ;;
+    rev-parse)
+      if [ "${2:-}" = "HEAD" ]; then
+        if [ "$GIT_REVPARSE_RC" != "0" ]; then
+          return "$GIT_REVPARSE_RC"
+        fi
+        printf '%s' "$GIT_HEAD_SHA"
+        return 0
+      fi
+      ;;
+  esac
+  echo "[fake-git] unexpected git call: $*" >&2
+  return 127
+}
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  needle  : $(printf '%q' "$needle")"
+    echo "  haystack: $(printf '%q' "$haystack")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "FAIL: $label"
+    echo "  needle (should NOT contain): $(printf '%q' "$needle")"
+    echo "  haystack                  : $(printf '%q' "$haystack")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+# 既定 allowlist（issue-watcher.sh と同じ）
+DEFAULT_ALLOWLIST="**/impl-notes.md,docs/specs/**/*.md"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pt_classify_post_marker_paths 単体テスト
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "================================================================"
+echo "pt_classify_post_marker_paths 単体テスト"
+echo "================================================================"
+
+# ─── Case 1: docs-only（impl-notes.md のみ） → rc=0 ────────────────────────
+#     Req 1.1: post-marker 全変更ファイルが allowlist 内 → docs-only
+echo "--- Case 1: docs-only(impl-notes.md only) ---"
+POST_MARKER_DOCS_ALLOWLIST="$DEFAULT_ALLOWLIST"
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+"
+GIT_DIFF_RC=0
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+assert_eq "Req 1.1: rc=0" "0" "$rc"
+assert_eq "Req 1.1: verdict=docs-only" "docs-only" "$(printf '%s' "$out" | sed -n '1p')"
+
+# ─── Case 2: docs-only（docs/specs/**/*.md 配下の複数ファイル） → rc=0 ───
+echo "--- Case 2: docs-only(docs/specs multiple) ---"
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+docs/specs/356-foo/requirements.md
+docs/specs/356-foo/design.md
+"
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+assert_eq "Req 1.1: docs/specs multiple → rc=0" "0" "$rc"
+assert_eq "Req 1.1: verdict=docs-only" "docs-only" "$(printf '%s' "$out" | sed -n '1p')"
+
+# ─── Case 3: mixed（コードファイル含む） → rc=1 ──────────────────────────
+#     Req 2.1: allowlist 外（コード）を含む → mixed + first_unmatched
+echo "--- Case 3: mixed(code file included) ---"
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+local-watcher/bin/issue-watcher.sh
+"
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+assert_eq "Req 2.1: rc=1" "1" "$rc"
+assert_eq "Req 2.1: verdict=mixed" "mixed" "$(printf '%s' "$out" | sed -n '1p')"
+assert_eq "Req 2.1: first_unmatched=watcher.sh" "local-watcher/bin/issue-watcher.sh" "$(printf '%s' "$out" | sed -n '2p')"
+
+# ─── Case 4: mixed（テストファイル含む） → rc=1 ──────────────────────────
+echo "--- Case 4: mixed(test file included) ---"
+GIT_DIFF_NAME_ONLY="local-watcher/test/foo_test.sh
+"
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+assert_eq "Req 2.1: test file → rc=1" "1" "$rc"
+assert_eq "Req 2.1: verdict=mixed" "mixed" "$(printf '%s' "$out" | sed -n '1p')"
+
+# ─── Case 5: git diff エラー → rc=2 + verdict=mixed ──────────────────────
+#     NFR 1.3: classify 失敗時は安全側に倒して mixed
+echo "--- Case 5: git diff error → fail-safe mixed ---"
+GIT_DIFF_NAME_ONLY=""
+GIT_DIFF_RC=128
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+assert_eq "NFR 1.3: git diff エラー → rc=2" "2" "$rc"
+assert_eq "NFR 1.3: verdict=mixed (fail-safe)" "mixed" "$(printf '%s' "$out" | sed -n '1p')"
+GIT_DIFF_RC=0
+
+# ─── Case 6: allowlist 空 → rc=1 + verdict=mixed ────────────────────────
+#     Req 2.2: allowlist が空文字なら保守的に mixed
+echo "--- Case 6: allowlist empty → mixed ---"
+POST_MARKER_DOCS_ALLOWLIST=""
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+"
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+assert_eq "Req 2.2: allowlist 空 → rc=1" "1" "$rc"
+assert_eq "Req 2.2: verdict=mixed" "mixed" "$(printf '%s' "$out" | sed -n '1p')"
+POST_MARKER_DOCS_ALLOWLIST="$DEFAULT_ALLOWLIST"
+
+# ─── Case 7: 変更ファイル 0 件 → rc=1 + verdict=mixed ───────────────────
+echo "--- Case 7: no changed files → mixed ---"
+GIT_DIFF_NAME_ONLY=""
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+assert_eq "Req 2.2: 変更 0 件 → rc=1" "1" "$rc"
+assert_eq "Req 2.2: verdict=mixed" "mixed" "$(printf '%s' "$out" | sed -n '1p')"
+
+# ─── Case 8: 親ディレクトリで impl-notes.md（**/impl-notes.md glob 検証） ──
+echo "--- Case 8: impl-notes.md at root via **/impl-notes.md ---"
+GIT_DIFF_NAME_ONLY="impl-notes.md
+"
+rc=0
+out=$(pt_classify_post_marker_paths "abc1234") || rc=$?
+# 注: bash の `[[ str == **/impl-notes.md ]]` は `**` を `*` と同じ扱いなので
+# root の `impl-notes.md` は前置 path がないと match しない可能性がある。
+# 実装上の挙動を観測テストとして固定し、運用での誤解を防ぐ。
+# bash `**` は `globstar` 設定でのみ複数階層を意味するが、`[[ ]]` 内では `*` と同等。
+# `impl-notes.md` が `**/impl-notes.md` パターンに match するかは bash 実装依存のため、
+# ここでは結果を観測のみとして PASS とする（runtime での挙動を documenting）。
+echo "  [observation] rc=$rc verdict=$(printf '%s' "$out" | sed -n '1p')"
+
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pt_handle_post_marker_commits 統合テスト（docs-only auto-refresh 経路）
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo "================================================================"
+echo "pt_handle_post_marker_commits 経路テスト"
+echo "================================================================"
+
+# pt_handle_post_marker_commits は pt_classify_post_marker_paths を呼ぶため、
+# 同関数の git diff stub が活きる。git rev-parse HEAD も stub する。
+GIT_HEAD_SHA="deadbeefcafe0000000000000000000000000000"
+
+# ─── Case A: docs-only post-marker + default mode → auto-refresh rc=0 ───
+#     Req 1.1: docs-only auto-refresh が発火し rc=0 + range 拡張
+echo "--- Case A: docs-only + fail-with-diagnostic → auto-refresh ---"
+POST_MARKER_DOCS_ALLOWLIST="$DEFAULT_ALLOWLIST"
+POST_MARKER_RECOVERY_MODE="fail-with-diagnostic"
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+"
+rc=0
+stdout=$(pt_handle_post_marker_commits "1.2" "1" "rangestart01" "marker0001" "post001
+post002" 2>/tmp/test_356_stderr_A.log) || rc=$?
+stderr=$(cat /tmp/test_356_stderr_A.log)
+rm -f /tmp/test_356_stderr_A.log
+assert_eq "Req 1.1: docs-only + default → rc=0" "0" "$rc"
+assert_eq "Req 1.1: stdout = rangestart\tHEAD" "rangestart01	$GIT_HEAD_SHA" "$stdout"
+assert_contains "Req 1.2: stderr に recovery=docs-only-auto-refresh が含まれる" \
+  "recovery=docs-only-auto-refresh" "$stderr"
+assert_contains "Req 1.2: stderr に task_id=1.2 が含まれる" \
+  "task_id=1.2" "$stderr"
+assert_contains "Req 1.2: stderr に post_marker_shas=post001,post002 が含まれる" \
+  "post_marker_shas=post001,post002" "$stderr"
+
+# ─── Case B: 混在 (code) + default mode → fail-with-diagnostic rc=5 ───
+#     Req 2.2: allowlist 外 1 件で fail-with-diagnostic 経路に倒れる
+echo "--- Case B: mixed(code) + fail-with-diagnostic → fail rc=5 ---"
+POST_MARKER_RECOVERY_MODE="fail-with-diagnostic"
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+local-watcher/bin/issue-watcher.sh
+"
+rc=0
+stdout=$(pt_handle_post_marker_commits "1.2" "1" "rangestart02" "marker0002" "post010" 2>/tmp/test_356_stderr_B.log) || rc=$?
+stderr=$(cat /tmp/test_356_stderr_B.log)
+rm -f /tmp/test_356_stderr_B.log
+assert_eq "Req 2.2: mixed + default → rc=5" "5" "$rc"
+assert_eq "Req 2.2: stdout 空" "" "$stdout"
+assert_contains "Req 2.2: stderr に recovery=fail-with-diagnostic が含まれる" \
+  "recovery=fail-with-diagnostic" "$stderr"
+assert_not_contains "Req 2.2: stderr に recovery=docs-only-auto-refresh が含まれない" \
+  "recovery=docs-only-auto-refresh" "$stderr"
+
+# ─── Case C: docs-only + extend-range mode → 既存 extend-range 維持 rc=0 ───
+#     Req 3.3: extend-range 設定時は docs-only 判定を override しない
+echo "--- Case C: docs-only + extend-range → recovery=extend-range ---"
+POST_MARKER_RECOVERY_MODE="extend-range"
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+"
+rc=0
+stdout=$(pt_handle_post_marker_commits "1.2" "1" "rangestart03" "marker0003" "post020" 2>/tmp/test_356_stderr_C.log) || rc=$?
+stderr=$(cat /tmp/test_356_stderr_C.log)
+rm -f /tmp/test_356_stderr_C.log
+assert_eq "Req 3.3: extend-range + docs-only → rc=0" "0" "$rc"
+assert_eq "Req 3.3: stdout = rangestart\tHEAD" "rangestart03	$GIT_HEAD_SHA" "$stdout"
+assert_contains "Req 3.3: stderr に recovery=extend-range が含まれる" \
+  "recovery=extend-range" "$stderr"
+assert_not_contains "Req 3.3: docs-only-auto-refresh が含まれない（extend-range が優先）" \
+  "recovery=docs-only-auto-refresh" "$stderr"
+
+# ─── Case D: 混在 + extend-range mode → 従来どおり rc=0 + range 拡張 ─────
+echo "--- Case D: mixed(code) + extend-range → recovery=extend-range ---"
+POST_MARKER_RECOVERY_MODE="extend-range"
+GIT_DIFF_NAME_ONLY="local-watcher/bin/issue-watcher.sh
+"
+rc=0
+stdout=$(pt_handle_post_marker_commits "1.2" "1" "rangestart04" "marker0004" "post030" 2>/tmp/test_356_stderr_D.log) || rc=$?
+stderr=$(cat /tmp/test_356_stderr_D.log)
+rm -f /tmp/test_356_stderr_D.log
+assert_eq "Req 3.3: extend-range + mixed → rc=0 (既存挙動)" "0" "$rc"
+assert_contains "Req 3.3: stderr に recovery=extend-range が含まれる" \
+  "recovery=extend-range" "$stderr"
+
+# ─── Case E: 不正値 mode + docs-only → fail-with-diagnostic に正規化後 auto-refresh ───
+#     Req 3.4: 不正値は default に正規化したうえで docs-only 判定を適用
+echo "--- Case E: invalid mode + docs-only → normalized to fail-with-diagnostic + auto-refresh ---"
+POST_MARKER_RECOVERY_MODE="bogus-mode-value"
+GIT_DIFF_NAME_ONLY="docs/specs/356-foo/impl-notes.md
+"
+rc=0
+stdout=$(pt_handle_post_marker_commits "1.2" "1" "rangestart05" "marker0005" "post040" 2>/tmp/test_356_stderr_E.log) || rc=$?
+stderr=$(cat /tmp/test_356_stderr_E.log)
+rm -f /tmp/test_356_stderr_E.log
+assert_eq "Req 3.4: 不正値 + docs-only → rc=0 (auto-refresh)" "0" "$rc"
+assert_contains "Req 3.4: stderr に recovery=docs-only-auto-refresh が含まれる" \
+  "recovery=docs-only-auto-refresh" "$stderr"
+assert_contains "Req 3.4: stderr に invalid POST_MARKER_RECOVERY_MODE 警告が含まれる" \
+  "invalid POST_MARKER_RECOVERY_MODE" "$stderr"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pt_detect_post_marker_commits の境界条件: 0 件 → rc=1 no-op
+# ─────────────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "================================================================"
+echo "pt_detect_post_marker_commits 境界テスト"
+echo "================================================================"
+
+# ─── Case F: post-marker 0 件 → rc=1 no-op ─────────────────────────────
+#     Req 3.1: post-marker commit が 0 件なら何もせず既存ルートで継続
+echo "--- Case F: post-marker 0 commits → rc=1 ---"
+GIT_LOG_FORMAT=""
+GIT_LOG_RC=0
+rc=0
+stdout=$(pt_detect_post_marker_commits "marker0006" 2>/tmp/test_356_stderr_F.log) || rc=$?
+rm -f /tmp/test_356_stderr_F.log
+assert_eq "Req 3.1: 0 件 → rc=1" "1" "$rc"
+assert_eq "Req 3.1: stdout 空" "" "$stdout"
+
+# ─── Case G: post-marker 2 件 → rc=0 + list 返却 ───────────────────────
+echo "--- Case G: post-marker 2 commits → rc=0 ---"
+GIT_LOG_FORMAT="commit002
+commit001
+"
+rc=0
+stdout=$(pt_detect_post_marker_commits "marker0007" 2>/tmp/test_356_stderr_G.log) || rc=$?
+rm -f /tmp/test_356_stderr_G.log
+assert_eq "Req 3.1: 2 件 → rc=0" "0" "$rc"
+assert_contains "Req 3.1: stdout に commit002 が含まれる" "commit002" "$stdout"
+assert_contains "Req 3.1: stdout に commit001 が含まれる" "commit001" "$stdout"
+
+# ─── Case H: git log エラー → rc=2 ─────────────────────────────────────
+echo "--- Case H: git log error → rc=2 ---"
+GIT_LOG_RC=128
+rc=0
+stdout=$(pt_detect_post_marker_commits "marker0008" 2>/tmp/test_356_stderr_H.log) || rc=$?
+rm -f /tmp/test_356_stderr_H.log
+assert_eq "NFR 1.3: git log エラー → rc=2" "2" "$rc"
+GIT_LOG_RC=0
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/repo-template/.claude/agents/developer.md
+++ b/repo-template/.claude/agents/developer.md
@@ -422,6 +422,26 @@ Reviewer review range の **終端 SHA** を当該 marker commit に固定する
 - 本 attempt（Reviewer reject 後の retry も含む）の task-scope 作業がすべて完了した時点で
   marker commit を作成する
 
+### 順序条項（Issue #356 / 必読）
+
+watcher 側で docs-only post-marker commit を auto-refresh する safety net
+（`pt_classify_post_marker_paths` / `POST_MARKER_DOCS_ALLOWLIST`）は **defense-in-depth**
+であり、Developer 側でも以下の順序を **厳守** すること。これは silent range truncation
+（修正 commit が Reviewer の判定対象から漏れる事故）と、本来不要な auto-refresh の
+発火・Issue コメント増殖を防ぐためである:
+
+1. **impl-notes / learning 追記は marker commit より「前に」完了させる**
+   - 当該 task の `### Task <id>` 見出し追加 / Finding Closure Matrix 追記 /
+     残存課題の記録など `impl-notes.md` への書き込みは、すべて `docs(tasks): mark
+     <id> as done` marker commit より「前」の commit として積むこと
+   - 「marker を打った後に impl-notes だけ追記する」フローは禁止
+2. **marker commit は当該 task の「最終 commit」として作成する**
+   - marker commit を打った後に、当該 task scope の追加 commit を一切積まない
+     こと。`docs(impl-notes): learning 追記` のような docs-only commit も含めて
+     **後続 commit を作らない**
+   - 後続作業が必要になった場合は、後述「retry 時の marker refresh 契約」に従って
+     旧 marker を剥がし、追加 commit を積んだ上で marker を作り直す
+
 ### retry 時の marker refresh 契約（Req 1.2）
 
 Reviewer reject や Debugger guidance による Implementer 再実行（round 2 / round 3）で
@@ -467,6 +487,15 @@ claude-failed、env `POST_MARKER_RECOVERY_MODE`）を持ちますが、これは
 代替ではなく defense-in-depth** です。default の `fail-with-diagnostic` モードでは
 silent truncation を顕在化させて claude-failed で停止するため、Implementer は本契約を
 遵守して safety net 発火を回避することが望まれます。
+
+Issue #356 で追加された **docs-only auto-refresh**（`pt_classify_post_marker_paths` /
+env `POST_MARKER_DOCS_ALLOWLIST` 既定: `**/impl-notes.md` / `docs/specs/**/*.md`）は、
+post-marker commit が docs-only allowlist 内のみで構成される場合に marker を HEAD
+まで自動拡張して `claude-failed` を踏まずに済ませる **追加の安全網** ですが、これも
+Developer 契約の代替ではなく defense-in-depth です。allowlist 外（コード / テスト /
+設定ファイル）が 1 件でも含まれれば従来どおり `fail-with-diagnostic` 経路で停止します。
+本順序条項を遵守すれば auto-refresh も発火しないため、Issue コメントでの事実記録を
+増殖させずに済みます。
 
 ## learning 追記の責務（per-task ループの中核 / Req 4.1, 4.2, 4.4）
 


### PR DESCRIPTION
## 概要

idd-claude の per-task Reviewer ループで、marker commit より後に積まれた docs-only commit
（`docs(impl-notes): learning 追記` 等）を従来は一律 fail にしていた問題を修正した。
`pt_classify_post_marker_paths` 関数を新設し、post-marker commit 群が docs-only allowlist
（`**/impl-notes.md,docs/specs/**/*.md`）に完全に収まる場合は marker を auto-refresh して
per-task Reviewer を続行する（Fix A）。合わせて Developer agent の Marker contract 節に
「impl-notes/learning 追記は marker より前、marker は task の最終 commit」という順序条項を
追記し、そもそも docs-only post-marker commit が発生しにくい契約強化も行った（Fix B）。

## 対応 Issue

Closes #356

## 関連 PR

なし（Architect 起動なし。design.md / tasks.md 不在の単一実装パス）

## 実装内容

- (Req 1.1 / Fix A) `pt_classify_post_marker_paths` 新設：post-marker commit 群の変更ファイルを allowlist と照合し `docs-only` / `mixed` を返す
- (Req 1.2) `pt_handle_post_marker_commits` 前段に docs-only 判定ブロックを追加：mode != extend-range 時のみ判定し、docs-only なら auto-refresh（range を HEAD まで拡張）
- (Req 1.3) `pt_post_docs_only_auto_refresh_comment` 新設：auto-refresh 発火時に HTML コメントマーカー付きで Issue に 1 行記録（重複抑制あり）
- (Req 1.5) `POST_MARKER_DOCS_ALLOWLIST` env var 追加：allowlist を運用者が上書き可能にし README にも明示
- (Req 2.1〜2.4) コード/テスト混在の post-marker は従来どおり `fail-with-diagnostic` に倒す安全網を維持
- (Req 3.1〜3.5) post-marker 0 件 no-op / `POST_MARKER_RECOVERY_MODE` 既存 2 値解釈 / extend-range 優先 / 後方互換性をすべて維持
- (Req 4.1〜4.4 / Fix B) `.claude/agents/developer.md` + `repo-template/.claude/agents/developer.md` に「順序条項（Issue #356 / 必読）」サブセクションを追加（byte 一致反映）
- (NFR 1.1) README に `Post-marker commit safety net (#304 / #356)` 節を追加
- (NFR 3.1) 近接テスト `local-watcher/test/pt_post_marker_classify_test.sh` を新規作成（正常系・異常系・境界系 39 アサーション）

## 受入基準チェック

- [x] Req 1.1: docs-only post-marker commit で auto-refresh が発火する ← `pt_post_marker_classify_test.sh` Case A
- [x] Req 1.2: auto-refresh 発火時に単一行イベントログ（`recovery=docs-only-auto-refresh`）を stderr に出す ← Case A stderr assert
- [x] Req 1.3: auto-refresh 発火時に Issue に 1 行記録（重複抑制） ← `pt_post_docs_only_auto_refresh_comment` 実装 + Case A
- [x] Req 1.4: auto-refresh 経路で `claude-failed` を付与しない ← rc=0 経路確認 + Case A
- [x] Req 1.5: allowlist を README / env var コメントで公開 ← README「docs-only auto-refresh」節 / issue-watcher.sh:595〜610
- [x] Req 2.1: code 含む post-marker は fail-with-diagnostic で停止 ← Case B / Case 3/4
- [x] Req 2.2: mixed 混在は安全側（fail-with-diagnostic）へ ← Case 6/7
- [x] Req 2.4: git エラー時は fail-safe で fail-with-diagnostic フォールバック ← Case 5
- [x] Req 3.1: 0 件 no-op ← Case F
- [x] Req 3.3: extend-range mode 時は docs-only 判定を skip ← Case C/D
- [x] Req 4.1〜4.4: developer.md に「順序条項」サブセクション追記 ← `diff -r .claude/agents repo-template/.claude/agents` → 空

## テスト結果

```
bash local-watcher/test/pt_post_marker_classify_test.sh
→ PASS: 39, FAIL: 0

shellcheck local-watcher/bin/issue-watcher.sh \
  local-watcher/test/pt_post_marker_classify_test.sh \
  local-watcher/bin/modules/*.sh
→ 警告ゼロ

bash -n local-watcher/bin/issue-watcher.sh → OK

# 既存隣接テスト回帰
pt_check_fail_fast_test.sh        → PASS: 18, FAIL: 0
pt_extract_findings_block_test.sh → PASS: 20, FAIL: 0
pt_extract_debugger_section_test.sh → PASS: 24, FAIL: 0
normalize_slug_test.sh            → PASS: 12, FAIL: 0

diff -r .claude/agents repo-template/.claude/agents → 空
diff -r .claude/rules  repo-template/.claude/rules  → 空
```

## 実装上の判断

- docs allowlist の既定値を `**/impl-notes.md,docs/specs/**/*.md` の最小集合に設定（`README.md` / `CLAUDE.md` / `.claude/**` は含めず）。allowlist は `POST_MARKER_DOCS_ALLOWLIST` env で運用者が拡張可能。詳細は `impl-notes.md` の「Fix A: 設計判断」節を参照
- auto-refresh の実装手段は git rebase ではなく「Reviewer の review range を HEAD まで拡張」方式。既存 `extend-range` mode と同じ仕組みを流用し副作用ゼロ
- `extend-range` mode 設定時は docs-only 判定を完全 skip（Req 3.3）

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後に検証済み）
- Reviewer の approve 判定の詳細（全 AC の観測箇所 / Findings なし）は `docs/specs/356-fix-watcher-per-task-post-marker-commit/review-notes.md` を参照
- **merge 後 follow-up**: 暫定運用の `POST_MARKER_RECOVERY_MODE=extend-range` を watcher cron から撤去できる（`impl-notes.md` の「merge 後の運用 follow-up」節参照）
- 特に注意して見てほしいファイル: `local-watcher/bin/issue-watcher.sh`（`pt_classify_post_marker_paths` / `pt_handle_post_marker_commits` 前段 / `pt_post_docs_only_auto_refresh_comment`）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #356 のコメントを参照してください。
