### PR TITLE
fix(#374): claude-review status が per-task フローで publish されない問題を catch-up processor で修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -2828,6 +2828,16 @@ required status checks による auto-merge ゲートに組み込めるように
   で抽出した `RESULT: approve` → `state=success`、`RESULT: reject` → `state=failure`。
   target_url は review-notes.md の GitHub blob URL（PR head sha 指定）。
 
+  なお per-task ループ運用（`PER_TASK_LOOP_ENABLED=true`）では Reviewer round=1〜3 直後の
+  publish 試行が PjM の impl PR 作成より前の時間軸に並ぶため、`gh pr list --head <branch>` が
+  PR を解決できず WARN skip で終わるケースが構造的に発生します。これに対する catch-up として、
+  watcher サイクル毎に `process_claude_review_status_catchup`（modules/pr-reviewer.sh）が
+  AND 二重 opt-in 配下で open PR を scan し、対応する head 側の `review-notes.md` から RESULT
+  を読み直して publish します（#374）。GitHub の latest-wins セマンティクスにより、Reviewer
+  ステージ直後の publish と catch-up publish が同じ (sha, context) に重なっても最新値に収束
+  します（Req 4.3 / 4.5）。catch-up は `PR_REVIEWER_ENABLED` の値に依存せず動作するため、
+  claude-review 単独有効化（codex / antigravity を使わない構成）でも catch-up は機能します。
+
 ### Publish の挙動と既知の特性
 
 - **同一 (sha, context) への再 POST**: GitHub Commit Status API の latest-wins 仕様により

--- a/docs/specs/374-fix-pr-reviewer-claude-review-status-per/impl-notes.md
+++ b/docs/specs/374-fix-pr-reviewer-claude-review-status-per/impl-notes.md
@@ -1,0 +1,160 @@
+# Implementation Notes — Issue #374
+
+## 設計判断
+
+修正方針スコープは PM 確定済みで「(A) PR 作成後に再 publish」「(B) pr-reviewer.sh 側で
+claude-review も publish」のいずれか／両方が許容範囲。本実装では **(B) を独立 processor
+として実装する** 方針を採用した。
+
+### 採用方針: 独立 catch-up processor (B' 派生)
+
+`pr-reviewer.sh` 内に新規 processor `process_claude_review_status_catchup` を追加し、
+watcher 1 サイクルあたり 1 回、`pr_fetch_candidate_prs`（既存 / open PR scan）から候補 PR を
+列挙して `claude-review` status の publish を試みる。
+
+#### 採用理由
+
+1. **PR 存在の構造的保証**: `pr_fetch_candidate_prs` は `gh pr list --state open` で
+   open PR のみを返すため、catch-up 時点で **PR が GitHub 側に存在することが構造的に保証** される。
+   per-task ループの Reviewer round 直後の publish が PR 作成より前に発火する問題
+   （Issue #374 の根本原因）が構造的に発生しない時間軸で publish が走る。
+2. **codex 経路との対称**: codex / antigravity の `codex-review` status は同じ `pr_run_review_for_pr`
+   経路で同じ「PR が存在する状態」で publish されており、claude-review の catch-up も同じ
+   入力（open PR scan）から駆動することで対称性が取れる。
+3. **per-task / 非 per-task 両方をカバー**: catch-up は `PER_TASK_LOOP_ENABLED` の値に依存せず
+   動作するため、非 per-task 経路（Stage B / B' / B''）でも latest-wins セマンティクスにより
+   最終状態への収束を強化する（Req 4.5）。既存の `publish_claude_review_status` 直接呼び出し
+   12 箇所は **一切変更していない**（Req 2.x 非 per-task 経路の挙動温存）。
+4. **`PR_REVIEWER_ENABLED` 非依存**: README #349 の既存契約（claude-review 単独有効化が可能）
+   を維持するため、catch-up は AND 二重 opt-in のみで gate する独立 processor とした。
+   既存 `pr_run_review_for_pr` 内に embed する案も検討したが、それだと `PR_REVIEWER_ENABLED=true`
+   が必須になり既存契約と矛盾するため不採用。
+
+### 検討して採用しなかった案
+
+- **(A) PR 作成完了後フック**: Stage C / PjM 完了時に publish を発火させる案も検討した
+  が、PjM 完了から GitHub の PR 取得 eventual consistency までのウィンドウ（最大 73〜135 秒の
+  edge cache lag が #108 / #110 で観測されている）を吸収する verify_stagec_pr_or_retry 経路に
+  publish を組み込む必要があり、副作用範囲が広い。watcher サイクル毎の catch-up は次回サイクル
+  （最短 2 分）で結果整合的に publish が完了するため、ラグ吸収は不要で実装が単純。
+- **`pr_run_review_for_pr` 内に embed**: 上記 4 の理由で不採用。
+
+## 変更ファイル一覧
+
+- `local-watcher/bin/modules/pr-reviewer.sh`
+  - 新規関数 `pr_publish_claude_status_from_branch(pr_number, sha, head_ref, pr_url)`
+    （1 PR 分の catch-up publish）。`pr_` prefix 踏襲。AND 二重 opt-in / head pattern
+    判定 / spec dir 解決 (`git ls-tree` + `git show`) / `parse_review_result` 呼び出し /
+    `pr_publish_claude_status` 呼び出しを含む。すべての skip 条件で WARN + return 0
+    （silent fail 禁止）。
+  - 新規 processor `process_claude_review_status_catchup()`（サイクルあたり 1 回起動 /
+    AND 二重 opt-in のみで gate / open PR scan→各 PR で `pr_publish_claude_status_from_branch`
+    を呼ぶ）。
+- `local-watcher/bin/issue-watcher.sh`
+  - `process_pr_reviewer` 呼び出し直後に `process_claude_review_status_catchup` を呼ぶ
+    1 行を追加（Phase A flock 内 / 後続 processor を阻害しない `|| pr_warn`）。
+- `README.md`
+  - 「PR Reviewer Commit Status Publishing (#349)」節の「Publish の発火タイミング」
+    `claude-review` 項目に per-task catch-up 経路の説明を追記（既存 #349 セマンティクスの
+    補完であることと、`PR_REVIEWER_ENABLED` 非依存であることを明記）。
+- `local-watcher/test/pr_publish_claude_status_from_branch_test.sh`（新規 / 近接テスト）
+  - 既存 `pr_publish_commit_status_test.sh` の `extract_function` イディオムを踏襲。
+
+## 追加した近接テストの概要
+
+`local-watcher/test/pr_publish_claude_status_from_branch_test.sh`（52 件のアサーション）:
+
+- **Section 1: AND 二重 opt-in 早期 return**（Req 5.1 / 5.2 / NFR 1.1）
+  - 両 gate 未設定 / 片方 ON / もう片方 ON の各ケースで gh / git 呼び出しがゼロであること。
+- **Section 2: head_ref パターン外 → silent skip**
+  - `feature/other` 等の非 claude/issue- 形式は WARN を残さず早期 return すること。
+- **Section 3: approve → state=success**（Req 1.4 / 4.1）
+  - gh api POST が 1 回 / payload に context=claude-review / description=claude: approve /
+    target_url に PR head sha 指定の blob URL が含まれること。catch-up サマリログ 1 行。
+- **Section 4: reject → state=failure**（Req 4.2）
+  - state=failure / description=claude: reject。
+- **Section 5: skip 経路の WARN ログ**（Req 3.1〜3.5）
+  - spec-dir-not-found / file-not-found / parse-failed / ls-tree-failed / invalid-result の
+    5 経路すべてで rc=0 + WARN ログに `branch=…` `pr=#…` `reason=…` 識別子を含むこと。
+- **Section 6: publish 呼び出し位置の回帰防止**（NFR 4.3）
+  - `process_claude_review_status_catchup` 内で `pr_publish_claude_status_from_branch` を呼ぶこと。
+  - `pr_fetch_candidate_prs`（open PR scan）を入力に取ること（= PR 存在状態で呼ばれる構造的保証）。
+  - `pr_status_check_enabled` で gate されること。
+  - `PR_REVIEWER_ENABLED` を参照していないこと。
+- **Section 7: processor orchestration**
+  - gate OFF / 候補 0 件 / 候補 1 件 / 候補 2 件 / head pattern 外の各シナリオで
+    publish 呼び出し回数とサマリログを検証。
+
+NFR 4.3「publish 呼び出し位置が再び PR 作成より前に戻る回帰がコミットされた場合に該当
+テストを fail させ、どの呼び出し位置が PR 未作成の時間軸に並んでいるかを 1 件以上特定可能
+な形で出力する」については、Section 6 の text-grep アサーションが該当機能。具体的には:
+- `process_claude_review_status_catchup` が `pr_fetch_candidate_prs` から入力を取らない
+  リファクタが入ると Section 6 が fail し、catch-up の構造的保証が崩れたことを検出する。
+- catch-up を `process_pr_reviewer` の embed に戻すリファクタが入っても Section 6 の
+  「`pr_status_check_enabled` で gate される」アサーションが残るため、AND opt-in 以外の
+  gate が混入したら fail する。
+
+## 静的検査・テスト実行結果
+
+### bash -n（構文チェック）
+
+- `bash -n local-watcher/bin/issue-watcher.sh` → OK
+- `bash -n local-watcher/bin/modules/pr-reviewer.sh` → OK
+- `bash -n local-watcher/test/pr_publish_claude_status_from_branch_test.sh` → OK
+
+### shellcheck（`.shellcheckrc` 反映 / 警告増加 0 が目標）
+
+- `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/pr-reviewer.sh
+  local-watcher/test/pr_publish_claude_status_from_branch_test.sh` → 警告ゼロ
+
+### テスト
+
+- `bash local-watcher/test/pr_publish_claude_status_from_branch_test.sh` → PASS=52 / FAIL=0
+- 既存 `pr_publish_commit_status_test.sh` → PASS=74 / FAIL=0（回帰なし）
+- `local-watcher/test/*_test.sh` 全件（49 ファイル） → 49 件すべて PASS
+
+### root ↔ repo-template 同期確認
+
+- `diff -r .claude/agents repo-template/.claude/agents` → diff なし
+- `diff -r .claude/rules repo-template/.claude/rules` → diff なし
+- `local-watcher/` は root 専用（`install.sh` 経由で `$HOME/bin/modules/` へ配布）
+- `.github/workflows/` は本 PR では編集していない
+
+## AC traceability（要件 ID → テスト / 実装の対応）
+
+| AC ID | テストケース / 実装 |
+|---|---|
+| Req 1.1 | per-task Reviewer round=1 approve / AND opt-in / PR 存在状態の同時成立 — Section 7 Case 7.C で fixture により再現 |
+| Req 1.2 | per-task Reviewer round reject → claude-review=failure — Section 4 + 関数仕様 |
+| Req 1.3 | context 名・state 解決・description 長制限が非 per-task と一致 — `pr_publish_claude_status` を流用するため契約一致（既存 #349 テスト pr_publish_commit_status_test.sh が回帰固定） |
+| Req 1.4 | PR 作成完了後の publish 1 回以上保証 — Section 7 Case 7.C / 7.D（catch-up が PR 作成後にサイクル毎に発火） |
+| Req 1.5 | 同一 PR 内で複数 task の Reviewer round 完了 → 最新 RESULT に収束 — GitHub latest-wins セマンティクス + catch-up がサイクル毎に最新 review-notes.md を読むため自然成立。本 issue では implicit |
+| Req 2.1 / 2.2 / 2.3 | 非 per-task 経路の挙動温存 — 既存 `publish_claude_review_status` 呼び出し 12 箇所は **一切変更していない** ことで保証 |
+| Req 3.1 | PR 未解決時 WARN + skip — Section 7 Case 7.E（head pattern 外） + Section 5（spec-dir-not-found） |
+| Req 3.2 | review-notes.md 不在時 WARN + skip — Section 5 Case 5.B |
+| Req 3.3 | parse 失敗時 WARN + skip — Section 5 Case 5.C / 5.E |
+| Req 3.4 | skip 時もパイプライン継続（rc=0） — Section 5 各 case の `rc=0` アサーション |
+| Req 3.5 | WARN に Issue 番号 / branch 名 / 理由を含む — Section 5 各 case の `assert_contains` |
+| Req 4.1 | per-task 最終 round approve + PR 作成完了 → success 観測可能 — Section 7 Case 7.C |
+| Req 4.2 | per-task 最終 round reject + PR 作成完了 → failure 観測可能 — Section 4 + Section 7 setup（approve は 7.C / reject は組み合わせで同じ経路を通る） |
+| Req 4.3 | latest-wins セマンティクス — `pr_publish_claude_status`（既存）を呼ぶため自然成立（既存 #349 動作） |
+| Req 4.4 | PR 未存在で publish しない（副作用ゼロ） — Section 7 Case 7.E + Section 2 |
+| Req 5.1 / 5.2 | AND 二重 opt-in OFF で API 呼び出しゼロ — Section 1 全 case / Section 7 Case 7.A |
+| Req 5.3 / 5.4 / 5.5 | env var 名・正規化規則・PR コメント挙動を変更しない — 本実装は新規 catch-up processor 追加のみ。既存 `pr_status_check_enabled` / `pr_publish_claude_status` / `parse_review_result` を流用 |
+| Req 6.1 / 6.2 / 6.3 | install.sh / README / E2E — `install.sh` の `copy_glob_to_homebin` が `modules/*.sh` を一括コピーするため `pr-reviewer.sh` の変更は自動配布される（既存挙動）。README は同一 PR で更新済み |
+| NFR 1.1 / 1.2 / 1.3 | 既存挙動温存 / 既存正規化規則 / 既存関数シグネチャ非破壊 — 新規関数追加のみ、既存関数は無変更 |
+| NFR 2.1 / 2.2 | 静的検査 — 上記「静的検査」セクション |
+| NFR 3.1 / 3.2 / 3.3 | 観測ログ — `pr_log` 経由で `pr-reviewer:` prefix 統一、suppression は既存 cycle-1-line 制限に委ねる |
+| NFR 4.1 / 4.2 / 4.3 | 回帰防止テスト — `pr_publish_claude_status_from_branch_test.sh` Section 6 / 7 |
+
+## 確認事項
+
+なし。要件は EARS 形式で十分に明確であり、実装方針スコープも PM 確定済みで Architect の
+領分との曖昧性はなかった。本実装は方針 (B) を独立 processor として実装する派生を採用した
+理由を本ファイル冒頭に明記している。
+
+## STATUS
+
+本 Issue の修正は完了し、Reviewer に渡してよい状態。
+
+STATUS: complete

--- a/docs/specs/374-fix-pr-reviewer-claude-review-status-per/requirements.md
+++ b/docs/specs/374-fix-pr-reviewer-claude-review-status-per/requirements.md
@@ -1,0 +1,133 @@
+# Requirements Document
+
+## Introduction
+
+`PR_REVIEWER_STATUS_CHECK_ENABLED=true` + `FULL_AUTO_ENABLED=true` の AND 二重 opt-in が
+成立した環境において、`codex-review` commit status は PR head sha に対して正しく publish される一方、
+`claude-review` commit status は **per-task ループ運用（`PER_TASK_LOOP_ENABLED=true`）では一度も
+publish されない**。Issue #349 が要件化した「Claude Reviewer の最終 `RESULT:` を `claude-review`
+context として PR head sha に publish する」契約（#349 Req 3.x / 4.x）が per-task 経路で
+構造的に成立しない状態にある。
+
+根本原因は、per-task ループの Reviewer round=1〜3 直後で claude-review status を publish する
+試行が、PjM による impl PR 作成より **前** の時間軸に並んでいることにある。publish 関数は
+ブランチから `gh pr list --head <branch>` で PR を解決して head sha を取得する設計のため、
+PR がまだ存在しないタイミングでは PR 解決に失敗し、WARN ログを残して skip して終わる。
+altpocket #85 の実トレースでは Reviewer round=1 approve 完了から PjM の PR 作成までに
+約 1 分 40 秒のタイムラグが観測されている。
+
+本要件は、per-task / 非 per-task いずれの実装経路でも、PR が GitHub 側に存在する状態で
+`claude-review` commit status が PR head sha に publish され、かつ Reviewer の最新 `RESULT:`
+（approve / reject）と整合した状態に収束することを保証する。後方互換として、AND 二重 opt-in が
+無効な既定環境では本修正後も commit status を一切 publish せず、外形挙動を導入前と完全に
+等価に保つ。
+
+## Requirements
+
+### Requirement 1: per-task 経路での `claude-review` status publish の発火
+
+**Objective:** As an idd-claude operator, I want claude-review commit status to be published against the impl PR head sha when per-task loop completes a Reviewer round, so that auto-merge の required status checks が per-task 運用環境でも `claude-review` を観測でき、ゲートが構造的に成立しないという現状の不具合が解消される
+
+#### Acceptance Criteria
+
+1. When per-task loop の Reviewer round=1〜3 のいずれかが approve を出し、かつ AND 二重 opt-in が成立し、かつ対応する impl PR が GitHub 側に存在する状態に到達した, the PR Reviewer Processor shall context `claude-review` / state `success` の commit status を PR head sha に対して 1 回 publish する
+2. When per-task loop の Reviewer round=1〜3 のいずれかが reject を出し、かつ AND 二重 opt-in が成立し、かつ対応する impl PR が GitHub 側に存在する状態に到達した, the PR Reviewer Processor shall context `claude-review` / state `failure` の commit status を PR head sha に対して 1 回 publish する
+3. The PR Reviewer Processor shall per-task 経路で publish する `claude-review` status の context 名・state 解決規則（approve→success / reject→failure）・description 長制限を、非 per-task 経路（#349 Req 3.1〜3.3）と一致させる
+4. When PjM が impl PR を作成する前に Reviewer の `RESULT:` が確定した, the PR Reviewer Processor shall PR 作成完了後に当該 Reviewer の `RESULT:` を反映した `claude-review` status の publish が 1 回以上行われることを保証する
+5. The PR Reviewer Processor shall 同一 impl PR 内で複数 task が連続して Reviewer round を完了した場合、各 task の最終 `RESULT:` を反映した最新の `claude-review` status が PR head sha に対して観測可能な状態に収束させる
+
+### Requirement 2: 非 per-task 経路の挙動温存
+
+**Objective:** As an idd-claude operator, I want non per-task 経路の `claude-review` publish 挙動を本修正で変更しないようにしたい, so that 既に正しく publish できている経路（Reviewer round=1〜3 / Debugger 経由 round=3 / Issue #349 で確立済み）が回帰しない
+
+#### Acceptance Criteria
+
+1. While `PER_TASK_LOOP_ENABLED` が `=true` 以外（既定 OFF）かつ AND 二重 opt-in が成立している, the PR Reviewer Processor shall 非 per-task 経路の Reviewer round=1〜3 完了直後に `claude-review` status を従来どおり PR head sha に publish する
+2. The PR Reviewer Processor shall 非 per-task 経路の publish 呼び出し位置（Stage B / Stage B' / Debugger 経由 Stage B''）における外形挙動（呼び出し回数・state・description・target_url）を本修正前後で一致させる
+3. The PR Reviewer Processor shall 非 per-task 経路では本修正前と同様に impl PR が既に存在する状態でのみ publish が試行されることを維持する
+
+### Requirement 3: PR 未作成時 / parse 失敗時の安全な skip
+
+**Objective:** As an idd-claude operator, I want publish 試行のタイミング不整合や `review-notes.md` parse 失敗が watcher パイプラインを停止させないようにしたい, so that GitHub API のタイミングや想定外の状態が原因で claude-failed に倒れる事故を防げる
+
+#### Acceptance Criteria
+
+1. If publish 試行時点で対応する impl PR が GitHub 側に解決できない（branch から PR が引けない）, the PR Reviewer Processor shall WARN レベルのログを 1 行残し commit status の publish を行わずに当該試行を skip する
+2. If `review-notes.md` が存在しない, the PR Reviewer Processor shall WARN レベルのログを 1 行残し commit status の publish を行わずに当該試行を skip する
+3. If `review-notes.md` を `parse_review_result` で解釈できない（最終 `RESULT:` 行不在 / 不正値）, the PR Reviewer Processor shall WARN レベルのログを 1 行残し commit status の publish を行わずに当該試行を skip する
+4. When publish 試行が PR 未作成・review-notes.md 不在・parse 失敗のいずれかで skip された, the PR Reviewer Processor shall watcher パイプライン（per-task ループ継続 / PjM PR 作成 / 後続 Reviewer round / claude-failed 判定）を停止させずに後続処理を続行する
+5. The PR Reviewer Processor shall WARN ログ 1 行に「Issue 番号」「branch 名」「round 番号（既知時）」「skip 理由（PR 未解決 / file 不在 / parse 失敗のいずれか）」を含めて、原因特定が grep 1 回で完了する形にする
+
+### Requirement 4: PR 作成後の最終 publish 整合（latest-wins）
+
+**Objective:** As an idd-claude operator, I want PjM の impl PR 作成完了後に当該 PR head sha 上で `claude-review` status が Reviewer の最終 `RESULT:` を反映する状態に収束することを保証したい, so that auto-merge ゲートが古い PR 不在時の WARN skip のまま claude-review status 欠落で永遠に成立しない事態を防ぐ
+
+#### Acceptance Criteria
+
+1. When per-task ループの最終 Reviewer round が `RESULT: approve` を出して PjM が impl PR を作成完了した, the PR Reviewer Processor shall PR head sha に対して context `claude-review` / state `success` の commit status が観測可能な状態に到達することを保証する
+2. When per-task ループの最終 Reviewer round が `RESULT: reject` を出して PjM が impl PR を作成完了した, the PR Reviewer Processor shall PR head sha に対して context `claude-review` / state `failure` の commit status が観測可能な状態に到達することを保証する
+3. When 同一 PR head sha に対して同一 context `claude-review` で複数回 publish が行われた, the PR Reviewer Processor shall GitHub Commit Status API の "latest wins per (sha, context)" セマンティクスにより最新の `RESULT:` を反映した state が表示される状態に収束させる（#349 Req 4.3 と整合）
+4. While impl PR が GitHub 側に存在しない状態, the PR Reviewer Processor shall PR head sha に対する `claude-review` status の publish を試行しない（試行しても解決不能なため Req 3.1 で skip される / 副作用ゼロ）
+
+### Requirement 5: 後方互換と既定動作の温存
+
+**Objective:** As an idd-claude operator, I want AND 二重 opt-in が無効な既定環境の挙動を本修正で一切変更しないようにしたい, so that 本修正をデプロイした既存 consumer repo が `claude-review` status の publish 試行・追加 API 呼び出し・追加ログ出力に巻き込まれない
+
+#### Acceptance Criteria
+
+1. While `PR_REVIEWER_STATUS_CHECK_ENABLED` が `=true` 以外（既定 `false`）, the PR Reviewer Processor shall `claude-review` status の publish 関連 API 呼び出し（`gh api -X POST /repos/.../statuses/<sha>` / `gh pr list --head <branch>` 等）を一切発火させない
+2. While `FULL_AUTO_ENABLED` が `=true` 以外（既定 `false`）, the PR Reviewer Processor shall `claude-review` status の publish 関連 API 呼び出しを一切発火させない（#348 kill switch 配下 / #349 Req 1.4 と整合）
+3. The PR Reviewer Processor shall `PR_REVIEWER_STATUS_CHECK_ENABLED` / `FULL_AUTO_ENABLED` env var 名・正規化規則・kill switch セマンティクスを本修正で変更しない
+4. The PR Reviewer Processor shall 既存の env var 名・ラベル名・exit code 意味・cron 登録文字列・ログ出力先・PR コメント投稿の挙動を本修正で変更しない
+5. While AND 二重 opt-in が無効, the PR Reviewer Processor shall 従来どおり `review-notes.md` の commit / push / PR コメント投稿挙動を一切変更せず、運用者がコメントから `RESULT:` を確認できる状態を維持する（#349 Req 6.x と整合）
+
+### Requirement 6: 同期と配布の整合性
+
+**Objective:** As an idd-claude メンテナ, I want 本修正が root 配下の watcher / module と installed consumer 配下（`$HOME/bin/...`）の双方で同一挙動になることを保証したい, so that `install.sh` 経由で配布される watcher にも修正が確実に反映され、本 Issue が「修正したのに動かない」と再発しないようにする
+
+#### Acceptance Criteria
+
+1. The Installer shall `install.sh` が `local-watcher/bin/issue-watcher.sh` および `local-watcher/bin/modules/*.sh` を `$HOME/bin/` 配下へ冪等にコピーする既存挙動を維持し、本修正後のファイルがそのまま配布される
+2. The Issue Watcher shall README の該当箇所（`PR_REVIEWER_STATUS_CHECK_ENABLED` / `claude-review` status の動作説明や既知の制約に関する記述があれば）と整合した状態で本修正を反映する
+3. When 本修正をデプロイ済みの環境で per-task ループ運用（`PER_TASK_LOOP_ENABLED=true`）の eligible Issue を投入した, the PR Reviewer Processor shall PjM が impl PR を作成した後に当該 PR head sha に対して `claude-review` commit status が観測される状態に到達する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The PR Reviewer Processor shall 本修正前後で AND 二重 opt-in 無効環境の外部観測挙動（exit code / stderr 出力 / ラベル遷移 / 外部副作用の有無 / PR コメント投稿）を一致させる
+2. The PR Reviewer Processor shall 本修正後も `PR_REVIEWER_STATUS_CHECK_ENABLED` / `FULL_AUTO_ENABLED` 正規化規則（`=true` 厳密一致、それ以外を OFF）を維持する
+3. The PR Reviewer Processor shall 本修正後も既存の `publish_claude_review_status` / `pr_publish_claude_status` 関数シグネチャ（引数・戻り値・既存呼び出し位置の round 番号引数）に対する直接破壊的変更を行わない（呼び出し位置の追加 / 補完は許容）
+
+### NFR 2: 静的検査
+
+1. The Issue Watcher shall 本修正後の `local-watcher/bin/issue-watcher.sh` および `local-watcher/bin/modules/pr-reviewer.sh` が `bash -n` で構文エラー 0、`shellcheck` で `.shellcheckrc` を踏まえた baseline 上の警告増加 0 を満たす
+2. The Test Suite shall 追加した近接テストの bash スクリプトが `bash -n` / `shellcheck` クリーンであることを満たす
+
+### NFR 3: 可観測性
+
+1. When publish が成功した, the PR Reviewer Processor shall PR 番号・head sha・context・state を含む 1 行のログを既存ロガー粒度（`pr_log`）と同形式で stdout に出力する（#349 NFR 1.x と整合）
+2. When publish が PR 未解決・file 不在・parse 失敗のいずれかで skip された, the PR Reviewer Processor shall skip 理由を識別可能な WARN ログを 1 行残し silent fail にしない（#349 Req 5.x と整合）
+3. The PR Reviewer Processor shall AND 二重 opt-in OFF 時の suppression ログを既存契約どおり「サイクルあたり最大 1 行」に制限する（#349 Req 7.2 と整合）
+
+### NFR 4: 回帰防止テスト粒度
+
+1. The Test Suite shall per-task 経路で「Reviewer round=1 approve / reject 後に publish 試行が PR 作成完了後に成立すること」を再現できる近接テストを `local-watcher/test/` 配下に追加する
+2. The Test Suite shall 上記近接テストを既存テストランナ（`local-watcher/test/` 配下の bash テストイディオム）から起動可能な単一スクリプトとして提供する
+3. If `publish_claude_review_status` の呼び出し位置が再び PR 作成より前に戻る回帰がコミットされた, the Test Suite shall 該当テストを fail させ、どの呼び出し位置が PR 未作成の時間軸に並んでいるかを 1 件以上特定可能な形で出力する
+
+## Out of Scope
+
+- `codex-review` commit status publish ロジックの変更（本 Issue は `claude-review` 経路の不具合修正に限定し、codex 側は #349 確定済みの挙動を維持する）
+- `pr_publish_commit_status` / `pr_publish_claude_status` の API call レイヤ・state 解決ロジック・description 長制限の変更（#349 で確立済み）
+- `PR_REVIEWER_STATUS_CHECK_ENABLED` / `FULL_AUTO_ENABLED` の env var 名・正規化規則・kill switch 概念の再設計（#348 / #349 で確定済み）
+- `review-notes.md` の `RESULT:` 規約・`parse_review_result` 関数本体の変更（既存契約をそのまま流用）
+- Debugger Gate 経由 Reviewer round=3（非 per-task 経路）の publish 呼び出し位置の変更（既に PR 存在状態で publish される経路のため対象外）
+- per-task ループ自体のタイミング設計変更（task 単位 Reviewer の起動順序 / Debugger Gate / fail-fast セマンティクス）— 本修正はあくまで `claude-review` status の publish タイミングに限定する
+- branch protection / required status checks 側の設定（GitHub 側設定 / consumer 運用責務）
+- altpocket-server 等 consumer repo 側での auto-merge ラベル運用・PR テンプレートの調整
+- `codex-review` 不在 / 失敗時の auto-merge ゲート挙動（D-03 / D-04 / 関連 Issue で扱う領域）
+
+## Open Questions
+
+- なし（Issue #374 本文・既存コード（`publish_claude_review_status` 呼び出し位置 12 箇所 / `pr_publish_claude_status` 実装）・関連 Issue #349 の確定済み契約を突き合わせることで、修正方針スコープ（PR 作成後再 publish フックの導入 / pr-reviewer.sh 内 publish 経路追加 / 両者併用）の選択は Architect の領域として委ね、本要件は publish 成立タイミングと AC ベースの外形契約に限定して記述した。要件レベルで人間判断が必要な未解決項目は識別されなかった）

--- a/docs/specs/374-fix-pr-reviewer-claude-review-status-per/review-notes.md
+++ b/docs/specs/374-fix-pr-reviewer-claude-review-status-per/review-notes.md
@@ -1,0 +1,120 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-374-impl-fix-pr-reviewer-claude-review-status-per
+- HEAD commit: 59d7a31e6fc17accba579a30cfe835547c969326
+- Compared to: main..HEAD
+- 変更ファイル統計: README.md (+10) / impl-notes.md (新規) / requirements.md (新規) /
+  local-watcher/bin/issue-watcher.sh (+8) / local-watcher/bin/modules/pr-reviewer.sh (+200) /
+  local-watcher/test/pr_publish_claude_status_from_branch_test.sh (新規 622 行)
+- Feature Flag Protocol: 本リポジトリ（root の CLAUDE.md）には `## Feature Flag Protocol` 節が
+  存在せず、`opt-in` 宣言ではないため、flag 観点の細目チェックは **行わない**。通常の 3 カテゴリ
+  判定のみを適用した。
+
+## Verified Requirements
+
+### Requirement 1: per-task 経路での claude-review status publish の発火
+
+- 1.1 — `process_claude_review_status_catchup`（pr-reviewer.sh:1310 付近）が AND 二重 opt-in 配下で
+  open PR scan → `pr_publish_claude_status_from_branch` → 既存 `pr_publish_claude_status`
+  へ approve→success を委譲。テスト Section 7 Case 7.C で `gh api POST ... state=success` を検証。
+- 1.2 — 同経路で reject→failure。テスト Section 4 で `state=failure` / `description=claude: reject`
+  を検証。
+- 1.3 — `pr_publish_claude_status`（既存）→ `pr_publish_commit_status` を経由するため、
+  context 名・state 解決・description 長制限は #349 既存契約と一致（既存 `pr_publish_commit_status_test.sh`
+  が回帰固定）。
+- 1.4 — catch-up は `pr_fetch_candidate_prs`（`gh pr list --state open`）から駆動するため、
+  publish 時点で PR の存在が構造的に保証される。テスト Section 7 Case 7.C / 7.D で確認。
+- 1.5 — catch-up は watcher サイクル毎に最新の review-notes.md（origin/<head_ref>:<spec>/review-notes.md）
+  を読み直すため、複数 task 連続完了時も最終 RESULT に収束。GitHub の latest-wins セマンティクスで担保。
+
+### Requirement 2: 非 per-task 経路の挙動温存
+
+- 2.1 / 2.2 / 2.3 — 既存 `publish_claude_review_status` 呼び出し 12 箇所は **一切変更されていない**
+  （`git diff main..HEAD -- local-watcher/bin/issue-watcher.sh` の差分は新規 `process_claude_review_status_catchup`
+  呼び出し追加のみ）。非 per-task 経路の publish タイミング・呼び出し回数・state・description・
+  target_url は本修正前後で同一。
+
+### Requirement 3: PR 未作成時 / parse 失敗時の安全な skip
+
+- 3.1 — head_ref パターン外（feature/...）は silent skip（テスト Section 2）。
+  spec-dir-not-found / ls-tree-failed も WARN + rc=0（テスト Section 5 Case 5.A / 5.D）。
+- 3.2 — review-notes.md 不在（`git cat-file -e` 失敗）で WARN + skip（テスト Section 5 Case 5.B）。
+- 3.3 — parse_review_result 失敗 / 不正 RESULT で WARN + skip（テスト Section 5 Case 5.C / 5.E）。
+- 3.4 — 全 skip 経路で rc=0、呼び出し元の `|| pr_warn`（issue-watcher.sh:1510）でパイプライン継続。
+- 3.5 — 全 WARN ログに `branch=` / `pr=#` / `reason=` 識別子を含む（テスト Section 5 で `assert_contains`）。
+
+### Requirement 4: PR 作成後の最終 publish 整合（latest-wins）
+
+- 4.1 / 4.2 — 上記 Req 1.1 / 1.2 と同経路。catch-up が PR head sha 宛てに `context=claude-review`
+  state=success/failure を publish。
+- 4.3 — 既存 `pr_publish_claude_status` → GitHub Commit Status API（latest-wins per (sha, context)）。
+  本修正で API レイヤは変更なし。
+- 4.4 — `pr_fetch_candidate_prs` が open PR のみを返すため、PR 未存在時は catch-up loop に
+  入らず副作用ゼロ。
+
+### Requirement 5: 後方互換と既定動作の温存
+
+- 5.1 / 5.2 — `pr_publish_claude_status_from_branch` 冒頭と `process_claude_review_status_catchup`
+  冒頭で `pr_status_check_enabled` 早期 return。テスト Section 1 Case 1.A〜1.C / Section 7 Case 7.A で
+  AND OFF 時 gh / git / pr_fetch 呼び出しゼロを確認。
+- 5.3 — `PR_REVIEWER_STATUS_CHECK_ENABLED` / `FULL_AUTO_ENABLED` の env var 名・正規化規則は
+  既存 `pr_status_check_enabled` を流用するため未変更。
+- 5.4 — 既存 env var 名 / ラベル名 / exit code / cron 文字列 / ログ出力先 / PR コメント挙動は無変更
+  （差分は新規関数追加と processor 呼び出し 1 行追加のみ）。
+- 5.5 — review-notes.md の commit / push / コメント投稿挙動は本修正範囲外（変更なし）。
+
+### Requirement 6: 同期と配布の整合性
+
+- 6.1 — `install.sh` の `copy_glob_to_homebin` が `modules/*.sh` を一括コピーする既存挙動を
+  維持（修正対象外）。新規ファイル追加なし（既存 `pr-reviewer.sh` への追記のみ）。
+- 6.2 — README.md「PR Reviewer Commit Status Publishing (#349)」節へ per-task catch-up 経路の
+  説明を追記（+10 行）。
+- 6.3 — catch-up は `process_pr_reviewer` 直後にサイクル毎発火する設計のため、配布後の watcher
+  で次サイクルで結果整合的に publish される。
+
+### Non-Functional Requirements
+
+- NFR 1.1 / 1.2 / 1.3 — AND OFF 時の外部観測挙動温存（Section 1 / Case 7.A）。`pr_status_check_enabled`
+  / `pr_publish_claude_status` / `parse_review_result` のシグネチャは無変更（流用のみ）。
+- NFR 2.1 / 2.2 — `bash -n` クリーン（issue-watcher.sh / pr-reviewer.sh / 新規テスト）、
+  `shellcheck` クリーン（reviewer 環境で再実行確認、警告ゼロ）。
+- NFR 3.1 / 3.2 / 3.3 — `pr_log` で成功 1 行 / skip 各経路で `pr_warn` 1 行、suppression は既存
+  `pr_publish_commit_status` の cycle あたり 1 行制限に委ねる（重複ログ抑止）。
+- NFR 4.1 / 4.2 / 4.3 — `local-watcher/test/pr_publish_claude_status_from_branch_test.sh` を
+  単一スクリプトとして追加。Section 6 grep アサーション 4 件で publish 呼び出し位置の構造的保証
+  （`pr_fetch_candidate_prs` を入力に取る / `pr_status_check_enabled` で gate / `PR_REVIEWER_ENABLED`
+  非依存）を回帰固定。
+
+## 追加検証
+
+- Reviewer 環境で `bash local-watcher/test/pr_publish_claude_status_from_branch_test.sh` を再実行
+  → `PASS=52, FAIL=0`。
+- `bash -n` / `shellcheck` を変更 3 ファイルへ再実行 → クリーン（出力ゼロ）。
+- `diff -r .claude/agents repo-template/.claude/agents` / `diff -r .claude/rules repo-template/.claude/rules`
+  → 差分なし（root↔repo-template 同期維持）。
+- 境界確認: 差分ファイルは `local-watcher/bin/issue-watcher.sh` / `local-watcher/bin/modules/pr-reviewer.sh`
+  / `local-watcher/test/` / `README.md` / `docs/specs/374-.../` の範囲内であり、impl-notes.md
+  記載の変更範囲と一致。tasks.md は本 Issue では生成されていないが、これは Architect 不在
+  （Triage が `needs_architect: false` 相当と判断）に伴うものであり、impl-notes.md の
+  「変更ファイル一覧」と「AC traceability」が境界の正本として機能している。本 reviewer は
+  3 カテゴリのみで判定するため、tasks.md 不在は reject 理由としない（boundary 違反は
+  検出していない）。
+
+## Findings
+
+なし
+
+## Summary
+
+per-task ループ運用での `claude-review` commit status 不発（Issue #374）に対し、独立 catch-up
+processor (`process_claude_review_status_catchup`) を `pr_fetch_candidate_prs` を入力源として
+追加する方針で、Req 1.1〜6.3 / NFR 1.1〜4.3 のすべてに対応する実装とテスト（52 件 PASS）が
+揃っている。AND 二重 opt-in OFF 時は外部副作用ゼロ、既存 `publish_claude_review_status`
+呼び出し 12 箇所は無変更、root↔repo-template / bash -n / shellcheck もクリーン。3 カテゴリ
+（AC 未カバー / missing test / boundary 逸脱）のいずれにも該当する問題は検出されなかった。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -1502,6 +1502,14 @@ process_design_review_release() {
 # （PR_REVIEWER_ENABLED!=true なら即 return 0 で本機能導入前と等価、NFR 1.1）。
 process_pr_reviewer || pr_warn "process_pr_reviewer が想定外のエラーで終了しました（後続 Issue 処理は継続）"
 
+# Issue #374 claude-review Catch-up Processor を PR Reviewer の直後に実行。
+# per-task ループ運用で `publish_claude_review_status` が PR 作成より前の時間軸で発火して
+# WARN skip した分を、open PR scan で読み直して publish する catch-up 経路。
+# AND 二重 opt-in（PR_REVIEWER_STATUS_CHECK_ENABLED=true AND FULL_AUTO_ENABLED=true）が
+# 成立した場合のみ動作。OFF（既定）なら即 return 0 で本機能導入前と等価（NFR 1.1）。
+# `PR_REVIEWER_ENABLED` の値には依存しない（claude-review 単独有効化を維持）。
+process_claude_review_status_catchup || pr_warn "process_claude_review_status_catchup が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+
 # Security Review Processor (#279) を PR Reviewer の直後・PR Iteration の直前に実行。
 # advisory 固定動作（ラベル操作なし）のため PR Reviewer の needs-iteration 付与とは
 # 競合しない。PR タイムライン上で「外部 AI レビュー → セキュリティレビュー → iteration

--- a/local-watcher/bin/modules/pr-reviewer.sh
+++ b/local-watcher/bin/modules/pr-reviewer.sh
@@ -861,6 +861,131 @@ pr_publish_claude_status() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# pr_publish_claude_status_from_branch: PR が存在する状態で claude-review status を
+#   publish する catch-up 経路（Issue #374）。
+#   入力: $1 = pr_number, $2 = sha, $3 = head_ref（例: claude/issue-123-impl-foo）,
+#         $4 = pr_url（target_url fallback 用）
+#   出力: なし（log のみ）
+#   戻り値: 0 固定（best-effort / skip / publish 失敗いずれもパイプライン継続）
+#
+#   背景（Issue #374）:
+#     per-task ループ運用（PER_TASK_LOOP_ENABLED=true）では `publish_claude_review_status`
+#     が Reviewer round=1〜3 直後に呼ばれる時系列が PjM の impl PR 作成より前になるため、
+#     `gh pr list --head <branch>` で PR が解決できず WARN skip で終わってしまう。
+#     本関数は `process_pr_reviewer` の review loop（open PR を scan する経路）から
+#     呼ばれることで「PR が GitHub 側に存在する状態」を構造的に保証し、AND 二重 opt-in
+#     成立時の claude-review status を確実に publish する catch-up 経路を提供する。
+#
+#   設計判断:
+#     - AND 二重 opt-in（`pr_status_check_enabled`）成立時のみ動作。OFF は外部副作用ゼロで
+#       即 return（Req 5.1, 5.2 / NFR 1.1）。
+#     - head_ref から issue 番号を抽出（`claude/issue-<N>-...`）。一致しなければ silent skip
+#       （他 head pattern は本機能対象外）。
+#     - workspace は呼び出し元 pr_run_review_for_pr 完了時点で BASE_BRANCH に復帰している
+#       前提のため、head 側の `docs/specs/<N>-*/review-notes.md` を `git ls-tree` + `git show`
+#       で読み出す（checkout 不要 / 副作用ゼロ）。
+#     - 既存 `parse_review_result` を呼び出して RESULT を抽出する（contract 流用 / NFR 1.3）。
+#     - 既存 `pr_publish_claude_status` をそのまま呼ぶ（codex 経路と対称 / API 経路は #349 完成形を維持）。
+#     - PR 未解決 / file 不在 / parse 失敗いずれも WARN を 1 行残して return 0
+#       （silent fail 禁止 / Req 3.1〜3.5）。
+pr_publish_claude_status_from_branch() {
+  local pr_number="${1:-}"
+  local sha="${2:-}"
+  local head_ref="${3:-}"
+  local pr_url="${4:-}"
+
+  # AND 二重 opt-in 早期判定（Req 5.1, 5.2 / NFR 1.1）
+  if ! pr_status_check_enabled; then
+    # suppression ログは pr_publish_commit_status 側の cycle あたり 1 行制限に委ねる
+    # （本関数で重複ログを出さない / Req 5.5 / NFR 3.3）。
+    return 0
+  fi
+
+  # head_ref から issue 番号を抽出（claude/issue-<N>-...）
+  local issue_number=""
+  if [[ "$head_ref" =~ ^claude/issue-([0-9]+)- ]]; then
+    issue_number="${BASH_REMATCH[1]}"
+  fi
+  if [ -z "$issue_number" ]; then
+    # 本関数対象外 head（design / 他 prefix 等）→ silent skip
+    return 0
+  fi
+
+  # spec dir を origin/$head_ref の tree から解決（cwd は呼び出し元で REPO_DIR / NFR 1.1）。
+  # `git ls-tree --name-only` で `docs/specs/<N>-<slug>/` の直下エントリ群を列挙し、
+  # `<N>-` で始まる最初のディレクトリを採用する。
+  # `--` でオプション解釈を打ち切り（path 由来のフラグ注入予防 / 既存 hardening 同方針）。
+  local tree_out spec_dir_rel=""
+  if ! tree_out=$(timeout "$PR_REVIEWER_GIT_TIMEOUT" \
+      git ls-tree --name-only "origin/${head_ref}" -- "docs/specs/" 2>/dev/null); then
+    pr_warn "claude-review status publish (catch-up): docs/specs 列挙失敗 branch=${head_ref} pr=#${pr_number} reason=ls-tree-failed"
+    return 0
+  fi
+  # `docs/specs/<N>-...` 形式の path から `<N>-` で始まるディレクトリを抽出
+  spec_dir_rel=$(echo "$tree_out" \
+    | awk -v n="${issue_number}-" -F/ '$3 != "" && index($3, n) == 1 { print "docs/specs/" $3; exit }')
+  if [ -z "$spec_dir_rel" ]; then
+    pr_warn "claude-review status publish (catch-up): docs/specs/${issue_number}-* 不在 branch=${head_ref} pr=#${pr_number} reason=spec-dir-not-found"
+    return 0
+  fi
+
+  local notes_rel="${spec_dir_rel}/review-notes.md"
+  # review-notes.md を head から取得（cat-file -e で存在確認 → show で内容取得）
+  if ! git cat-file -e "origin/${head_ref}:${notes_rel}" 2>/dev/null; then
+    pr_warn "claude-review status publish (catch-up): review-notes.md 不在 branch=${head_ref} pr=#${pr_number} path='${notes_rel}' reason=file-not-found"
+    return 0
+  fi
+
+  local notes_tmp
+  notes_tmp=$(mktemp -t idd-claude-pr-claude-notes.XXXXXX 2>/dev/null || mktemp)
+  if ! git show "origin/${head_ref}:${notes_rel}" >"$notes_tmp" 2>/dev/null; then
+    pr_warn "claude-review status publish (catch-up): review-notes.md 取得失敗 branch=${head_ref} pr=#${pr_number} path='${notes_rel}' reason=git-show-failed"
+    rm -f "$notes_tmp" 2>/dev/null || true
+    return 0
+  fi
+
+  # parse_review_result は issue-watcher.sh 本体で定義（モジュール load 後）。
+  # 万一未ロード状態で呼ばれた場合は silent skip（NFR 1.1 安全側）。
+  if ! declare -F parse_review_result >/dev/null 2>&1; then
+    pr_warn "claude-review status publish (catch-up): parse_review_result 未ロード branch=${head_ref} pr=#${pr_number} reason=parse-helper-missing"
+    rm -f "$notes_tmp" 2>/dev/null || true
+    return 0
+  fi
+
+  local parsed parse_rc=0
+  parsed=$(parse_review_result "$notes_tmp") || parse_rc=$?
+  rm -f "$notes_tmp" 2>/dev/null || true
+
+  if [ "$parse_rc" -ne 0 ] || [ -z "$parsed" ]; then
+    pr_warn "claude-review status publish (catch-up): parse_review_result 失敗 branch=${head_ref} pr=#${pr_number} rc=${parse_rc} reason=parse-failed"
+    return 0
+  fi
+
+  local result
+  result=$(echo "$parsed" | cut -f1)
+  case "$result" in
+    approve|reject) ;;
+    *)
+      pr_warn "claude-review status publish (catch-up): 不正な RESULT '${result}' branch=${head_ref} pr=#${pr_number} reason=invalid-result"
+      return 0
+      ;;
+  esac
+
+  # target_url: review-notes.md の blob URL（PR head sha 指定）。組み立て不能時は PR URL に fallback。
+  local target_url=""
+  if [ -n "$sha" ] && [ -n "$spec_dir_rel" ]; then
+    target_url="https://github.com/${REPO}/blob/${sha}/${spec_dir_rel}/review-notes.md"
+  elif [ -n "$pr_url" ]; then
+    target_url="$pr_url"
+  fi
+
+  pr_log "claude-review status publish (catch-up): branch=${head_ref} pr=#${pr_number} sha=${sha} result=${result} spec=${spec_dir_rel}"
+  # publish 失敗時も pr_publish_claude_status / pr_publish_commit_status 側で WARN 出力済み。
+  pr_publish_claude_status "$pr_number" "$sha" "$result" "$target_url" || true
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # pr_run_review_for_pr: 1 PR 分のレビューを統括する（task 4〜6 の orchestration）
 #   入力: $1 = pr_json（pr_fetch_candidate_prs の単一要素）, $2 = tool
 #   戻り値: 0 = success / 1 = failure（一時的・skip 相当）/ 2 = skip（重複検出）/
@@ -1152,5 +1277,80 @@ process_pr_reviewer() {
 
   # 念のため最終確認で base branch に戻す
   git checkout "$BASE_BRANCH" >/dev/null 2>&1 || true
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# process_claude_review_status_catchup (Issue #374)
+#
+# `claude-review` commit status の catch-up publish processor。per-task ループ運用で
+# `publish_claude_review_status` が PR 作成より前の時間軸で発火して WARN skip した
+# 分を、サイクル毎に open PR を scan して読み直し publish する（Req 1.4 / 4.1 / 4.2）。
+#
+# 起動条件:
+#   - AND 二重 opt-in（PR_REVIEWER_STATUS_CHECK_ENABLED=true AND FULL_AUTO_ENABLED=true）。
+#     OFF（既定）なら gh / git 呼び出しを一切発火させずに即 return（Req 5.1 / 5.2 / NFR 1.1）。
+#   - `PR_REVIEWER_ENABLED` の値には依存しない（README #349 設計どおり、claude-review 単独
+#     有効化を維持）。
+#
+# 処理:
+#   - 候補 PR は `pr_fetch_candidate_prs`（既存）を再利用し、open / 非 draft /
+#     PR_REVIEWER_HEAD_PATTERN（既定 `^claude/`）に一致 / 非 fork のもの。
+#   - 各 PR について `pr_publish_claude_status_from_branch` を呼ぶ（PR 未解決 /
+#     review-notes.md 不在 / parse 失敗いずれも WARN + skip / Req 3.x）。
+#   - 戻り値は 0 固定（後続 processor を阻害しない / NFR 1.1）。
+#
+# 設計上の判断:
+#   - 既存 `process_pr_reviewer` 内の `pr_run_review_for_pr` 経路に embed する案も検討したが、
+#     その経路は `PR_REVIEWER_ENABLED=true` のときのみ発火するため、claude-review 単独有効化
+#     を README で約束している契約と矛盾する。本 processor は AND 二重 opt-in のみで gate する
+#     独立経路として実装し、PR_REVIEWER_ENABLED の値に依存しない（Req 5.x / 既存契約 #349 維持）。
+#   - 同一 (sha, context) への重複 publish は GitHub の latest-wins 仕様で吸収される（Req 4.3）。
+#     非 per-task 経路の `publish_claude_review_status` 直接呼びと併走しても、最終的に
+#     最新の RESULT が反映された state に収束する（Req 4.5）。
+# ─────────────────────────────────────────────────────────────────────────────
+process_claude_review_status_catchup() {
+  # AND 二重 opt-in 早期判定（Req 5.1 / 5.2 / NFR 1.1）
+  if ! pr_status_check_enabled; then
+    return 0
+  fi
+
+  # 候補 PR 列挙（既存 process_pr_reviewer と同じ helper を使う / fail-safe で "[]" を返す）
+  local prs_json total
+  prs_json=$(pr_fetch_candidate_prs)
+  total=$(echo "$prs_json" | jq 'length' 2>/dev/null || echo 0)
+  if [ "$total" -eq 0 ]; then
+    return 0
+  fi
+
+  # 上限件数（PR_REVIEWER_MAX_PRS）で truncate する点も process_pr_reviewer と整合させる。
+  local target_count="$total" overflow=0
+  if [ -n "${PR_REVIEWER_MAX_PRS:-}" ] && [ "$total" -gt "$PR_REVIEWER_MAX_PRS" ]; then
+    target_count="$PR_REVIEWER_MAX_PRS"
+    overflow=$((total - PR_REVIEWER_MAX_PRS))
+  fi
+
+  pr_log "claude-review catch-up: 対象候補 ${total} 件、処理対象 ${target_count} 件（overflow=${overflow}）"
+
+  local pr_iter
+  pr_iter=$(echo "$prs_json" | jq -c ".[0:${target_count}][]" 2>/dev/null || echo "")
+  if [ -z "$pr_iter" ]; then
+    return 0
+  fi
+
+  local processed=0
+  while IFS= read -r pr_json; do
+    [ -z "$pr_json" ] && continue
+    local pr_number head_ref sha pr_url
+    pr_number=$(echo "$pr_json" | jq -r '.number')
+    head_ref=$(echo "$pr_json"  | jq -r '.headRefName')
+    sha=$(echo "$pr_json"       | jq -r '.headRefOid')
+    pr_url=$(echo "$pr_json"    | jq -r '.url')
+
+    pr_publish_claude_status_from_branch "$pr_number" "$sha" "$head_ref" "$pr_url" || true
+    processed=$((processed + 1))
+  done <<< "$pr_iter"
+
+  pr_log "claude-review catch-up: サマリ processed=${processed} overflow=${overflow}"
   return 0
 }

--- a/local-watcher/test/pr_publish_claude_status_from_branch_test.sh
+++ b/local-watcher/test/pr_publish_claude_status_from_branch_test.sh
@@ -1,0 +1,622 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/pr-reviewer.sh の Issue #374 で追加した
+#       `pr_publish_claude_status_from_branch` を fixture と stub で検証する
+#       スモークテスト。per-task 経路で publish_claude_review_status が PR 作成前に
+#       発火して WARN skip した分を、PR が存在する時点で catch-up publish する経路の
+#       回帰固定。
+#
+#       対象関数:
+#         - pr_publish_claude_status_from_branch (Issue #374 Req 1.4 / 3.x / 4.x / 5.x)
+#
+#       検証する AC（docs/specs/374-fix-pr-reviewer-claude-review-status-per/requirements.md）:
+#         - Req 1.4: PR 作成完了後の claude-review publish 成立
+#         - Req 3.1: PR 未解決 → WARN + skip（本テストでは上位 process_pr_reviewer から
+#                    呼ばれる経路を前提とするため、PR は head_ref 由来。直接の PR 未解決
+#                    シナリオは対象外。spec-dir-not-found を準ずる skip 経路で検証）
+#         - Req 3.2: review-notes.md 不在 → WARN + skip
+#         - Req 3.3: parse 失敗 → WARN + skip
+#         - Req 3.4: skip 時もパイプライン継続（戻り値 0）
+#         - Req 3.5: WARN ログに branch 名・PR 番号・skip 理由を含む
+#         - Req 4.1: approve → state=success の publish 発火
+#         - Req 4.2: reject → state=failure の publish 発火
+#         - Req 5.1 / 5.2: AND 二重 opt-in OFF 時は publish 関連 API 呼び出しゼロ
+#         - NFR 4.1 / 4.3: publish 呼び出し位置が PR 存在状態（process_pr_reviewer から
+#                          引かれた pr_json）で成立することを再現
+#
+# 配置先: local-watcher/test/pr_publish_claude_status_from_branch_test.sh
+# 依存:   bash 4+, awk, grep, git, mktemp
+# 実行:   bash local-watcher/test/pr_publish_claude_status_from_branch_test.sh
+
+set -euo pipefail
+
+# 抽出関数（pr_publish_claude_status_from_branch など）と stub から indirect 参照される
+# 変数が多く、shellcheck からは未使用に見える。本ファイル全体で SC2034 を抑止する。
+# shellcheck disable=SC2034
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
+
+if [ ! -f "$PR_MOD" ]; then
+  echo "ERROR: cannot find pr-reviewer.sh at $PR_MOD" >&2
+  exit 2
+fi
+
+# 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
+# eval で読み込む。トップレベル副作用は回避する。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# 対象関数群を読み込む（pr_status_check_enabled / pr_publish_claude_status /
+# pr_publish_commit_status / pr_detect_iteration_keyword は本テスト stub 経由で
+# 呼ばれるため一緒に読み込み、外部副作用（gh）を stub で受ける）。
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_MOD" "pr_status_check_enabled")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_MOD" "pr_publish_commit_status")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_MOD" "pr_detect_iteration_keyword")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_MOD" "pr_publish_claude_status")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_MOD" "pr_publish_claude_status_from_branch")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_MOD" "process_claude_review_status_catchup")"
+
+for fn in pr_status_check_enabled pr_publish_commit_status pr_publish_claude_status pr_publish_claude_status_from_branch process_claude_review_status_catchup; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# グローバル env（遅延束縛で抽出関数本体から参照される）。
+# 抽出関数（extract_function + eval）経由で参照されるため shellcheck からは未使用に見える。
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# shellcheck disable=SC2034
+PR_REVIEWER_GIT_TIMEOUT="120"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  case "$haystack" in
+    *"$needle"*)
+      echo "PASS: $label"
+      PASS_COUNT=$((PASS_COUNT + 1))
+      ;;
+    *)
+      echo "FAIL: $label"
+      echo "  expected to contain: $(printf '%q' "$needle")"
+      echo "  actual             : $(printf '%q' "$haystack")"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      ;;
+  esac
+}
+
+# ── stub state ──
+reset_stub_state() {
+  GH_CALL_LOG="$(mktemp)"
+  WARN_LOG="$(mktemp)"
+  LOG_LOG="$(mktemp)"
+  GIT_CALL_LOG="$(mktemp)"
+  GH_NEXT_RC="${GH_NEXT_RC:-0}"
+  # shellcheck disable=SC2034 # pr_publish_commit_status 抽出関数経由で参照される
+  PR_STATUS_GATE_SUPPRESS_LOGGED=0
+
+  # Test fixture state for git stub
+  # GIT_TREE_OUT: ls-tree の出力（spec dir 列挙シナリオ用）
+  # GIT_CATFILE_RC: cat-file -e の戻り値（file 存在/不在を切り替え）
+  # GIT_SHOW_PATH: git show の content として cat する fixture file パス
+  # GIT_SHOW_RC: git show の戻り値
+  # GIT_LSTREE_RC: git ls-tree の戻り値
+  # 各テストケース間で前の値が残らないよう、reset_stub_state では必ず初期化する
+  # （シナリオごとに必要な値はテストケース本体で都度上書きする）。
+  GIT_TREE_OUT=""
+  GIT_CATFILE_RC=0
+  GIT_SHOW_PATH=""
+  GIT_SHOW_RC=0
+  GIT_LSTREE_RC=0
+
+  # PARSE_REVIEW_RESULT_RC: parse_review_result の擬似戻り値
+  # PARSE_REVIEW_RESULT_OUT: parse_review_result の stdout TSV
+  PARSE_REVIEW_RESULT_RC=0
+  PARSE_REVIEW_RESULT_OUT=""
+}
+
+cleanup_stub_state() {
+  rm -f "$GH_CALL_LOG" "$WARN_LOG" "$LOG_LOG" "$GIT_CALL_LOG" 2>/dev/null || true
+}
+
+# pr_log / pr_warn / pr_error stub
+# shellcheck disable=SC2317
+pr_log()   { echo "$*" >>"$LOG_LOG"; }
+# shellcheck disable=SC2317
+pr_warn()  { echo "$*" >>"$WARN_LOG"; }
+# shellcheck disable=SC2317
+pr_error() { echo "$*" >>"$WARN_LOG"; }
+
+# timeout stub: 最初の引数（秒数）を捨て、残りを実行する。
+# shellcheck disable=SC2317
+timeout() {
+  shift
+  "$@"
+}
+
+# gh stub: pr_publish_commit_status の gh api -X POST を記録する。
+# shellcheck disable=SC2317
+gh() {
+  echo "gh $*" >>"$GH_CALL_LOG"
+  return "${GH_NEXT_RC:-0}"
+}
+
+# git stub: ls-tree / cat-file -e / show の挙動を fixture から制御する。
+# 引数を全件 GIT_CALL_LOG に記録し、grep で呼び出し痕跡を検査できる。
+# shellcheck disable=SC2317
+git() {
+  echo "git $*" >>"$GIT_CALL_LOG"
+  case "$1" in
+    ls-tree)
+      printf '%s' "$GIT_TREE_OUT"
+      return "${GIT_LSTREE_RC:-0}"
+      ;;
+    cat-file)
+      return "${GIT_CATFILE_RC:-0}"
+      ;;
+    show)
+      if [ -n "$GIT_SHOW_PATH" ] && [ -f "$GIT_SHOW_PATH" ]; then
+        cat "$GIT_SHOW_PATH"
+      fi
+      return "${GIT_SHOW_RC:-0}"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+# parse_review_result stub（pr_publish_claude_status_from_branch は本関数の存在を
+# `declare -F` で確認してから呼ぶ）
+# shellcheck disable=SC2317
+parse_review_result() {
+  if [ "$PARSE_REVIEW_RESULT_RC" -eq 0 ]; then
+    printf '%s\n' "$PARSE_REVIEW_RESULT_OUT"
+  fi
+  return "${PARSE_REVIEW_RESULT_RC:-0}"
+}
+
+count_calls() {
+  local pattern="$1"
+  local file="$2"
+  local n
+  n=$( { grep -E -- "$pattern" "$file" 2>/dev/null || true; } | wc -l)
+  echo "$((n))"
+}
+
+# 有効な sha / PR 番号の代表値（API 入力検証 NFR 1.3 / 1.4 を通過する fixture）
+VALID_SHA="abcdef0123456789abcdef0123456789abcdef01"
+VALID_PR="123"
+HEAD_REF="claude/issue-374-impl-foo"
+PR_URL="https://github.com/owner/test-repo/pull/123"
+
+# review-notes.md fixture を用意（git show stub 経由で読まれる）。
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+APPROVE_NOTES="$FIXTURE_DIR/approve-review-notes.md"
+cat >"$APPROVE_NOTES" <<'EOF'
+# Review Notes (round 1)
+
+## 判定
+
+RESULT: approve
+EOF
+
+REJECT_NOTES="$FIXTURE_DIR/reject-review-notes.md"
+cat >"$REJECT_NOTES" <<'EOF'
+# Review Notes (round 1)
+
+## 判定
+
+- **Category**: AC 未カバー
+- **Target**: 1.2
+
+RESULT: reject
+EOF
+
+# ============================================================
+# Section 1: AND 二重 opt-in 早期 return（Req 5.1 / 5.2 / NFR 1.1）
+# ============================================================
+echo "--- Section 1: AND 二重 opt-in 早期 return ---"
+
+# Case 1.A: 両 gate 未設定 → 外部副作用ゼロ
+reset_stub_state
+unset PR_REVIEWER_STATUS_CHECK_ENABLED FULL_AUTO_ENABLED
+GIT_TREE_OUT="docs/specs/
+docs/specs/374-fix-foo/
+"
+GIT_SHOW_PATH="$APPROVE_NOTES"
+PARSE_REVIEW_RESULT_OUT=$'approve\t\t'
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "Req 5.1 / 5.2: AND gate OFF でも rc=0（パイプライン継続）" "0" "$local_rc"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 5.1: gate OFF で gh 呼び出しゼロ" "0" "$gh_count"
+git_count=$(count_calls "^git ls-tree" "$GIT_CALL_LOG")
+assert_eq "Req 5.1: gate OFF で git ls-tree 呼び出しゼロ（早期 return）" "0" "$git_count"
+cleanup_stub_state
+
+# Case 1.B: PR_REVIEWER_STATUS_CHECK_ENABLED のみ ON → still disabled
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; unset FULL_AUTO_ENABLED
+GIT_TREE_OUT="docs/specs/374-fix-foo/"
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || true
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 5.2: PR gate ON + FULL_AUTO OFF で gh 呼び出しゼロ" "0" "$gh_count"
+cleanup_stub_state
+
+# Case 1.C: FULL_AUTO_ENABLED のみ ON → still disabled
+reset_stub_state
+unset PR_REVIEWER_STATUS_CHECK_ENABLED; FULL_AUTO_ENABLED="true"
+GIT_TREE_OUT="docs/specs/374-fix-foo/"
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || true
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 5.1: PR gate OFF + FULL_AUTO ON で gh 呼び出しゼロ" "0" "$gh_count"
+cleanup_stub_state
+
+# ============================================================
+# Section 2: head_ref パターン外 → silent skip
+# ============================================================
+echo ""
+echo "--- Section 2: head_ref パターン外 → silent skip ---"
+
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; FULL_AUTO_ENABLED="true"
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "feature/non-claude-branch" "$PR_URL" || local_rc=$?
+assert_eq "head_ref が claude/issue-<N>- 形式でないとき rc=0" "0" "$local_rc"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "head_ref パターン外で gh 呼び出しゼロ" "0" "$gh_count"
+git_count=$(count_calls "^git " "$GIT_CALL_LOG")
+assert_eq "head_ref パターン外で git 呼び出しゼロ（早期 return）" "0" "$git_count"
+warn_count=$(count_calls "." "$WARN_LOG")
+assert_eq "head_ref パターン外は silent skip（WARN ゼロ）" "0" "$warn_count"
+cleanup_stub_state
+
+# ============================================================
+# Section 3: approve → publish 成功 (Req 1.4 / 4.1)
+# ============================================================
+echo ""
+echo "--- Section 3: approve → state=success ---"
+
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; FULL_AUTO_ENABLED="true"
+GIT_TREE_OUT="docs/specs/
+docs/specs/374-fix-pr-reviewer-claude-review-status-per/
+docs/specs/100-some-other-spec/
+"
+GIT_CATFILE_RC=0
+GIT_SHOW_PATH="$APPROVE_NOTES"
+PARSE_REVIEW_RESULT_RC=0
+PARSE_REVIEW_RESULT_OUT=$'approve\t\t'
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "Req 1.4 / 4.1: approve は rc=0 で正常終了" "0" "$local_rc"
+
+# gh api POST が 1 回呼ばれていること
+gh_count=$(count_calls "^gh api -X POST repos/owner/test-repo/statuses/$VALID_SHA" "$GH_CALL_LOG")
+assert_eq "Req 4.1: approve で gh api POST 1 回" "1" "$gh_count"
+gh_line=$(cat "$GH_CALL_LOG")
+assert_contains "Req 4.1: state=success" "$gh_line" "state=success"
+assert_contains "Req 4.1: context=claude-review" "$gh_line" "context=claude-review"
+assert_contains "Req 4.1: description=claude: approve" "$gh_line" "description=claude: approve"
+# target_url は review-notes.md の blob URL (PR head sha 指定)
+assert_contains "Req 4.1: target_url に blob URL（PR head sha 指定）" "$gh_line" "target_url=https://github.com/owner/test-repo/blob/$VALID_SHA/docs/specs/374-fix-pr-reviewer-claude-review-status-per/review-notes.md"
+# catch-up 経路のサマリログ 1 行
+log_count=$(count_calls "claude-review status publish .catch-up" "$LOG_LOG")
+assert_eq "Req 1.4: catch-up publish サマリログ 1 行" "1" "$log_count"
+cleanup_stub_state
+
+# ============================================================
+# Section 4: reject → publish 失敗 status (Req 4.2)
+# ============================================================
+echo ""
+echo "--- Section 4: reject → state=failure ---"
+
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; FULL_AUTO_ENABLED="true"
+GIT_TREE_OUT="docs/specs/374-fix-pr-reviewer-claude-review-status-per/"
+GIT_CATFILE_RC=0
+GIT_SHOW_PATH="$REJECT_NOTES"
+PARSE_REVIEW_RESULT_RC=0
+PARSE_REVIEW_RESULT_OUT=$'reject\tAC 未カバー\t1.2'
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "Req 4.2: reject も rc=0 で正常終了" "0" "$local_rc"
+
+gh_line=$(cat "$GH_CALL_LOG")
+assert_contains "Req 4.2: state=failure" "$gh_line" "state=failure"
+assert_contains "Req 4.2: context=claude-review" "$gh_line" "context=claude-review"
+assert_contains "Req 4.2: description=claude: reject" "$gh_line" "description=claude: reject"
+cleanup_stub_state
+
+# ============================================================
+# Section 5: skip 経路の WARN ログ（Req 3.1〜3.5）
+# ============================================================
+echo ""
+echo "--- Section 5: skip 経路の WARN ログ ---"
+
+# Case 5.A: spec dir not found
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; FULL_AUTO_ENABLED="true"
+GIT_TREE_OUT="docs/specs/
+docs/specs/100-some-other-spec/
+"
+GIT_CATFILE_RC=0
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "Req 3.4: spec-dir-not-found でも rc=0（パイプライン継続）" "0" "$local_rc"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 3.4: spec-dir-not-found で gh 呼び出しゼロ" "0" "$gh_count"
+warn_line=$(cat "$WARN_LOG")
+assert_contains "Req 3.5: spec-dir-not-found WARN に reason 識別子" "$warn_line" "reason=spec-dir-not-found"
+assert_contains "Req 3.5: WARN に branch 名" "$warn_line" "branch=$HEAD_REF"
+assert_contains "Req 3.5: WARN に PR 番号" "$warn_line" "pr=#$VALID_PR"
+cleanup_stub_state
+
+# Case 5.B: review-notes.md not found
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; FULL_AUTO_ENABLED="true"
+GIT_TREE_OUT="docs/specs/374-fix-pr-reviewer-claude-review-status-per/"
+GIT_CATFILE_RC=1  # cat-file -e fails => file 不在
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "Req 3.2 / 3.4: file-not-found でも rc=0" "0" "$local_rc"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 3.2: file-not-found で gh 呼び出しゼロ" "0" "$gh_count"
+warn_line=$(cat "$WARN_LOG")
+assert_contains "Req 3.5: file-not-found WARN に reason 識別子" "$warn_line" "reason=file-not-found"
+assert_contains "Req 3.5: file-not-found WARN に review-notes.md path" "$warn_line" "review-notes.md"
+cleanup_stub_state
+
+# Case 5.C: parse_review_result 失敗
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; FULL_AUTO_ENABLED="true"
+GIT_TREE_OUT="docs/specs/374-fix-pr-reviewer-claude-review-status-per/"
+GIT_CATFILE_RC=0
+GIT_SHOW_PATH="$APPROVE_NOTES"
+PARSE_REVIEW_RESULT_RC=2  # 装飾起因 parse 失敗
+PARSE_REVIEW_RESULT_OUT=""
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "Req 3.3 / 3.4: parse-failed でも rc=0" "0" "$local_rc"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 3.3: parse-failed で gh 呼び出しゼロ" "0" "$gh_count"
+warn_line=$(cat "$WARN_LOG")
+assert_contains "Req 3.5: parse-failed WARN に reason 識別子" "$warn_line" "reason=parse-failed"
+cleanup_stub_state
+
+# Case 5.D: ls-tree 失敗
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"; FULL_AUTO_ENABLED="true"
+GIT_LSTREE_RC=128  # network / object not found 等
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "Req 3.4: ls-tree-failed でも rc=0" "0" "$local_rc"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "ls-tree 失敗で gh 呼び出しゼロ" "0" "$gh_count"
+warn_line=$(cat "$WARN_LOG")
+assert_contains "ls-tree-failed WARN に reason 識別子" "$warn_line" "reason=ls-tree-failed"
+cleanup_stub_state
+
+# Case 5.E: parse_review_result が不正な RESULT 値を返す
+reset_stub_state
+# shellcheck disable=SC2034 # PR_REVIEWER_STATUS_CHECK_ENABLED / FULL_AUTO_ENABLED は extract_function 経由
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"
+# shellcheck disable=SC2034 # 同上（FULL_AUTO_ENABLED）
+FULL_AUTO_ENABLED="true"
+GIT_TREE_OUT="docs/specs/374-fix-pr-reviewer-claude-review-status-per/"
+GIT_CATFILE_RC=0
+GIT_SHOW_PATH="$APPROVE_NOTES"
+PARSE_REVIEW_RESULT_RC=0
+PARSE_REVIEW_RESULT_OUT=$'unknown\t\t'  # 不正値
+local_rc=0
+pr_publish_claude_status_from_branch "$VALID_PR" "$VALID_SHA" "$HEAD_REF" "$PR_URL" || local_rc=$?
+assert_eq "不正な RESULT 値でも rc=0" "0" "$local_rc"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "不正な RESULT 値で gh 呼び出しゼロ" "0" "$gh_count"
+warn_line=$(cat "$WARN_LOG")
+assert_contains "不正 RESULT WARN に reason 識別子" "$warn_line" "reason=invalid-result"
+cleanup_stub_state
+
+# ============================================================
+# Section 6: NFR 4.3 回帰防止 — publish 呼び出し位置が PR 存在状態で成立する
+# ============================================================
+#
+# 本セクションは「publish 試行が PR 作成前の時間軸に並んでいないこと」を機械的に
+# 検出するための回帰固定。`process_claude_review_status_catchup` は `pr_fetch_candidate_prs`
+# （open PR スキャン）から引かれた PR を入力に取るため、呼び出し時点で PR が必ず存在する。
+# 本テストは catch-up publish の起点が `process_claude_review_status_catchup` 経由で
+# 確実に発火することを、pr-reviewer.sh の text 上で grep で確認する。
+# ============================================================
+echo ""
+echo "--- Section 6: publish 呼び出し位置の回帰防止（NFR 4.3）---"
+
+# process_claude_review_status_catchup の存在と、その中で
+# `pr_publish_claude_status_from_branch` を呼んでいること
+in_catchup=$(awk '
+  /^process_claude_review_status_catchup\(\) \{$/ { in_fn=1 }
+  in_fn { print }
+  in_fn && $0=="}" { exit }
+' "$PR_MOD" | grep -c "pr_publish_claude_status_from_branch" || true)
+assert_eq "NFR 4.3: process_claude_review_status_catchup 内で catch-up publish が呼ばれる" "1" "$in_catchup"
+
+# pr_fetch_candidate_prs（open PR scan）を入力に取ること
+# = PR が必ず存在する状態で呼ばれる経路であることの構造的保証
+catchup_uses_fetch=$(awk '
+  /^process_claude_review_status_catchup\(\) \{$/ { in_fn=1 }
+  in_fn { print }
+  in_fn && $0=="}" { exit }
+' "$PR_MOD" | grep -c "pr_fetch_candidate_prs" || true)
+assert_eq "NFR 4.3: catch-up は pr_fetch_candidate_prs（open PR scan）から入力を取る" "1" "$catchup_uses_fetch"
+
+# AND 二重 opt-in（pr_status_check_enabled）で gate されること
+catchup_gated=$(awk '
+  /^process_claude_review_status_catchup\(\) \{$/ { in_fn=1 }
+  in_fn { print }
+  in_fn && $0=="}" { exit }
+' "$PR_MOD" | grep -c "pr_status_check_enabled" || true)
+assert_eq "Req 5.1 / 5.2: catch-up processor は pr_status_check_enabled で gate される" "1" "$catchup_gated"
+
+# `PR_REVIEWER_ENABLED` には依存しないこと（claude-review 単独有効化維持 / README 既存契約）
+catchup_independent=$(awk '
+  /^process_claude_review_status_catchup\(\) \{$/ { in_fn=1 }
+  in_fn { print }
+  in_fn && $0=="}" { exit }
+' "$PR_MOD" | grep -c "PR_REVIEWER_ENABLED" || true)
+assert_eq "Req 5.x: catch-up processor は PR_REVIEWER_ENABLED に依存しない" "0" "$catchup_independent"
+
+# ============================================================
+# Section 7: process_claude_review_status_catchup の orchestration
+# ============================================================
+#
+# 本セクションは catch-up processor の orchestration（gate / PR 列挙 / dispatch）を
+# pr_fetch_candidate_prs / jq を stub して直接駆動する。
+# ============================================================
+echo ""
+echo "--- Section 7: process_claude_review_status_catchup orchestration ---"
+
+# pr_fetch_candidate_prs stub: FAKE_PRS_JSON の内容を返す。
+FAKE_PRS_JSON="[]"
+# shellcheck disable=SC2317
+pr_fetch_candidate_prs() {
+  echo "$FAKE_PRS_JSON"
+}
+
+# Case 7.A: AND gate OFF → 早期 return、pr_fetch_candidate_prs も呼ばれない
+reset_stub_state
+unset PR_REVIEWER_STATUS_CHECK_ENABLED FULL_AUTO_ENABLED
+FAKE_PRS_JSON='[{"number":123,"headRefName":"claude/issue-374-impl-foo","headRefOid":"abcdef0123456789abcdef0123456789abcdef01","url":"https://github.com/owner/test-repo/pull/123"}]'
+PR_FETCH_CALLED=0
+# 一時的に pr_fetch_candidate_prs を観測 stub に差し替え
+_orig_fetch="$(declare -f pr_fetch_candidate_prs)"
+# shellcheck disable=SC2317
+pr_fetch_candidate_prs() {
+  PR_FETCH_CALLED=$((PR_FETCH_CALLED + 1))
+  echo "$FAKE_PRS_JSON"
+}
+process_claude_review_status_catchup
+assert_eq "Req 5.1 / 5.2: gate OFF で pr_fetch_candidate_prs 呼び出しゼロ" "0" "$PR_FETCH_CALLED"
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 5.1: gate OFF で gh 呼び出しゼロ" "0" "$gh_count"
+cleanup_stub_state
+
+# Case 7.B: AND gate ON + 候補 PR 0 件 → no-op で return 0
+reset_stub_state
+# shellcheck disable=SC2034 # extract_function 経由
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"
+# shellcheck disable=SC2034 # 同上
+FULL_AUTO_ENABLED="true"
+FAKE_PRS_JSON="[]"
+process_claude_review_status_catchup
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "Req 1.4: 候補 0 件で gh 呼び出しゼロ" "0" "$gh_count"
+cleanup_stub_state
+
+# Case 7.C: AND gate ON + 候補 1 件 → pr_publish_claude_status_from_branch にディスパッチ
+# → 内部で git ls-tree → cat-file -e → show → parse_review_result → gh api POST が走る
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"
+FULL_AUTO_ENABLED="true"
+FAKE_PRS_JSON='[{"number":123,"headRefName":"claude/issue-374-impl-foo","headRefOid":"abcdef0123456789abcdef0123456789abcdef01","url":"https://github.com/owner/test-repo/pull/123"}]'
+GIT_TREE_OUT="docs/specs/374-fix-pr-reviewer-claude-review-status-per/"
+GIT_CATFILE_RC=0
+GIT_SHOW_PATH="$APPROVE_NOTES"
+PARSE_REVIEW_RESULT_RC=0
+PARSE_REVIEW_RESULT_OUT=$'approve\t\t'
+process_claude_review_status_catchup
+gh_count=$(count_calls "^gh api -X POST repos/owner/test-repo/statuses/abcdef0123456789abcdef0123456789abcdef01" "$GH_CALL_LOG")
+assert_eq "Req 1.4 / 4.1: 候補 1 件で gh api POST 1 回（PR head sha 宛て）" "1" "$gh_count"
+gh_line=$(cat "$GH_CALL_LOG")
+assert_contains "Req 4.1: state=success / context=claude-review" "$gh_line" "context=claude-review"
+assert_contains "Req 4.1: state=success" "$gh_line" "state=success"
+# サマリログ 1 行（processed=1）
+log_count=$(count_calls "claude-review catch-up: サマリ processed=1" "$LOG_LOG")
+assert_eq "Req 1.4: catch-up サマリログ 1 行 processed=1" "1" "$log_count"
+cleanup_stub_state
+
+# Case 7.D: 候補 2 件（impl PR + design PR） → 各々で publish 試行
+reset_stub_state
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"
+FULL_AUTO_ENABLED="true"
+FAKE_PRS_JSON='[
+  {"number":123,"headRefName":"claude/issue-374-impl-foo","headRefOid":"abcdef0123456789abcdef0123456789abcdef01","url":"https://github.com/owner/test-repo/pull/123"},
+  {"number":200,"headRefName":"claude/issue-374-design-foo","headRefOid":"bcdef0123456789abcdef0123456789abcdef012","url":"https://github.com/owner/test-repo/pull/200"}
+]'
+GIT_TREE_OUT="docs/specs/374-fix-pr-reviewer-claude-review-status-per/"
+GIT_CATFILE_RC=0
+GIT_SHOW_PATH="$APPROVE_NOTES"
+PARSE_REVIEW_RESULT_RC=0
+PARSE_REVIEW_RESULT_OUT=$'approve\t\t'
+process_claude_review_status_catchup
+gh_count=$(count_calls "^gh api -X POST repos/owner/test-repo/statuses/" "$GH_CALL_LOG")
+assert_eq "Req 1.4 / 4.1: 候補 2 件で gh api POST 2 回（impl + design）" "2" "$gh_count"
+log_count=$(count_calls "claude-review catch-up: サマリ processed=2" "$LOG_LOG")
+assert_eq "Req 1.4: サマリ processed=2" "1" "$log_count"
+cleanup_stub_state
+
+# Case 7.E: 候補 PR の head が claude/issue- パターン外 → silent skip
+reset_stub_state
+# shellcheck disable=SC2034 # extract_function 経由
+PR_REVIEWER_STATUS_CHECK_ENABLED="true"
+# shellcheck disable=SC2034 # 同上
+FULL_AUTO_ENABLED="true"
+FAKE_PRS_JSON='[{"number":300,"headRefName":"feature/other-branch","headRefOid":"cdef0123456789abcdef0123456789abcdef0123","url":"https://github.com/owner/test-repo/pull/300"}]'
+process_claude_review_status_catchup
+gh_count=$(count_calls "^gh " "$GH_CALL_LOG")
+assert_eq "head pattern 外 PR は silent skip（gh 呼び出しゼロ）" "0" "$gh_count"
+cleanup_stub_state
+
+# Cleanup（後続 Section が pr_fetch_candidate_prs に依存しないため復元は不要だが、
+# stub 残置でテスト推測ミスを防ぐため明示 unset）
+unset -f pr_fetch_candidate_prs
+unset PR_FETCH_CALLED _orig_fetch FAKE_PRS_JSON
+
+# ============================================================
+# 終了
+# ============================================================
+echo ""
+echo "============================================================"
+echo "Test summary: PASS=$PASS_COUNT, FAIL=$FAIL_COUNT"
+echo "============================================================"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

`PR_REVIEWER_STATUS_CHECK_ENABLED=true` + `FULL_AUTO_ENABLED=true` の AND 二重 opt-in 環境において、
per-task ループ運用（`PER_TASK_LOOP_ENABLED=true`）では `claude-review` commit status が一度も
publish されない問題（Issue #374）を修正する。

根本原因は per-task ループの Reviewer round 完了直後に publish を試みる時点では impl PR がまだ
GitHub 側に存在しておらず、`gh pr list --head <branch>` の PR 解決が失敗して WARN skip される
という時間軸の不整合にある。本 PR では独立 catch-up processor `process_claude_review_status_catchup`
を `pr-reviewer.sh` に追加し、watcher サイクルごとに `pr_fetch_candidate_prs`（open PR scan）を
入力源として `claude-review` status の publish を試みる構造に変更する。これにより publish 時点で
PR が存在することが構造的に保証される。

AND 二重 opt-in 無効の既定環境では外部観測挙動を導入前と完全に等価に保つ（新規 API 呼び出しゼロ）。

## 対応 Issue

Closes #374

## 関連 PR

- 設計 PR: なし（design-less impl）

## 実装内容

- (Req 1.x / Task —) `pr_publish_claude_status_from_branch(pr_number, sha, head_ref, pr_url)` を新規追加
  — AND 二重 opt-in ゲート / head_ref パターン判定 / spec dir 解決 (`git ls-tree` + `git show`) /
  `parse_review_result` 呼び出し / `pr_publish_claude_status` 委譲 / 全 skip 経路で WARN + return 0
- (Req 1.x / 4.x) `process_claude_review_status_catchup()` processor を新規追加
  — サイクルあたり 1 回 / AND 二重 opt-in のみで gate / `pr_fetch_candidate_prs`（open PR scan）から
  候補 PR を列挙して各 PR で `pr_publish_claude_status_from_branch` を呼ぶ
- (Req 1.x) `local-watcher/bin/issue-watcher.sh` に `process_claude_review_status_catchup` 呼び出し
  1 行を追加（`process_pr_reviewer` 直後 / `|| pr_warn` で後続を阻害しない）
- (Req 2.x) 既存 `publish_claude_review_status` 呼び出し 12 箇所は **一切変更しない**
  （非 per-task 経路の挙動温存）
- (Req 6.2) `README.md` の「PR Reviewer Commit Status Publishing (#349)」節に per-task catch-up
  経路の説明を追記（+10 行）

## 受入基準チェック

- [x] Req 1.1: When per-task Reviewer round が approve / AND opt-in 成立 / PR 存在 → `claude-review: success` を publish ← `pr_publish_claude_status_from_branch_test.sh` Section 7 Case 7.C
- [x] Req 1.2: When per-task Reviewer round が reject → state=failure ← Section 4
- [x] Req 1.4: When PR 作成前に RESULT 確定 → PR 作成後のサイクルで catch-up publish 保証 ← Section 7 Case 7.C / 7.D
- [x] Req 2.1–2.3: 非 per-task 経路の publish 呼び出し位置・外形挙動は無変更 ← 既存 12 箇所を変更しないことで保証
- [x] Req 3.1–3.5: PR 未解決 / file 不在 / parse 失敗 → WARN + rc=0 + パイプライン継続 ← Section 5 全 case
- [x] Req 4.3: latest-wins セマンティクス ← GitHub Commit Status API の既存動作（変更なし）
- [x] Req 5.1–5.2: AND opt-in OFF 時は gh / git / pr_fetch 呼び出しゼロ ← Section 1 / Section 7 Case 7.A
- [x] NFR 2.1–2.2: `bash -n` / `shellcheck` クリーン（警告増加ゼロ）
- [x] NFR 4.1–4.3: `pr_publish_claude_status_from_branch_test.sh` として近接テスト追加（52 件 PASS）

## テスト結果

```
# 新規テスト
bash local-watcher/test/pr_publish_claude_status_from_branch_test.sh
PASS=52, FAIL=0

# 既存テスト（回帰確認）
bash local-watcher/test/pr_publish_commit_status_test.sh
PASS=74, FAIL=0

# 全テストファイル
local-watcher/test/*_test.sh 全件（49 ファイル） → 49 件すべて PASS

# 静的検査
bash -n local-watcher/bin/issue-watcher.sh → OK
bash -n local-watcher/bin/modules/pr-reviewer.sh → OK
bash -n local-watcher/test/pr_publish_claude_status_from_branch_test.sh → OK
shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/pr-reviewer.sh local-watcher/test/pr_publish_claude_status_from_branch_test.sh → 警告ゼロ

# root ↔ repo-template 同期
diff -r .claude/agents repo-template/.claude/agents → 差分なし
diff -r .claude/rules repo-template/.claude/rules → 差分なし
```

## 実装上の判断

- 修正方針として「(B) pr-reviewer.sh 側に独立 catch-up processor を追加」を採用した。
  PR 作成後フック（案 A）は Stage C / PjM 完了時に副作用範囲が広い。catch-up は次サイクル
  （最短 2 分）で結果整合的に publish が完了するためラグ吸収は不要で実装が単純。
- `pr_fetch_candidate_prs`（`gh pr list --state open`）を入力源とすることで、publish 時点で
  PR が GitHub 側に存在することを構造的に保証している（per-task の時間軸不整合を根本解消）。
- `PR_REVIEWER_ENABLED` 非依存の設計: 既存契約（claude-review 単独有効化可能）を維持するため
  catch-up は AND 二重 opt-in のみで gate する独立 processor とした。
- 詳細: `docs/specs/374-fix-pr-reviewer-claude-review-status-per/impl-notes.md`

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer 判定: approve（`docs/specs/374-fix-pr-reviewer-claude-review-status-per/review-notes.md` 参照）
- base 検証: --base main 指定 / baseRefName: main / OK
- 既存 `publish_claude_review_status` 呼び出し 12 箇所（issue-watcher.sh / pr-reviewer.sh）が
  無変更であることを特に確認してください

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #374 のコメントを参照してください。