### PR TITLE
feat(#383): spec-dir 経路の slug guard を resumable state 実在時のみ発火させる

### DIFF
--- a/docs/specs/383-fix-watcher-stage-checkpoint-resumable-s/impl-notes.md
+++ b/docs/specs/383-fix-watcher-stage-checkpoint-resumable-s/impl-notes.md
@@ -1,0 +1,139 @@
+# Implementation Notes (Issue #383)
+
+## 実装概要
+
+spec-dir 経路の slug 照合ガード (`_stage_checkpoint_assert_slug_match`) が
+`docs/specs/<N>-*/` の番号一致だけで発火していた問題を、resumable state が実在する
+ときのみ発火させるよう修正した。Issue #114 が守る fork/mirror 番号衝突誤 resume 防止は
+resumable state 実在経路で完全に維持され、umbrella spec を sub-issue が共有する構成で
+fresh issue（resumable state 一切不在）を不当に `needs-decisions` で block しなくなる。
+
+## 修正対象ファイル
+
+- `local-watcher/bin/issue-watcher.sh`
+  - 新規関数 `_stage_checkpoint_has_resumable_state` を追加（`_stage_checkpoint_assert_slug_match`
+    定義直後に配置）
+  - spec-dir 経路の slug guard 呼び出し元（`_slot_run_issue` 内、`_matched_dir` が空の
+    fallback ブロック）で新関数を call して発火可否を判定
+- `local-watcher/test/stage_checkpoint_resumable_state_test.sh`（新規追加）
+
+## 修正関数 / 追加関数
+
+### 追加: `_stage_checkpoint_has_resumable_state` (Req 1, 3, 4, NFR 2)
+
+- 引数: spec dir 絶対パス
+- 戻り値:
+  - 0 = resumable state 実在（呼び出し元は従来どおり slug guard を発火）
+  - 1 = resumable state 不在（呼び出し元は slug guard を skip）
+  - 2 = 判定失敗 (safe-side / 発火経路に倒す)
+- 4 観点（OR 判定）:
+  - (a) `stage_checkpoint_find_impl_pr` rc=0（OPEN / MERGED の impl PR 実在）
+  - (b) `git ls-remote --heads origin -- "refs/heads/claude/issue-<N>-impl-*"` で 1 本以上
+        の branch を検出（slug 不問の prefix マッチ。確認事項に従う）
+  - (c) `git ls-tree HEAD -- <spec_dir>/impl-notes.md` が非空（tracked）
+  - (d) `git ls-tree HEAD -- <spec_dir>/review-notes.md` が非空（tracked）
+- ログ: 検出ヒット時に `stage-checkpoint: resumable-state-found ...` を 1 行 LOG 出力。
+  観測失敗時は `stage-checkpoint: WARN resumable-state-detection ...` を stderr に 1 行
+  出力（Req 4.3）
+- 入力検証: `NUMBER` が numeric でなければ即 rc=2 を返す（safe-side）
+
+### 修正: spec-dir 経路の slug guard 呼び出し元（`_slot_run_issue` 内）
+
+- `_matched_dir` 非空ブロック（slug match 経路）は無変更（既存 behavior が要件と整合する
+  ため。`_stage_checkpoint_assert_slug_match` は match 時 0 を返し escalate しない）
+- `_matched_dir` 空ブロック（既存実装の mismatch 経路 = 誤爆元）に新判定を挿入:
+  - 新関数 rc=1（不在確定）→ slug guard skip、`SLUG="$EXPECTED_SLUG"` を採用、
+    `stage-checkpoint: slug-guard-skipped issue=#<N> expected=<exp> found=<found>
+    reason=no-resumable-state` を 1 行 LOG 出力（Req 1.2, 1.3, 1.4, 4.1）
+  - 新関数 rc=0/2/その他 → 従来どおり `_stage_checkpoint_assert_slug_match` を call
+    （Req 2.1, 2.3, NFR 2.1）
+
+## テスト追加内容
+
+`local-watcher/test/stage_checkpoint_resumable_state_test.sh`（12 ケース・18 アサーション）:
+
+- Case 1: Req 1.2 — 4 観点いずれも不在 → return 1（skip 経路）
+- Case 2: Req 2.1/3.1(a) — impl PR 実在 → return 0
+- Case 3: Req 2.1/3.1(b) — origin impl-* branch 実在 → return 0
+- Case 3b: Req 3.1(b) — slug 不問 prefix マッチで mismatch slug branch も検出
+- Case 4: Req 2.1/3.1(c) — impl-notes.md tracked → return 0
+- Case 5: Req 2.1/3.1(d) — review-notes.md tracked → return 0
+- Case 6: Req 3.1 — 4 観点全部真でも return 0（OR 判定）
+- Case 7: NFR 2.1 — gh API 失敗 + 他観点不在 → return 2（safe-side）
+- Case 8: NFR 2.1 — git ls-remote 失敗 + 他観点不在 → return 2（safe-side）
+- Case 9: NFR 2.1 — 観測失敗があっても 1 観点で実在ヒットすれば return 0
+- Case 10: NFR 2.1 — NUMBER 未設定 → return 2（safe-side）
+- Case 11: NFR 2.1 — NUMBER 非数値 → return 2（safe-side）
+- Case 12: Req 4.1 — skip 経路では `resumable-state-found` ログを出さない
+
+テスト方式: `extract_function` で関数を関数定義のみ抽出、`stage_checkpoint_find_impl_pr` /
+`git` / `timeout` を test 内で stub し、副作用を全テストプロセスに閉じ込める。
+`local-watcher/test/slug_match_guard_test.sh` と同じ extract_function イディオムに準拠
+（NFR 4.1）。
+
+## AC Traceability（要件 ID → テスト）
+
+| Req ID | カバーするテスト |
+|--------|------------------|
+| 1.1 | `stage_checkpoint_resumable_state_test.sh` 全 case（spec dir 検出時に判定が走ることを Case 12 で示す） |
+| 1.2 | Case 1, 12（4 観点不在 → return 1 → 呼出側で skip） |
+| 1.3 | Case 1 + 呼出側コードレビュー（rc=1 で `_slug_mismatch_escalate` を呼ばないため `needs-decisions` 付与なし） |
+| 1.4 | Case 1 + 呼出側コードレビュー（rc=1 で `_slug_mismatch_escalate` 不呼び出し） |
+| 1.5 | Case 1（複数候補存在 + 不一致は最終的に `_first` 経路へ落ち、resumable state 不在で skip） |
+| 2.1 | Case 2, 3, 4, 5（4 観点各々で return 0） |
+| 2.2 | `slug_match_guard_test.sh` 既存 Case 1（match → return 0 → resume 継続） |
+| 2.3 | `slug_match_guard_test.sh` 既存 Case 2（mismatch → escalate） + 新呼出側で rc=0/2/* の case 分岐 |
+| 2.4 | 既存 NFR 1.3 経路の維持（`SPEC_CANDIDATES` が空のとき従来どおり `SLUG="$EXPECTED_SLUG"`） |
+| 3.1 | Case 2, 3, 3b, 4, 5, 6（4 観点が OR で判定） |
+| 3.2 | Case 7, 8（観測失敗 → return 2 = safe-side） |
+| 3.3 | コードレビュー（新関数は `stage_checkpoint_resolve_resume_point` を呼ばず独立に観測） |
+| 4.1 | Case 2-5（`resumable-state-found ...` ログ）+ Case 12（skip ログ）+ 呼出側 `slug-guard-skipped` ログ |
+| 4.2 | `slug_match_guard_test.sh` 既存 Case 1, 2（`slug-match` / `slug-mismatch` ログ） |
+| 4.3 | コードレビュー（`stage-checkpoint: WARN ...` を stderr へ 1 行出力） |
+| NFR 1.1 | env var / ラベル / cron / exit code を変更していない（コードレビュー） |
+| NFR 1.2 | 既存 slug-match 経路は無変更 |
+| NFR 1.3 | 既存 SPEC_CANDIDATES 空経路は無変更 |
+| NFR 1.4 | 新規 env var なし（コードレビュー） |
+| NFR 2.1 | Case 7, 8, 9, 10, 11（safe-side 倒し込み） |
+| NFR 2.2 | 既存 spec dir を削除・リネームしない（コードレビュー） |
+| NFR 2.3 | 新規 docs/specs/ 作成や umbrella spec 書き換えを本修正に含めない（コードレビュー） |
+| NFR 3.1 | コードレビュー（全 echo 行が 1 イベント 1 行で改行を含まない） |
+| NFR 3.2 | コードレビュー（issue 番号・expected-slug・found-slug を skip ログに含める） |
+| NFR 4.1 | `stage_checkpoint_resumable_state_test.sh` は extract_function + stub 方式 |
+| NFR 4.2 | `slug_match_guard_test.sh` を全 13 ケース回帰なしで通過 |
+| NFR 4.3 | Case 1 (skip 経路) と Case 2-5 (発火経路) を最低 1 件ずつ実装 |
+
+## 通したコマンド（サマリ）
+
+- `bash -n local-watcher/bin/issue-watcher.sh` → OK
+- `shellcheck local-watcher/bin/issue-watcher.sh` → 警告なし
+- `shellcheck local-watcher/test/stage_checkpoint_resumable_state_test.sh` → 警告なし
+- `bash local-watcher/test/slug_match_guard_test.sh` → PASS 13 / FAIL 0（回帰なし）
+- `bash local-watcher/test/stage_checkpoint_resumable_state_test.sh` → PASS 18 / FAIL 0
+- `bash local-watcher/test/normalize_slug_test.sh` → PASS 12 / FAIL 0
+- `bash local-watcher/test/stage_checkpoint_pending_tasks_test.sh` → PASS 3 / FAIL 0
+- 関連 Stage C テスト群（stagec_pr_verify_*, parse_review_result_test）→ 全て exit=0
+
+## 確認事項
+
+- 二次的所見（needs-decisions 再エスカレーションループ）の解消は requirements.md の
+  Out of Scope と「確認事項」節に従い、本 PR では着手せず follow-up issue 化を提案する。
+  本修正で「正常 fresh issue」が skip 経路に倒れることで二次的所見の発火頻度自体は
+  下がる見込みだが、既に `needs-decisions` で人手 unblock 済みの Issue を triage が
+  再度 needs-decisions 付与する経路は本 PR では触れていない。
+- `repo-template/` には `issue-watcher.sh` の mirror が存在しないため、本 PR では
+  repo-template 側に反映する変更はない（`repo-template/CLAUDE.md` のみ確認）。
+- 呼出側の `case` 分岐は `1) ... *)` の 2 分岐としており、`*)` は「rc=0 (実在) /
+  rc=2 (safe-side) / 想定外 rc」のすべてを slug guard 発火側にまとめる safe-side
+  default として動く。これは NFR 2.1 の「resumable state が実在するかもしれない側に
+  倒す」要件と整合する。
+- `_matched_dir` 非空（slug 一致）経路は本修正の対象外とした。既存実装の
+  `_stage_checkpoint_assert_slug_match` は match 時に 0 を返し escalate しないため、
+  この経路では誤 block は構造的に起きない（slug が一致しているので Issue #114
+  の防御対象でもない）。
+
+## 残存課題
+
+- なし。本要件は全 AC をテストで担保し、Out of Scope を逸脱していない。
+
+STATUS: complete

--- a/docs/specs/383-fix-watcher-stage-checkpoint-resumable-s/requirements.md
+++ b/docs/specs/383-fix-watcher-stage-checkpoint-resumable-s/requirements.md
@@ -1,0 +1,149 @@
+# Requirements Document
+
+## Introduction
+
+watcher の Stage Checkpoint Resume スラグ照合ガード `_stage_checkpoint_assert_slug_match`
+（`local-watcher/bin/issue-watcher.sh:9410`）は、`docs/specs/<N>-*/` に
+番号一致するディレクトリが存在するだけで発火する設計になっており（呼び出し元
+`local-watcher/bin/issue-watcher.sh:10545` および `:10554`）、resumable state
+（既存 impl PR / `claude/issue-<N>-impl-*` ブランチ / tracked な `impl-notes.md` /
+`review-notes.md`）の有無を一切判定していない。
+
+このため umbrella issue + sub-issue 構成で 1 つの spec dir
+（例: `docs/specs/1-<umbrella-slug>/`）を共有しているリポジトリでは、
+sub-issue #1 のように番号プレフィックスが衝突する fresh issue（impl ブランチも
+checkpoint も存在しない）が、Issue タイトル由来 slug と spec dir slug の
+不一致だけを根拠に `needs-decisions` でブロックされる。回避策（spec dir 番号の改番）は
+存在するが、full-auto 初手の依存グラフ先頭でこれが起きると後続全 Issue が止まる。
+
+本要件は、`stage_checkpoint_resolve_resume_point`
+（`local-watcher/bin/issue-watcher.sh:1879`）が impl-PR / impl-notes.md /
+review-notes.md / origin の impl-* ブランチで定義する **resumable state**
+の概念をスラグ照合ガード側にも適用し、resumable state が実在する場合のみ
+slug guard を発火させて Issue #114 の fork/mirror 衝突誤 resume 防止を維持しつつ、
+resumable state 不在の fresh issue を不当にブロックしないよう挙動を補正することを目的とする。
+
+## Requirements
+
+### Requirement 1: spec-dir 経路の slug guard を resumable state 実在時のみ発火させる
+
+**Objective:** As a watcher 運用者, I want spec-dir 経路の slug 照合ガードを resumable state が実在するときに限定して発火させること, so that umbrella spec を sub-issue と共有する構成で fresh issue が誤って block されない
+
+#### Acceptance Criteria
+
+1. When watcher が Issue 処理開始時に `docs/specs/<N>-*/` を検出したとき, the Watcher shall 当該 Issue について「resumable state が実在するか」を判定したうえで slug guard を発火するか決定する
+2. If `docs/specs/<N>-*/` が存在し、かつ resumable state が一切実在しない（impl PR 不在 / `claude/issue-<N>-impl-*` origin ブランチ不在 / tracked な `impl-notes.md` 不在 / tracked な `review-notes.md` 不在）とき, the Watcher shall slug guard を発火させず Stage A を新規実装として継続する
+3. When Requirement 1.2 の経路で slug guard を skip したとき, the Watcher shall 当該 Issue に `needs-decisions` ラベルを付与しない
+4. When Requirement 1.2 の経路で slug guard を skip したとき, the Watcher shall `_slug_mismatch_escalate` を呼び出さずスラグ不一致コメントを投稿しない
+5. While `docs/specs/<N>-*/` が複数存在し expected-slug と一致するものが無いケースでも resumable state が一切実在しないとき, the Watcher shall Requirement 1.2 と同じ skip 経路に倒す
+
+### Requirement 2: resumable state 実在時の slug guard 挙動を維持する
+
+**Objective:** As a watcher 運用者, I want resumable state が実在する Issue では従来どおり slug guard を発火させること, so that Issue #114 の fork/mirror clone 番号衝突誤 resume 防止が回帰なしで維持される
+
+#### Acceptance Criteria
+
+1. When `docs/specs/<N>-*/` が存在し、かつ resumable state（impl PR / `claude/issue-<N>-impl-*` origin ブランチ / tracked な `impl-notes.md` / tracked な `review-notes.md` の少なくとも 1 つ）が実在するとき, the Watcher shall expected-slug と found-slug を照合する
+2. When Requirement 2.1 の照合で expected-slug と found-slug が一致したとき, the Watcher shall 従来どおり Stage Checkpoint Resume を継続する
+3. If Requirement 2.1 の照合で expected-slug と found-slug が一致しないとき, the Watcher shall Issue #114 の既存挙動と同一の経路（`needs-decisions` 付与・1 件のコメント投稿・当該 Issue 処理 skip）を選択する
+4. While `docs/specs/<N>-*/` が存在しないとき, the Watcher shall 本 Issue 修正前と同一の新規スラグ導出経路を選択する
+
+### Requirement 3: resumable state の定義と判定範囲
+
+**Objective:** As a watcher 開発者, I want resumable state の定義を 1 か所で表現すること, so that spec-dir 経路の slug guard と既存 Stage Checkpoint Resume 判定で同じ「実体観測」が共有される
+
+#### Acceptance Criteria
+
+1. The Watcher shall 「resumable state が実在する」を以下 4 観点のいずれか 1 つ以上が真であることと定義する: (a) `stage_checkpoint_find_impl_pr` が OPEN または MERGED 状態の impl PR を 1 件以上検出する, (b) origin 上に `refs/heads/claude/issue-<N>-impl-*` 形式の branch が 1 本以上存在する, (c) 当該 Issue branch HEAD（または検出対象の spec dir）上で `impl-notes.md` が tracked である, (d) 当該 Issue branch HEAD（または検出対象の spec dir）上で `review-notes.md` が tracked である
+2. The Watcher shall Requirement 3.1 の 4 観点をいずれも検出失敗（gh API エラー・ネットワーク失敗・タイムアウト）したときも slug guard を skip する側に倒さない（NFR 2 の safe-side 規約に従う）
+3. The Watcher shall Requirement 3.1 の判定結果を `stage_checkpoint_resolve_resume_point` の判定経路から独立に観測可能とし、spec-dir 経路 slug guard の発火可否判定にだけ用いる
+
+### Requirement 4: 判定経路のログ可観測性
+
+**Objective:** As a watcher 運用者, I want slug guard を skip した経路と発火した経路をログから機械的に区別できること, so that 障害発生時に grep で原因を辿れる
+
+#### Acceptance Criteria
+
+1. When Requirement 1.2 / 1.5 の skip 経路に入ったとき, the Watcher shall ログに `stage-checkpoint:` prefix で 1 行のイベントを記録し issue 番号・expected-slug・found-slug・skip 理由（resumable state 不在）を含める
+2. When Requirement 2.1 の照合経路に入ったとき, the Watcher shall 既存 `stage-checkpoint: slug-match` / `stage-checkpoint: slug-mismatch` ログを従来と同形式で 1 行記録する
+3. When Requirement 3.1 の判定中に I/O エラーや gh API 失敗を観測したとき, the Watcher shall ログに `stage-checkpoint: WARN` 形式で観測失敗の事実を 1 行記録する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Watcher shall 既存の環境変数名（`STAGE_CHECKPOINT_ENABLED` 等）・既存ラベル名（`needs-decisions` / `claude-claimed`）・cron 登録文字列・exit code 意味を変更しない
+2. While Issue 番号もスラグも一致し resumable state が実在する spec dir が存在するとき, the Watcher shall Issue #114 導入後の Stage Checkpoint Resume 経路（resume-mode・ブランチ起点・push 戦略）と完全に同一の挙動を選択する
+3. While `docs/specs/<N>-*/` が存在しないとき, the Watcher shall 本 Issue 修正前と同一の新規スラグ導出経路を選択する
+4. The Watcher shall 本 Issue の挙動変更を新規 env var の opt-in gate なしで適用する（既存挙動は「resumable state 実在時に slug guard を発火」というスーパーセットに包含されるため、後方互換 no-op として導入できる）
+
+### NFR 2: 異常系の安全側挙動
+
+1. If Requirement 3.1 の resumable state 判定の途中で gh API エラー・ネットワーク失敗・タイムアウトを観測したとき, the Watcher shall 「resumable state が実在するかもしれない」側に倒し（=従来挙動と同じ slug guard 発火経路を選択する）誤った skip による fork/mirror 誤 resume を発生させない
+2. The Watcher shall 既存 spec dir / 既存ブランチを自動削除・自動リネーム・自動上書きしない
+3. While slug guard を skip する判定経路を選択しているとき, the Watcher shall 当該 Issue に対して新規 `docs/specs/<N>-<slug>/` ディレクトリを作成したり既存 umbrella spec を書き換えたりする処理を本修正の責務として追加しない（後続 Stage A 実装が判断する）
+
+### NFR 3: ログ出力の運用基準
+
+1. The Watcher shall Requirement 4 の各ログ行を 1 イベント 1 行で出力し改行を含めない
+2. The Watcher shall Requirement 4 のログ行に issue 番号・expected-slug・found-slug の 3 値をすべて含める（skip 経路でも found-slug を出力できないケースは空文字または `(none)` リテラルとする）
+
+### NFR 4: テスト方針
+
+1. The Watcher shall 本要件の判定ロジックを `local-watcher/test/` 配下の既存テスト方式（`extract_function` で関数を関数定義のみ抽出 → `gh` / `slot_log` / `_slug_mismatch_escalate` 等の副作用関数を stub → 観測）に従って検証可能な単位に分割して実装する
+2. The Watcher shall 既存の `local-watcher/test/slug_match_guard_test.sh` の検証観点（slug-match / slug-mismatch / NUMBER 未設定 / spec dir prefix 不一致）を回帰させない
+3. The Watcher shall Requirement 1.2 の skip 経路と Requirement 2.1 の発火経路を最低 1 件ずつ test fixture で検証する
+
+## Out of Scope
+
+- 二次的所見（watcher 自身のエスカレーションコメントが stale 化して Triage が
+  `needs-decisions` を再起票するループ）の解消。Issue 本文「スコープ外」節は
+  「slug ガードの誤爆解消に限定」と明言しており、二次的所見は別 issue として
+  follow-up 化する。「確認事項」節に follow-up 化判断を明示する
+- 「1 umbrella spec を複数 sub-issue で共有する」構成自体の idd-claude
+  一級サポート（Issue 本文「スコープ外」節と同一）
+- watcher 自身がエスカレーションコメントを条件解消時に自動 close / 注記する
+  機構の新規追加（二次的所見の根本解決に該当するため follow-up）
+- Triage プロンプト側の過去 watcher コメントを未解決決定事項として誤読する
+  挙動の修正（PM/Triage プロンプト変更を要するため follow-up）
+- `_resume_branch_assert_slug_match`（`local-watcher/bin/issue-watcher.sh:9453`）
+  の挙動変更。ブランチ経路は元々 origin に impl-* ブランチが存在することを
+  前提に発火する設計のため resumable state 判定が暗黙に組み込まれており、
+  本要件のスコープ外
+- スラグ正規化規則（Issue #114 Req 5 の `_normalize_slug`）の変更
+- `needs-decisions` ラベル以外へのエスカレーション先切替
+
+## 確認事項
+
+- 二次的所見（needs-decisions 再エスカレーションループ）の扱い:
+  Issue 本文「受入基準」節の (二次) 項目には記載があるが、同 Issue「スコープ外」節は
+  「本 Issue は slug ガードの誤爆解消に限定」と明言している。コメント欄に
+  人間からの追加指示は存在しない（Path Overlap Checker と watcher 起動通知のみ）。
+  PM 判断として **本 Issue では Out of Scope に倒し、follow-up issue 化を提案する**
+  方針を採用した。Architect / Developer は本判断を上書きしないこと。
+  もし運用上「同じ PR で二次的所見もまとめて解消したい」という要求がある場合は、
+  本 requirements を再オープンし Requirement 5 として追加する（現時点では追加しない）。
+- Requirement 3.1 で定義した resumable state の 4 観点（impl PR / impl-* origin
+  ブランチ / impl-notes.md tracked / review-notes.md tracked）の AND/OR 条件は
+  「OR（1 つでも真なら resumable state 実在）」と確定。設計判断として
+  `stage_checkpoint_resolve_resume_point` が個別観点を独立に観測している
+  既存挙動と整合させた（impl-notes 単独でも Stage B 以降へ resume するため）
+- Requirement 3.1 (b) の origin ブランチ判定について、spec-dir 経路 slug guard の
+  時点では BRANCH 変数（`claude/issue-<N>-impl-<slug>`）の slug 部がまだ
+  expected-slug ベースで確定していない可能性がある。実装では
+  `_resume_branch_assert_slug_match` と同様に `git ls-remote --heads origin
+  "refs/heads/claude/issue-<N>-impl-*"` で **slug 不問の prefix マッチ**を
+  行うこと（特定 slug ブランチに限定すると mismatch ブランチを resumable state
+  として検出できず本 Issue が解消しないため）
+- NFR 1.4 の「opt-in gate なし」判断について、idd-claude の原則は「外部挙動を
+  変える機能は env gate で opt-in」だが、本修正は「従来 block していた fresh
+  issue を block しない方向への緩和」であり、Issue #114 が守る fork/mirror
+  誤 resume 防止は resumable state 実在時の発火経路で完全に維持される。
+  CLAUDE.md「opt-in gate と後方互換」節の趣旨（既定挙動の no-op 維持）と整合する
+  ため gate なしでよいと判断した
+
+## 関連
+
+- Depends on: なし
+- Parent: なし
+- Related: #114（Stage Checkpoint Resume slug 照合ガードの原典）

--- a/docs/specs/383-fix-watcher-stage-checkpoint-resumable-s/review-notes.md
+++ b/docs/specs/383-fix-watcher-stage-checkpoint-resumable-s/review-notes.md
@@ -1,0 +1,115 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-383-impl-fix-watcher-stage-checkpoint-resumable-s
+- HEAD commit: 8f51e41de5083fd2d9bfc30f75221ba6f304b517
+- Compared to: main..HEAD
+- 変更ファイル:
+  - `local-watcher/bin/issue-watcher.sh` (+141 / -10) — 新規ヘルパ
+    `_stage_checkpoint_has_resumable_state` 追加 + spec-dir 経路 slug guard 呼び出し元
+    （`_slot_run_issue` 内、`_matched_dir` 空の fallback ブロック）の case 分岐挿入
+  - `local-watcher/test/stage_checkpoint_resumable_state_test.sh` (+359, new) —
+    12 ケース・18 アサーションの近接テスト
+  - `docs/specs/383-*/{requirements,impl-notes}.md` — spec 成果物
+- tasks.md は本 Issue では未生成（Triage 経路で Architect が起動されなかったため。
+  小規模な watcher 単一関数修正であり Boundary 判断は requirements.md の Out of Scope と
+  既存ファイル境界で十分に決まる）
+
+## Verified Requirements
+
+- **1.1** — spec dir 検出時に判定が走る: `_slot_run_issue` 内の SPEC_CANDIDATES 非空 +
+  `_matched_dir` 空ブロック（`local-watcher/bin/issue-watcher.sh:10670-10672`）で
+  `_stage_checkpoint_has_resumable_state` を call
+- **1.2** — 4 観点不在 → skip: 新関数 return 1 → caller `case 1)` 分岐で
+  `SLUG="$EXPECTED_SLUG"` 採用（test Case 1, 12 + caller code 10674-10679）
+- **1.3** — skip 時に needs-decisions 付与なし: `case 1)` 分岐は
+  `_slug_mismatch_escalate` を call しないため `_slug_mismatch_escalate` 内の
+  `gh issue edit ... --add-label needs-decisions` 経路に入らない（caller code 10674-10679）
+- **1.4** — skip 時に escalate コメント投稿なし: 同上（`_slug_mismatch_escalate` 不呼び出し）
+- **1.5** — 複数候補 + expected 不一致 → 同 skip 経路: `_matched_dir` ループで
+  match が見つからなければ `_first="${SPEC_CANDIDATES[0]}"` から `_stage_checkpoint_has_resumable_state`
+  を call し、return 1 なら同じ `case 1)` 分岐へ落ちる（caller code 10670）
+- **2.1** — 4 観点いずれか実在 → fire: 新関数 return 0 → caller `case *)` 分岐で
+  `_stage_checkpoint_assert_slug_match` を call（test Cases 2, 3, 4, 5, 6, 3b +
+  caller code 10680-10691）
+- **2.2** — match 時の resume 継続: `_matched_dir` 非空経路（10654-10662）は無変更で
+  既存 `_stage_checkpoint_assert_slug_match` 経路を維持
+- **2.3** — mismatch + resumable state 実在 → escalate: caller `case *)` 分岐内で
+  `_stage_checkpoint_assert_slug_match` が rc=1 を返した時に `return 1`（既存挙動を維持）
+- **2.4** — spec dir 不在時の新規スラグ導出: 10694-10698 の else 経路は無変更
+- **3.1** — OR 4 観点判定: `_stage_checkpoint_has_resumable_state` 内で (a) impl PR
+  (b) origin impl-* branch (c) impl-notes.md tracked (d) review-notes.md tracked を
+  順次評価、最初に hit したら return 0（test Cases 2, 3, 3b, 4, 5, 6）
+- **3.2** — 観測失敗時 safe-side: 各観点で gh API rc≠0/1 や `git ls-remote` rc≠0、
+  `git ls-tree` 失敗を `detection_failed=true` に集約し、全観点が hit せず failure が
+  1 件でもあれば return 2（test Cases 7, 8, 10, 11）
+- **3.3** — `stage_checkpoint_resolve_resume_point` から独立観測: 新関数は
+  `stage_checkpoint_resolve_resume_point` を call せず、`stage_checkpoint_find_impl_pr` /
+  `git ls-remote` / `git ls-tree` のみを直接呼ぶ（code review）
+- **4.1** — skip 経路のログ: caller の `case 1)` で
+  `stage-checkpoint: slug-guard-skipped issue=#<N> expected=<exp> found=<found>
+  reason=no-resumable-state` を 1 行 LOG 出力（issue/expected/found を含む。NFR 3.2 充足）
+- **4.2** — slug-match / slug-mismatch ログ: `_stage_checkpoint_assert_slug_match` は
+  無変更で既存 `slug_match_guard_test.sh` 13 ケース全 PASS（回帰なし）
+- **4.3** — WARN ログ: gh API / git failure 時に `stage-checkpoint: WARN
+  resumable-state-detection ...` を stderr へ 1 行出力（code review）
+- **NFR 1.1** — env var / label / cron / exit code 不変: 新規 env var なし、
+  既存ラベル `needs-decisions` `claude-claimed` は無変更（code review）
+- **NFR 1.2** — resumable state 実在 + slug 一致時の挙動維持: `_matched_dir` 非空経路は
+  無変更（10654-10662）
+- **NFR 1.3** — spec dir 不在時の新規スラグ導出: 10694-10698 は無変更
+- **NFR 1.4** — opt-in gate なしで導入: 新規 env var を追加していない。CLAUDE.md
+  「opt-in gate と後方互換」原則の「既定挙動の no-op 維持」と整合（fork/mirror 誤
+  resume 防止は resumable state 実在経路で完全維持されるため、緩和の方向の挙動変更
+  であり gate 不要）
+- **NFR 2.1** — 安全側挙動: 観測失敗は return 2 → caller の `*)` 分岐で従来の
+  `_stage_checkpoint_assert_slug_match` 経路を call（fork/mirror 誤 resume 防止維持）
+- **NFR 2.2** — 既存 spec dir 無変更: 新関数は `git ls-tree` / `git ls-remote` /
+  `gh pr list` の read-only ops のみ
+- **NFR 2.3** — 新規 docs/specs/ 作成や umbrella 書き換えを含めない: 新関数は読み取り
+  のみ、caller は `SLUG="$EXPECTED_SLUG"` 設定のみで `mkdir` 等を行わない
+- **NFR 3.1** — 1 イベント 1 行: 全 echo 行が改行を含まない単一行（code review）
+- **NFR 3.2** — issue 番号・expected・found 3 値の含有: caller `slug-guard-skipped`
+  ログに 3 値すべて含まれる（10677）
+- **NFR 4.1** — extract_function + stub イディオム: 新規 test は
+  `extract_function "$WATCHER_SH" "_stage_checkpoint_has_resumable_state"` で関数定義
+  のみ抽出し、`stage_checkpoint_find_impl_pr` / `git` / `timeout` を test 内で stub
+- **NFR 4.2** — 既存 `slug_match_guard_test.sh` 全 13 ケース PASS（実行確認済）
+- **NFR 4.3** — skip 経路 + 発火経路を最低 1 件ずつ: Case 1（skip）+ Cases 2-5（発火）
+
+## Boundary Check
+
+- 修正対象は `local-watcher/bin/issue-watcher.sh` の Stage Checkpoint 関連関数 +
+  近接テストの追加のみ。CLAUDE.md「機能追加ガイドライン」の「本体 inline ではなく
+  module へ切り出す」原則からは inline 追加に該当するが、`_stage_checkpoint_assert_slug_match`
+  と同居領域への近接配置であり、Stage Checkpoint module（`stage-checkpoint.sh` 等）が
+  独立 module として存在しない現状（同関数群が本体 inline）に整合する
+- `repo-template/` 配下に `issue-watcher.sh` の mirror は存在しない（`repo-template/`
+  には `CLAUDE.md` のみ。impl-notes.md の主張と一致）。二重管理同期の対象外
+- Out of Scope（requirements.md 97-115）の boundary は遵守（二次的所見の解消・
+  Triage プロンプト変更・`_resume_branch_assert_slug_match` 変更・`_normalize_slug`
+  変更・新規 escalation 先追加は本 PR に含まれていない）
+
+## Test Execution Verification
+
+- `bash local-watcher/test/stage_checkpoint_resumable_state_test.sh` → PASS 18 / FAIL 0
+- `bash local-watcher/test/slug_match_guard_test.sh` → PASS 13 / FAIL 0（回帰なし）
+- `shellcheck local-watcher/bin/issue-watcher.sh
+  local-watcher/test/stage_checkpoint_resumable_state_test.sh` → 警告ゼロ
+
+## Findings
+
+なし
+
+## Summary
+
+requirements.md の全 numeric ID（Req 1.1〜1.5 / 2.1〜2.4 / 3.1〜3.3 / 4.1〜4.3 /
+NFR 1.1〜1.4 / 2.1〜2.3 / 3.1〜3.2 / 4.1〜4.3）が実装または近接テストでカバーされており、
+新規ヘルパ `_stage_checkpoint_has_resumable_state` の発火経路・skip 経路・safe-side
+経路がいずれも fixture テストで検証されている。既存 `slug_match_guard_test.sh` も
+13 ケース全 PASS で回帰なし。境界も requirements.md の Out of Scope を逸脱していない。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -9434,6 +9434,119 @@ _stage_checkpoint_assert_slug_match() {
   return 1
 }
 
+# spec-dir 経路の slug guard を発火させる前に「resumable state が実在するか」を判定する
+# read-only ヘルパ（Issue #383 Req 1, 3）。Issue #114 が守る fork/mirror 番号衝突誤 resume
+# 防止は resumable state が実在する Issue では従来どおり発火し、resumable state が一切
+# 不在の fresh issue については slug guard を skip して Stage A を新規実装として継続させる。
+#
+# resumable state の定義（Req 3.1, OR 条件 / 4 観点いずれか 1 つでも真なら実在）:
+#   (a) `stage_checkpoint_find_impl_pr` が OPEN または MERGED 状態の impl PR を 1 件以上検出
+#   (b) origin 上に `refs/heads/claude/issue-<N>-impl-*` 形式の branch が 1 本以上存在
+#   (c) 検出対象 spec dir 配下で `impl-notes.md` が branch HEAD 上で tracked
+#   (d) 検出対象 spec dir 配下で `review-notes.md` が branch HEAD 上で tracked
+#
+# 引数:
+#   $1 = 検出対象の spec dir 絶対パス（`$WT/docs/specs/<N>-<slug>` 形式）
+# 戻り値:
+#   0 = resumable state 実在（呼び出し元は従来どおり slug guard を発火）
+#   1 = resumable state 不在（呼び出し元は slug guard を skip して Stage A 継続）
+#   2 = 判定失敗（gh API エラー・git エラー等。NFR 2.1 の safe-side により呼び出し元は
+#       0 と同等に扱い slug guard を発火させる）
+# 副作用:
+#   - LOG に `stage-checkpoint:` prefix で 1 行の判定結果ログを出力（Req 4.1, 4.3）
+#   - 検出失敗時は `stage-checkpoint: WARN` 形式で観測失敗の事実を 1 行出力（Req 4.3）
+#
+# `BRANCH` 変数はこの時点では未確定なので、(b) の branch 判定は
+# `_resume_branch_assert_slug_match` と同様に slug 不問の prefix マッチ
+# （`refs/heads/claude/issue-<N>-impl-*`）で行う（確認事項参照）。
+_stage_checkpoint_has_resumable_state() {
+  local spec_dir="$1"
+  local issue_num="${NUMBER:-}"
+
+  # 入力検証: Issue 番号が numeric でない場合は判定不能 → safe-side（実在扱い）
+  case "$issue_num" in
+    ''|*[!0-9]*)
+      echo "stage-checkpoint: WARN resumable-state-detection issue=#${issue_num:-?} reason=invalid-issue-number" >&2
+      return 2
+      ;;
+  esac
+
+  local detection_failed="false"
+
+  # (a) 既存 impl PR を gh から観測。stage_checkpoint_find_impl_pr の戻り値:
+  #     0 = OPEN/MERGED の impl PR あり / 1 = なし / 2 = gh API エラー
+  local pr_info pr_rc=0
+  pr_info=$(stage_checkpoint_find_impl_pr 2>/dev/null) || pr_rc=$?
+  case "$pr_rc" in
+    0)
+      echo "stage-checkpoint: resumable-state-found issue=#${issue_num} observation=impl-pr detail=${pr_info}" | tee -a "$LOG"
+      return 0
+      ;;
+    1)
+      : # 不在。後続観点へ
+      ;;
+    *)
+      echo "stage-checkpoint: WARN resumable-state-detection issue=#${issue_num} observation=impl-pr reason=gh-api-failure rc=${pr_rc}" >&2
+      detection_failed="true"
+      ;;
+  esac
+
+  # (b) origin 上に `claude/issue-<N>-impl-*` ブランチが 1 本でも存在するか。
+  # `_resume_branch_assert_slug_match` と同じ prefix マッチを使う（slug 不問）。
+  local prefix="claude/issue-${issue_num}-impl-"
+  local remote_refs ls_rc=0
+  remote_refs=$(timeout 30 git ls-remote --heads origin -- "refs/heads/${prefix}*" 2>/dev/null) || ls_rc=$?
+  if [ "$ls_rc" -eq 0 ]; then
+    if [ -n "$remote_refs" ]; then
+      echo "stage-checkpoint: resumable-state-found issue=#${issue_num} observation=impl-branch detail=${prefix}*" | tee -a "$LOG"
+      return 0
+    fi
+  else
+    echo "stage-checkpoint: WARN resumable-state-detection issue=#${issue_num} observation=impl-branch reason=ls-remote-failure rc=${ls_rc}" >&2
+    detection_failed="true"
+  fi
+
+  # (c) / (d) 検出対象 spec dir 配下の impl-notes.md / review-notes.md を branch HEAD 上で
+  # tracked 判定する。worktree の HEAD は base ブランチ（spec-dir 検出時点）なので、
+  # umbrella spec が main に merge 済みでも impl-notes.md / review-notes.md は通常
+  # impl PR ブランチ側にのみ存在するため、ここで tracked = resumable state ありとみなす。
+  #
+  # REPO_DIR は worktree path に上書き済（呼び出し元 _slot_run_issue が REPO_DIR=$WT に
+  # 設定する）ため、`git -C "$REPO_DIR"` と spec_dir は同一 worktree を指す。
+  local rel
+  rel="docs/specs/$(basename "$spec_dir")"
+
+  local impl_tracked review_tracked
+  if impl_tracked=$(git -C "$REPO_DIR" ls-tree --name-only HEAD -- "$rel/impl-notes.md" 2>/dev/null); then
+    if [ -n "$impl_tracked" ]; then
+      echo "stage-checkpoint: resumable-state-found issue=#${issue_num} observation=impl-notes detail=${rel}/impl-notes.md" | tee -a "$LOG"
+      return 0
+    fi
+  else
+    echo "stage-checkpoint: WARN resumable-state-detection issue=#${issue_num} observation=impl-notes reason=git-ls-tree-failure" >&2
+    detection_failed="true"
+  fi
+
+  if review_tracked=$(git -C "$REPO_DIR" ls-tree --name-only HEAD -- "$rel/review-notes.md" 2>/dev/null); then
+    if [ -n "$review_tracked" ]; then
+      echo "stage-checkpoint: resumable-state-found issue=#${issue_num} observation=review-notes detail=${rel}/review-notes.md" | tee -a "$LOG"
+      return 0
+    fi
+  else
+    echo "stage-checkpoint: WARN resumable-state-detection issue=#${issue_num} observation=review-notes reason=git-ls-tree-failure" >&2
+    detection_failed="true"
+  fi
+
+  # 全 4 観点で「不在」または「観測失敗」。安全側挙動として、観測失敗が 1 件でも
+  # あれば 2（実在不明）を返し、呼び出し元は slug guard 発火経路に倒す（NFR 2.1）。
+  if [ "$detection_failed" = "true" ]; then
+    return 2
+  fi
+
+  # 全 4 観点が確定的に「不在」だった場合のみ slug guard を skip する。
+  return 1
+}
+
 # origin の `claude/issue-<N>-impl-*` ブランチを resume 候補として検出した際に
 # 行うスラグ照合（Req 2.1, 2.2, 2.3）。origin の全 impl-* ブランチを ls-remote で
 # 列挙し、expected-slug と一致するブランチが 1 つでも見つかれば match、見つからず
@@ -10548,17 +10661,35 @@ _slot_run_issue() {
       SLUG=$(basename "$EXISTING_SPEC_DIR" | sed "s/^${NUMBER}-//")
       echo "📂 既存 spec 検出: $EXISTING_SPEC_DIR (slug=$SLUG)" | tee -a "$LOG"
     else
-      # Req 1.4, 1.5: docs/specs/<N>-* は存在するが expected-slug と一致するものがない
-      # → 先頭候補を mismatch 対象として LOG/escalate し、当該 Issue を skip する。
+      # Issue #383 Req 1.2, 1.5: docs/specs/<N>-* は存在するが expected-slug と一致する
+      # ものがないケースは、umbrella spec を sub-issue が共有する構成での fresh issue を
+      # 誤 block しないため、resumable state が実在するときのみ slug guard を発火させる。
+      # resumable state 不在（fresh issue）なら slug guard を skip して Stage A を新規実装
+      # として継続する（SLUG は Issue タイトル由来の EXPECTED_SLUG を採用）。
+      # 判定失敗（gh API エラー等）は NFR 2.1 の safe-side に倒して従来の発火経路を維持する。
       local _first="${SPEC_CANDIDATES[0]}"
-      if ! _stage_checkpoint_assert_slug_match "$EXPECTED_SLUG" "$_first"; then
-        return 1
-      fi
-      # 防御: _stage_checkpoint_assert_slug_match が 0 を返した（一致した）場合の
-      # フォールバック（実装上は到達しないが silent fail を作らないため）
-      HAS_EXISTING_SPEC=true
-      EXISTING_SPEC_DIR="$_first"
-      SLUG=$(basename "$EXISTING_SPEC_DIR" | sed "s/^${NUMBER}-//")
+      local _resumable_rc=0
+      _stage_checkpoint_has_resumable_state "$_first" || _resumable_rc=$?
+      case "$_resumable_rc" in
+        1)
+          # Req 1.2, 1.3, 1.4: resumable state 不在 → slug guard skip。`needs-decisions`
+          # 付与なし / escalation コメント投稿なし / SLUG は Issue タイトル由来を採用。
+          echo "stage-checkpoint: slug-guard-skipped issue=#${NUMBER:-?} expected=${EXPECTED_SLUG} found=$(basename "$_first" | sed "s/^${NUMBER}-//") reason=no-resumable-state" | tee -a "$LOG"
+          SLUG="$EXPECTED_SLUG"
+          ;;
+        *)
+          # Req 2.1, 2.3 / NFR 2.1: resumable state 実在（0）/ 判定失敗の safe-side（2）/
+          # 想定外 rc は全て従来どおり slug guard を発火させる方に倒す（safe-side default）。
+          if ! _stage_checkpoint_assert_slug_match "$EXPECTED_SLUG" "$_first"; then
+            return 1
+          fi
+          # 防御: _stage_checkpoint_assert_slug_match が 0 を返した（一致した）場合の
+          # フォールバック（実装上は到達しないが silent fail を作らないため）
+          HAS_EXISTING_SPEC=true
+          EXISTING_SPEC_DIR="$_first"
+          SLUG=$(basename "$EXISTING_SPEC_DIR" | sed "s/^${NUMBER}-//")
+          ;;
+      esac
     fi
   else
     # Req 1.6: `docs/specs/<N>-*/` が存在しないとき → 本要件のスラグ照合は発火させず

--- a/local-watcher/test/stage_checkpoint_resumable_state_test.sh
+++ b/local-watcher/test/stage_checkpoint_resumable_state_test.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh の Stage Checkpoint Resume 用 resumable state
+#       判定ヘルパ `_stage_checkpoint_has_resumable_state` を fixture で検証する
+#       スモークテスト。Issue #383 で導入。
+#
+#       検証範囲:
+#         Req 1.2 (skip 経路): spec dir 存在 + 4 観点いずれも不在 → return 1（skip）
+#         Req 2.1 (発火経路): impl PR / impl branch / impl-notes / review-notes の
+#                              いずれか 1 つでも実在 → return 0（fire）
+#         Req 3.1: 4 観点が OR で判定される（個別に return 0）
+#         NFR 2.1 (safe-side): gh API / git ls-remote / git ls-tree 失敗時は return 2
+#                              （呼び出し元は 0 と同等に扱い slug guard を発火）
+#
+# 配置先: local-watcher/test/stage_checkpoint_resumable_state_test.sh
+# 依存:   bash 4+, awk
+# 実行:   bash local-watcher/test/stage_checkpoint_resumable_state_test.sh
+# 前提:   issue-watcher.sh から関数定義を awk で切り出して eval で読み込み、
+#         `stage_checkpoint_find_impl_pr` / `git` は test 内で stub する。
+#
+# shellcheck disable=SC2317
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+extract_function() {
+  local script="$1" fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# ─── 対象関数の load ───
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "_stage_checkpoint_has_resumable_state")"
+
+if ! declare -F _stage_checkpoint_has_resumable_state >/dev/null; then
+  echo "ERROR: _stage_checkpoint_has_resumable_state not loaded" >&2
+  exit 2
+fi
+
+# ─── 依存関数の stub ───
+# 各テストケースの fixture で MOCK_* 変数を差し替えて挙動を制御する。
+
+# stage_checkpoint_find_impl_pr の stub。
+# MOCK_FIND_IMPL_PR_RC で戻り値、MOCK_FIND_IMPL_PR_OUT で stdout を制御する。
+MOCK_FIND_IMPL_PR_RC=1
+MOCK_FIND_IMPL_PR_OUT=""
+stage_checkpoint_find_impl_pr() {
+  if [ -n "$MOCK_FIND_IMPL_PR_OUT" ]; then
+    echo "$MOCK_FIND_IMPL_PR_OUT"
+  fi
+  return "$MOCK_FIND_IMPL_PR_RC"
+}
+export -f stage_checkpoint_find_impl_pr
+
+# git の stub。引数パターンで分岐させる。
+#   - `git ls-remote --heads origin ...` → MOCK_LS_REMOTE_RC / MOCK_LS_REMOTE_OUT
+#   - `git -C <dir> ls-tree --name-only HEAD -- <path>` → MOCK_LS_TREE_RC_<basename> /
+#                                                         MOCK_LS_TREE_OUT_<basename>
+MOCK_LS_REMOTE_RC=0
+MOCK_LS_REMOTE_OUT=""
+MOCK_LS_TREE_IMPL_RC=0
+MOCK_LS_TREE_IMPL_OUT=""
+MOCK_LS_TREE_REVIEW_RC=0
+MOCK_LS_TREE_REVIEW_OUT=""
+
+git() {
+  # サブコマンド位置: `git -C <dir> <subcmd> ...` の場合 $3 が subcmd、それ以外は $1
+  local subcmd=""
+  local args=()
+  if [ "${1:-}" = "-C" ]; then
+    shift 2  # -C と <dir> を捨てる
+  fi
+  subcmd="${1:-}"
+  shift || true
+  args=("$@")
+
+  case "$subcmd" in
+    ls-remote)
+      # 形式: git ls-remote --heads origin -- "refs/heads/claude/issue-<N>-impl-*"
+      if [ -n "$MOCK_LS_REMOTE_OUT" ]; then
+        echo "$MOCK_LS_REMOTE_OUT"
+      fi
+      return "$MOCK_LS_REMOTE_RC"
+      ;;
+    ls-tree)
+      # 形式: git ls-tree --name-only HEAD -- <path>
+      # 最後の引数（path）の basename で impl-notes / review-notes を判別
+      local path="${args[$((${#args[@]} - 1))]}"
+      case "$path" in
+        */impl-notes.md)
+          if [ -n "$MOCK_LS_TREE_IMPL_OUT" ]; then
+            echo "$MOCK_LS_TREE_IMPL_OUT"
+          fi
+          return "$MOCK_LS_TREE_IMPL_RC"
+          ;;
+        */review-notes.md)
+          if [ -n "$MOCK_LS_TREE_REVIEW_OUT" ]; then
+            echo "$MOCK_LS_TREE_REVIEW_OUT"
+          fi
+          return "$MOCK_LS_TREE_REVIEW_RC"
+          ;;
+        *)
+          return 0
+          ;;
+      esac
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+export -f git
+
+# timeout の stub: 引数の最初の token（秒数）を捨てて残りを実行する。
+# `git ls-remote` 経路の `timeout 30 git ls-remote ...` を再現するため。
+timeout() {
+  shift  # 秒数を捨てる
+  "$@"
+}
+export -f timeout
+
+# ─── アサーションヘルパ ───
+PASS=0
+FAIL=0
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL=$((FAIL + 1))
+  fi
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*)
+      echo "PASS: $label"
+      PASS=$((PASS + 1))
+      ;;
+    *)
+      echo "FAIL: $label"
+      echo "  needle  : $(printf '%q' "$needle")"
+      echo "  haystack: $(printf '%q' "$haystack")"
+      FAIL=$((FAIL + 1))
+      ;;
+  esac
+}
+
+# ─── テスト環境のセットアップ ───
+TMP_LOG=$(mktemp -t resumable-state-test-XXXXXX.log)
+TMP_REPO=$(mktemp -d -t resumable-state-repo-XXXXXX)
+mkdir -p "$TMP_REPO/docs/specs/383-test-slug"
+export LOG="$TMP_LOG"
+export REPO_DIR="$TMP_REPO"
+export REPO="owner/test"
+trap 'rm -f "$TMP_LOG"; rm -rf "$TMP_REPO"' EXIT
+
+# 各ケース実行前に MOCK 変数を全 reset するヘルパ
+reset_mocks() {
+  MOCK_FIND_IMPL_PR_RC=1
+  MOCK_FIND_IMPL_PR_OUT=""
+  MOCK_LS_REMOTE_RC=0
+  MOCK_LS_REMOTE_OUT=""
+  MOCK_LS_TREE_IMPL_RC=0
+  MOCK_LS_TREE_IMPL_OUT=""
+  MOCK_LS_TREE_REVIEW_RC=0
+  MOCK_LS_TREE_REVIEW_OUT=""
+  : > "$TMP_LOG"
+}
+
+SPEC_DIR="$TMP_REPO/docs/specs/383-test-slug"
+
+# ─── テストケース ───
+
+echo "--- _stage_checkpoint_has_resumable_state cases (Issue #383 Req 1, 2, 3, 4, NFR 2) ---"
+
+# ===========================================================================
+# Case 1: Req 1.2 — spec dir 存在 + 4 観点いずれも不在 → return 1（skip 経路）
+# ===========================================================================
+NUMBER=383
+export NUMBER
+reset_mocks
+# 全 mock を「不在」状態のままにする
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 1.2: 4 観点不在 → return 1（skip 経路）" "1" "$rc"
+
+# ===========================================================================
+# Case 2: Req 3.1(a) — impl PR 実在 → return 0
+# ===========================================================================
+reset_mocks
+MOCK_FIND_IMPL_PR_RC=0
+MOCK_FIND_IMPL_PR_OUT="42,OPEN"
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 2.1/3.1(a): impl PR 実在 → return 0" "0" "$rc"
+assert_contains "Req 4.1: impl PR 実在ログに observation=impl-pr が含まれる" \
+  "stage-checkpoint: resumable-state-found issue=#383 observation=impl-pr" \
+  "$(cat "$TMP_LOG")"
+
+# ===========================================================================
+# Case 3: Req 3.1(b) — origin impl-* ブランチ実在 → return 0
+# ===========================================================================
+reset_mocks
+MOCK_LS_REMOTE_OUT="abc123	refs/heads/claude/issue-383-impl-test-slug"
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 2.1/3.1(b): origin impl branch 実在 → return 0" "0" "$rc"
+assert_contains "Req 4.1: impl branch 実在ログに observation=impl-branch が含まれる" \
+  "stage-checkpoint: resumable-state-found issue=#383 observation=impl-branch" \
+  "$(cat "$TMP_LOG")"
+
+# ===========================================================================
+# Case 3b: Req 3.1(b) — slug 不問の prefix マッチ（mismatch slug でも検出する）
+# 確認事項に従い、ブランチ slug が expected と異なっても resumable state として検出する
+# ===========================================================================
+reset_mocks
+MOCK_LS_REMOTE_OUT="abc123	refs/heads/claude/issue-383-impl-different-slug"
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 3.1(b): slug 不問の prefix マッチで mismatch slug ブランチも検出" "0" "$rc"
+
+# ===========================================================================
+# Case 4: Req 3.1(c) — impl-notes.md tracked → return 0
+# ===========================================================================
+reset_mocks
+MOCK_LS_TREE_IMPL_OUT="docs/specs/383-test-slug/impl-notes.md"
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 2.1/3.1(c): impl-notes.md tracked → return 0" "0" "$rc"
+assert_contains "Req 4.1: impl-notes 検出ログに observation=impl-notes が含まれる" \
+  "stage-checkpoint: resumable-state-found issue=#383 observation=impl-notes" \
+  "$(cat "$TMP_LOG")"
+
+# ===========================================================================
+# Case 5: Req 3.1(d) — review-notes.md tracked → return 0
+# ===========================================================================
+reset_mocks
+MOCK_LS_TREE_REVIEW_OUT="docs/specs/383-test-slug/review-notes.md"
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 2.1/3.1(d): review-notes.md tracked → return 0" "0" "$rc"
+assert_contains "Req 4.1: review-notes 検出ログに observation=review-notes が含まれる" \
+  "stage-checkpoint: resumable-state-found issue=#383 observation=review-notes" \
+  "$(cat "$TMP_LOG")"
+
+# ===========================================================================
+# Case 6: Req 3.1 OR — 4 観点が OR で判定される（複数同時に真でも 1 件目で return 0）
+# 既に Case 2-5 で個別観点を確認したことが OR 性の証拠（OR semantics: any 1 → return 0）
+# ===========================================================================
+reset_mocks
+MOCK_FIND_IMPL_PR_RC=0
+MOCK_FIND_IMPL_PR_OUT="99,MERGED"
+MOCK_LS_REMOTE_OUT="abc	refs/heads/claude/issue-383-impl-x"
+MOCK_LS_TREE_IMPL_OUT="docs/specs/383-test-slug/impl-notes.md"
+MOCK_LS_TREE_REVIEW_OUT="docs/specs/383-test-slug/review-notes.md"
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 3.1: 4 観点全部真 → return 0（OR 判定）" "0" "$rc"
+
+# ===========================================================================
+# Case 7: NFR 2.1 — gh API 失敗（stage_checkpoint_find_impl_pr rc=2）+ 他観点不在
+#         → return 2（safe-side）
+# ===========================================================================
+reset_mocks
+MOCK_FIND_IMPL_PR_RC=2
+MOCK_FIND_IMPL_PR_OUT=""
+# 他観点は不在のまま
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "NFR 2.1: gh API 失敗 + 他観点不在 → return 2（safe-side）" "2" "$rc"
+
+# ===========================================================================
+# Case 8: NFR 2.1 — git ls-remote 失敗 + 他観点不在 → return 2（safe-side）
+# ===========================================================================
+reset_mocks
+MOCK_LS_REMOTE_RC=128
+# その他観点は不在のまま
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "NFR 2.1: git ls-remote 失敗 + 他観点不在 → return 2（safe-side）" "2" "$rc"
+
+# ===========================================================================
+# Case 9: NFR 2.1 — gh API 失敗だが impl-notes tracked → return 0（観測成功優先）
+# 「観測失敗があっても 1 つでも実在観測が成功すれば実在として扱う」semantics の確認
+# ===========================================================================
+reset_mocks
+MOCK_FIND_IMPL_PR_RC=2
+MOCK_LS_TREE_IMPL_OUT="docs/specs/383-test-slug/impl-notes.md"
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "NFR 2.1: 観測失敗があっても 1 つ実在ヒットすれば return 0" "0" "$rc"
+
+# ===========================================================================
+# Case 10: Req 3.1 入力検証 — NUMBER 未設定 → return 2（safe-side）
+# ===========================================================================
+reset_mocks
+unset NUMBER
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "NFR 2.1: NUMBER 未設定 → return 2（safe-side）" "2" "$rc"
+NUMBER=383
+export NUMBER
+
+# ===========================================================================
+# Case 11: Req 3.1 入力検証 — NUMBER 非数値 → return 2（safe-side）
+# ===========================================================================
+reset_mocks
+NUMBER="abc"
+export NUMBER
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "NFR 2.1: NUMBER 非数値 → return 2（safe-side）" "2" "$rc"
+NUMBER=383
+export NUMBER
+
+# ===========================================================================
+# Case 12: Req 4.1 — skip 経路では resumable-state-found ログを出さない
+# ===========================================================================
+reset_mocks
+rc=0
+_stage_checkpoint_has_resumable_state "$SPEC_DIR" >/dev/null 2>&1 || rc=$?
+assert_eq "Req 1.2: 4 観点不在 → return 1" "1" "$rc"
+# Skip 経路では resumable-state-found ログを出さない
+case "$(cat "$TMP_LOG")" in
+  *"resumable-state-found"*)
+    echo "FAIL: Req 4.1: skip 経路で resumable-state-found ログが出ている"
+    FAIL=$((FAIL + 1))
+    ;;
+  *)
+    echo "PASS: Req 4.1: skip 経路では resumable-state-found ログを出さない"
+    PASS=$((PASS + 1))
+    ;;
+esac
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS, FAIL: $FAIL"
+echo "==========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

watcher の Stage Checkpoint スラグ照合ガード（`_stage_checkpoint_assert_slug_match`）が、
`docs/specs/<N>-*/` に番号一致するディレクトリが存在するだけで発火する設計になっており、
umbrella spec を sub-issue と共有する構成で fresh issue（resumable state が一切存在しない）
が誤って `needs-decisions` でブロックされる問題を修正した。

新規ヘルパ関数 `_stage_checkpoint_has_resumable_state` を追加し、impl PR / origin 上の
`claude/issue-<N>-impl-*` ブランチ / tracked な `impl-notes.md` / `review-notes.md` の
4 観点（OR 判定）で resumable state の実在を確認する。resumable state が不在の場合は
slug guard を skip し、resumable state が実在する場合は Issue #114 の fork/mirror
誤 resume 防止のため従来どおり slug guard を発火させる。

## 対応 Issue

Closes #383

## 関連 PR

なし（Architect が走っておらず設計 PR は作成されていない小規模修正）

## 実装内容

- (Req 1, 3) `_stage_checkpoint_has_resumable_state` 新規追加: 4 観点 OR 判定で resumable
  state の実在を確認。rc=0（実在）/ rc=1（不在）/ rc=2（safe-side: 判定失敗）を返す
- (Req 1.2, NFR 2.1) spec-dir 経路の slug guard 呼び出し元（`_slot_run_issue` 内
  `_matched_dir` 空ブロック）に case 分岐を挿入し、rc=1（不在）の場合のみ slug guard を skip
- (NFR 2.1) 観測失敗（gh API エラー / git ls-remote 失敗 / NUMBER 非数値）は rc=2 で
  safe-side として従来の slug guard 発火経路に倒す
- (Req 4.1) skip 経路で `stage-checkpoint: slug-guard-skipped issue=# expected= found=
  reason=no-resumable-state` を 1 行 LOG 出力
- (NFR 4.1–4.3) `local-watcher/test/stage_checkpoint_resumable_state_test.sh` 新規追加
  （12 ケース・18 アサーション。`extract_function` + stub イディオムを踏襲）

## 受入基準チェック

- [x] Req 1.2: `docs/specs/<N>-*/` 存在 + resumable state 不在 → slug guard skip, `needs-decisions` 付与なし ← stage_checkpoint_resumable_state_test.sh Case 1, 12
- [x] Req 2.1: resumable state 実在（4 観点いずれか）→ slug guard 発火 ← Case 2, 3, 3b, 4, 5, 6
- [x] Req 2.3: mismatch + resumable state 実在 → escalate（既存挙動維持） ← slug_match_guard_test.sh Case 2
- [x] Req 3.2: 観測失敗 → return 2（safe-side）← Case 7, 8, 10, 11
- [x] Req 4.1: skip 経路ログに issue 番号・expected・found を含む ← Case 12 + caller code
- [x] NFR 1.1: env var / ラベル / cron / exit code 不変 ← コードレビュー
- [x] NFR 2.1: 観測失敗は safe-side（発火経路）に倒す ← Case 7, 8, 9, 10, 11

## テスト結果

```
bash -n local-watcher/bin/issue-watcher.sh → OK
shellcheck local-watcher/bin/issue-watcher.sh → 警告なし
shellcheck local-watcher/test/stage_checkpoint_resumable_state_test.sh → 警告なし
bash local-watcher/test/slug_match_guard_test.sh → PASS 13 / FAIL 0（回帰なし）
bash local-watcher/test/stage_checkpoint_resumable_state_test.sh → PASS 18 / FAIL 0
bash local-watcher/test/normalize_slug_test.sh → PASS 12 / FAIL 0
bash local-watcher/test/stage_checkpoint_pending_tasks_test.sh → PASS 3 / FAIL 0
関連 Stage C テスト群（stagec_pr_verify_*, parse_review_result_test）→ 全て exit=0
```

## 実装上の判断

- **slug 不問の prefix マッチ（Req 3.1(b)）**: origin ブランチ判定は `git ls-remote --heads origin "refs/heads/claude/issue-<N>-impl-*"` で slug 不問の prefix マッチを行う。spec-dir 経路 slug guard の時点で BRANCH 変数の slug 部がまだ確定していない可能性があるため（requirements.md 確認事項に記載）。
- **case 分岐の default `*)`**: rc=0（実在）/ rc=2（safe-side）/ 想定外 rc をまとめて slug guard 発火側に集約し、NFR 2.1「resumable state が実在するかもしれない側に倒す」と整合させた。
- **`_matched_dir` 非空（slug 一致）経路は無変更**: match 時は `_stage_checkpoint_assert_slug_match` が 0 を返して escalate しないため、誤 block が構造的に起きない。本修正の対象外。
- **opt-in gate なし（NFR 1.4）**: 本修正は「従来 block していた fresh issue を block しない方向への緩和」であり、fork/mirror 誤 resume 防止は resumable state 実在経路で完全維持されるため、env gate なしで後方互換 no-op として導入できる（CLAUDE.md opt-in gate 規約と整合）。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後に検証済み）
- **二次的所見（needs-decisions 再エスカレーションループ）は本 PR の Out of Scope**。requirements.md「確認事項」節に記載のとおり follow-up issue として別途対応予定。本修正で fresh issue の誤 block が解消されるため発火頻度は下がる見込みだが、既に `needs-decisions` で人手 unblock 済みの Issue を Triage が再付与する経路は本 PR では変更していない。
- レビュー判定詳細は `docs/specs/383-fix-watcher-stage-checkpoint-resumable-s/review-notes.md` を参照

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #383 のコメントを参照してください。
