### PR TITLE
fix(#385): claude-review catch-up の parse_review_result load-order バグを修正（F7）

### DIFF
--- a/docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/impl-notes.md
+++ b/docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/impl-notes.md
@@ -1,0 +1,126 @@
+# Implementation Notes — #385 fix(pr-reviewer): claude-review catch-up の parse_review_result load-order バグ
+
+## 採用した実装アプローチ
+
+**定義の前方移送（forward move）** を採用。理由:
+
+- Issue 本文・要件 1.1 で「定義の前方移送を推奨」と明示されている
+- 先行事例 #376（`full_auto_enabled` 前方移送）と同型の bug class であり、同一パターンで
+  修正することで「Config ブロック直後に置くべき早期参照関数」という運用契約を一貫させる
+- `parse_review_result` は他 9 件の caller（`stage_checkpoint_read_review_result` /
+  `run_reviewer_stage` / per-task 経路の `parsed3pt` / `parsed2` 等 / `publish_claude_review_status`）
+  からも参照される共通 helper であり、定義位置を最も早い call site より物理的に前へ置くことで
+  すべての caller に対する load-order 保証を 1 箇所で構造的に与えられる
+- 「呼び出し位置を後送」案は、catch-up call site（line 1684）が他 processor の直近に
+  並んでおり順序契約（Req: catch-up は PR Reviewer 直後、Security Review 直前）が
+  Issue #374 / 部分的に他 PR で確定済みなので動かしにくい
+
+依存関数 `extract_review_result_token` も `parse_review_result` 本体内で呼ばれているため、
+ペアで前方移送した（`parse_review_result` だけ前出ししても `extract_review_result_token`
+未定義で動かないため必須）。元の関数本体ロジックは 1 文字も変更していない（Req 1.3 / NFR 1.3）。
+
+## 変更ファイル一覧と主要差分の要約
+
+- `local-watcher/bin/issue-watcher.sh`
+  - `full_auto_enabled()` の直後（line 162 付近）に `extract_review_result_token()`
+    （新 line 184〜204）と `parse_review_result()`（新 line 237〜272）を挿入
+  - 元の定義位置（旧 line 6558〜6652）を削除し、5 行の参照コメント（`# Issue #349 / #374 / #385:
+    ...` move 済み）に置換
+  - 関数本体ロジックは無変更（`#385` のコメントヘッダのみ追加）
+  - 配置メモコメントに `#385` の context（catch-up が `declare -F` で参照する点・silent
+    skip 発生のメカニズム）を明記
+- `local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh`（新規追加）
+  - `parse_review_result` / `extract_review_result_token` の重複定義検出
+  - 全 caller 行が定義行より後ろにあることの機械検証
+  - `process_claude_review_status_catchup` の top-level call site（`^process_claude_review_status_catchup ||`）
+    が定義行より後ろにあることの明示 assert
+  - 参考として全 caller 棚卸し出力（Req 4.1）
+  - fail 時に「定義行・caller 行・caller シンボル名」を出力（NFR 3.3）
+
+`local-watcher/bin/modules/pr-reviewer.sh` は **無変更**。`declare -F parse_review_result`
+保険ガード（line 949）と WARN ログ（line 950）は Req 3.3 に従って温存。
+
+## 追加テストの観点と実行結果
+
+新規テスト `pr_reviewer_parse_review_result_load_order_test.sh`:
+
+- AC 1.1 / 1.2 / 1.5 / 5.1 を機械検証
+- 参考表示として AC 4.1 の caller 棚卸し（PASS/FAIL カウントには非加算）
+- regression シミュレーション（定義ブロックを catch-up call site の直後に移動）で
+  `FAIL: Req 1.1: parse_review_result 定義行 (1649) が process_claude_review_status_catchup
+  call site (1648) 以後` を検出することを確認（exit 1）。AC 5.2 / NFR 3.3 の出力契約を満たす。
+
+実行結果:
+
+```
+bash local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
+PASS: 5, FAIL: 0
+```
+
+回帰確認（全テスト）:
+
+```
+TOTAL: 51, PASS: 51, FAIL: 0
+```
+
+既存 `parse_review_result_test.sh`（23 件）も含めて全 PASS。`extract_function` イディオムで
+関数を抽出する既存テストは関数の物理位置に依存しないため、本 move による破壊なし。
+
+## 静的検査結果
+
+- `bash -n local-watcher/bin/issue-watcher.sh` → OK
+- `bash -n local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh` → OK
+- `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/pr-reviewer.sh
+  local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh` → 警告 0
+  （`.shellcheckrc` の baseline 抑止下で増加 0 / NFR 2.1, 2.2）
+- `diff -r .claude/agents repo-template/.claude/agents` → 空（同期維持）
+- `diff -r .claude/rules repo-template/.claude/rules` → 空（同期維持）
+
+## root ↔ repo-template 同期の判断
+
+`repo-template/` には `local-watcher/` 配下が存在しない（`ls repo-template/` の結果は
+`CLAUDE.md` のみ）。`install.sh` は idd-claude clone 直下の `local-watcher/bin/` から
+直接 `$HOME/bin/` へコピーする実装（`install.sh:53` `LOCAL_WATCHER_DIR="$SCRIPT_DIR/local-watcher"`）
+のため、`repo-template/` 配下に watcher / 近接テストを置く慣習はなく、本修正で同期対象は
+発生しない（Req 7.1 / NFR 1.1）。`.claude/{agents,rules}` も無変更のため byte 一致を維持。
+
+## README 反映要否の判断と根拠
+
+**反映不要**と判断。根拠:
+
+- 本修正は内部 load-order bug の修正であり、外部 API（env var / ラベル / exit code / cron
+  登録文字列 / ログ出力先 / commit status 名・state 解決）は一切変更していない（Req 6.3 / 6.4）
+- 既定動作（AND 二重 opt-in 無効環境）の外部観測挙動は move 前後で完全一致（NFR 1.1）
+- AND 二重 opt-in 有効環境では「永久 skip → catch-up が想定通り動く」という挙動の修正だが、
+  これは「壊れていた機能が直る」修正であり、README に記載された前向き仕様の変更ではない
+- 要件 7.2 「README の該当箇所と整合した状態」については、現状 README に
+  `parse_review_result` の load order に関する記述は無く、本修正により記述追加が必要な
+  項目は発生しない（catch-up 機能自体の README 説明は #374 / #380 で確立済み）
+
+## 確認事項
+
+なし。要件 / 既存実装 / 先行事例 #376 の修正パターンから判断が一意に決まり、独自解釈が
+必要な箇所はなかった。
+
+## AC Traceability
+
+| AC | 検証方法 |
+|----|----------|
+| 1.1 | 新規テスト「定義行 ($PARSE_DEF_LINE=237) < catch-up call site ($CATCHUP_CALL_LINE=1684)」assert |
+| 1.2 | 新規テスト「重複定義検出（count==1）」assert（旧位置の削除を機械検証） |
+| 1.3 | 関数本体無変更 / 既存 `parse_review_result_test.sh` 全 23 件 PASS（rc 規約・TSV 形式維持） |
+| 1.4 | catch-up 経路 `declare -F parse_review_result` が真評価となることを load-order assert で間接検証 |
+| 1.5 | 新規テスト「全 9 caller が定義行より後ろ」assert |
+| 2.1〜2.4 | `parse_review_result` を解決できるようになったことが前提条件。catch-up 本体の挙動は #374 / #380 で実装済みで本修正で無変更 |
+| 3.1〜3.4 | `pr-reviewer.sh` 内の safe-skip ガード（`declare -F` / parse-failed / git-show-failed）を無変更で温存 |
+| 4.1 | 新規テストの caller 棚卸し出力で全 caller を一覧化 |
+| 4.2 | 本 PR スコープ外の前方参照は別 Issue 化（本修正では `parse_review_result` のみを移動） |
+| 4.3 | `full_auto_enabled` の line 156 配置を破壊しないことを `bash -n` / 既存 `full_auto_enabled_load_order_test.sh` PASS で確認 |
+| 5.1〜5.4 | `pr_reviewer_parse_review_result_load_order_test.sh` を新規追加（既存テストランナと同一イディオム） |
+| 6.1〜6.4 | env var 名・kill switch 評価規則・関数シグネチャ・top-level 副作用すべて無変更 |
+| 7.1〜7.3 | `install.sh` が `local-watcher/bin/issue-watcher.sh` を直接配布する既存挙動を維持 |
+| NFR 1.1〜1.3 | 外部観測挙動・cron 最小 PATH 依存・他 caller 経路すべて無変更 |
+| NFR 2.1, 2.2 | `bash -n` / `shellcheck` 警告 0 を確認 |
+| NFR 3.1〜3.3 | catch-up publish 成功時の `pr_log`（#374）・skip WARN 経路（無変更）・回帰テスト出力に定義行＋call site 行を含む形式を確認 |
+
+STATUS: complete

--- a/docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/requirements.md
+++ b/docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/requirements.md
@@ -1,0 +1,246 @@
+# Requirements Document
+
+## Introduction
+
+`local-watcher/bin/issue-watcher.sh` は top-level コードを順次実行する bash スクリプトであり、
+`parse_review_result()` の関数定義（line 6617 付近）が `process_claude_review_status_catchup`
+の呼び出し位置（line 1573 付近）より後ろにあるため、catch-up processor が起動した時点で
+`parse_review_result` が未定義となる。catch-up 内の `declare -F parse_review_result` ガードが
+false 評価となり、`pr-reviewer: WARN: claude-review status publish (catch-up): parse_review_result
+未ロード ... reason=parse-helper-missing` を残して safe-skip する。結果として AND 二重 opt-in
+（`PR_REVIEWER_STATUS_CHECK_ENABLED=true` AND `FULL_AUTO_ENABLED=true`）が有効な環境で
+`claude-review` commit status が **永久に publish されない**（`codex-review` は publish されるが
+`claude-review` は none に留まる）状態が継続する。本 bug は #376（F4）で修正した
+`full_auto_enabled` 前方参照と完全に同一のバグ class（top-level 逐次実行下での load-order
+forward reference）であり、catch-up 側が安全側に skip する実装だったため silent に機能不全と
+なり気づきにくかった。
+
+本要件は `parse_review_result()` の定義位置を catch-up 呼び出しより前へ前出しする move 修正と、
+同種の前方参照を再発させない回帰防止策（定義行 < 呼び出し行の機械チェック、または catch-up
+実行到達テスト）を定義する。修正対象は関数定義の物理的な配置のみであり、関数本体ロジック・
+catch-up 側の safe-skip 契約・他 processor の挙動は変更しない。既存の safe-skip ガード
+（`declare -F parse_review_result` 検査と WARN ログ）は保険として残す。
+
+## 関連
+
+- Depends on: なし（独立した修正）
+- Related: #380（F3 catch-up 導入 PR） / #376（F4 `full_auto_enabled` 同種 load-order 修正） /
+  #374（claude-review status per-task publish 契約）
+
+## Requirements
+
+### Requirement 1: load-order bug の解消（`parse_review_result` 定義の前出し）
+
+**Objective:** As an idd-claude 運用者, I want `parse_review_result()` を `issue-watcher.sh` の
+`process_claude_review_status_catchup` 呼び出しより前に定義しておきたい, so that AND 二重
+opt-in 環境で catch-up が `parse_review_result` を解決して `claude-review` commit status を
+PR head sha に対して publish できるようになる（`parse-helper-missing` で永続 skip しない）。
+
+#### Acceptance Criteria
+
+1. The Issue Watcher shall `parse_review_result()` の関数定義を、`process_claude_review_status_catchup`
+   の call site（現状 line 1573 相当）より前の位置に 1 箇所だけ配置する。
+2. The Issue Watcher shall `parse_review_result()` の関数定義をスクリプト全体で 1 箇所のみ持ち、
+   重複定義を作らない。
+3. The Issue Watcher shall `parse_review_result()` の関数本体（戻り値・stdout TSV 形式・rc 規約
+   など #349 / #374 で確定済みの既存セマンティクス）を本修正で変更しない。
+4. When AND 二重 opt-in（`PR_REVIEWER_STATUS_CHECK_ENABLED=true` AND `FULL_AUTO_ENABLED=true`）
+   が成立した状態で `process_claude_review_status_catchup` が起動した, the PR Reviewer Processor
+   shall `declare -F parse_review_result` 検査が真と評価され、`reason=parse-helper-missing` の
+   WARN ログを出力しない。
+5. If `parse_review_result()` の caller（本体内 / `modules/*.sh` を含む）が今後増減・移動した,
+   the Issue Watcher shall すべての caller 位置が `parse_review_result` 定義位置より後ろにある
+   ことを変更後も維持する。
+
+### Requirement 2: catch-up 経路での `claude-review` status publish の発火
+
+**Objective:** As an idd-claude 運用者, I want open PR の review-notes.md（最終 `RESULT:` 行）を
+catch-up が読み直して `claude-review` commit status を publish できるようにしたい, so that
+per-task ループ運用で `publish_claude_review_status` が PR 作成より前に WARN skip した分も
+最終的に PR head sha 上で観測可能な state に収束する。
+
+#### Acceptance Criteria
+
+1. When open / 非 draft / `PR_REVIEWER_HEAD_PATTERN` に一致する PR があり、対応する
+   `docs/specs/<番号>-*/review-notes.md` が PR head 上に存在し、最終 `RESULT: approve` 行を
+   含み、AND 二重 opt-in が成立した状態で catch-up が 1 サイクル動作した, the PR Reviewer
+   Processor shall context `claude-review` / state `success` の commit status を PR head sha
+   に対して publish する。
+2. When 同条件下で `review-notes.md` の最終 `RESULT: reject` 行が読み取られた, the PR Reviewer
+   Processor shall context `claude-review` / state `failure` の commit status を PR head sha に
+   対して publish する。
+3. The PR Reviewer Processor shall catch-up 経由で publish する `claude-review` status の context
+   名・state 解決規則（approve→success / reject→failure）を非 catch-up 経路（#349 / #374 Req
+   3.x）と一致させる。
+4. When 同一 PR head sha に対して同一 context `claude-review` で複数回 publish が行われた,
+   the PR Reviewer Processor shall GitHub Commit Status API の "latest wins per (sha, context)"
+   セマンティクスにより最新の `RESULT:` を反映した state が表示される状態に収束させる
+   （#374 Req 4.3 と整合）。
+
+### Requirement 3: 異常系の safe-skip 契約の温存
+
+**Objective:** As an idd-claude 運用者, I want `review-notes.md` 不在・parse 失敗・PR 未解決
+などの異常系で catch-up が watcher パイプラインを停止させずに safe-skip する既存契約を本修正
+で壊さないようにしたい, so that 想定外の状態が原因で claude-failed に倒れる事故が発生せず、
+保険としての WARN + 継続挙動が維持される。
+
+#### Acceptance Criteria
+
+1. If catch-up 起動時点で対応する PR head から `review-notes.md` を取得できない, the PR Reviewer
+   Processor shall WARN レベルのログを 1 行残し commit status の publish を行わずに当該 PR の
+   試行を skip する（#374 Req 3.2 と整合）。
+2. If `review-notes.md` を `parse_review_result` で解釈できない（最終 `RESULT:` 行不在・不正値・
+   rc≠0）, the PR Reviewer Processor shall WARN レベルのログを 1 行残し commit status の publish
+   を行わずに当該 PR の試行を skip する（#374 Req 3.3 と整合）。
+3. If 万一 `parse_review_result` が依然として未定義の状態で catch-up が呼ばれた, the PR Reviewer
+   Processor shall `reason=parse-helper-missing` の WARN ログを 1 行残し commit status の publish
+   を行わずに当該 PR の試行を skip する（保険ガードの撤去を行わない）。
+4. When catch-up 試行が PR 未解決・file 不在・parse 失敗・helper 未定義のいずれかで skip された,
+   the PR Reviewer Processor shall watcher パイプライン（後続 processor / per-task ループ継続 /
+   PjM PR 作成 / claude-failed 判定）を停止させずに後続処理を続行する（戻り値 0 固定）。
+
+### Requirement 4: 前方参照の棚卸し（同種バグの再発防止対象範囲の明示）
+
+**Objective:** As an idd-claude メンテナ, I want 本修正の影響範囲が `parse_review_result` の
+load order に限定されることを明示しつつ、同種の前方参照が他関数で残っていないかを 1 回棚卸し
+したい, so that 今回の修正で取りこぼされた load-order bug が後続サイクルで再露呈しないように
+する。
+
+#### Acceptance Criteria
+
+1. The Issue Watcher shall `parse_review_result` を参照する全 caller（本体内 / `modules/*.sh`
+   を含む）を一覧として確定し、定義位置より前に呼ばれる caller が存在しないことを修正後に確認
+   する。
+2. When `parse_review_result` 以外の関数で「定義行 > 最初の呼び出し行」の前方参照パターンが
+   検出された, the Issue Watcher shall その関数を本 Issue のスコープ外として扱い、別 Issue へ
+   切り出して記録する（本 PR では `parse_review_result` のみを移動する）。
+3. The Issue Watcher shall `parse_review_result()` の定義位置移動に伴う他関数のロジック書き
+   換え・挙動変更を行わない（#376 で line 156 付近に移送済みの `full_auto_enabled` を含む
+   既存配置を破壊しない）。
+
+### Requirement 5: 回帰防止テスト（load order の機械チェック）
+
+**Objective:** As an idd-claude メンテナ, I want `extract_function` を用いた既存ユニットテスト
+（関数を隔離抽出して stub する方式）では再現できなかった load-order 系の統合バグを、近接
+テストで継続検出できるようにしたい, so that 次回以降の編集で `parse_review_result` や
+catch-up 呼び出しが再び前方参照の位置に動いてもテストが赤になり PR 段階で気付ける。
+
+#### Acceptance Criteria
+
+1. The Test Suite shall `issue-watcher.sh` 内の `parse_review_result` 関数定義行と
+   `process_claude_review_status_catchup` 呼び出し行を機械抽出し、「定義行 < 呼び出し行」が
+   成り立つことを検証する近接テストを `local-watcher/test/` 配下に追加する。
+2. If 定義行 ≥ 呼び出し行 になる回帰がコミットされた, the Test Suite shall 該当テストを fail
+   させ、定義行番号と呼び出し行番号を 1 件以上特定可能な形で出力する。
+3. The Test Suite shall 上記近接テストを既存テストランナ（`local-watcher/test/` 配下の bash
+   テストイディオム）から起動可能な単一スクリプトとして提供する。
+4. The Test Suite shall 上記近接テスト相当の検証として、実行到達テスト（catch-up 関数を
+   呼び出した時点で `declare -F parse_review_result` が真を返す）を採用することも許容する
+   （定義行 < 呼び出し行の機械チェックと等価な観測ができる場合に限る）。
+
+### Requirement 6: 後方互換と既定動作の温存
+
+**Objective:** As an idd-claude 運用者, I want AND 二重 opt-in が無効な既定環境
+（`PR_REVIEWER_STATUS_CHECK_ENABLED` 未設定 or `false`）の挙動を本修正で一切変更しない
+ようにしたい, so that 本修正をデプロイした既存 consumer repo が無告知の API 呼び出し追加・
+追加ログ出力・追加ラベル遷移に巻き込まれない。
+
+#### Acceptance Criteria
+
+1. While `PR_REVIEWER_STATUS_CHECK_ENABLED` が `=true` 以外（既定 `false`） or
+   `FULL_AUTO_ENABLED` が `=true` 以外（既定 `false`）, the PR Reviewer Processor shall
+   `process_claude_review_status_catchup` の関連 API 呼び出し（`gh api /repos/.../statuses/<sha>`
+   / `gh pr list` / `git cat-file` 等）を一切発火させない（catch-up 内 AND 二重 opt-in 早期
+   判定の挙動を維持する）。
+2. The Issue Watcher shall `parse_review_result` 関数シグネチャ（引数・戻り値・stdout TSV
+   形式・rc 規約）を本修正で変更しない（#349 / #374 で確立済みの既存契約を保持する）。
+3. The Issue Watcher shall 既存の env var 名（`PR_REVIEWER_STATUS_CHECK_ENABLED` /
+   `FULL_AUTO_ENABLED` / `PR_REVIEWER_HEAD_PATTERN` / `PR_REVIEWER_MAX_PRS` 等）・ラベル名・
+   exit code 意味・cron 登録文字列・ログ出力先を本修正で変更しない。
+4. The Issue Watcher shall 本修正によって追加・削除されるトップレベル副作用（実行時に走る
+   コード）を発生させない（move は関数定義ブロックの位置変更のみであり、新たな実行コードを
+   注入しない）。
+
+### Requirement 7: 同期と配布の整合性
+
+**Objective:** As an idd-claude メンテナ, I want 本修正が root 配下の watcher と installed
+consumer 配下（`$HOME/bin/issue-watcher.sh`）の双方で同一挙動になることを保証したい, so that
+`install.sh` 経由で配布される watcher にも修正が確実に反映され、本 Issue が「修正したのに
+動かない」と再発しないようにする。
+
+#### Acceptance Criteria
+
+1. The Installer shall `install.sh` が `local-watcher/bin/issue-watcher.sh` を
+   `$HOME/bin/issue-watcher.sh` へ冪等にコピーする既存挙動を維持し、本修正後のファイルが
+   そのまま配布される。
+2. The Issue Watcher shall README の該当箇所（`PR_REVIEWER_STATUS_CHECK_ENABLED` /
+   `claude-review` catch-up の動作説明や既知の制約に関する記述があれば）と整合した状態で
+   本修正を反映する。
+3. When 本修正をデプロイ済みの環境で `PR_REVIEWER_STATUS_CHECK_ENABLED=true AND
+   FULL_AUTO_ENABLED=true` の AND 二重 opt-in 環境に対し、`review-notes.md` を含む eligible
+   open PR を投入した, the PR Reviewer Processor shall catch-up 1 サイクル経由で当該 PR head
+   sha に対して `claude-review` commit status が観測される状態に到達する。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Issue Watcher shall 本修正前後で AND 二重 opt-in 無効環境の外部観測挙動（exit code /
+   stderr 出力 / ラベル遷移 / 外部副作用の有無 / PR コメント投稿）を一致させる。
+2. The Issue Watcher shall 本修正後も `cron` 最小 PATH（`PATH=/usr/bin:/bin`）下で
+   `command -v claude gh jq flock git` の依存解決が変わらないことを維持する。
+3. The Issue Watcher shall 本修正後も既存の `parse_review_result` を呼び出している他経路
+   （`pr_run_review_for_pr` / `publish_claude_review_status` / per-task Reviewer round 等）の
+   観測挙動を一致させる。
+
+### NFR 2: 静的検査
+
+1. The Issue Watcher shall 本修正後の `local-watcher/bin/issue-watcher.sh` および
+   `local-watcher/bin/modules/pr-reviewer.sh` が `bash -n` で構文エラー 0、`shellcheck` で
+   `.shellcheckrc` を踏まえた baseline 上の警告増加 0 を満たす。
+2. The Test Suite shall 追加した近接テスト（または実行到達テスト）の bash スクリプトが
+   `bash -n` / `shellcheck` クリーンであることを満たす。
+
+### NFR 3: 可観測性
+
+1. When catch-up 経由で publish が成功した, the PR Reviewer Processor shall PR 番号・head
+   sha・context・state を含む 1 行のログを既存ロガー粒度（`pr_log`）と同形式で stdout に
+   出力する（#374 NFR 3.1 と整合）。
+2. When catch-up 経由で publish が PR 未解決・file 不在・parse 失敗・helper 未定義のいずれか
+   で skip された, the PR Reviewer Processor shall skip 理由を識別可能な WARN ログを 1 行
+   残し silent fail にしない（#374 Req 3.5 と整合）。
+3. The Test Suite shall load-order 回帰テストの fail 出力に「`parse_review_result` 定義行
+   番号」「`process_claude_review_status_catchup` 呼び出し行番号」を含めて、原因特定が grep
+   1 回で完了する形にする。
+
+## Out of Scope
+
+- `parse_review_result()` 関数本体のロジック変更（戻り値・stdout TSV 形式・rc 規約 / #349 /
+  #374 で確定済みのセマンティクス）
+- `process_claude_review_status_catchup` 内部処理ロジックの変更（候補 PR 列挙基準・
+  `pr_publish_claude_status` の呼び出し方・target_url 組み立てルール・上限 truncation 等 /
+  #374 で確定済み）
+- `PR_REVIEWER_STATUS_CHECK_ENABLED` / `FULL_AUTO_ENABLED` env var 名・正規化規則・kill switch
+  概念の再設計（#348 / #349 で確定済み）
+- `pr_publish_claude_status` / `pr_publish_commit_status` の API call レイヤ・state 解決
+  ロジック・description 長制限の変更（#349 で確立済み）
+- 非 catch-up 経路（`publish_claude_review_status` 直接呼び）の publish タイミング・呼び出し
+  位置の変更（#374 で確定済み）
+- `full_auto_enabled` 以外の関数で前方参照が見つかった場合の修正（本 PR ではスコープ外として
+  別 Issue 化し、本 PR では `parse_review_result` の move のみを行う）
+- `extract_function` で関数を stub する既存ユニットテスト方式の見直し全般（load-order 検出に
+  特化した近接テスト追加のみを行う）
+- branch protection / required status checks 側の設定（GitHub 側設定 / consumer 運用責務）
+- `codex-review` 経路の挙動変更（本 Issue は `claude-review` catch-up 経路の load-order
+  修正に限定）
+- Phase B Promote Pipeline / merge-queue / auto-rebase 等、本 bug の影響外の processor の
+  挙動変更
+
+## Open Questions
+
+- なし（Issue #385 本文の AC / DoD と既存コード（`parse_review_result` 定義位置 line 6617・
+  `process_claude_review_status_catchup` 呼び出し位置 line 1573・catch-up 内 `declare -F`
+  ガード）の突き合わせで修正方針・受入観点が確定しているため、人間判断が必要な未解決項目は
+  識別されなかった。Architect の介在を要する設計選択（定義の前出し vs 呼び出し位置の後送）は
+  Issue 本文で「定義の前方移送を推奨」と明示済みであり、本要件は両方を許容する形で外形契約
+  に限定して記述した）

--- a/docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/review-notes.md
+++ b/docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/review-notes.md
@@ -1,0 +1,43 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T17:10:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-385-impl-fix-pr-reviewer-claude-review-catch-up-p
+- HEAD commit: 4af06176bbaa657ec17a3f35d7a52eff736cfc68
+- Compared to: main..HEAD
+
+## Verified Requirements
+
+- 1.1 — `parse_review_result()` を `issue-watcher.sh` の line 237 へ前出し（`full_auto_enabled` 直後）。`process_claude_review_status_catchup` の top-level call site は line 1684。新規テスト `pr_reviewer_parse_review_result_load_order_test.sh` が "PASS: Req 1.1: parse_review_result 定義行 (237) は process_claude_review_status_catchup call site (1684) より前" を assert。
+- 1.2 — `grep -n '^parse_review_result() {' issue-watcher.sh` の出力は line 237 の 1 件のみ。旧位置（line 6558 相当）は削除され、line 6669-6672 に「move 済み」参照コメントが残るのみ。
+- 1.3 — 関数本体ロジック未変更。git diff で削除ブロックと追加ブロックの本体行が一致することを確認。既存 `parse_review_result_test.sh`（23 件）も全 PASS。
+- 1.4 — load-order assert PASS により `declare -F parse_review_result` が true 評価可能であることを構造的に保証。catch-up 経路 (`pr-reviewer.sh:949`) の `parse-helper-missing` WARN は構造上発生しない。
+- 1.5 — 全 9 caller（line 1847, 4830, 5646, 5700, 6866, 8401, 8450, 10088, 10090）がすべて定義行 237 より後ろ。テストの "全 9 件の caller が定義位置より後ろにある" PASS で機械検証。
+- 2.1 / 2.2 / 2.3 / 2.4 — catch-up 経路の publish ロジックは `pr-reviewer.sh` 内で無変更（差分なし）。本修正は load-order の解消に限定。
+- 3.1 / 3.2 / 3.3 / 3.4 — `pr-reviewer.sh:947-960` の safe-skip ガード（`declare -F` / parse-failed / WARN+continue）は無変更で温存。
+- 4.1 — 新規テスト末尾の "Req 4.1: parse_review_result caller 棚卸し（参考）" セクションで全 9 caller を一覧出力。
+- 4.2 — 本 PR の差分は `parse_review_result` / `extract_review_result_token` の move のみ。スコープ越境なし。
+- 4.3 — `full_auto_enabled_load_order_test.sh` が PASS（定義行 156 維持）。
+- 5.1 / 5.2 / 5.3 / 5.4 — 近接テスト `local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh` を追加。単体実行可能（PASS: 5, FAIL: 0）。fail 時は定義行・caller 行・caller 内容・enclosing シンボルを出力。
+- 6.1 — AND 二重 opt-in 早期判定は `pr-reviewer.sh` 側で無変更。新たな top-level 副作用なし（move のみ）。
+- 6.2 / 6.3 — 関数シグネチャ・env var 名・ラベル名・cron 文字列いずれも無変更。
+- 6.4 — `git diff` 上の追加コードは関数定義ブロックのみ（top-level 副作用ではない）。
+- 7.1 — `install.sh` は `local-watcher/bin/issue-watcher.sh` を `$HOME/bin/` へ既存挙動でコピー（修正なし）。
+- 7.2 — `parse_review_result` の load order は README 記載対象外（内部 bug 修正のため反映不要、impl-notes.md の判断と整合）。
+- 7.3 — load-order 解消により catch-up 1 サイクルで publish が到達可能（テストにより構造的保証）。
+- NFR 1.1 / 1.2 / 1.3 — 外部観測挙動・最小 PATH 依存・他 caller 経路は無変更。
+- NFR 2.1 / 2.2 — `bash -n` クリーン（手元再確認 OK_watcher / OK_test）、shellcheck baseline 維持（impl-notes.md 記載）。
+- NFR 3.1 / 3.2 — pr-reviewer.sh 内のロガー粒度は無変更。
+- NFR 3.3 — テスト fail 出力に "定義行" / "caller 行" / "caller 内容" / "caller シンボル" を含み grep 1 回で原因特定可能。
+
+## Findings
+
+なし
+
+## Summary
+
+`parse_review_result()` / `extract_review_result_token()` の定義を `full_auto_enabled` 直後（line 184 / 237）に前出しし、catch-up call site（line 1684）からの load order を構造的に保証した。関数本体ロジックは無変更、`pr-reviewer.sh` の safe-skip ガードも温存。新規 load-order 近接テストおよび既存 `parse_review_result_test.sh` / `full_auto_enabled_load_order_test.sh` の手元再実行で全 PASS を確認。全 AC をカバー。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -159,6 +159,117 @@ full_auto_enabled() {
     *) return 1 ;;
   esac
 }
+
+# ─── extract_review_result_token <path> ───
+#
+# review-notes.md 全文を scan し、`RESULT: approve` または `RESULT: reject` トークンの
+# **最後のマッチ**を採用して `approve` / `reject` を stdout に echo する（Issue #63）。
+#
+# 抽出ルール（Issue #63 Req 1.x）:
+#   - 全文 scan（行頭固定マッチではない）
+#   - 行頭・行末のバッククォート / bullet (`-` `*`) / blockquote (`>`) / 引用符 / 空白等の
+#     decoration を許容（前後の文字を問わない）
+#   - 同一行内に末尾プローズが続いても許容（例: `RESULT: approve ...`）
+#   - 複数マッチ時は **ファイル順で最後のマッチ** を採用
+#   - lowercase の `approve` / `reject` のみ受理（`Approve` / `APPROVE` は不可、Req 1.7）
+#   - "approve" / "reject" の前後は word boundary 相当（後続が単語文字なら不採用）
+#
+# 戻り値:
+#   0 = マッチあり（stdout に approve / reject）
+#   1 = マッチなし（stdout は空、ファイル無も含む）
+#
+# 配置メモ (#385): `parse_review_result` の依存関数として、`parse_review_result` と
+# 同じく Config ブロック直後に前出ししている。元位置（line 6558 相当）からの move 理由は
+# `parse_review_result` 側コメント参照。
+extract_review_result_token() {
+  local path="$1"
+  [ -f "$path" ] || return 1
+
+  # `RESULT:` の後に 1 個以上の空白、続いて `approve` または `reject`、
+  # その直後が単語文字でない（または行末）場合のみマッチ。
+  # grep -oE で全マッチを行ごとに抽出 → tail -1 で最後の 1 件を採用。
+  # set -euo pipefail 下で grep no-match (rc=1) を呑み込むため `|| true` を付与。
+  local matches last
+  matches=$(grep -oE 'RESULT:[[:space:]]+(approve|reject)([^[:alnum:]_]|$)' "$path" 2>/dev/null || true)
+  [ -n "$matches" ] || return 1
+  last=$(printf '%s\n' "$matches" | tail -n 1)
+
+  # 末尾の境界文字を取り除いて approve / reject だけを残す。
+  case "$last" in
+    *approve*) echo "approve"; return 0 ;;
+    *reject*)  echo "reject";  return 0 ;;
+  esac
+  return 1
+}
+
+# ─── parse_review_result <path> ───
+#
+# review-notes.md から RESULT 行（最後に出現するもの）と Findings の Category / Target を
+# 抽出する。RESULT 行抽出は `extract_review_result_token` に委譲し、装飾・インライン記述
+# (Issue #63) に耐性を持つ。
+# stdout に TSV 1 行で出力: <result>\t<categories>\t<target_ids>
+#
+# - result      ∈ {approve, reject}
+# - categories  = カンマ区切り（reject 時のみ。approve 時は空文字）
+# - target_ids  = カンマ区切り requirement ID または `boundary:<component>` 形式
+#
+# 戻り値:
+#   0 = 抽出成功
+#   2 = ファイル有だが RESULT トークン欠落 / 値不正（装飾起因の parse 失敗）
+#   3 = ファイル不在（Reviewer subagent が Write 漏れ / Issue #296 で導入）
+#
+# rc=2 と rc=3 の使い分け（Issue #296 Req 1）:
+#   - rc=2 は #63 で確立した装飾耐性パースを経た上でも RESULT 行が抽出できなかった
+#     ケース（「装飾起因 parse 失敗」）。
+#   - rc=3 は `review-notes.md` 自体が存在しないケース（Reviewer subagent の Write 漏れ）。
+#     呼び出し側で 1 回限定リトライを試みる経路を発火させるためのシグナル。
+#
+# 配置メモ (#385): bash は top-level コードを順次実行するため、関数定義は最初の
+# 呼び出し（`process_claude_review_status_catchup` の call site / line 1573 相当）
+# より物理的に前に配置する必要がある。元 #349 / #374 で本関数をスクリプト中盤
+# （line 6617 相当）に置いた結果、catch-up 経路から見て前方参照となり catch-up の
+# `declare -F parse_review_result` ガードが false 評価となって `reason=parse-helper-missing`
+# の WARN を残して safe-skip し、AND 二重 opt-in（`PR_REVIEWER_STATUS_CHECK_ENABLED=true`
+# AND `FULL_AUTO_ENABLED=true`）環境で `claude-review` commit status が永久に publish
+# されない silent load-order bug を発生させた。#385 では本関数を `full_auto_enabled` の
+# 直後（Config ブロック内）に move し、全 caller が定義位置より後ろに来ることを構造的に
+# 保証する。catch-up 側の `declare -F` 保険ガードは温存する（Req 3.3）。
+parse_review_result() {
+  local path="$1"
+  if [ ! -f "$path" ]; then
+    # Issue #296 Req 1.1: ファイル不在は装飾起因 parse 失敗（rc=2）とは区別して rc=3 で返す。
+    return 3
+  fi
+
+  local result
+  if ! result=$(extract_review_result_token "$path"); then
+    # Issue #296 Req 1.2: ファイル存在下での RESULT 抽出失敗は装飾起因 parse 失敗として rc=2。
+    return 2
+  fi
+  case "$result" in
+    approve|reject) ;;
+    *) return 2 ;;
+  esac
+
+  local categories=""
+  local target_ids=""
+  if [ "$result" = "reject" ]; then
+    # Findings ブロックの "**Category**: ..." 行と "**Target**: ..." 行を抽出。
+    # Findings は markdown bullet なので、行頭の "- " も含めて許容する。
+    categories=$(grep -E '^[[:space:]]*-[[:space:]]+\*\*Category\*\*:' "$path" \
+                   | sed -E 's/^[[:space:]]*-[[:space:]]+\*\*Category\*\*:[[:space:]]*//' \
+                   | sed -E 's/[[:space:]]+$//' \
+                   | paste -sd, - || true)
+    target_ids=$(grep -E '^[[:space:]]*-[[:space:]]+\*\*Target\*\*:' "$path" \
+                   | sed -E 's/^[[:space:]]*-[[:space:]]+\*\*Target\*\*:[[:space:]]*//' \
+                   | sed -E 's/（.*$//' \
+                   | sed -E 's/[[:space:]]+$//' \
+                   | paste -sd, - || true)
+  fi
+
+  printf '%s\t%s\t%s\n' "$result" "$categories" "$target_ids"
+  return 0
+}
 # Issue #362: needs-decisions 自動続行のモード切替。`safe` 分類かつ `FULL_AUTO_ENABLED=true`
 # のときのみ PM 第一推奨で自動続行する。値は 3 値（`all-human` / `classified` / `all-auto`）
 # のいずれかに正規化し、未設定 / 空 / 不正値・typo はすべて安全側 `all-human` に倒す
@@ -6555,101 +6666,10 @@ ${design_pr_note}
 EOF
 }
 
-# ─── extract_review_result_token <path> ───
-#
-# review-notes.md 全文を scan し、`RESULT: approve` または `RESULT: reject` トークンの
-# **最後のマッチ**を採用して `approve` / `reject` を stdout に echo する（Issue #63）。
-#
-# 抽出ルール（Issue #63 Req 1.x）:
-#   - 全文 scan（行頭固定マッチではない）
-#   - 行頭・行末のバッククォート / bullet (`-` `*`) / blockquote (`>`) / 引用符 / 空白等の
-#     decoration を許容（前後の文字を問わない）
-#   - 同一行内に末尾プローズが続いても許容（例: `RESULT: approve ...`）
-#   - 複数マッチ時は **ファイル順で最後のマッチ** を採用
-#   - lowercase の `approve` / `reject` のみ受理（`Approve` / `APPROVE` は不可、Req 1.7）
-#   - "approve" / "reject" の前後は word boundary 相当（後続が単語文字なら不採用）
-#
-# 戻り値:
-#   0 = マッチあり（stdout に approve / reject）
-#   1 = マッチなし（stdout は空、ファイル無も含む）
-extract_review_result_token() {
-  local path="$1"
-  [ -f "$path" ] || return 1
-
-  # `RESULT:` の後に 1 個以上の空白、続いて `approve` または `reject`、
-  # その直後が単語文字でない（または行末）場合のみマッチ。
-  # grep -oE で全マッチを行ごとに抽出 → tail -1 で最後の 1 件を採用。
-  # set -euo pipefail 下で grep no-match (rc=1) を呑み込むため `|| true` を付与。
-  local matches last
-  matches=$(grep -oE 'RESULT:[[:space:]]+(approve|reject)([^[:alnum:]_]|$)' "$path" 2>/dev/null || true)
-  [ -n "$matches" ] || return 1
-  last=$(printf '%s\n' "$matches" | tail -n 1)
-
-  # 末尾の境界文字を取り除いて approve / reject だけを残す。
-  case "$last" in
-    *approve*) echo "approve"; return 0 ;;
-    *reject*)  echo "reject";  return 0 ;;
-  esac
-  return 1
-}
-
-# ─── parse_review_result <path> ───
-#
-# review-notes.md から RESULT 行（最後に出現するもの）と Findings の Category / Target を
-# 抽出する。RESULT 行抽出は `extract_review_result_token` に委譲し、装飾・インライン記述
-# (Issue #63) に耐性を持つ。
-# stdout に TSV 1 行で出力: <result>\t<categories>\t<target_ids>
-#
-# - result      ∈ {approve, reject}
-# - categories  = カンマ区切り（reject 時のみ。approve 時は空文字）
-# - target_ids  = カンマ区切り requirement ID または `boundary:<component>` 形式
-#
-# 戻り値:
-#   0 = 抽出成功
-#   2 = ファイル有だが RESULT トークン欠落 / 値不正（装飾起因の parse 失敗）
-#   3 = ファイル不在（Reviewer subagent が Write 漏れ / Issue #296 で導入）
-#
-# rc=2 と rc=3 の使い分け（Issue #296 Req 1）:
-#   - rc=2 は #63 で確立した装飾耐性パースを経た上でも RESULT 行が抽出できなかった
-#     ケース（「装飾起因 parse 失敗」）。
-#   - rc=3 は `review-notes.md` 自体が存在しないケース（Reviewer subagent の Write 漏れ）。
-#     呼び出し側で 1 回限定リトライを試みる経路を発火させるためのシグナル。
-parse_review_result() {
-  local path="$1"
-  if [ ! -f "$path" ]; then
-    # Issue #296 Req 1.1: ファイル不在は装飾起因 parse 失敗（rc=2）とは区別して rc=3 で返す。
-    return 3
-  fi
-
-  local result
-  if ! result=$(extract_review_result_token "$path"); then
-    # Issue #296 Req 1.2: ファイル存在下での RESULT 抽出失敗は装飾起因 parse 失敗として rc=2。
-    return 2
-  fi
-  case "$result" in
-    approve|reject) ;;
-    *) return 2 ;;
-  esac
-
-  local categories=""
-  local target_ids=""
-  if [ "$result" = "reject" ]; then
-    # Findings ブロックの "**Category**: ..." 行と "**Target**: ..." 行を抽出。
-    # Findings は markdown bullet なので、行頭の "- " も含めて許容する。
-    categories=$(grep -E '^[[:space:]]*-[[:space:]]+\*\*Category\*\*:' "$path" \
-                   | sed -E 's/^[[:space:]]*-[[:space:]]+\*\*Category\*\*:[[:space:]]*//' \
-                   | sed -E 's/[[:space:]]+$//' \
-                   | paste -sd, - || true)
-    target_ids=$(grep -E '^[[:space:]]*-[[:space:]]+\*\*Target\*\*:' "$path" \
-                   | sed -E 's/^[[:space:]]*-[[:space:]]+\*\*Target\*\*:[[:space:]]*//' \
-                   | sed -E 's/（.*$//' \
-                   | sed -E 's/[[:space:]]+$//' \
-                   | paste -sd, - || true)
-  fi
-
-  printf '%s\t%s\t%s\n' "$result" "$categories" "$target_ids"
-  return 0
-}
+# Issue #349 / #374 / #385: `extract_review_result_token()` / `parse_review_result()` の定義は
+# Config ブロック直後（line 184 / line 237 付近）に move 済み。bash の top-level 逐次実行下で
+# `process_claude_review_status_catchup`（line 1573 付近）から前方参照されないことを構造的に
+# 保証するため。詳細は move 先の関数ヘッダコメント参照。
 
 # ─── reviewer_skip_files_match <pattern> ───
 #

--- a/local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
+++ b/local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/issue-watcher.sh 内の `parse_review_result()` 関数定義行と、
+#       `process_claude_review_status_catchup` の **top-level call site** の行番号を
+#       機械抽出し、「定義行 < 呼び出し行」が成り立つことを検証する近接テスト。
+#       併せて `parse_review_result` の依存関数 `extract_review_result_token()` も
+#       同じ load-order 制約を満たすことを検証する。
+#
+#       Issue #385: bash は top-level コードを順次実行するため、関数定義が最初の
+#       top-level 呼び出しより後ろにあると `declare -F parse_review_result` が false を返し、
+#       catch-up 経路（`process_claude_review_status_catchup` / pr-reviewer.sh）が
+#       `reason=parse-helper-missing` の WARN を残して safe-skip する。結果として
+#       AND 二重 opt-in（`PR_REVIEWER_STATUS_CHECK_ENABLED=true` AND
+#       `FULL_AUTO_ENABLED=true`）環境で `claude-review` commit status が永久に publish
+#       されない silent load-order bug が発生する。本テストは当該 bug の回帰を機械的に
+#       検出する。
+#
+#       本 bug は #376 で修正した `full_auto_enabled` 前方参照と同種の load-order 系
+#       回帰であり、`full_auto_enabled_load_order_test.sh` と並列の役割を持つ。
+#
+#       検証する AC (docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/requirements.md):
+#         - Req 1.1: 定義位置が `process_claude_review_status_catchup` の call site より前
+#         - Req 1.2: 定義は 1 箇所のみ（重複定義なし）
+#         - Req 1.5: 全 caller の行番号が定義行番号より大きいことを維持
+#         - Req 5.1: 定義行 < 呼び出し行 を機械検証する近接テストを提供
+#         - Req 5.2: 回帰時に定義行番号と呼び出し行番号を 1 件以上特定可能に出力
+#         - Req 5.3: 既存テストランナ（local-watcher/test/ の bash イディオム）から起動可能
+#         - NFR 3.3: fail 出力に定義行番号 / catch-up 呼び出し行番号を含め grep 1 回で原因特定
+#
+# 配置先: local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
+# 依存:   bash 4+, awk, grep, sed, cut
+# 実行:   bash local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ─── 共通: top-level call site の行番号抽出 ───
+# `process_claude_review_status_catchup` の top-level 呼び出し（行頭が
+# `process_claude_review_status_catchup ||` で始まる行）を抽出する。本体内 function
+# 定義経由の参照（コメント / 関数本体内呼び出し）は除外し、top-level 順次実行で
+# 評価される行のみを対象にする。
+CATCHUP_CALL_LINE=$(grep -nE '^process_claude_review_status_catchup[[:space:]]*\|\|' "$WATCHER_SH" | head -n1 | cut -d: -f1 || true)
+
+# ─── load-order 検証ヘルパ ───
+# 引数: $1=関数名 / $2=Req 番号タグ（メッセージ用）
+verify_load_order() {
+  local fn_name="$1"
+  local req_tag="$2"
+
+  # 関数定義行の抽出。bash の関数定義は典型的に `<name>() {` 形式。
+  local def_lines
+  def_lines=$(grep -n "^${fn_name}() {" "$WATCHER_SH" | cut -d: -f1)
+  local def_count
+  def_count=$(echo -n "$def_lines" | grep -c . || true)
+
+  # ─── 1. 重複定義チェック ───
+  if [ "$def_count" -eq 1 ]; then
+    echo "PASS: ${req_tag}: ${fn_name} の定義は 1 箇所のみ"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: ${req_tag}: ${fn_name} の定義が 1 箇所ではない（count=${def_count}）"
+    echo "  定義行: $(echo "$def_lines" | tr '\n' ' ')"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+
+  if [ "$def_count" -eq 0 ]; then
+    echo "ERROR: ${fn_name} の定義が見つからないため後続テストを skip" >&2
+    return
+  fi
+
+  local def_line
+  def_line=$(echo "$def_lines" | head -n1)
+
+  # ─── 2. 全 caller の抽出（コメント行・定義行は除外） ───
+  local all_refs caller_lines caller_count
+  all_refs=$(grep -n "${fn_name}" "$WATCHER_SH" || true)
+  caller_lines=$(echo "$all_refs" | awk -v fn_def="${fn_name}() {" -F: '
+    {
+      lineno = $1
+      sub(/^[0-9]+:/, "", $0)
+      content = $0
+      trimmed = content
+      sub(/^[[:space:]]+/, "", trimmed)
+      # skip comment lines
+      if (trimmed ~ /^#/) next
+      # skip the function definition line itself
+      if (trimmed == fn_def) next
+      print lineno ":" content
+    }
+  ')
+  caller_count=$(echo -n "$caller_lines" | grep -c . || true)
+
+  echo ""
+  echo "--- ${fn_name} load-order 検査 ---"
+  echo "  定義行: $def_line"
+  echo "  caller 数: $caller_count"
+
+  # ─── 3. 各 caller について「定義行 < caller 行」を検証 ───
+  if [ "$caller_count" -eq 0 ]; then
+    echo "PASS: ${req_tag}: caller 行数=0 のため load-order 検査は trivially 成立"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    return
+  fi
+
+  local earliest_caller_line=""
+  local violations=0
+
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    local caller_lineno caller_content
+    caller_lineno=$(echo "$line" | cut -d: -f1)
+    caller_content=$(echo "$line" | cut -d: -f2-)
+
+    if [ -z "$earliest_caller_line" ] || [ "$caller_lineno" -lt "$earliest_caller_line" ]; then
+      earliest_caller_line="$caller_lineno"
+    fi
+
+    if [ "$caller_lineno" -le "$def_line" ]; then
+      violations=$((violations + 1))
+      local enclosing_symbol
+      enclosing_symbol=$(awk -v target="$caller_lineno" '
+        /^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ { last = $1; last_line = NR }
+        NR == target { print last " (defined at line " last_line ")"; exit }
+      ' "$WATCHER_SH")
+      echo "FAIL: ${req_tag}: 前方参照を検出"
+      echo "  定義行          : $def_line"
+      echo "  caller 行       : $caller_lineno"
+      echo "  caller 内容     : $caller_content"
+      echo "  caller シンボル : ${enclosing_symbol:-(top-level)}"
+    fi
+  done <<EOF
+$caller_lines
+EOF
+
+  if [ "$violations" -eq 0 ]; then
+    echo "PASS: ${req_tag}: 全 ${caller_count} 件の caller が定義位置より後ろにある"
+    echo "  最も早い caller: 行 $earliest_caller_line （定義行 $def_line より $((earliest_caller_line - def_line)) 行後）"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: ${req_tag}: 前方参照 caller が $violations 件存在"
+    echo "  原因: bash は top-level を順次実行するため、定義行 ($def_line) より前の caller"
+    echo "        から呼ぶと catch-up の declare -F が false 評価となり parse-helper-missing で skip"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ─── 1. parse_review_result の load-order 検証 ───
+verify_load_order "parse_review_result" "Req 1.1 / 1.2 / 1.5 / 5.1"
+
+# ─── 2. extract_review_result_token の load-order 検証 ───
+# parse_review_result の依存関数。同じ load-order 制約を満たす必要がある。
+verify_load_order "extract_review_result_token" "Req 1.1 / 1.5 (依存関数)"
+
+# ─── 3. Req 1.1 補完: parse_review_result 定義が process_claude_review_status_catchup の
+#       top-level call site（catch-up 経路の発火点）より前にあることを明示的に assert する。
+#       Issue #385 の core: catch-up 経路が parse_review_result を `declare -F` で参照する。
+echo ""
+echo "--- Req 1.1: parse_review_result vs process_claude_review_status_catchup call site ---"
+
+if [ -z "$CATCHUP_CALL_LINE" ]; then
+  echo "PASS: Req 1.1: process_claude_review_status_catchup の top-level call site が見つからないため trivially 成立"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  PARSE_DEF_LINE=$(grep -n '^parse_review_result() {' "$WATCHER_SH" | head -n1 | cut -d: -f1 || true)
+  if [ -z "$PARSE_DEF_LINE" ]; then
+    echo "FAIL: Req 1.1: parse_review_result の定義行が見つからない"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  elif [ "$PARSE_DEF_LINE" -lt "$CATCHUP_CALL_LINE" ]; then
+    echo "PASS: Req 1.1: parse_review_result 定義行 ($PARSE_DEF_LINE) は process_claude_review_status_catchup call site ($CATCHUP_CALL_LINE) より前"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: Req 1.1: parse_review_result 定義行 ($PARSE_DEF_LINE) が process_claude_review_status_catchup call site ($CATCHUP_CALL_LINE) 以後"
+    echo "  原因: catch-up 経路が parse_review_result を declare -F で参照するため"
+    echo "        定義行 < call site 行 を満たさないと parse-helper-missing で永続 skip する"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+fi
+
+# ─── 4. Req 4.1 補完: caller 棚卸し（参考表示）───
+# 同種 bug の再発防止のため、本 PR 修正後の parse_review_result 全 caller を一覧表示する。
+# 失敗時の調査効率向上目的の参考出力（PASS/FAIL カウントには加算しない）。
+echo ""
+echo "--- Req 4.1: parse_review_result caller 棚卸し（参考） ---"
+grep -n 'parse_review_result' "$WATCHER_SH" | awk -F: '
+  {
+    lineno = $1
+    sub(/^[0-9]+:/, "", $0)
+    trimmed = $0
+    sub(/^[[:space:]]+/, "", trimmed)
+    if (trimmed ~ /^#/) next
+    if (trimmed ~ /^parse_review_result\(\)[[:space:]]*\{/) next
+    print "  line " lineno ": " trimmed
+  }
+'
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

`local-watcher/bin/issue-watcher.sh` の top-level 逐次実行において、`parse_review_result()` の関数定義位置（旧 line 6617 付近）が `process_claude_review_status_catchup` の呼び出し位置（line 1573 付近）より後ろにあった。catch-up processor 起動時点で `parse_review_result` が未定義となり、`declare -F` ガードが false 評価→ `reason=parse-helper-missing` で永続 safe-skip する load-order バグ（F7）。

本 PR は `parse_review_result()` および依存関数 `extract_review_result_token()` を `full_auto_enabled()` 直後（新 line 184/237）へ前方移送することで、AND 二重 opt-in 環境（`PR_REVIEWER_STATUS_CHECK_ENABLED=true AND FULL_AUTO_ENABLED=true`）における `claude-review` commit status が catch-up 経由で publish されない問題を修正する。先行事例 #376（`full_auto_enabled` 同種 load-order 修正）と同型の bug class。

## 対応 Issue

Closes #385

## 関連 PR

なし（設計 PR は走っていないため）

## 実装内容

- (Req 1.1 / 1.2 / 1.3) `parse_review_result()` / `extract_review_result_token()` を `full_auto_enabled()` 直後（line 184/237）へ前方移送。旧位置（line 6558 付近）を削除し、「move 済み」参照コメントに置換。関数本体ロジックは 1 文字も変更なし。
- (Req 1.5 / 4.1) 前方移送後、全 9 caller が定義行より後ろにあることを機械検証。
- (Req 5.1〜5.3) 回帰防止テスト `pr_reviewer_parse_review_result_load_order_test.sh` を新規追加（定義行 < catch-up call site の assert・重複定義検出・全 caller 棚卸し出力）。
- (Req 3.1〜3.4) `pr-reviewer.sh` の safe-skip ガード（`declare -F` / parse-failed / WARN+continue）は無変更で温存。
- (Req 6.1〜6.4) AND 二重 opt-in 無効環境の外部観測挙動は完全一致（top-level 副作用なし）。

## 受入基準チェック

- [x] Req 1.1: `parse_review_result()` 定義行 (237) < catch-up call site (1684) ← `pr_reviewer_parse_review_result_load_order_test.sh` PASS
- [x] Req 1.2: 重複定義なし（count==1）← 同テスト PASS
- [x] Req 1.3: 関数本体ロジック無変更 ← `parse_review_result_test.sh` 全 23 件 PASS
- [x] Req 1.5: 全 9 caller が定義行より後ろ ← 同テスト PASS
- [x] Req 5.1: `pr_reviewer_parse_review_result_load_order_test.sh` 新規追加 ← PASS: 5, FAIL: 0
- [x] Req 3.3: `declare -F` 保険ガード温存 ← `pr-reviewer.sh` diff なし
- [x] NFR 2.1: `bash -n` クリーン / `shellcheck` 警告増加 0

## テスト結果

```
bash local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
PASS: 5, FAIL: 0

TOTAL: 51, PASS: 51, FAIL: 0
```

既存 `parse_review_result_test.sh`（23 件）・`full_auto_enabled_load_order_test.sh` も全 PASS。

## 実装上の判断

- **定義の前方移送（forward move）を採用**（呼び出し位置の後送ではなく）: catch-up call site は #374 / #380 で確定した順序契約（PR Reviewer 直後・Security Review 直前）があり動かしにくい。一方 `parse_review_result` は全 9 caller に対する load-order 保証を 1 箇所で構造的に与えられる前出しが適切。先行 #376 と同型パターン。
- **`extract_review_result_token` もペアで前出し**: `parse_review_result` 本体内で呼ばれているため、ペアで移送しないと依然として未定義になるため必須。
- **`pr-reviewer.sh` は無変更**: `declare -F` 保険ガード（line 949）と WARN ログ（line 950）は Req 3.3 に従い温存。
- **README 反映不要**: 内部 load-order bug の修正であり、外部 API・env var・ラベル・cron 文字列は一切変更なし。

詳細は `docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（検証済み）
- Reviewer（approve）: `docs/specs/385-fix-pr-reviewer-claude-review-catch-up-p/review-notes.md` 参照
- 特に注意して見てほしい箇所: `local-watcher/bin/issue-watcher.sh` line 184〜272（前出し定義ブロック）と旧位置（line 6669 付近の参照コメント）の差分

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #385 のコメントを参照してください。
