### PR TITLE
feat(#386): per-repo env ファイルローダで crontab 行長限界を解消（F8）

### DIFF
--- a/README.md
+++ b/README.md
@@ -828,6 +828,135 @@ Settings → Secrets and variables → Actions → **Secrets** タブ
 
 ---
 
+## per-repo env ファイル（crontab 行長限界の解消 / F8 / Issue #386）
+
+idd-claude watcher は `*_ENABLED` 系の opt-in フラグを crontab 行内に inline 環境変数として
+列挙する運用が定着しており、フラグ追加が継続した結果、**crontab 1 行が ~1024 文字の
+`command too long` 限界に到達**する事象が複数 repo で発生しています。本機能（F8）は watcher
+起動時に **per-repo の env ファイル** を source して flag を供給する経路を追加し、crontab 行を
+schedule / `REPO` / `REPO_DIR` / `BASE_BRANCH` といった repo 識別系の最小限に保てるようにします。
+
+### 探索順
+
+watcher は起動時の **REPO_SLUG 算出直後**（`*_ENABLED` 系 default 評価より前）に、以下の順で
+env ファイルを 1 度だけ探索します。
+
+1. `WATCHER_ENV_FILE`（絶対パス指定、明示優先）
+2. `$HOME/.issue-watcher/<REPO_SLUG>.env`（`<REPO_SLUG>` は `REPO` の `/` を `-` に変換した値）
+
+いずれの候補も読取可能でなければ、本機能導入前と完全に **byte 等価な起動経路**（環境変数集合・
+ログ・exit code）を辿ります。opt-in は「ファイルの存在」のみで判定し、新規 gate env は
+導入しません。
+
+### 形式（`KEY=VALUE`）
+
+- 1 行 1 件の `KEY=VALUE` 形式
+- 行頭 `#` のコメント行・空行・空白のみ行は無視
+- `KEY` は bash 識別子規約に従う（`[A-Za-z_][A-Za-z0-9_]*`）
+- `VALUE` 中に `$HOME` / `$VAR` / `$(...)` を含めて評価可能（運用者管理ファイル = 信頼境界の
+  内側として扱うため、コマンド置換も許可）
+
+例:
+
+```ini
+# ~/.issue-watcher/owner-myrepo.env
+FULL_AUTO_ENABLED=true
+DEP_AUTO_UNBLOCK_ENABLED=true
+AUTO_MERGE_ENABLED=true
+PROMOTE_PIPELINE_ENABLED=true
+
+# webhook URL は別ファイルから読み込んで env ファイル本体に平文埋め込みしない
+SLACK_NOTIFY_ENABLED=true
+SLACK_WEBHOOK_URL=$(cat $HOME/.config/idd-claude/slack-webhook)
+
+PARALLEL_SLOTS=2
+WORKTREE_BASE_DIR=$HOME/.issue-watcher/worktrees
+```
+
+### precedence（inline cron env > env ファイル）
+
+同一 `KEY` が **inline cron env**（crontab 行 / launchd plist の `EnvironmentVariables` /
+watcher 起動シェルの環境）と env ファイルの両方に存在する場合、**inline 値が優先** されます。
+これにより、一時的な override / 実験的なフラグ調整 / 特定 repo の例外設定を crontab 1 行で
+完結できます。
+
+```cron
+# inline で FULL_AUTO_ENABLED=false を渡せば、env ファイル側 `FULL_AUTO_ENABLED=true` は無視される
+*/2 * * * * REPO=owner/repo REPO_DIR=$HOME/work/repo FULL_AUTO_ENABLED=false $HOME/bin/issue-watcher.sh
+```
+
+precedence は全 `KEY` に一貫して適用されます。
+
+### 推奨パーミッション
+
+env ファイルにはコマンド置換経由で機密情報（webhook URL 等）を流すケースがあるため、
+**所有者のみ読書可能（`chmod 600`）** を推奨します:
+
+```bash
+mkdir -p "$HOME/.issue-watcher"
+chmod 700 "$HOME/.issue-watcher"
+touch "$HOME/.issue-watcher/owner-myrepo.env"
+chmod 600 "$HOME/.issue-watcher/owner-myrepo.env"
+```
+
+watcher は env ファイル内の値を log / Issue コメント / PR 本文 / 標準ログへ平文出力しません
+（NFR 2.2）。採用したファイルパスのみが起動時に 1 行ログとして出ます:
+
+```
+[2026-06-23 09:00:01] [owner/repo] env-loader: env ファイル採用: /home/user/.issue-watcher/owner-repo.env
+```
+
+### 異常系
+
+- **読取不能**（権限不足等）: warn を `>&2` に出して当該ファイルを無視し、watcher は継続
+- **構文不正行**（`=` 欠落 / `KEY` が識別子として無効）: 当該行のみ skip + warn（パスと行番号を
+  含む）、後続行の処理は継続
+- **コマンド置換失敗**: 当該 `KEY` を未設定のまま残し、warn + 次行へ継続。inline cron env が
+  当該 KEY を定義していれば inline 値で補完される（precedence 維持）
+
+1 行のタイプミスや権限ミスで repo の cron が無音停止する事故を防ぎます。
+
+### 移行ガイド（既存 inline 列挙 → env ファイル）
+
+precedence「inline > env ファイル」を活用して **段階移行** が可能です:
+
+1. **env ファイルを作成**（既存 inline 列挙と同じ値を `KEY=VALUE` で 1 行ずつ並べる）
+
+   ```bash
+   cat > "$HOME/.issue-watcher/owner-myrepo.env" <<'EOF'
+   FULL_AUTO_ENABLED=true
+   DEP_AUTO_UNBLOCK_ENABLED=true
+   AUTO_MERGE_ENABLED=true
+   # ... 既存 inline 列挙をそのまま転記 ...
+   EOF
+   chmod 600 "$HOME/.issue-watcher/owner-myrepo.env"
+   ```
+
+2. **watcher を 1 サイクル動かし、起動ログで env ファイル採用を確認**（`grep 'env-loader:' $HOME/.issue-watcher/logs/<repo-slug>/dispatcher.log`）。
+   この時点では inline 列挙が優先されるため、挙動は不変。
+
+3. **crontab 行から inline 列挙を 1 つずつ削除**（precedence により env ファイル側の値が
+   採用されるようになる）。1 つ削除するたびに 1 サイクル動かして観測値を確認。
+
+4. **最終的に crontab 行が `REPO` / `REPO_DIR` / `BASE_BRANCH` + watcher パスのみ**になる:
+
+   ```cron
+   */2 * * * * REPO=owner/myrepo REPO_DIR=$HOME/work/myrepo BASE_BRANCH=main $HOME/bin/issue-watcher.sh
+   ```
+
+5. **戻したいときは env ファイルから当該行を削るか inline で override**。
+
+### Out of Scope（本機能では実装しない）
+
+- env ファイルを有効化する新規 gate env の導入（opt-in は「ファイルの存在」のみ）
+- 既存 crontab 行から env ファイルへの **自動移行スクリプト**（手動 / 上記移行ガイド参照）
+- `install.sh` / `setup.sh` 内での **テンプレート展開・scaffold**
+- env ファイルの **暗号化 / KMS 連携 / secrets manager 統合**
+- 起動後の **hot reload / inotify**（本機能は起動時 1 回限りの source）
+- env ファイル内での **他 env ファイルの再帰 source**
+- **launchd plist 側**の env ファイル取扱変更（plist の `EnvironmentVariables` は inline cron
+  env と同じ precedence 階に置きます）
+
 ## ブランチ運用と `BASE_BRANCH`
 
 idd-claude は **base branch を表す `BASE_BRANCH` env var**（Actions 経路では repository

--- a/docs/specs/386-feat-watcher-per-repo-env-crontab-f8/impl-notes.md
+++ b/docs/specs/386-feat-watcher-per-repo-env-crontab-f8/impl-notes.md
@@ -1,0 +1,173 @@
+# Implementation Notes — Issue #386 / F8
+
+## 採用した module 構成と挿入点
+
+- **module**: `local-watcher/bin/modules/env-loader.sh`（新規作成）
+- **関数 prefix**: `el_`（新規未使用 prefix。CLAUDE.md §2 prefix 表に追記候補）
+- **公開関数**:
+  - `el_log` / `el_warn`: 既存 `fr_log` / `sn_log` と同形式の `[$REPO] env-loader:` 3 段 prefix
+  - `el_resolve_env_file`: `WATCHER_ENV_FILE`（絶対パス）→ `$HOME/.issue-watcher/<REPO_SLUG>.env` の
+    探索順で 1 つを stdout 出力、候補なし時 rc=1（純粋関数 / NFR 2.1 検証付き）
+  - `el_apply_env_file`: 1 行ずつパースして export（precedence は `${KEY+x}` で判定）
+  - `el_load`: public entry point（候補なしで silent no-op）
+- **本体差し込み位置**: `local-watcher/bin/issue-watcher.sh` で REPO_SLUG 算出（line 57）の
+  直後に **単独 source + `el_load` 呼出**。`REQUIRED_MODULES` への追加（line 1052）も併せて
+  行い、開発時 / 本番配布の両方で module 欠落時に明示 exit する safety net を維持。
+- **挿入位置の理由**: 本体内のすべての `*_ENABLED` 系 `${VAR:-default}` 評価より前で実行
+  する必要がある（env ファイル経由で供給された値が Config 行で参照される）。Module loader
+  本体（line 1052）より前に置く必要があるため、env-loader.sh のみ単独 source する 2 段構成。
+  env-loader.sh は他 module に依存しない自己完結関数群のみで構成されるため、単独 source
+  しても前方参照を踏まない。
+
+## precedence 実現方式（inline cron env > env ファイル）
+
+bash の **`${KEY+x}` 構文**（KEY が定義済みなら `"x"`、未定義なら空文字を返す）を用いて
+「env に既に定義済みか」を判定。env-loader は **未定義 KEY のみ** export することで、
+inline cron env の値を温存する。
+
+- 空文字値の KEY も「定義済み」として扱う（inline での明示 unset と区別しない / Req 4.4）
+- 本体の `KEY="${KEY:-default}"` 形式は `:-` を使うため空文字は default に置換されるが、
+  env-loader は `${KEY+x}` で「key 存在性」のみを見る（NFR 1.3 後方互換性）
+
+## `$HOME` / `$(...)` 値評価の実現方式
+
+- env ファイルは「運用者管理ファイル = 信頼境界の内側」（NFR 2.4）として扱い、`eval` で
+  起動シェルの展開を借りる
+- ただし `eval "export $key=\"$value\""` 形式は POSIX 上 **export の rc を返す** ため、
+  内部の command 置換失敗（非 0 終了）が rc=0 で覆い隠されてしまう
+- 対策: **2 段構成** で実装
+  1. `eval "$key=\"$value\""` （単純代入のみ）で値評価を試行。代入の rc は内部 command
+     置換の rc を継承するため、コマンド置換失敗が rc=1 として観測される
+  2. 代入成功時のみ `export "$key"`（既存変数の export 属性付与のみ、失敗しない）
+- これにより、Req 3.2（正常コマンド置換）と Req 3.3（コマンド置換失敗 skip + 継続）の
+  両方を満たす
+
+## 異常系ハンドリング方針
+
+| 異常系 | 挙動 | 対応 AC |
+|---|---|---|
+| ファイル不在 | silent return 0（no-op） | Req 5.1 / NFR 1.1 / NFR 3.3 |
+| ファイル読取不能（権限不足等） | el_warn + return 1 | Req 6.1 |
+| 構文不正行（`=` なし / 無効 KEY） | el_warn（パス + 行番号付き） + 当該行 skip + 後続継続 | Req 6.2 / 6.5 |
+| コマンド置換失敗 | el_warn（パス + 行番号 + KEY 名）+ 当該 KEY skip + 後続継続 + unset で痕跡除去 | Req 3.3 / 6.3 |
+| 採用後の値ログ | 採用パスのみ 1 行 log（値は出さない） | NFR 2.2 / NFR 3.1 |
+| 候補なし時のログ | 一切出さない（通常運用の標準ログを増やさない） | NFR 3.3 |
+
+## 後方互換確認の根拠（不在時のコードパス byte 等価性）
+
+`issue-watcher.sh` への差し込みは以下の最小 7 行のみ:
+
+```bash
+IDD_ENV_LOADER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/modules/env-loader.sh"
+if [ -f "$IDD_ENV_LOADER_PATH" ]; then
+  # shellcheck source=/dev/null
+  . "$IDD_ENV_LOADER_PATH"
+  el_load
+fi
+unset IDD_ENV_LOADER_PATH
+```
+
+env ファイル不在時の `el_load` の挙動:
+1. `el_resolve_env_file` が rc=1 で即 return（stdout / stderr いずれにも出力なし）
+2. `el_load` が rc=0 で即 return（log なし）
+
+つまり「候補なし」のとき、本体起動シーケンスへの実質的な影響は:
+- 関数定義のメモリ消費（数 KB）
+- `el_load` 1 回の関数呼び出しオーバーヘッド（< 1ms）
+
+環境変数集合 / ログ出力 / exit code は不在時と完全に同一（NFR 1.1 / 1.3 byte 等価性は
+意味的に維持 / 物理的には関数定義行が増えるが本体起動経路に観測可能な変化はない）。
+
+`REQUIRED_MODULES` への追加（line 1052）は本体 module loader の冪等な再 source であり、
+関数定義の上書きのみで副作用はない（既存 module の double-source 慣行と同等）。
+
+スモークテストで 3 シナリオを確認:
+1. env file あり → `full-auto=true` 反映
+2. env file あり + inline `FULL_AUTO_ENABLED=false` → `full-auto=false` 反映（inline 勝ち）
+3. env file なし → env-loader ログなし / 起動経路完全不変
+
+## 追加テストの一覧と狙い
+
+`local-watcher/test/env-loader_test.sh`（20 ケース、全 PASS）
+
+| Section | テスト | 対応 AC |
+|---|---|---|
+| 1.1〜1.7 | el_resolve_env_file の探索順（明示 / per-repo fallback / 不在 / 相対パス無視 / 読取不能 fallback） | Req 1.1〜1.5 / NFR 2.1 |
+| 2.1〜2.2 | KEY=VALUE 反映 / コメント・空行 skip | Req 2.2〜2.4 |
+| 3.1〜3.3 | `$HOME` 展開 / `$(...)` 評価 / 置換失敗 skip + 後続継続 | Req 3.1〜3.3 / 6.3 |
+| 4.1〜4.3 | inline > env ファイル / env ファイル単独採用 / 空文字 inline も「定義済み」 | Req 4.1〜4.4 |
+| 5.1〜5.3 | 構文不正行 skip + warn / 無効識別子 KEY skip / 読取不能ファイル warn + rc=1 | Req 6.1 / 6.2 / 6.5 |
+| 6.1〜6.2 | el_load entry point: 候補不在で no-op / 採用時 1 行ログ（値は出さない） | Req 5.1 / NFR 1.1 / NFR 2.2 / NFR 3.1 / NFR 3.3 |
+
+## 同期確認結果
+
+- `diff -r .claude/agents repo-template/.claude/agents` → 空（rc=0）
+- `diff -r .claude/rules repo-template/.claude/rules` → 空（rc=0）
+- `repo-template/` 配下に local-watcher copies なし（root-only 配布、install.sh 経由）→ 確認済
+- README.md に「per-repo env ファイル（crontab 行長限界の解消 / F8 / Issue #386）」節を追加
+  - 探索順 / 形式 / precedence / 推奨パーミッション / 異常系 / 移行ガイド / Out of Scope を網羅
+  - NFR 5.2 / 5.3 同一 PR 同期義務を満たす
+- `install.sh` の module 配布は `copy_glob_to_homebin ... "*.sh"` のため、新規 module は
+  install.sh 改修なしで自動配布される（既存 #177 Part 1 の設計を踏襲）
+
+## 検証結果
+
+| ツール | 結果 |
+|---|---|
+| `bash -n` (env-loader.sh / issue-watcher.sh / env-loader_test.sh) | OK |
+| `shellcheck` (env-loader.sh / issue-watcher.sh / install.sh / setup.sh) | warning ゼロ |
+| `shellcheck` (env-loader_test.sh) | info SC2016 のみ（CLAUDE.md「info 許容」基準内） |
+| `bash local-watcher/test/env-loader_test.sh` | PASS=20 FAIL=0 |
+| `bash local-watcher/test/full_auto_enabled_load_order_test.sh` | PASS=3 FAIL=0（既存回帰なし） |
+| `bash local-watcher/test/module_loader_missing_test.sh` | PASS=7 FAIL=0（既存回帰なし） |
+| `bash local-watcher/test/full_auto_enabled_test.sh` | PASS=28 FAIL=0（既存回帰なし） |
+| `bash local-watcher/test/normalize_slug_test.sh` | PASS=12 FAIL=0（既存回帰なし） |
+| `bash local-watcher/test/repo_prefix_log_test.sh` | PASS=36 FAIL=0（既存回帰なし） |
+| `--doctor` smoke test（env file 採用 / inline override / 候補なし） | 3 経路すべて期待通り |
+
+## AC Traceability
+
+| Req | 担保 |
+|---|---|
+| Req 1.1 | env-loader.sh は issue-watcher.sh L60 で REPO_SLUG 算出直後に source・el_load 実行（flag 解決より前） |
+| Req 1.2 | `el_resolve_env_file` テスト Sub 1.1 / 1.2（絶対パス採用 / 他候補無視） |
+| Req 1.3 | テスト Sub 1.3 / 1.4（未設定 / 空文字で per-repo パス採用） |
+| Req 1.4 | テスト Sub 1.3（per-repo パス採用） |
+| Req 1.5 | テスト Sub 1.6（候補不在で rc=1 / silent） |
+| Req 2.1〜2.4 | テスト Sub 2.1 / 2.2 / 3.1 / 3.2（KEY=VALUE / コメント / 空行 / 値展開） |
+| Req 3.1 | テスト Sub 3.1（`$HOME` 展開） |
+| Req 3.2 | テスト Sub 3.2（`$(...)` 評価） |
+| Req 3.3 | テスト Sub 3.3 / 5.1（コマンド置換失敗 skip + 後続継続） |
+| Req 3.4 | NFR 2.2 と同等。el_log / el_warn は値を含めない（実装上の制約） |
+| Req 4.1〜4.4 | テスト Sub 4.1 / 4.2 / 4.3（inline > env ファイル / 単独 KEY / 空文字も定義済み扱い） |
+| Req 5.1 | テスト Sub 6.1（候補不在で no-op、出力なし、rc=0） |
+| Req 5.2 | 新規 gate env を追加していない（実装の構造的担保） |
+| Req 5.3 | precedence テスト（Sub 4.1）で inline 列挙の従来挙動を確認 |
+| Req 6.1 | テスト Sub 5.3（読取不能ファイルで warn + rc=1） |
+| Req 6.2 | テスト Sub 5.1 / 5.2（構文不正 / 無効 KEY 行 skip + warn） |
+| Req 6.3 | テスト Sub 3.3（コマンド置換失敗で当該 KEY 未設定維持） |
+| Req 6.4 | テスト Sub 4.1 + 上記 Req 6.3 の組合せで担保（inline 補完が利く構造） |
+| Req 6.5 | テスト Sub 5.1（warn に `section5.env:1` 形式でパスと行番号を含む） |
+| NFR 1.1〜1.3 | スモーク 3 経路で env 集合・ログ・exit code 不変を確認 |
+| NFR 2.1 | el_resolve_env_file の `case "$path" in /*)` 絶対パス検査 + `[ -f ] && [ -r ]` 通常ファイル + 読取権限検査 |
+| NFR 2.2 | テスト Sub 6.2（採用ログにパスのみ・値は含まない） |
+| NFR 2.3 | README.md「推奨パーミッション」節で `chmod 600` を明記 |
+| NFR 2.4 | 実装上 `eval` を使い、サニタイズしない方針 |
+| NFR 3.1 | テスト Sub 6.2（採用時 1 行 stdout ログ） |
+| NFR 3.2 | テスト Sub 5.1 / 5.2 / 5.3（skip 理由 / 行番号を warn に含む） |
+| NFR 3.3 | テスト Sub 6.1（候補不在で出力なし） |
+| NFR 4.1 | `shellcheck` warning ゼロ / `bash -n` エラーなし |
+| NFR 4.2 | env-loader_test.sh が 5 経路（採用 / precedence / `$(...)` / byte 等価 / 構文不正）すべてを fixture でカバー |
+| NFR 5.1 | `repo-template/` に local-watcher copies は無く（root-only）、本機能は consumer 配布に影響しない（install.sh glob で自動配布） |
+| NFR 5.2 | README.md に探索順 / 形式 / precedence / 推奨パーミッションを記述 |
+| NFR 5.3 | README.md に「移行ガイド（既存 inline 列挙 → env ファイル）」節を記述 |
+
+## 確認事項
+
+なし。
+
+- 要件定義は EARS 形式の AC が numeric ID で揃っており実装方針は一意に決まる
+- design.md / tasks.md は本機能では作成されていないが（小規模実装のため Architect 起動不要）、
+  実装上の判断は本 impl-notes.md に集約
+
+STATUS: complete

--- a/docs/specs/386-feat-watcher-per-repo-env-crontab-f8/requirements.md
+++ b/docs/specs/386-feat-watcher-per-repo-env-crontab-f8/requirements.md
@@ -1,0 +1,151 @@
+# Requirements Document
+
+## Introduction
+
+idd-claude watcher は cron / launchd から起動される際、feature flag（`*_ENABLED` 系の opt-in
+gate など）を **crontab 行内に inline 環境変数として列挙する**運用が定着している。フラグ追加が
+継続した結果、ae-mdm リポジトリ運用で 1 行が ~1024 文字の crontab 行長限界に達し、
+`command too long` で `install.sh` が失敗する事象が複数回発生した。本機能（F8）は watcher 起動時
+に **per-repo の env ファイル**を source して flag を供給する経路を追加し、crontab 行を
+schedule / `REPO` / `REPO_DIR` / `BASE_BRANCH` といった repo 識別系の最小限に保てるようにする。
+env ファイル不在時は導入前と完全に byte 等価な挙動を保ち（opt-in は「ファイルの存在」で判定し、
+新規の gate env を必要としない）、inline cron env が env ファイルの値より優先される precedence を
+保証することで、フラグ調整を crontab 編集ではなく単一ファイル編集へ移行できる状態にする。
+
+## 用語定義
+
+- **REPO_SLUG** — watcher が `REPO`（例 `owner/name`）の `/` を `-` に変換して得る repo 単位の
+  識別子（例 `owner-name`）。既存 lock / log ファイル名と共通の slug 規約を流用する。
+- **WATCHER_ENV_FILE** — env ファイルの場所を運用者が明示指定するための環境変数。値は絶対パス。
+- **inline cron env** — crontab 行（または launchd plist の `EnvironmentVariables`、または
+  watcher 起動シェルの環境）で watcher プロセスへ供給される環境変数。env ファイル source 前の
+  時点で既に export 済みである値を指す。
+- **env ファイル** — watcher が起動時に source する `KEY=VALUE` 形式のシェルスクリプト風
+  テキストファイル。本機能で新規導入される。
+
+## Requirements
+
+### Requirement 1: env ファイルの探索順
+
+**Objective:** As a idd-claude 運用者, I want watcher が per-repo の env ファイルを決定論的な順序で探索する, so that 複数 repo を 1 つの watcher スクリプトで運用する際に repo ごとの flag セットを明示パスまたは規約パスから取得できる
+
+#### Acceptance Criteria
+
+1. When watcher プロセスが起動した, the watcher shall env ファイル探索を flag 解決より前に実施する
+2. Where `WATCHER_ENV_FILE` が絶対パスとして指定されており当該ファイルが読取可能である, the watcher shall そのファイルを env ファイルとして採用し、他の候補を探索しない
+3. If `WATCHER_ENV_FILE` が未設定または空文字である, the watcher shall `$HOME/.issue-watcher/<REPO_SLUG>.env` を次候補として参照する（`<REPO_SLUG>` は `REPO` の `/` を `-` に変換した値）
+4. When 次候補 `$HOME/.issue-watcher/<REPO_SLUG>.env` が読取可能である, the watcher shall そのファイルを env ファイルとして採用する
+5. If 探索順のいずれの候補も読取可能でない, the watcher shall env ファイルを採用せず、後方互換の no-op 経路（本機能導入前と等価な起動シーケンス）を辿る
+
+### Requirement 2: env ファイルの形式
+
+**Objective:** As a idd-claude 運用者, I want env ファイルが運用しやすい単純な `KEY=VALUE` 形式である, so that crontab 1 行への詰込みを避け、フラグ追加・削除・コメントによる注釈を単一ファイル編集で完結できる
+
+#### Acceptance Criteria
+
+1. The env ファイル shall 1 行 1 件の `KEY=VALUE` 形式で記述される
+2. Where 行頭文字が `#` である行が含まれる, the watcher shall 当該行をコメントとして無視し、副作用を発生させない
+3. Where 行が空または空白のみで構成される, the watcher shall 当該行を読み飛ばし、副作用を発生させない
+4. When env ファイル内の `KEY=VALUE` 行を採用した, the watcher shall 当該 `KEY` を後続処理（flag 解決・gate 評価）で参照可能な環境変数として供給する
+
+### Requirement 3: 値評価（変数展開・コマンド置換）
+
+**Objective:** As a idd-claude 運用者, I want env ファイル内の値で `$HOME` や `$(...)` を解決できる, so that webhook URL のような機密値を別ファイルから読み込んでフラグへ注入し、env ファイル自体に平文埋込みせずに済む
+
+#### Acceptance Criteria
+
+1. When env ファイル内の `KEY=VALUE` 行を採用した, the watcher shall 値文字列中の `$HOME` を起動シェルの `$HOME` 実値へ解決する
+2. When env ファイル内の `KEY=VALUE` 行を採用した, the watcher shall 値文字列中の `$(...)` 形式のコマンド置換を起動時に実行し、その出力を `KEY` の値として採用する
+3. If 値評価中にコマンド置換が失敗した（非 0 終了 / 実行不能）, the watcher shall 当該行のみ skip し、警告を `>&2` へ出力し、watcher プロセスを継続する
+4. While env ファイル内の値が機密情報（webhook URL 等）を含む, the watcher shall 評価結果の値をログ・Issue コメントへ出力しない
+
+### Requirement 4: precedence（inline cron env 優先）
+
+**Objective:** As a idd-claude 運用者, I want crontab 行で明示した値が env ファイルの値より優先される, so that 一時的な override・実験的なフラグ調整・特定 repo の例外設定を crontab 1 行で完結できる
+
+#### Acceptance Criteria
+
+1. When 同一の `KEY` が inline cron env と env ファイルの両方に存在する, the watcher shall inline cron env の値を採用し、env ファイルの値で上書きしない
+2. When `KEY` が env ファイルにのみ存在する, the watcher shall env ファイルの値を採用する
+3. When `KEY` が inline cron env にのみ存在する, the watcher shall inline cron env の値を採用する（env ファイル不在時と同一の挙動）
+4. The watcher shall precedence 規約を「inline cron env > env ファイル」の単一順序として全 `KEY` に一貫して適用する
+
+### Requirement 5: 後方互換性（env ファイル不在時の byte 等価性）
+
+**Objective:** As a idd-claude 運用者, I want env ファイルを置かない既存運用の挙動が変わらない, so that 本機能導入による回帰リスクなしに段階的に env ファイル運用へ移行できる
+
+#### Acceptance Criteria
+
+1. While env ファイル探索順のいずれの候補も読取可能でない, the watcher shall 本機能導入前と完全に同一の起動シーケンス・環境変数集合・ログ出力・exit code を保つ
+2. The watcher shall env ファイル機能の有効化に新規 gate env（`*_ENABLED` 系）を要求せず、「ファイルの存在」のみを opt-in シグナルとして扱う
+3. While 既存運用者が crontab 行に全 flag を inline 列挙している, the watcher shall 当該 inline 値を Requirement 4 の precedence 規約により従来どおりに反映する
+
+### Requirement 6: 異常系（読取・構文エラーの扱い）
+
+**Objective:** As a idd-claude 運用者, I want 壊れた env ファイルが watcher 全体を停止させない, so that 1 行のタイプミスや権限ミスで repo の cron が無音停止する事故を防げる
+
+#### Acceptance Criteria
+
+1. If 採用した env ファイルが読取不能（権限不足・I/O エラー等）, the watcher shall 警告を `>&2` へ出力し、env ファイルを採用しなかった経路（Requirement 5.1 と等価）で起動を継続する
+2. If env ファイル内の特定行が `KEY=VALUE` 形式として解釈できない（`=` 欠落 / `KEY` が識別子として無効 等）, the watcher shall 当該行のみ skip し、警告を `>&2` へ出力し、残りの行の処理を継続する
+3. If env ファイル内の値評価（Requirement 3）でコマンド置換が失敗した, the watcher shall 当該 `KEY` を未設定のまま残し、watcher プロセスを継続する
+4. While 異常系で行 skip が発生している, the watcher shall 当該 `KEY` を inline cron env が定義していれば inline 値で補完する（precedence 規約は維持）
+5. The watcher shall 異常系の警告メッセージに env ファイルパスと該当行番号を含める（行 skip の場合は行番号、ファイル全体の場合はパスのみ）
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The watcher shall 既存 env var 名（`REPO` / `REPO_DIR` / `LOG_DIR` / `LOCK_FILE` / `BASE_BRANCH` / `TRIAGE_MODEL` / `DEV_MODEL` 等）の名前・意味を変更しない
+2. The watcher shall 既存 cron / launchd 登録文字列を破壊せず、現行の inline env のみで運用している repo が `install.sh` を再実行しても挙動が変わらない
+3. While env ファイル探索で候補が見つからない, the watcher shall 本機能導入前と完全に byte 等価な起動経路（環境変数集合・ログ・exit code）を辿る
+
+### NFR 2: セキュリティ
+
+1. The watcher shall env ファイルの読込で path traversal 防止のため、`WATCHER_ENV_FILE` の値および `$HOME/.issue-watcher/<REPO_SLUG>.env` のパスを使用前に「絶対パスかつ通常ファイルかつ読取権限あり」であることを確認する
+2. The watcher shall env ファイル内の値評価結果を Issue 本文・Issue コメント・PR 本文・標準ログへ平文出力しない（機密情報のリーク防止）
+3. The README / 運用ドキュメント shall env ファイルの推奨パーミッションを 600（owner 読書のみ）として明記する
+4. The watcher shall env ファイルを運用者管理ファイル（信頼境界の内側）として扱い、未信頼入力サニタイズ（Issue 本文等に適用するもの）の対象とはしない
+
+### NFR 3: 可観測性
+
+1. When watcher が env ファイルを採用した, the watcher shall 採用したファイルパスを 1 行ログとしてログ出力先へ記録する（値は出力しない）
+2. When watcher が env ファイル内の行を skip した, the watcher shall skip 理由（構文不正 / コマンド置換失敗等）と行番号を 1 行ログとして記録する
+3. While env ファイル探索で候補が見つからない, the watcher shall 探索結果を debug レベル以上のログにのみ記録し、通常運用の標準ログを増やさない
+
+### NFR 4: 静的解析と近接テスト
+
+1. The watcher 配布物 shall `shellcheck` を警告ゼロ、`bash -n` をエラーなしでクリアする
+2. The watcher shall 「env ファイル存在 + 値反映」「inline > env ファイル precedence」「`$(...)` 評価」「env ファイル不在時の byte 等価性」「構文不正行 skip + 警告」の 5 経路に対する近接テスト（`local-watcher/test/` 配下に stub ベースで配置）を備える
+
+### NFR 5: テンプレート同期と README 連動
+
+1. The watcher 配布物（`local-watcher/bin/issue-watcher.sh` および関連 module）shall 挙動変更を `repo-template/` 配下の対応物と byte 一致または機能等価で同期する
+2. The README shall env ファイルの「探索順 / 形式 / precedence / 推奨パーミッション」を同一 PR で記述する
+3. The README shall 既存運用者向けの移行ガイド（inline env を env ファイルへ移し替える手順と precedence による段階移行の方法）を同一 PR で記述する
+
+## Out of Scope
+
+- env ファイル機能を有効化する新規 gate env（`*_ENABLED` 系）の導入（opt-in は「ファイルの存在」のみで判定する）
+- 既存運用者の crontab 行から inline env を自動的に env ファイルへ移行するスクリプト（移行は手動 / README の移行ガイド参照）
+- env ファイルの自動生成・テンプレート展開（`install.sh` / `setup.sh` 内での scaffold は本機能の対象外）
+- env ファイルの暗号化・KMS 連携・secrets manager 統合
+- env ファイル変更の即時反映（hot reload / inotify 等。本機能は watcher プロセス起動時の 1 回限りの source とする）
+- env ファイル内で他の env ファイルを再帰的に source する仕組み
+- launchd plist 側の env ファイル取り扱い変更（plist の `EnvironmentVariables` は inline cron env と同じ precedence 階に置く）
+- env ファイルローダの内部関数構成 / 公開 IF シグネチャ / module 切り出しの可否（Architect の責務）
+- crontab 行長限界そのものを回避する別アプローチ（ラッパースクリプト経由起動・systemd timer 移行等）
+
+## Open Questions
+
+- なし（Issue 本文の探索順・形式・precedence・後方互換・異常系・セキュリティが要件確定に十分な記述を備えているため）
+
+## 関連
+
+- Parent: なし（F8 単独機能）
+- Related: なし
+
+## レビュー結果
+
+- Mechanical Checks: 全要件見出しが numeric ID（1〜6 / NFR 1〜5）/ 各要件に EARS 形式 AC を 1 件以上含む / 実装語彙（特定の関数名・module 名・bash builtin 名指定）の混入なし
+- 判断レビュー: 探索順（Req 1）・形式（Req 2）・値評価（Req 3）・precedence（Req 4）・後方互換（Req 5）・異常系（Req 6）の 6 軸で Issue 記載 AC を網羅、Out of Scope で Architect 責務（内部関数構成）と隣接機能（hot reload / 自動移行 / 暗号化）を明示的に切り出し、NFR でセキュリティ（600 / 機密ログ抑制 / path 検証）と同期義務（README / repo-template）を確定 — 1 パスで確定

--- a/docs/specs/386-feat-watcher-per-repo-env-crontab-f8/review-notes.md
+++ b/docs/specs/386-feat-watcher-per-repo-env-crontab-f8/review-notes.md
@@ -1,0 +1,81 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T08:30:17Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-386-impl-feat-watcher-per-repo-env-crontab-f8
+- HEAD commit: 916641e665e7dbed42b3bf3d989ae27f1882a8dd
+- Compared to: main..HEAD
+- Diff stat: 6 files changed, 1139 insertions(+), 1 deletion(-)
+  - `README.md`（+129 行 / NFR 5.2・5.3）
+  - `local-watcher/bin/issue-watcher.sh`（+26 行 / 挿入点と REQUIRED_MODULES 追加）
+  - `local-watcher/bin/modules/env-loader.sh`（新規 +213 行 / 本体 module）
+  - `local-watcher/test/env-loader_test.sh`（新規 +447 行 / 近接テスト 20 ケース）
+  - `docs/specs/386-feat-watcher-per-repo-env-crontab-f8/{requirements,impl-notes}.md`（成果物）
+- Feature Flag Protocol 採否: CLAUDE.md に該当節なし → opt-out 扱い、flag 细目は適用しない
+
+## Verified Requirements
+
+- **1.1** — `issue-watcher.sh` L57〜81 で REPO_SLUG 算出直後（全 `*_ENABLED` 系 default 評価より前）に `el_load` を呼ぶ。スモークテスト「env file あり → `full-auto=true` 反映」で flag 解決前に走ることを確認（impl-notes）
+- **1.2** — `env-loader.sh` `el_resolve_env_file` の case `/*)` 絶対パス検査 → `el_apply_env_file` ループに分岐前 return。テスト Sub 1.1 / Sub 1.2（明示 + per-repo パス無視）
+- **1.3** — `el_resolve_env_file` の `[ -n "${WATCHER_ENV_FILE:-}" ]` で未設定/空文字の場合に次候補へ。テスト Sub 1.3 / Sub 1.4
+- **1.4** — per-repo パスの `[ -f ] && [ -r ]` で採用。テスト Sub 1.3
+- **1.5** — `el_resolve_env_file` は候補なしで `return 1`。`el_load` は rc=1 で silent return。テスト Sub 1.6 / Sub 6.1（rc=0 / 出力なし）
+- **2.1** — `el_apply_env_file` の `^([A-Za-z_][A-Za-z0-9_]*)=(.*)$` regex で 1 行 1 件を強制
+- **2.2** — `case "$stripped" in ''|'#'*) continue ;;` で行頭 `#` を skip。テスト Sub 2.2
+- **2.3** — 同じく空行 / 空白のみ行を `${raw%%[![:space:]]*}` の leading strip 後に `''` 判定で skip。テスト Sub 2.2（連続空行・空白行）
+- **2.4** — `export "$key"` で後続処理へ供給。テスト Sub 2.1
+- **3.1** — `eval "$key=\"$value\""` で `$HOME` を起動シェルが展開。テスト Sub 3.1（`/test/home/foo` 期待値）
+- **3.2** — 同 eval で `$(...)` を実行。テスト Sub 3.2（`cat secret.txt` 経由で値取得）
+- **3.3** — eval rc 非 0 で warn + unset + 後続継続。テスト Sub 3.3（`/nonexistent/command-that-fails` → 後続 KEY 反映）
+- **3.4** — `el_log` / `el_warn` 実装が KEY 名 / パス / 行番号 / 失敗種別のみを受け取り、VALUE 本体は引数に取らない構造（コメントに明記）。テスト Sub 6.2（`should-not-be-logged` が log に出ないこと）
+- **4.1** — `[ -n "${!key+x}" ]` 判定で既存 KEY を skip。テスト Sub 4.1（`INLINE_KEY=from-inline` 温存）
+- **4.2** — テスト Sub 4.2（`FILE_ONLY=from-file` 反映）
+- **4.3** — 実装は env ファイルに無い KEY を一切触らないため inline 値が温存される（構造的担保 + テスト Sub 1.6 / Sub 6.1 の不在時 no-op で副次的に確認）
+- **4.4** — `${KEY+x}` で空文字値の KEY も「定義済み」扱い。テスト Sub 4.3（`INLINE_EMPTY=""` 温存）
+- **5.1** — `el_load` 内で `el_resolve_env_file` rc=1 → silent return 0。テスト Sub 6.1（stdout/stderr 空 / rc=0）+ impl-notes スモークテスト 3 シナリオ
+- **5.2** — 実装に新規 `*_ENABLED` gate を追加しておらず、`if [ -f "$IDD_ENV_LOADER_PATH" ]` でファイル存在のみを opt-in シグナルとする（構造的担保）
+- **5.3** — テスト Sub 4.1 で inline 列挙の優先を確認 + スモーク 2「inline `FULL_AUTO_ENABLED=false` で env file の `true` を上書き」確認
+- **6.1** — `[ ! -r "$env_file" ]` で `el_warn` + return 1。テスト Sub 5.3（chmod 0 環境で rc=1 + WARN）
+- **6.2** — 正規表現不一致時 `el_warn "構文不正行 skip: $env_file:$lineno"`。テスト Sub 5.1（`=` なし）/ Sub 5.2（数字始まり KEY）
+- **6.3** — eval 失敗時 `el_warn` + `unset "$key"`。テスト Sub 3.3
+- **6.4** — Req 4.1 の precedence は eval 結果に関係なく適用される（既存 inline 定義 KEY は entry の `${!key+x}` でそもそも eval 自体に到達しない。構造的担保 + impl-notes 言及）
+- **6.5** — warn メッセージに `"$env_file:$lineno"` を含める。テスト Sub 5.1 が `section5.env:1` を grep 検査
+- **NFR 1.1** — テスト Sub 6.1（候補不在で stdout/stderr 空 / rc=0）+ スモーク 3
+- **NFR 1.2** — diff で既存 env var 名・登録文字列に変更なし（新規挿入のみ）
+- **NFR 1.3** — Sub 6.1 / スモーク 3 で byte 等価性確認
+- **NFR 2.1** — `el_resolve_env_file` の `case "$path" in /*)` 絶対パス検査 + `[ -f ]` 通常ファイル + `[ -r ]` 読取権限の 3 段検査。テスト Sub 1.5（相対パス無視）
+- **NFR 2.2** — テスト Sub 6.2（値 `should-not-be-logged` がログに含まれないことを否定確認）
+- **NFR 2.3** — README に `chmod 600 "$HOME/.issue-watcher/owner-myrepo.env"` を明記
+- **NFR 2.4** — 実装コメント / README に「運用者管理ファイル = 信頼境界の内側」「サニタイズしない」明記
+- **NFR 3.1** — `el_log "env ファイル採用: $env_file"` を採用時に 1 行出力。テスト Sub 6.2
+- **NFR 3.2** — `el_warn` がパス / 行番号 / 理由を含む。テスト Sub 5.1 / 5.2 / 5.3
+- **NFR 3.3** — 候補なしで `el_load` が silent return（log を出さない）。テスト Sub 6.1
+- **NFR 4.1** — impl-notes に `shellcheck` warning ゼロ / `bash -n` エラーなし記載
+- **NFR 4.2** — env-loader_test.sh が 5 経路（採用 / precedence / `$(...)` / byte 等価 / 構文不正）すべてを fixture でカバー（PASS=20 FAIL=0）
+- **NFR 5.1** — `repo-template/` に local-watcher copies は無く（root-only）、本機能は consumer 配布に影響しない構造（impl-notes 確認済）
+- **NFR 5.2** — README に「探索順 / 形式（`KEY=VALUE`） / precedence / 推奨パーミッション」節を同一 PR で追加
+- **NFR 5.3** — README に「移行ガイド」節（既存 inline 列挙を `KEY=VALUE` 転記 → precedence で段階移行 → crontab 最小化）を同一 PR で追加
+
+## Boundary 確認
+
+- 変更ファイル: README.md / issue-watcher.sh / modules/env-loader.sh（新規）/ test/env-loader_test.sh（新規）/ requirements.md / impl-notes.md
+- 本 Issue は Architect 不在の直接実装経路（tasks.md 不在）。boundary は requirements.md と CLAUDE.md「機能追加ガイドライン」で照合
+- 新規 module `env-loader.sh` は `el_` prefix を採用（CLAUDE.md §2 未使用 prefix）/ 関数定義のみ / `REQUIRED_MODULES` 配列に追記済み — §1〜§2 遵守
+- 既存 env var 名・ラベル名・exit code・cron 登録文字列を変更しない — §3「禁止事項」遵守
+- README 同一 PR 反映 / `diff -r .claude/{agents,rules}` 空（impl-notes 確認済）— §4 遵守
+- 新規 gate env を導入せず、ファイル存在のみで opt-in（Req 5.2 / CLAUDE.md §3 後方互換）— §3 遵守
+- 未信頼入力扱い: env ファイル本体は「運用者管理ファイル = 信頼境界の内側」（NFR 2.4）として `eval` 評価する明示的設計判断。要件側で承認済み（Out of Scope に「サニタイズ」「暗号化」を切出し）
+
+逸脱は検出されず。
+
+## Findings
+
+なし。
+
+## Summary
+
+Req 1〜6 / NFR 1〜5 のすべての numeric ID が `env-loader.sh` 実装と `env-loader_test.sh`（20 ケース PASS）+ README 追記 + `issue-watcher.sh` 挿入点で観測可能にカバーされている。precedence（inline > env ファイル）は `${!key+x}` 構造的担保 + Sub 4.1 / 4.3 テストで二重に検証されており、候補不在時の byte 等価性は Sub 6.1 + スモーク 3 で確認済み。boundary 逸脱・missing test・AC 未カバー のいずれも検出されない。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -56,6 +56,31 @@ REPO_DIR="${REPO_DIR:-$HOME/work/your-repo}"
 # REPO から repo-unique な slug を導出（lock / log / 一時ファイルの隔離に使う）
 REPO_SLUG="$(echo "$REPO" | tr '/' '-')"
 
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# per-repo env ファイル ロード（Issue #386 / F8）
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# crontab 行長限界（~1024 文字）で `command too long` を回避するため、watcher 起動時に
+# per-repo env ファイル（`WATCHER_ENV_FILE` 明示パス または `$HOME/.issue-watcher/<REPO_SLUG>.env`）
+# を source して `*_ENABLED` 系フラグを供給する。inline cron env が env ファイル値より優先される
+# 単一順序 precedence（Req 4.1〜4.4）を保証するため、ロード時点は本体内の **すべての**
+# `*_ENABLED` 系 `${VAR:-default}` 評価より前 = REPO_SLUG 算出直後の本位置に置く。
+# 候補ファイル不在時は何もせず（Req 5.1 / NFR 1.1）、本機能導入前と完全に byte 等価な
+# 起動経路を辿る。
+#
+# 配置順序の制約上、`REQUIRED_MODULES` ローダ（line 1052 付近）より前の本位置で
+# `env-loader.sh` のみ単独 source する必要がある（env ファイル経由で供給される値は
+# 後続の Config 行の `${VAR:-default}` で参照されるため、Config 行より前に確定させる
+# 必要がある）。本 module は他 module に依存しない自己完結関数群（el_log / el_warn /
+# el_resolve_env_file / el_apply_env_file / el_load）のみを定義するため、単独 source
+# しても他 module の前方参照を踏まない。
+IDD_ENV_LOADER_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/modules/env-loader.sh"
+if [ -f "$IDD_ENV_LOADER_PATH" ]; then
+  # shellcheck source=/dev/null
+  . "$IDD_ENV_LOADER_PATH"
+  el_load
+fi
+unset IDD_ENV_LOADER_PATH
+
 LABEL_TRIGGER="auto-dev"
 LABEL_CLAIMED="claude-claimed"
 LABEL_PICKED="claude-picked-up"
@@ -1049,7 +1074,7 @@ IDD_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/mo
 # 3 プロセッサ（promote-pipeline / pr-iteration / stage-a-verify）を並べ、末尾に
 # #238 の scaffolding-health.sh と #239 の per-run evidence サマリ（run-summary.sh）、
 # #325 の token usage 計測（token-usage.sh）を置く。
-REQUIRED_MODULES=( "core_utils.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "auto-merge.sh" "auto-merge-design.sh" "promote-pipeline.sh" "pr-iteration.sh" "pr-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "token-usage.sh" "security-review.sh" "guard-hook.sh" "context-map.sh" "failed-recovery.sh" "stale-pickup-reaper.sh" "needs-decisions-auto.sh" "dep-cycle-detect.sh" "slack-notify.sh" )
+REQUIRED_MODULES=( "core_utils.sh" "env-loader.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "auto-merge.sh" "auto-merge-design.sh" "promote-pipeline.sh" "pr-iteration.sh" "pr-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "token-usage.sh" "security-review.sh" "guard-hook.sh" "context-map.sh" "failed-recovery.sh" "stale-pickup-reaper.sh" "needs-decisions-auto.sh" "dep-cycle-detect.sh" "slack-notify.sh" )
 for _idd_mod in "${REQUIRED_MODULES[@]}"; do
   _idd_mod_path="$IDD_MODULE_DIR/$_idd_mod"
   if [ ! -f "$_idd_mod_path" ]; then

--- a/local-watcher/bin/modules/env-loader.sh
+++ b/local-watcher/bin/modules/env-loader.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# env-loader.sh — watcher の per-repo env ファイル ローダモジュール（Issue #386 / F8）
+#
+# 用途:
+#   watcher 起動時に per-repo env ファイルを source して `*_ENABLED` 系フラグを供給し、
+#   crontab 行を `REPO` / `REPO_DIR` / `BASE_BRANCH` といった repo 識別系の最小限に保てる
+#   ようにする。crontab 行長限界（~1024 文字）で `command too long` が発生する事態を解消する。
+#
+#   - el_log / el_warn               : ロガー（既存 *_log / *_warn と同形式の `[$REPO]` 3 段 prefix）
+#   - el_resolve_env_file            : `WATCHER_ENV_FILE` → `$HOME/.issue-watcher/<REPO_SLUG>.env`
+#                                       の探索順で読取可能な絶対パスを 1 つ解決（純粋関数）
+#   - el_apply_env_file              : 解決済み env ファイルを 1 行ずつ解釈し、未設定 KEY のみ
+#                                       環境変数として export する
+#   - el_load                        : 上記 2 つを束ねる public entry point。本体から 1 回だけ呼ぶ
+#
+#   評価順序（el_load）:
+#     1. el_resolve_env_file rc=1（候補なし）→ silent return 0（NFR 1.1 / Req 5.1）
+#     2. 解決済みパスを el_log で 1 行記録（NFR 3.1）
+#     3. el_apply_env_file が 1 行ずつパース → 値評価 → precedence 判定 → export
+#
+#   precedence:
+#     - inline cron env > env ファイル（Req 4.1〜4.4）。
+#     - 「inline cron env」とは el_apply_env_file 呼出時点で既にプロセス env に存在する変数。
+#     - 同一 KEY が env ファイルに含まれていても、`${KEY+x}` が定義済みなら skip する。
+#     - watcher 本体側の `KEY="${KEY:-default}"` 形式の後方で、本 module 経由で export された
+#       KEY も「inline cron env と同様に既存値」として扱われ、ハードコードされた default で
+#       上書きされない（Req 4.2 / NFR 1.3）。
+#
+#   値評価:
+#     - 値文字列に `$HOME` / `$VAR` / `$(...)` を含められる（Req 3.1, 3.2）。
+#     - `eval "export $KEY=\"$VALUE\""` で起動シェルの展開を借りる。env ファイルは運用者管理
+#       ファイル（信頼境界の内側 / NFR 2.4）として扱い、サニタイズは行わない。
+#     - コマンド置換が非 0 終了した場合は当該 KEY を未設定のまま残し、warn + 次行へ継続
+#       （Req 3.3 / Req 6.3）。
+#
+#   異常系:
+#     - 構文不正行（`=` 欠落 / `KEY` が識別子として無効）は当該行のみ skip + warn（Req 6.2）。
+#     - ファイル読取不能（権限不足等）は warn + 何もせず継続（Req 6.1）。
+#     - 警告メッセージにはパスと行番号を含める（Req 6.5）。
+#
+# 配置先:
+#   $HOME/bin/modules/env-loader.sh（install.sh が local-watcher/bin/modules/ から配置する）
+#
+# 依存:
+#   - 本モジュールは issue-watcher.sh 本体から `source` される前提（単体起動しない）。
+#   - `set -euo pipefail` は本体側で宣言済みのため、本モジュールでは宣言せず関数定義のみを持つ。
+#   - グローバル変数（$REPO / $REPO_SLUG / $HOME）は本体側 Config ブロックで定義済みである前提。
+#   - 外部 CLI: date のみ（ロガー用）。
+#   - 関数 prefix `el_` を namespace として採用する（新規未使用 prefix / CLAUDE.md §2）。
+#
+# セットアップ参照先:
+#   README.md（オプション機能一覧 / per-repo env ファイル節）
+#   docs/specs/386-feat-watcher-per-repo-env-crontab-f8/requirements.md
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# ロガー（既存 fr_log / sn_log と同形式の 3 段 prefix）
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# NFR 2.2 / 3.4: env ファイル内の値（webhook URL 等の機密候補）は warn 出力にも載せない。
+# 呼び出し側は KEY 名 / パス / 行番号 / 失敗種別のみを渡す契約。
+el_log() {
+  echo "[$(date '+%F %T')] [${REPO:-?}] env-loader: $*"
+}
+el_warn() {
+  echo "[$(date '+%F %T')] [${REPO:-?}] env-loader: WARN: $*" >&2
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# el_resolve_env_file: env ファイルの絶対パスを探索順で解決する（Req 1.1〜1.5）
+#
+#   探索順:
+#     1. `WATCHER_ENV_FILE` が絶対パス + 通常ファイル + 読取可能 → 採用（Req 1.2）
+#     2. `$HOME/.issue-watcher/<REPO_SLUG>.env` が同条件を満たす → 採用（Req 1.3 / 1.4）
+#     3. いずれも該当しなければ rc=1（候補なし / Req 1.5）
+#
+#   引数: なし（env から `WATCHER_ENV_FILE` / `HOME` / `REPO_SLUG` を読む）
+#   stdout: 採用した env ファイルの絶対パス（成功時）
+#   戻り値: 0 = 採用 / 1 = 候補なし
+#   副作用: なし（純粋関数 / NFR 2.1: 絶対パス + 通常ファイル + 読取権限あり の使用前検証）
+# ─────────────────────────────────────────────────────────────────────────────
+el_resolve_env_file() {
+  local candidate=""
+
+  # 候補 1: WATCHER_ENV_FILE（運用者明示指定 / Req 1.2）
+  # 絶対パスのみ受理（path traversal 予防 / NFR 2.1）。空文字 / 未設定 / 相対パスは次候補へ。
+  if [ -n "${WATCHER_ENV_FILE:-}" ]; then
+    case "$WATCHER_ENV_FILE" in
+      /*)
+        if [ -f "$WATCHER_ENV_FILE" ] && [ -r "$WATCHER_ENV_FILE" ]; then
+          printf '%s\n' "$WATCHER_ENV_FILE"
+          return 0
+        fi
+        ;;
+    esac
+  fi
+
+  # 候補 2: $HOME/.issue-watcher/<REPO_SLUG>.env（規約パス / Req 1.3 / 1.4）
+  # REPO_SLUG / HOME が空のときは候補生成不能として次へ（NFR 2.1 安全側）。
+  if [ -n "${HOME:-}" ] && [ -n "${REPO_SLUG:-}" ]; then
+    candidate="${HOME}/.issue-watcher/${REPO_SLUG}.env"
+    if [ -f "$candidate" ] && [ -r "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# el_apply_env_file: 解決済み env ファイルを 1 行ずつ解釈して環境変数を export する
+#
+#   引数: $1 = 採用済み env ファイルの絶対パス
+#   戻り値: 0 = 通常終了（行 skip 含む） / 1 = ファイル読取不能（Req 6.1）
+#   副作用: 各 KEY を export（既に env に存在する KEY はスキップ / Req 4.1）
+#
+#   1 行のパース仕様:
+#     - 空行 / 先頭文字が `#` の行 → skip（Req 2.2 / 2.3）
+#     - 行頭の空白は除去（leading whitespace のみ）
+#     - `KEY=VALUE` 形式: `^[A-Za-z_][A-Za-z0-9_]*=` を正規表現で検査
+#     - KEY が識別子として無効 / `=` なし → warn + skip（Req 6.2）
+#     - VALUE は KEY= 以降の残り全文字（trailing newline は read -r が消化済み）
+#     - VALUE 評価: `eval "export $KEY=\"$VALUE\""` で `$HOME` / `$VAR` / `$(...)` を展開
+#     - eval rc != 0（コマンド置換失敗等）→ warn + skip（Req 3.3 / 6.3）
+#
+#   precedence（Req 4.1 / NFR 1.3）:
+#     - `${KEY+x}` で「env に既に定義済み」を判定し、定義済みなら skip。
+#     - inline cron env で既に export された KEY が env ファイルで上書きされない。
+#
+#   NFR 2.2 / 3.4: warn 出力に KEY 名 / パス / 行番号は含めるが、VALUE 本体は含めない。
+# ─────────────────────────────────────────────────────────────────────────────
+el_apply_env_file() {
+  local env_file="$1"
+
+  if [ ! -r "$env_file" ]; then
+    el_warn "env ファイルが読取不能: $env_file"
+    return 1
+  fi
+
+  local lineno=0
+  local raw key value
+  # `read -r` で改行までを 1 行として読む。最終行に改行がない場合に取りこぼさないよう
+  # `|| [ -n "$raw" ]` で while ループを抜けずに最後の 1 行を処理する。
+  while IFS= read -r raw || [ -n "$raw" ]; do
+    lineno=$((lineno + 1))
+
+    # 行頭の空白を除去（行末はそのまま：VALUE に意図的な trailing space を残す可能性）。
+    local stripped="${raw#"${raw%%[![:space:]]*}"}"
+
+    # 空行 / コメント行 skip（Req 2.2 / 2.3）。
+    case "$stripped" in
+      ''|'#'*) continue ;;
+    esac
+
+    # `KEY=VALUE` 形式を正規表現で検査（Req 6.2）。
+    # KEY は `[A-Za-z_][A-Za-z0-9_]*` の bash 識別子規約に従う。
+    if ! [[ "$stripped" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
+      el_warn "構文不正行 skip: $env_file:$lineno"
+      continue
+    fi
+    key="${BASH_REMATCH[1]}"
+    value="${BASH_REMATCH[2]}"
+
+    # precedence: inline cron env > env ファイル（Req 4.1）。
+    # `${KEY+x}` は KEY が定義済みなら "x"、未定義なら空文字を返す。空文字値を持つ KEY も
+    # 「定義済み」として扱い、env ファイルでは上書きしない（inline 側の明示 unset 同義扱い）。
+    if [ -n "${!key+x}" ]; then
+      continue
+    fi
+
+    # 値評価: `eval` で `$HOME` / `$VAR` / `$(...)` を展開（Req 3.1 / 3.2）。
+    # env ファイルは運用者管理ファイル（信頼境界の内側 / NFR 2.4）として扱う。
+    #
+    # `export VAR=$(cmd)` は POSIX 仕様上 export の rc を返すため、内部の command 置換が
+    # 失敗（非 0 終了 / 実行不能）しても rc=0 で「成功した」ように見えてしまう。これを避ける
+    # ため、(1) 単純代入だけを eval してその rc で置換失敗を検出（Req 3.3 / 6.3）し、
+    # (2) 代入が成功した KEY を改めて `export` する 2 段構成にする。
+    # `2>/dev/null` で stderr を握り潰してから自前 warn を出すことで、コマンド置換の
+    # `command not found` 等のシステム由来メッセージで運用者のログを汚さない（NFR 3.4）。
+    # NFR 2.2: 評価成功した値は warn / log に出力しない。
+    if eval "$key=\"$value\"" 2>/dev/null; then
+      # 代入成功 → export する。`export` 自体は失敗しない（既に代入済みの変数を flag するのみ）。
+      # shellcheck disable=SC2163  # 動的 KEY を export するため間接 export を使う
+      export "$key"
+    else
+      el_warn "値評価に失敗（コマンド置換不可 / 構文エラー等） skip: $env_file:$lineno KEY=$key"
+      # 部分的に export された痕跡が残らないよう unset（保守的に状態を安定化）。
+      unset "$key" 2>/dev/null || true
+    fi
+  done < "$env_file"
+
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# el_load: env-loader の public entry point。本体 Config ブロックから 1 回だけ呼ぶ。
+#
+#   引数: なし
+#   戻り値: 常に 0（NFR 1.1 安全側 / 候補なしは silent / 異常系も警告のみで継続）
+#   副作用: 採用した env ファイル経由で KEY を export（precedence は el_apply_env_file 参照）。
+#           NFR 3.1: 採用時に 1 行 stdout ログを出す（値は出さない）。
+#           NFR 3.3: 候補なし時はログを出さない（通常運用の標準ログを増やさない）。
+# ─────────────────────────────────────────────────────────────────────────────
+el_load() {
+  local env_file=""
+  if ! env_file="$(el_resolve_env_file)"; then
+    # 候補なし → silent return（Req 5.1 / NFR 3.3）。
+    return 0
+  fi
+  # NFR 3.1: 採用したファイルパスを 1 行ログ（値は出さない）。
+  el_log "env ファイル採用: $env_file"
+  el_apply_env_file "$env_file" || true
+  return 0
+}

--- a/local-watcher/test/env-loader_test.sh
+++ b/local-watcher/test/env-loader_test.sh
@@ -1,0 +1,447 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/env-loader.sh の Issue #386（per-repo env ファイル ローダ）の
+#       探索順 / 値評価 / precedence / 構文不正 skip / 後方互換性を fixture で検証する近接テスト。
+#
+#       対象関数:
+#         - el_resolve_env_file  (Req 1.1〜1.5 / NFR 2.1)
+#         - el_apply_env_file    (Req 2.1〜2.4 / 3.1〜3.3 / 4.1〜4.4 / 6.1〜6.5)
+#         - el_load              (Req 1.1 / 5.1 / NFR 3.1 / 3.3 entry point)
+#
+#       検証する AC（docs/specs/386-feat-watcher-per-repo-env-crontab-f8/requirements.md）:
+#         - Req 1.2: WATCHER_ENV_FILE 指定優先 / 他候補無視
+#         - Req 1.3 / 1.4: per-repo パス `$HOME/.issue-watcher/<REPO_SLUG>.env` を採用
+#         - Req 1.5 / Req 5.1 / NFR 1.1: 候補不在で no-op（warn なし）
+#         - Req 2.2 / 2.3: コメント行 / 空行 skip
+#         - Req 2.4: KEY を環境変数として export
+#         - Req 3.1: 値中の $HOME 展開
+#         - Req 3.2: 値中の $(...) コマンド置換評価
+#         - Req 3.3 / 6.3: コマンド置換失敗で当該行 skip + 継続
+#         - Req 4.1 / 4.4: inline cron env > env ファイル precedence
+#         - Req 4.2 / 4.3: env ファイルのみ存在の KEY は env ファイル値採用
+#         - Req 6.2: 構文不正行（`=` なし / KEY 無効）は当該行 skip + warn + 継続
+#
+# 配置先: local-watcher/test/env-loader_test.sh
+# 依存:   bash 4+, mktemp
+# 実行:   bash local-watcher/test/env-loader_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_SH="$SCRIPT_DIR/../bin/modules/env-loader.sh"
+
+if [ ! -f "$MODULE_SH" ]; then
+  echo "ERROR: cannot find env-loader.sh at $MODULE_SH" >&2
+  exit 2
+fi
+
+# テストごとに変数汚染を起こさないため、サブシェル経由で実行する。
+# 各テストはサブシェルで `. "$MODULE_SH"` してから実装関数を呼ぶ。
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "FAIL: $1"; if [ -n "${2:-}" ]; then echo "  detail: $2"; fi; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# テスト用に共通の REPO / REPO_SLUG / HOME を上書きできる fixture root を作る。
+FIX_ROOT="$(mktemp -d -t env-loader-test-XXXXXX)"
+trap 'rm -rf "$FIX_ROOT"' EXIT
+
+# ============================================================
+# Section 1: el_resolve_env_file の探索順（Req 1.1〜1.5 / NFR 2.1）
+# ============================================================
+echo "--- Section 1: el_resolve_env_file の探索順 ---"
+
+# Sub 1.1: WATCHER_ENV_FILE 指定（絶対パス + 読取可能）→ それを採用（Req 1.2）
+out_sub1=$(mktemp -p "$FIX_ROOT" sub1-XXXX)
+explicit_env="$out_sub1"
+echo "FOO=1" > "$explicit_env"
+got=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  WATCHER_ENV_FILE="$explicit_env" HOME="$FIX_ROOT/should-not-be-used" REPO_SLUG="x" \
+    el_resolve_env_file 2>/dev/null || true
+)
+if [ "$got" = "$explicit_env" ]; then
+  pass "Req 1.2: WATCHER_ENV_FILE 絶対パス指定で当該パス採用"
+else
+  fail "Req 1.2: WATCHER_ENV_FILE 絶対パス指定で当該パス採用" "expected=$explicit_env actual=$got"
+fi
+
+# Sub 1.2: WATCHER_ENV_FILE 指定済みで他候補無視（per-repo パスにファイルがあっても採用しない）
+mkdir -p "$FIX_ROOT/home1/.issue-watcher"
+echo "BAR=should-be-ignored" > "$FIX_ROOT/home1/.issue-watcher/owner-repo.env"
+got=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  WATCHER_ENV_FILE="$explicit_env" HOME="$FIX_ROOT/home1" REPO_SLUG="owner-repo" \
+    el_resolve_env_file 2>/dev/null || true
+)
+if [ "$got" = "$explicit_env" ]; then
+  pass "Req 1.2: WATCHER_ENV_FILE 採用時に per-repo パスを参照しない"
+else
+  fail "Req 1.2: WATCHER_ENV_FILE 採用時に per-repo パスを参照しない" "actual=$got"
+fi
+
+# Sub 1.3: WATCHER_ENV_FILE 未設定 → per-repo パス採用（Req 1.3 / 1.4）
+got=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset WATCHER_ENV_FILE
+  HOME="$FIX_ROOT/home1" REPO_SLUG="owner-repo" \
+    el_resolve_env_file 2>/dev/null || true
+)
+expected="$FIX_ROOT/home1/.issue-watcher/owner-repo.env"
+if [ "$got" = "$expected" ]; then
+  pass "Req 1.3 / 1.4: WATCHER_ENV_FILE 未設定で per-repo パス採用"
+else
+  fail "Req 1.3 / 1.4: WATCHER_ENV_FILE 未設定で per-repo パス採用" "expected=$expected actual=$got"
+fi
+
+# Sub 1.4: WATCHER_ENV_FILE 空文字でも per-repo パス採用（NFR 2.1 安全側）
+got=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  WATCHER_ENV_FILE="" HOME="$FIX_ROOT/home1" REPO_SLUG="owner-repo" \
+    el_resolve_env_file 2>/dev/null || true
+)
+if [ "$got" = "$expected" ]; then
+  pass "Req 1.3: WATCHER_ENV_FILE 空文字で per-repo パス採用"
+else
+  fail "Req 1.3: WATCHER_ENV_FILE 空文字で per-repo パス採用" "actual=$got"
+fi
+
+# Sub 1.5: WATCHER_ENV_FILE が相対パスは無視（NFR 2.1 path traversal 予防）
+got=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  WATCHER_ENV_FILE="relative/path.env" HOME="$FIX_ROOT/home1" REPO_SLUG="owner-repo" \
+    el_resolve_env_file 2>/dev/null || true
+)
+if [ "$got" = "$expected" ]; then
+  pass "NFR 2.1: WATCHER_ENV_FILE 相対パス無視で per-repo パスに fallback"
+else
+  fail "NFR 2.1: WATCHER_ENV_FILE 相対パス無視で per-repo パスに fallback" "actual=$got"
+fi
+
+# Sub 1.6: 候補ファイル不在 → rc=1 / stdout 空（Req 1.5）
+out_rc=0
+got=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset WATCHER_ENV_FILE
+  HOME="$FIX_ROOT/none" REPO_SLUG="nonexistent" \
+    el_resolve_env_file 2>/dev/null
+) || out_rc=$?
+if [ "$out_rc" = 1 ] && [ -z "$got" ]; then
+  pass "Req 1.5: 候補不在で rc=1 / stdout 空"
+else
+  fail "Req 1.5: 候補不在で rc=1 / stdout 空" "rc=$out_rc stdout=$got"
+fi
+
+# Sub 1.7: WATCHER_ENV_FILE 指定が読取不能 → per-repo に fallback（Req 1.2 失敗時）
+unreadable="$FIX_ROOT/unreadable.env"
+echo "X=1" > "$unreadable"
+chmod 0 "$unreadable" 2>/dev/null || true
+# root では `chmod 0` でも読めるため、root 環境はスキップ。
+if [ ! -r "$unreadable" ]; then
+  got=$(
+    # shellcheck disable=SC1090
+    . "$MODULE_SH"
+    WATCHER_ENV_FILE="$unreadable" HOME="$FIX_ROOT/home1" REPO_SLUG="owner-repo" \
+      el_resolve_env_file 2>/dev/null || true
+  )
+  if [ "$got" = "$expected" ]; then
+    pass "Req 1.2 失敗時: WATCHER_ENV_FILE 読取不能で per-repo パスに fallback"
+  else
+    fail "Req 1.2 失敗時: WATCHER_ENV_FILE 読取不能で per-repo パスに fallback" "actual=$got"
+  fi
+else
+  echo "SKIP: chmod 0 が効かない環境（root 等）のため Req 1.2 読取不能ケースはスキップ"
+fi
+chmod 644 "$unreadable" 2>/dev/null || true
+
+# ============================================================
+# Section 2: el_apply_env_file の値反映 / 形式（Req 2.2〜2.4）
+# ============================================================
+echo ""
+echo "--- Section 2: el_apply_env_file の値反映 / 形式 ---"
+
+# Sub 2.1: 単純な KEY=VALUE で export される（Req 2.4）
+env2="$FIX_ROOT/section2.env"
+cat >"$env2" <<'EOF'
+SIMPLE_KEY=hello
+EOF
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset SIMPLE_KEY
+  el_apply_env_file "$env2" 2>/dev/null
+  echo "got=${SIMPLE_KEY:-UNSET}"
+)
+if echo "$result" | grep -q "got=hello"; then
+  pass "Req 2.4: 単純 KEY=VALUE が export される"
+else
+  fail "Req 2.4: 単純 KEY=VALUE が export される" "$result"
+fi
+
+# Sub 2.2: # コメント行 / 空行 / 空白のみ行 skip（Req 2.2 / 2.3）
+env2b="$FIX_ROOT/section2b.env"
+cat >"$env2b" <<'EOF'
+# comment line should be skipped
+   # indented comment skipped
+
+
+KEEP_THIS=ok
+EOF
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset KEEP_THIS
+  el_apply_env_file "$env2b" 2>&1
+  echo "got=${KEEP_THIS:-UNSET}"
+)
+if echo "$result" | grep -q "got=ok" && ! echo "$result" | grep -q "WARN"; then
+  pass "Req 2.2 / 2.3: コメント・空行 skip + 後続 KEY 反映 + WARN なし"
+else
+  fail "Req 2.2 / 2.3: コメント・空行 skip + 後続 KEY 反映 + WARN なし" "$result"
+fi
+
+# ============================================================
+# Section 3: 値評価（$HOME / $(...) 展開）（Req 3.1 / 3.2 / 3.3）
+# ============================================================
+echo ""
+echo '--- Section 3: 値評価（$HOME / $(...) 展開） ---'
+
+# Sub 3.1: $HOME 展開（Req 3.1）
+env3="$FIX_ROOT/section3.env"
+echo 'HOME_VAL=$HOME/foo' > "$env3"
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset HOME_VAL
+  HOME="/test/home" el_apply_env_file "$env3" 2>/dev/null
+  echo "got=${HOME_VAL:-UNSET}"
+)
+if echo "$result" | grep -q "got=/test/home/foo"; then
+  pass "Req 3.1: 値中の \$HOME が展開される"
+else
+  fail "Req 3.1: 値中の \$HOME が展開される" "$result"
+fi
+
+# Sub 3.2: $(...) コマンド置換評価（Req 3.2）
+env3b="$FIX_ROOT/section3b.env"
+secret_file="$FIX_ROOT/secret.txt"
+echo "s3cret-value" > "$secret_file"
+echo "SECRET=\$(cat $secret_file)" > "$env3b"
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset SECRET
+  el_apply_env_file "$env3b" 2>/dev/null
+  echo "got=${SECRET:-UNSET}"
+)
+if echo "$result" | grep -q "got=s3cret-value"; then
+  pass "Req 3.2: 値中の \$(...) コマンド置換が評価される"
+else
+  fail "Req 3.2: 値中の \$(...) コマンド置換が評価される" "$result"
+fi
+
+# Sub 3.3: $(...) コマンド置換失敗で当該行 skip + 後続行は処理継続（Req 3.3 / 6.3）
+env3c="$FIX_ROOT/section3c.env"
+cat >"$env3c" <<EOF
+FAIL_KEY=\$(/nonexistent/command-that-fails)
+NEXT_KEY=after-fail
+EOF
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset FAIL_KEY NEXT_KEY
+  el_apply_env_file "$env3c" 2>&1
+  echo "fail=${FAIL_KEY:-UNSET}|next=${NEXT_KEY:-UNSET}"
+)
+# FAIL_KEY は未設定 or 空、NEXT_KEY は反映、WARN メッセージが出ること
+if echo "$result" | grep -qE "fail=(UNSET\|next=after-fail|\|next=after-fail)" \
+   && echo "$result" | grep -q "WARN"; then
+  pass "Req 3.3 / 6.3: コマンド置換失敗で当該行 skip + 後続継続 + WARN 出力"
+else
+  fail "Req 3.3 / 6.3: コマンド置換失敗で当該行 skip + 後続継続 + WARN 出力" "$result"
+fi
+
+# ============================================================
+# Section 4: precedence（inline cron env > env ファイル）（Req 4.1〜4.4）
+# ============================================================
+echo ""
+echo "--- Section 4: precedence ---"
+
+# Sub 4.1: inline 設定済みの KEY は env ファイル値で上書きされない（Req 4.1）
+env4="$FIX_ROOT/section4.env"
+echo "INLINE_KEY=from-file" > "$env4"
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  INLINE_KEY="from-inline"
+  el_apply_env_file "$env4" 2>/dev/null
+  echo "got=${INLINE_KEY:-UNSET}"
+)
+if echo "$result" | grep -q "got=from-inline"; then
+  pass "Req 4.1: inline cron env > env ファイル（inline 値温存）"
+else
+  fail "Req 4.1: inline cron env > env ファイル（inline 値温存）" "$result"
+fi
+
+# Sub 4.2: env ファイルにのみ存在の KEY は env ファイル値採用（Req 4.2）
+env4b="$FIX_ROOT/section4b.env"
+echo "FILE_ONLY=from-file" > "$env4b"
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset FILE_ONLY
+  el_apply_env_file "$env4b" 2>/dev/null
+  echo "got=${FILE_ONLY:-UNSET}"
+)
+if echo "$result" | grep -q "got=from-file"; then
+  pass "Req 4.2: env ファイルのみの KEY は env ファイル値採用"
+else
+  fail "Req 4.2: env ファイルのみの KEY は env ファイル値採用" "$result"
+fi
+
+# Sub 4.3: inline 設定済み（空文字）も「定義済み」扱いで上書きされない（Req 4.4）
+env4c="$FIX_ROOT/section4c.env"
+echo "INLINE_EMPTY=from-file" > "$env4c"
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  INLINE_EMPTY=""
+  el_apply_env_file "$env4c" 2>/dev/null
+  # `${VAR-default}` でも空文字を「定義済み」と区別する
+  if [ -n "${INLINE_EMPTY+x}" ]; then
+    echo "got=defined:${INLINE_EMPTY}"
+  else
+    echo "got=undefined"
+  fi
+)
+if echo "$result" | grep -q "got=defined:$"; then
+  pass "Req 4.4: inline 空文字も「定義済み」として温存される"
+else
+  fail "Req 4.4: inline 空文字も「定義済み」として温存される" "$result"
+fi
+
+# ============================================================
+# Section 5: 異常系（構文不正行 skip + warn）（Req 6.1 / 6.2 / 6.5）
+# ============================================================
+echo ""
+echo "--- Section 5: 異常系 ---"
+
+# Sub 5.1: `=` なしの構文不正行 → skip + warn、後続行は処理継続（Req 6.2 / 6.5）
+env5="$FIX_ROOT/section5.env"
+cat >"$env5" <<'EOF'
+INVALID LINE NO EQUAL
+VALID_KEY=valid
+EOF
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset VALID_KEY
+  el_apply_env_file "$env5" 2>&1
+  echo "got=${VALID_KEY:-UNSET}"
+)
+if echo "$result" | grep -q "got=valid" \
+   && echo "$result" | grep -q "WARN" \
+   && echo "$result" | grep -q "section5.env:1"; then
+  pass "Req 6.2 / 6.5: 構文不正行 skip + warn（行番号 + パス） + 後続継続"
+else
+  fail "Req 6.2 / 6.5: 構文不正行 skip + warn（行番号 + パス） + 後続継続" "$result"
+fi
+
+# Sub 5.2: KEY が無効識別子（数字始まり）→ skip + warn（Req 6.2）
+env5b="$FIX_ROOT/section5b.env"
+cat >"$env5b" <<'EOF'
+9BAD_KEY=oops
+GOOD=ok
+EOF
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset GOOD
+  el_apply_env_file "$env5b" 2>&1
+  echo "got=${GOOD:-UNSET}"
+)
+if echo "$result" | grep -q "got=ok" && echo "$result" | grep -q "WARN"; then
+  pass "Req 6.2: 数字始まり KEY は無効識別子として skip + warn"
+else
+  fail "Req 6.2: 数字始まり KEY は無効識別子として skip + warn" "$result"
+fi
+
+# Sub 5.3: 読取不能ファイル → warn + rc=1（Req 6.1）
+# root では chmod 0 が効かないためスキップロジックを入れる
+env5c="$FIX_ROOT/section5c.env"
+echo "X=1" > "$env5c"
+chmod 0 "$env5c" 2>/dev/null || true
+if [ ! -r "$env5c" ]; then
+  rc=0
+  out=$(
+    # shellcheck disable=SC1090
+    . "$MODULE_SH"
+    el_apply_env_file "$env5c" 2>&1
+  ) || rc=$?
+  if [ "$rc" = 1 ] && echo "$out" | grep -q "WARN"; then
+    pass "Req 6.1: 読取不能ファイルで warn + rc=1"
+  else
+    fail "Req 6.1: 読取不能ファイルで warn + rc=1" "rc=$rc out=$out"
+  fi
+else
+  echo "SKIP: chmod 0 が効かない環境（root 等）のため Req 6.1 はスキップ"
+fi
+chmod 644 "$env5c" 2>/dev/null || true
+
+# ============================================================
+# Section 6: el_load entry point（候補不在で no-op / NFR 1.1 / 3.3）
+# ============================================================
+echo ""
+echo "--- Section 6: el_load entry point ---"
+
+# Sub 6.1: 候補不在で stdout / stderr いずれも空、rc=0（Req 5.1 / NFR 1.1 / 3.3）
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  unset WATCHER_ENV_FILE
+  HOME="$FIX_ROOT/empty-home" REPO_SLUG="no-such-repo" REPO="owner/no-such-repo" \
+    el_load 2>&1
+)
+rc=$?
+if [ "$rc" = 0 ] && [ -z "$result" ]; then
+  pass "Req 5.1 / NFR 1.1 / NFR 3.3: 候補不在で no-op（出力なし / rc=0）"
+else
+  fail "Req 5.1 / NFR 1.1 / NFR 3.3: 候補不在で no-op（出力なし / rc=0）" "rc=$rc out=$result"
+fi
+
+# Sub 6.2: 採用時に 1 行 stdout ログ（NFR 3.1）、値そのものは出さない
+env6="$FIX_ROOT/section6.env"
+echo "SECRET_VAL=should-not-be-logged" > "$env6"
+result=$(
+  # shellcheck disable=SC1090
+  . "$MODULE_SH"
+  WATCHER_ENV_FILE="$env6" REPO="owner/test" el_load 2>&1
+)
+if echo "$result" | grep -q "env ファイル採用" \
+   && echo "$result" | grep -q "$env6" \
+   && ! echo "$result" | grep -q "should-not-be-logged"; then
+  pass "NFR 3.1 / NFR 2.2: 採用時 1 行ログにパスのみ含む / 値は含まない"
+else
+  fail "NFR 3.1 / NFR 2.2: 採用時 1 行ログにパスのみ含む / 値は含まない" "$result"
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=================================================="
+echo "RESULT: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "=================================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

idd-claude watcher は cron / launchd 起動時に feature flag を **crontab 行内 inline 環境変数として列挙**する運用が定着しているが、フラグ追加が続いた結果 ~1024 文字の行長限制に達し `command too long` 事象が複数回発生した。

本 PR（F8）は watcher 起動時に **per-repo の env ファイル**（`$HOME/.issue-watcher/<REPO_SLUG>.env` または `WATCHER_ENV_FILE` 明示パス）を source してフラグを供給する新規 module `env-loader.sh`（`el_` prefix）を追加する。env ファイル不在時は導入前と完全に同一の起動経路を辿り（byte 等価）、inline cron env が env ファイルの値より優先される precedence を保証することで、フラグ管理を crontab 編集から単一ファイル編集へ移行できるようにする。

## 対応 Issue

Closes #386

## 関連 PR

なし（Architect 不在の直接実装経路）

## 実装内容

- (Req 1 / NFR 2.1) `el_resolve_env_file`: `WATCHER_ENV_FILE`（絶対パス）→ `$HOME/.issue-watcher/<REPO_SLUG>.env` の優先順で候補を決定論的に探索。絶対パス・通常ファイル・読取権限の 3 段検査でパス横断・権限不足を防止
- (Req 2〜3) `el_apply_env_file`: `KEY=VALUE` を 1 行ずつパース。コメント行・空行を skip し、`eval` の 2 段構成（変数代入 → `export` 分離）で `$HOME` 展開・`$()` コマンド置換・コマンド置換失敗の skip + 継続を実現
- (Req 4 / NFR 1.3) `${!key+x}` による precedence 制御: inline cron env の値（空文字含む）を env ファイルで上書きしない
- (Req 5 / NFR 1.1) `el_load` の silent no-op: 候補不在時は stdout / stderr いずれにも出力せず rc=0 で即 return（既存起動経路との byte 等価性を維持）
- (Req 6) 異常系ハンドリング: 読取不能ファイル / 構文不正行 / コマンド置換失敗に対して `el_warn`（パス + 行番号付き）+ 行 skip + プロセス継続
- (NFR 4) 近接テスト `local-watcher/test/env-loader_test.sh` 20 ケース（採用 / precedence / `$()` / byte 等価 / 構文不正の 5 経路）
- (NFR 5.2〜5.3) README に探索順 / 形式 / precedence / 推奨パーミッション（600）/ 移行ガイドを同一 PR で追記

## 受入基準チェック

- [x] Req 1.1: When watcher プロセスが起動した, the watcher shall env ファイル探索を flag 解決より前に実施する ← `issue-watcher.sh` L60 の REPO_SLUG 算出直後・`el_load` 呼出（スモークテスト 1〜3）
- [x] Req 1.2: 絶対パス `WATCHER_ENV_FILE` を採用し他候補を探索しない ← Sub 1.1 / 1.2
- [x] Req 1.3〜1.4: 未設定 / 空文字時に per-repo パスへ fallback ← Sub 1.3 / 1.4
- [x] Req 1.5: 候補不在で no-op ← Sub 1.6 / Sub 6.1
- [x] Req 2.2〜2.3: コメント行・空行 skip ← Sub 2.2
- [x] Req 2.4: `KEY` を環境変数として後続処理に供給 ← Sub 2.1
- [x] Req 3.1: `$HOME` 展開 ← Sub 3.1
- [x] Req 3.2: `$(...)` コマンド置換 ← Sub 3.2
- [x] Req 3.3: コマンド置換失敗 → 当該行 skip + 後続継続 ← Sub 3.3
- [x] Req 3.4: 値をログへ出力しない ← Sub 6.2（値 `should-not-be-logged` が log に不在）
- [x] Req 4.1: inline cron env が env ファイルより優先 ← Sub 4.1 / スモーク 2
- [x] Req 4.2〜4.4: env ファイル単独 KEY 採用 / 空文字 inline も定義済み扱い ← Sub 4.2 / 4.3
- [x] Req 5.1〜5.3: 候補不在で byte 等価 / 新規 gate env 不要 / inline 優先維持 ← Sub 6.1 + スモーク 3
- [x] Req 6.1: 読取不能で warn + rc=1 ← Sub 5.3
- [x] Req 6.2 / 6.5: 構文不正行 skip + warn（パス + 行番号） ← Sub 5.1 / 5.2
- [x] Req 6.3: コマンド置換失敗で当該 KEY 未設定維持 ← Sub 3.3
- [x] NFR 2.2: 値をログ出力しない ← Sub 6.2
- [x] NFR 2.3: README に `chmod 600` 推奨を記載
- [x] NFR 4.1: `shellcheck` warning ゼロ / `bash -n` OK
- [x] NFR 4.2: 5 経路を近接テストでカバー（PASS=20 FAIL=0）
- [x] NFR 5.2〜5.3: README 探索順 / 移行ガイドを同一 PR で追記

## テスト結果

```
# env-loader モジュール専用テスト
bash local-watcher/test/env-loader_test.sh
PASS=20 FAIL=0

# 既存回帰テスト
bash local-watcher/test/full_auto_enabled_load_order_test.sh   PASS=3  FAIL=0
bash local-watcher/test/module_loader_missing_test.sh          PASS=7  FAIL=0
bash local-watcher/test/full_auto_enabled_test.sh              PASS=28 FAIL=0
bash local-watcher/test/normalize_slug_test.sh                 PASS=12 FAIL=0
bash local-watcher/test/repo_prefix_log_test.sh                PASS=36 FAIL=0

# 静的解析
shellcheck local-watcher/bin/modules/env-loader.sh             → warning ゼロ
shellcheck local-watcher/bin/issue-watcher.sh                  → warning ゼロ
shellcheck install.sh setup.sh                                 → warning ゼロ
bash -n local-watcher/bin/modules/env-loader.sh                → OK
bash -n local-watcher/bin/issue-watcher.sh                     → OK

# --doctor スモークテスト（3 経路）
1. env file あり → full-auto=true 反映     ✓
2. env file あり + inline override=false   ✓ (inline 勝ち)
3. env file なし → 起動経路完全不変        ✓
```

## 実装上の判断

- **挿入位置の 2 段構成**: `issue-watcher.sh` の `REQUIRED_MODULES` loader（L1052）より前に `env-loader.sh` を単独 source する必要があるため、他 module に依存しない自己完結関数群のみで構成することで前方参照を回避
- **`eval` の 2 段構成**: `eval "export $key=\"$value\""` は export の rc でコマンド置換失敗を覆い隠すため、`eval "$key=\"$value\""` で代入 rc を観測してから `export "$key"` を分離実行
- **未信頼入力扱い**: env ファイルは「運用者管理ファイル = 信頼境界の内側」（NFR 2.4）として扱い、`eval` 評価する設計判断を要件側で明示承認（Out of Scope に「サニタイズ」「暗号化」を切出し済み）
- **`${!key+x}` による precedence 制御**: 空文字値の inline KEY も「定義済み」として env ファイルが上書きしない

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK
- Reviewer（claude-opus-4.7, round=1）は全 Req 1〜6 / NFR 1〜5 を approve 判定（`RESULT: approve`）。詳細は [`docs/specs/386-feat-watcher-per-repo-env-crontab-f8/review-notes.md`](docs/specs/386-feat-watcher-per-repo-env-crontab-f8/review-notes.md) を参照
- 特に注意して見てほしいファイル: `local-watcher/bin/modules/env-loader.sh`（precedence の `${!key+x}` 判定 / eval 2 段構成）、`local-watcher/bin/issue-watcher.sh`（L57〜81 の挿入点）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #386 のコメントを参照してください。
