### PR TITLE
feat(#389): closingIssuesReferences 非依存化で BASE_BRANCH=develop でも staged-for-release を自動付与

### DIFF
--- a/docs/specs/389-fix-promote-pipeline-staged-for-release/impl-notes.md
+++ b/docs/specs/389-fix-promote-pipeline-staged-for-release/impl-notes.md
@@ -1,0 +1,86 @@
+# Implementation Notes (#389)
+
+## 実装サマリ
+
+`pp_collect_merged_issues` の Issue 番号導出ソースを `closingIssuesReferences` 単独から、
+**「`closingIssuesReferences` + head ブランチ名 `^claude/issue-([0-9]+)-impl-` 経由」の和集合**
+へ拡張した。これにより `BASE_BRANCH=develop` 等の gitflow 運用（GitHub が closing-issue
+リンクを自動生成しない条件）でも、impl PR の merge 直後に対象 Issue へ `staged-for-release`
+が自動付与される。
+
+主な変更点:
+
+- `local-watcher/bin/modules/promote-pipeline.sh`
+  - 新規 helper `pp_extract_linked_issues` を追加（純関数 / jq で和集合 + unique 抽出）
+  - `pp_collect_merged_issues` 内の `gh pr list --json` フィールドに `headRefName` を追加
+    （gh API 呼び出し回数は変えない / Req 3.5）
+  - linked issues 抽出を `pp_extract_linked_issues` 呼び出しに置換
+  - issue 番号使用直前に `^[0-9]+$` 防御検証を追加（Req 1.5 / NFR 4.2）
+- `local-watcher/test/pp_extract_linked_issues_test.sh` を新規追加（`extract_function`
+  イディオム / 10 ケース）
+
+## AC Traceability
+
+| AC | カバーするテスト / 実装 |
+|----|------------------------|
+| Req 1.1 (head パターン導出) | Case 2, 4, 6, 8, 9 / `pp_extract_linked_issues` 内 jq `capture` |
+| Req 1.2 (和集合 + 重複排除) | Case 3, 6 / jq `+ unique` |
+| Req 1.3 (パターン不一致時の除外) | Case 4 (`feature/manual-fix`, `claude/issue-50-design-spec`) |
+| Req 1.4 (BASE_BRANCH=develop 補完) | Case 2, 9 (`closingIssuesReferences=[]` でも #N 抽出) |
+| Req 1.5 (`^[0-9]+$` 検証) | Case 8 (`abc`/`implfoo` 不一致) / `[[ =~ ^[0-9]+$ ]]` 防御層 |
+| Req 2.1.1-2.1.5 (既存付与契約維持) | 既存 `pp_collect_merged_issues` 後段ループは未変更 |
+| Req 2.3 (fork PR 除外) | Case 5 (fork user の `claude/issue-77-impl-fork` を除外) |
+| Req 2.4 (source 区別なし) | `pp_log` フォーマット文字列を変更せず |
+| Req 3.1 (opt-in gate 維持) | `pp_collect_merged_issues` 呼び出し条件は未変更 |
+| Req 3.2 (main 既存運用の不変) | Case 1 (closing 単独で #42 抽出) / Case 3 (両経路同一 #N → 1 件) |
+| Req 3.3 (env var / ラベル名不変) | diff 確認: `LABEL_STAGED_FOR_RELEASE` / `PROMOTE_GIT_TIMEOUT` 等参照のみ |
+| Req 3.4 (limit 不変) | `--limit 50` / `--limit 100` を変更せず |
+| Req 3.5 (gh API 呼び出し回数不変) | `gh pr list` の `--json` フィールドに `headRefName` を追加するのみ |
+| Req 4.1-4.4 (スコープ外不可侵) | `pp_resolve_merge_sha` / `pp_get_st_state` / `pp_handle_st_*` / `po_*` は未変更 |
+| Req 5.1 (4 ケース近接テスト) | Case 1-4 |
+| Req 5.2 (fork PR 近接テスト) | Case 5 |
+| Req 5.3 (単一スクリプトで起動可) | `bash local-watcher/test/pp_extract_linked_issues_test.sh` |
+| Req 5.4 (develop 想定 fail-condition) | Case 9（fail 時に PR 番号 / head 名 / 期待 Issue を出力） |
+| NFR 1.1-1.3 (後方互換) | Case 1 / diff: ラベル名・env var 名・ログ書式の改変なし |
+| NFR 2.1-2.2 (静的検査) | `bash -n` OK / `shellcheck` warnings 0 |
+| NFR 3.1-3.3 (可観測性) | `pp_log` / `pp_warn` のフォーマット文字列を一切変更せず |
+| NFR 4.1 (jq `--arg` で未信頼入力) | `pp_extract_linked_issues` は `--arg owner`、`headRefName` は jq 内で完結 |
+| NFR 4.2 (`^[0-9]+$` 検証) | bash 側で使用直前 `[[ =~ ^[0-9]+$ ]]` + jq の `capture` 二重防御 |
+
+## テスト結果
+
+- `bash -n local-watcher/bin/modules/promote-pipeline.sh` → OK
+- `shellcheck local-watcher/bin/modules/promote-pipeline.sh local-watcher/bin/issue-watcher.sh` → warnings 0
+- `shellcheck local-watcher/test/pp_extract_linked_issues_test.sh` → warnings 0
+- `bash local-watcher/test/pp_extract_linked_issues_test.sh` → **PASS=10 FAIL=0**
+- regression: `sn_callsite_promote_test.sh` (PASS=15) / `po_apply_awaiting_slot_test.sh`
+  (PASS=19) / `po_sticky_comment_helpers_test.sh` (PASS=10) すべて PASS
+
+## 設計上の判断
+
+- **jq 1 pass 内処理**: head 経路導出を bash ループではなく jq 内で `capture` + 和集合 +
+  unique 完結とした。理由: (1) PR JSON を 2 周しなくて済み Req 3.5 (gh API 呼び出し回数
+  不変) と整合しやすい、(2) `headRefName` を `--arg` 経由ではなく jq 内で `capture`
+  すれば値の bash 展開が発生せず NFR 4.1 (未信頼入力フラグ注入防止) 上安全、(3)
+  既存 `closingIssuesReferences` 抽出も jq 内で完結している既存スタイルに合わせられる。
+- **helper 切り出し**: `pp_extract_linked_issues` を独立した純関数として切り出した。
+  理由: Req 5.1 が `extract_function` で隔離抽出可能な近接テストを要求しており、`gh`
+  呼び出しを含む `pp_collect_merged_issues` 全体を抽出するより、JSON in → 番号 out の
+  純関数として分離した方が gh stub 不要でテストが簡潔になる。
+- **bash 側二重検証**: jq の `capture("^claude/issue-(?<n>[0-9]+)-impl-")` で数値 ID は
+  保証されるが、closingIssuesReferences 側の異常値や jq エラー時の防御として
+  `[[ "$issue_number" =~ ^[0-9]+$ ]]` を bash 側にも入れた。Req 1.5 / NFR 4.2 のテキスト
+  「使用直前に検証」の要求にも合致する。
+- **`AUTO_MERGE_HEAD_PATTERN` との関係**: 既存 `AUTO_MERGE_HEAD_PATTERN` は
+  `^claude/issue-.*-impl`（Issue 番号キャプチャなし）で、本機能とは正規表現セマンティクス
+  が異なる。本実装は専用パターン `^claude/issue-([0-9]+)-impl-` を `pp_extract_linked_issues`
+  内に literal で持つ（要件で許容: 「同パターンの正規表現セマンティクスと整合させるのみ」
+  / Out of Scope「既定値の変更はしない」）。
+
+## 確認事項
+
+なし。要件定義は明瞭で、人間レビュー判断が必要な未解決項目は識別されなかった。
+
+## STATUS
+
+STATUS: complete

--- a/docs/specs/389-fix-promote-pipeline-staged-for-release/requirements.md
+++ b/docs/specs/389-fix-promote-pipeline-staged-for-release/requirements.md
@@ -1,0 +1,217 @@
+# Requirements Document
+
+## Introduction
+
+Phase B Promote Pipeline の自動ラベル付与（`modules/promote-pipeline.sh` の
+`pp_collect_merged_issues`）は、`is:merged base:$BASE_BRANCH` で取得した PR の
+`closingIssuesReferences` のみを根拠に対象 Issue を特定し、`staged-for-release` を付与している。
+GitHub の closing-issue リンクは **PR の base がリポジトリの default ブランチである場合のみ**
+生成されるため、gitflow 運用（`BASE_BRANCH=develop` 等）では impl PR の本文に `Closes #N` を
+書いていても `closingIssuesReferences` が空になり、`staged-for-release` が自動付与されない。
+結果として `依存: #N` を持つ後続 Issue の `DEP_AUTO_UNBLOCK` が永久に発火せず、依存付き Issue
+を順送りで処理する full-auto 運用が `BASE_BRANCH != main` 環境で停止する。
+
+本要件は、`pp_collect_merged_issues` の Issue 番号導出ソースを `closingIssuesReferences` 単独から
+**「head ブランチ名 `claude/issue-<N>-impl-<slug>` からの導出 + `closingIssuesReferences` の併用」**
+へ拡張し、base ブランチが default かどうかに依存せずに `staged-for-release` を自動付与できる
+ようにする。同時に `BASE_BRANCH=main` 既存運用の挙動・fork PR 除外・自動付与と人間付与の区別なし
+ポリシー・opt-in gate などの既存契約を一切壊さないことを保証する。
+
+## 関連
+
+- Depends on: なし（独立した修正）
+- Related: #15（Phase B Promote Pipeline 全体） / #100（`staged-for-release` 人間付与運用） /
+  #346（`DEP_AUTO_UNBLOCK` / blocked 解除）
+
+## Requirements
+
+### Requirement 1: head ブランチ名からの Issue 番号導出（base ブランチ非依存化）
+
+**Objective:** As an idd-claude 運用者, I want `pp_collect_merged_issues` が `closingIssuesReferences`
+が空でも merged impl PR の head ブランチ名から Issue 番号を導出してくれることを期待する,
+so that `BASE_BRANCH=develop` 等の gitflow 運用でも impl PR が merge された直後に対象 Issue へ
+`staged-for-release` が自動付与され、依存チェーンが止まらない。
+
+#### Acceptance Criteria
+
+1. When `pp_collect_merged_issues` が `is:merged base:$BASE_BRANCH` の PR 集合を走査した,
+   the Promote Pipeline shall 各 PR の head ブランチ名が `claude/issue-<N>-impl-<slug>` パターン
+   （`AUTO_MERGE_HEAD_PATTERN` と整合する `^claude/issue-([0-9]+)-impl-` 形式）に一致する場合、
+   キャプチャした `<N>` を当該 PR が紐付く Issue 番号として収集対象に加える。
+2. When `closingIssuesReferences` から取得した Issue 番号集合と head ブランチ名から導出した
+   Issue 番号集合の両方が同一 PR について得られた, the Promote Pipeline shall 両者の和集合を
+   対象 Issue 集合とし、同一 Issue 番号の重複を排除する。
+3. When head ブランチ名が `claude/issue-<N>-impl-<slug>` パターンに一致しない PR
+   （人間が手書きした PR・設計 PR `claude/issue-<N>-design-*`・他フォーマットの head 等）が
+   merged 集合に含まれた, the Promote Pipeline shall その PR から head 経由での Issue 番号
+   導出を行わない（`closingIssuesReferences` 単独経路は従来どおり継続）。
+4. While `BASE_BRANCH` がリポジトリの default ブランチでない（例: `develop`）状態で impl PR
+   `claude/issue-<N>-impl-<slug>` が `$BASE_BRANCH` に merge された, the Promote Pipeline shall
+   `closingIssuesReferences` が空であっても当該 `#N` を `staged-for-release` 自動付与の対象
+   Issue として収集する。
+5. The Promote Pipeline shall head ブランチ名からのキャプチャ値 `<N>` を Issue 番号として
+   使用する前に `^[0-9]+$` で検証し、検証に失敗した場合は当該 PR の head 経路導出を行わない。
+
+### Requirement 2: 既存 `staged-for-release` 自動付与契約の維持
+
+**Objective:** As an idd-claude 運用者, I want head ブランチ経由で導出された Issue 番号に対しても
+従来の自動付与契約（重複付与抑止・自動 / 人間付与の区別なし・fork PR 除外）が変わらず適用される
+ことを期待する, so that 本修正によって既存 Issue 群へ意図しないラベル更新・PR コメント発火・
+status 遷移の差異が生まれない。
+
+#### Acceptance Criteria
+
+1. When head ブランチ名導出により対象 Issue 集合が拡張された, the Promote Pipeline shall 各 Issue
+   について `staged-for-release` ラベルの既存付与有無を確認し、既付与の Issue に対しては
+   `gh issue edit --add-label` を再送しない（既存 AC 2.1.3 と整合）。
+2. When head ブランチ名導出により新規に `staged-for-release` を付与した, the Promote Pipeline
+   shall `issue=#${issue_number} action=label-add label=staged-for-release source=auto` 形式の
+   ログを 1 行残す（既存 AC 2.1.1 / 2.1.2 と整合し、`source` 区別は行わない）。
+3. The Promote Pipeline shall fork PR 除外条件（`headRepositoryOwner.login == "$repo_owner"`）を
+   head ブランチ名経路でも適用し、fork PR の head ブランチ名から導出された Issue 番号を対象
+   集合に加えない（既存 NFR 2.4 と整合）。
+4. The Promote Pipeline shall 自動付与した `staged-for-release` と人間が手付与した
+   `staged-for-release`（#100 系統）を同一ラベルで共有し、`source` 区別を行わない既存ポリシー
+   を維持する。
+5. While 自動付与に失敗した（`gh issue edit` がタイムアウト or non-zero）, the Promote Pipeline
+   shall WARN ログを 1 行残し、後続 Issue の処理を継続する（既存挙動を維持する）。
+
+### Requirement 3: 後方互換と既定挙動の温存
+
+**Objective:** As an idd-claude 運用者, I want `BASE_BRANCH=main` 既存運用および
+`PROMOTE_PIPELINE_ENABLED` 未設定 / `false` 環境で本修正による外部観測差異が一切発生しない
+ことを期待する, so that 既存 consumer repo のラベル遷移・依存解決・cron 実行コスト・log 出力
+形式が無告知で変わらない。
+
+#### Acceptance Criteria
+
+1. While `PROMOTE_PIPELINE_ENABLED` が `=true` 以外（既定 `false` を含む）, the Promote Pipeline
+   shall `pp_collect_merged_issues` を起動させず、本修正による追加コードパスにも到達しない
+   （既存 opt-in gate の挙動を維持する）。
+2. While `BASE_BRANCH` がリポジトリの default ブランチ（典型的に `main`）で運用されている,
+   the Promote Pipeline shall 本修正前後で `staged-for-release` 付与対象 Issue 集合・付与順序・
+   per-Issue ログ・skip ログを観測上一致させる（`closingIssuesReferences` が常に充足する状況
+   下では head 導出経路が和集合の追加要素を生まないことを担保する）。
+3. The Promote Pipeline shall 既存の env var 名（`PROMOTE_PIPELINE_ENABLED` / `BASE_BRANCH` /
+   `LABEL_STAGED_FOR_RELEASE` / `PROMOTE_GIT_TIMEOUT` 等）・ラベル名・exit code 意味・cron
+   登録文字列・ログ出力先を本修正で変更しない。
+4. The Promote Pipeline shall 1 サイクルで処理する merged PR 取得件数の上限（現状 `--limit 50`）
+   と `staged-for-release` 付き open Issue の取得件数上限（現状 `--limit 100`）を本修正で変更
+   しない。
+5. The Promote Pipeline shall head ブランチ名導出経路を `pp_collect_merged_issues` の既存
+   `gh pr list` 呼び出しで取得済みの PR 集合に対して追加 in-process 処理として実装する想定
+   であり、`pp_collect_merged_issues` 内の gh API 呼び出し回数を本修正で増やさない（追加の
+   gh API call を発火させない）。
+
+### Requirement 4: スコープ外要素の不可侵
+
+**Objective:** As an idd-claude メンテナ, I want 本修正が `pp_collect_merged_issues` の Issue 番号
+導出ロジックに局所化され、後段の ST 判定・promote 実行・revert 系の挙動に副作用を与えないこと
+を期待する, so that 修正範囲が局所化され、レビューと回帰テストが Phase B 全体に波及しない。
+
+#### Acceptance Criteria
+
+1. The Promote Pipeline shall `ST_CHECK_RUN_NAME` 未設定時の `skip-warn` 挙動（既存 AC 2.2.3）・
+   `pp_resolve_merge_sha` の `closedByPullRequestsReferences` 経由 merge SHA 解決ロジック・
+   `pp_get_st_state` の状態 5 種分類（`success` / `failure` / `pending` / `missing` / `skip-warn`）
+   を本修正で変更しない。
+2. The Promote Pipeline shall develop→main の promote トリガ（`ST_CHECK_RUN_NAME` / `pp_handle_st_success`
+   経由の `staged-for-release` 除去動線）を本修正で変更せず、ST 連動部分は別レイヤとして扱う。
+3. The Promote Pipeline shall `pp_collect_merged_issues` 以外の関数（`po_*` / `pp_get_st_state` /
+   `pp_handle_st_success` / `pp_handle_st_failure` / `pp_resolve_merge_sha` / `pp_resolve_st_log_url`
+   等）のシグネチャ・stdout 形式・戻り値規約を本修正で変更しない。
+4. The Promote Pipeline shall `staged-for-release` 付き open Issue を後段に渡す `stdout` 形式
+   （1 行 1 件の Issue 番号列）を本修正で変更しない。
+
+### Requirement 5: 回帰防止テスト
+
+**Objective:** As an idd-claude メンテナ, I want `pp_collect_merged_issues` の head ブランチ名
+経由導出ロジックを `extract_function` イディオムで隔離抽出した近接テストでカバーしたい,
+so that 次回以降の編集で head パターン正規表現・和集合ロジック・fork PR 除外条件が破壊された
+場合に PR 段階で検出できる。
+
+#### Acceptance Criteria
+
+1. The Test Suite shall `pp_collect_merged_issues`（または抽出可能なら head 導出ヘルパ）を
+   `extract_function` で隔離抽出し、`gh` コマンドを stub して以下 4 ケースを観測する近接
+   テストを `local-watcher/test/` 配下に追加する:
+   `closingIssuesReferences` 単独で導出できるケース /
+   head ブランチ名単独で導出できるケース（`closingIssuesReferences=[]`） /
+   両方から同一 `#N` が導出され和集合で重複排除されるケース /
+   head ブランチ名が `claude/issue-<N>-impl-` パターンに一致しないため除外されるケース。
+2. The Test Suite shall fork PR（`headRepositoryOwner.login != "$repo_owner"`）が head ブランチ名
+   `claude/issue-<N>-impl-<slug>` を持つ場合でも対象集合に加わらないことを観測する近接テスト
+   ケースを含める。
+3. The Test Suite shall 上記近接テストを既存テストランナ（`local-watcher/test/` 配下の bash
+   テストイディオム）から起動可能な単一スクリプトとして提供する。
+4. If `BASE_BRANCH=develop` 想定の入力（`closingIssuesReferences=[]` かつ head=`claude/issue-1-impl-x`）
+   に対して `#1` が対象集合に含まれない結果を観測した, the Test Suite shall 該当テストを fail
+   させ、当該 PR 番号・head ブランチ名・期待される Issue 番号を出力する。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Promote Pipeline shall 本修正前後で `BASE_BRANCH=main` 環境の外部観測挙動（付与対象
+   Issue 集合・ラベル付与順序・per-Issue ログ・WARN ログ・stdout 行集合）を一致させる。
+2. The Promote Pipeline shall 本修正前後で `PROMOTE_PIPELINE_ENABLED` 未設定 / `false` 環境の
+   外部観測挙動（API 呼び出しゼロ・log 出力ゼロ・ラベル遷移ゼロ）を一致させる。
+3. The Promote Pipeline shall 既存ラベル名 `staged-for-release` を本修正で改名・別名追加せず、
+   `LABEL_STAGED_FOR_RELEASE` 定数経由の参照を破壊しない。
+
+### NFR 2: 静的検査
+
+1. The Promote Pipeline shall 本修正後の `local-watcher/bin/modules/promote-pipeline.sh` が
+   `bash -n` で構文エラー 0、`shellcheck` で `.shellcheckrc` を踏まえた baseline 上の警告増加
+   0 を満たす。
+2. The Test Suite shall 追加した近接テストの bash スクリプトが `bash -n` / `shellcheck` クリーン
+   であることを満たす。
+
+### NFR 3: 可観測性
+
+1. When head ブランチ名経由で `staged-for-release` を新規付与した, the Promote Pipeline shall
+   既存 `pp_log` フォーマット（`issue=#${issue_number} action=label-add label=staged-for-release
+   source=auto`）と同一形式で 1 行出力し、`closingIssuesReferences` 経由付与のログと区別しない。
+2. When `pp_collect_merged_issues` が完了した, the Promote Pipeline shall 既存サマリログ
+   （`auto-label サマリ: staged-for-release-added=<N>, already-labeled-skipped=<M>`）の形式・
+   フィールド名を変更せず、`added` / `skipped` の集計に head 経路の付与結果を合算する。
+3. While head ブランチ名から導出した Issue 番号に対する `gh issue edit` が失敗した,
+   the Promote Pipeline shall 既存 WARN フォーマット（`issue=#${issue_number} staged-for-release
+   自動付与に失敗（後続 Issue は継続）`）と同一形で 1 行残す。
+
+### NFR 4: 未信頼入力の取り扱い
+
+1. The Promote Pipeline shall PR の head ブランチ名（GitHub API から取得する未信頼文字列）を
+   `jq` に渡す際は `--arg` で受け渡し、`grep` / `sed` / `bash -c` に渡す際は `--` でオプション
+   解釈を打ち切る・クォートする等して、`-` 始まりの branch 名や正規表現メタ文字によるフラグ
+   注入・コマンド注入を防ぐ（CLAUDE.md「未信頼 GitHub 入力の取り扱い」と整合）。
+2. The Promote Pipeline shall head ブランチ名から抽出した数値 ID を Issue 番号として使用する
+   前に `^[0-9]+$` で検証し、検証に失敗した値を `gh issue edit` の引数や URL に展開しない。
+
+## Out of Scope
+
+- develop→main の promote トリガ（`ST_CHECK_RUN_NAME` / `pp_handle_st_success` 系統）の設計
+  変更（Issue 本文「スコープ外」と整合）。
+- `closingIssuesReferences` を GitHub 側で非 default base PR に対して生成させるためのリポジトリ
+  設定変更（GitHub 側仕様であり idd-claude のスコープ外）。
+- `staged-for-release` ラベルの人間付与運用（#100）と自動付与の区別を新規に導入すること
+  （現行どおり同一ラベルで共有する）。
+- `AUTO_MERGE_HEAD_PATTERN` 既定値の変更（本要件は同パターンの正規表現セマンティクスと整合
+  させるのみであり、env var の既定値・命名・正規化規則は触らない）。
+- 設計 PR（`claude/issue-<N>-design-*`）や非 `impl-` 系 head ブランチを `staged-for-release`
+  の対象に含めること（impl PR のみ対象という既存スコープを維持する）。
+- 他 processor（`pr-reviewer` / `auto-merge` / `merge-queue` / `auto-rebase` / `pr-iteration` /
+  `security-review` / `stage-a-verify` 等）の挙動変更。
+- `pp_collect_merged_issues` 以外の Phase B 関数（ST 判定・revert・promote 実行）のロジック
+  変更。
+- README の挙動説明文の大幅な再構成（必要な差分更新は別途 PR 内で行うが、本要件は外形契約に
+  限定する）。
+
+## Open Questions
+
+- なし（Issue #389 本文の AC / スコープ外 / 仮案・判断を委ねたい点・実装影響範囲のヒント
+  （`modules/promote-pipeline.sh:1094` `pp_collect_merged_issues` L1097-1116 / `AUTO_MERGE_HEAD_PATTERN`
+  `^claude/issue-[0-9]+-impl-`）が出揃っており、head ブランチ名からの Issue 番号導出を
+  `closingIssuesReferences` と併用する方針が Issue 本文の「期待する挙動」「仮案」で明示
+  済みのため、人間判断が必要な未解決項目は識別されなかった。実装上の選択肢（jq 内部処理 vs
+  bash 内ループ処理）は設計レイヤの裁量であり requirements では規定しない）

--- a/docs/specs/389-fix-promote-pipeline-staged-for-release/review-notes.md
+++ b/docs/specs/389-fix-promote-pipeline-staged-for-release/review-notes.md
@@ -1,0 +1,61 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-389-impl-fix-promote-pipeline-staged-for-release
+- HEAD commit: 713c0a3b35f471f115520019f8a1b68378512ced
+- Compared to: main..HEAD
+
+## Verified Requirements
+
+- 1.1 — `pp_extract_linked_issues` 内 jq `capture("^claude/issue-(?<n>[0-9]+)-impl-")` で head ブランチ名からの `<N>` 抽出を実装（`promote-pipeline.sh:1083-1121`）。テスト Case 2/8/9 が観測
+- 1.2 — jq `((closingIssuesReferences[].number) + (headRefName capture)) | unique` で和集合 + 重複排除（同関数内）。テスト Case 3/6 が観測
+- 1.3 — head パターン不一致時は `capture // empty` で素通り。テスト Case 4（`feature/manual-fix` / `claude/issue-50-design-spec` 除外）が観測
+- 1.4 — `closingIssuesReferences=[]` でも head 経路で `<N>` を収集。テスト Case 2/9（develop 想定）が観測
+- 1.5 — `[[ "$issue_number" =~ ^[0-9]+$ ]]` の bash 防御層を `pp_collect_merged_issues:1165-1170` に追加。jq の `capture` でも数値 ID は保証。テスト Case 8 が観測
+- 2.1 — `pp_issue_has_label` による既付与スキップ（既存ロジック未変更、`promote-pipeline.sh:1175`）
+- 2.2 — `pp_log` フォーマット文字列（`source=auto`）を変更せず（diff 確認）
+- 2.3 — fork PR 除外 `select((.headRepositoryOwner.login // "") == $owner)` を head 経路にも適用。テスト Case 5 が観測
+- 2.4 — `staged-for-release` ラベル名・`source=auto` ログを単一化（diff で改変なし）
+- 2.5 — WARN ログ `pp_warn` は既存挙動を維持（後段 while ループ未変更）
+- 3.1 — `pp_collect_merged_issues` 呼び出し条件（`PROMOTE_PIPELINE_ENABLED`）は本 PR で変更されていない
+- 3.2 — Case 1（closing 単独 #42）/ Case 3（両経路同一 #99）で main 既存挙動の不変を観測
+- 3.3 — `LABEL_STAGED_FOR_RELEASE` / `PROMOTE_GIT_TIMEOUT` / `BASE_BRANCH` 参照のみで改名・追加なし（diff 確認）
+- 3.4 — `--limit 50` / `--limit 100` は未変更（diff 確認）
+- 3.5 — `gh pr list` 呼び出しは 1 回のまま、`--json` フィールドに `headRefName` を追加するのみ
+- 4.1 — `pp_get_st_state` / `pp_resolve_merge_sha` / `ST_CHECK_RUN_NAME` 経路は未変更（diff は `pp_extract_linked_issues` 追加 + `pp_collect_merged_issues` のみ）
+- 4.2 — `pp_handle_st_success` / `pp_handle_st_failure` の promote 動線は未変更
+- 4.3 — `po_*` / `pp_get_st_state` / `pp_resolve_merge_sha` / `pp_resolve_st_log_url` の関数シグネチャ・stdout 形式は未変更
+- 4.4 — `staged-for-release` 付き open Issue を後段に渡す stdout 形式は未変更（後段ループは保持）
+- 5.1 — `local-watcher/test/pp_extract_linked_issues_test.sh` Case 1-4 で 4 ケースを観測
+- 5.2 — テスト Case 5 で fork PR 除外を観測
+- 5.3 — `bash local-watcher/test/pp_extract_linked_issues_test.sh` 単一スクリプトで起動可能（PASS=10 FAIL=0 を再実行確認）
+- 5.4 — Case 9 で develop 想定入力に対する fail 出力（PR 番号 / head ブランチ名 / 期待 Issue 番号）を実装
+- NFR 1.1 — Case 1/3 が main 既存運用の不変を観測、diff にラベル名・順序・ログ形式の改変なし
+- NFR 1.2 — opt-in gate は本 PR で改変なし
+- NFR 1.3 — `LABEL_STAGED_FOR_RELEASE` 定数参照を破壊せず
+- NFR 2.1 — `bash -n` OK / `shellcheck local-watcher/bin/modules/promote-pipeline.sh` warnings 0 を再実行確認
+- NFR 2.2 — 追加テストの `bash -n` OK / `shellcheck` warnings 0 を再実行確認
+- NFR 3.1 — `pp_log` フォーマット文字列を改変せず（diff 確認、head 経路導出ログも同形式）
+- NFR 3.2 — サマリログ書式と `added` / `skipped` 集計の合算（後段共通ループ通過）を保持
+- NFR 3.3 — `pp_warn` フォーマットを改変せず（後段共通 while ループ通過）
+- NFR 4.1 — `headRefName` は jq 内 `capture` で完結し、bash 展開を経由させない設計
+- NFR 4.2 — bash 側 `[[ =~ ^[0-9]+$ ]]` + jq `capture` の二重検証
+
+## Findings
+
+なし
+
+## Summary
+
+`pp_collect_merged_issues` の Issue 番号導出を `closingIssuesReferences` 単独から
+`pp_extract_linked_issues` ヘルパー経由の「closingIssuesReferences + head ブランチ名
+`^claude/issue-([0-9]+)-impl-` capture」の和集合へ拡張する変更は、Requirements 1〜5 と
+NFR 1〜4 をすべて充足。境界も `pp_collect_merged_issues` 周辺と新規 helper／近接テストに
+局所化されており、`pp_get_st_state` / `pp_resolve_merge_sha` / promote 動線等のスコープ外
+要素には触れていない。`bash -n` / `shellcheck` / 近接テスト（PASS=10 FAIL=0）を再実行
+して green を確認した。
+
+RESULT: approve

--- a/local-watcher/bin/modules/promote-pipeline.sh
+++ b/local-watcher/bin/modules/promote-pipeline.sh
@@ -1083,37 +1083,79 @@ pp_issue_has_label() {
     '.labels // [] | map(.name) | index($l)' >/dev/null 2>&1
 }
 
+# pp_extract_linked_issues: `gh pr list --json number,headRefName,headRepositoryOwner,
+# closingIssuesReferences` の JSON 出力を受け取り、`staged-for-release` 自動付与対象
+# Issue 番号集合を抽出する純関数ヘルパー（#389）。
+#
+# 抽出ロジック:
+#   - fork PR を除外（headRepositoryOwner.login != $owner の PR は対象外 / NFR 2.4）
+#   - 各 PR について以下 2 経路で Issue 番号を導出し、和集合で重複排除する:
+#     1. closingIssuesReferences[].number（GitHub 自動リンク。base=default branch のみ生成）
+#     2. headRefName が `^claude/issue-([0-9]+)-impl-` に一致した場合のキャプチャ値
+#        （#389: base=default branch でない gitflow 運用での補完経路）
+#   - 抽出した数値 ID は jq の `capture` で `^[0-9]+$` を満たしているが、bash 側でも
+#     使用直前に再検証する（NFR 4.2 / 防御層）
+#
+# 入力（$1）: gh pr list の JSON 文字列（配列）
+# 入力（$2）: repo_owner（fork 判定用、headRepositoryOwner.login と完全一致比較）
+# 出力（stdout）: 抽出された Issue 番号を 1 行 1 件、numeric 昇順で unique 出力
+# 戻り値: 常に 0（jq エラーは空出力として扱う）
+#
+# Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.3, NFR 4.1, NFR 4.2
+pp_extract_linked_issues() {
+  local prs_json="$1"
+  local repo_owner="$2"
+  # jq 内で fork 除外 + 2 経路の和集合 + unique を一括処理する。head 経路は
+  # `capture` で `^claude/issue-(?<n>[0-9]+)-impl-` に一致するもののみ採用し、不一致
+  # （人間 PR / 設計 PR / 他フォーマット）は素通り（Req 1.3）。`headRefName` は未信頼
+  # 文字列なので `--arg owner` 同様に jq 内で扱い、bash 展開を経由させない（NFR 4.1）。
+  echo "$prs_json" | jq -r \
+    --arg owner "$repo_owner" \
+    '[.[]
+      | select((.headRepositoryOwner.login // "") == $owner)
+      | (
+          ((.closingIssuesReferences // []) | map(.number))
+          +
+          ((.headRefName // "")
+            | [capture("^claude/issue-(?<n>[0-9]+)-impl-") // empty | .n | tonumber])
+        )
+      | .[]
+    ] | unique | .[]' 2>/dev/null
+}
+
 # pp_collect_merged_issues: Phase A 直後の状態で「`BASE_BRANCH` に merge 済みかつ
 # `Closes #N` でリンクされている Issue」を抽出し、未付与の Issue には
 # `staged-for-release` を自動付与する。fork PR は除外する（NFR 2.4）。
 # 自動付与と人間付与の source 区別は行わない（Req 2.1.2、同一ラベル共有）。
 #
+# #389: `closingIssuesReferences` は GitHub 側で「PR の base がリポジトリの default
+# branch」のときだけ自動生成されるため、gitflow 運用（`BASE_BRANCH=develop` 等）では
+# 空になる。head ブランチ名 `^claude/issue-([0-9]+)-impl-` からの導出経路を併用して
+# base ブランチが default かどうかに依存しない収集を行う（pp_extract_linked_issues 参照）。
+#
 # stdout: 現時点で `staged-for-release` を持つ全 open Issue の番号を 1 行 1 件で出力
 #         （次のステップで ST 判定する対象集合になる）
-# Requirements: 2.1, NFR 2.4, NFR 5.2
+# Requirements: 2.1, NFR 2.4, NFR 5.2, #389 Req 1.1-1.5
 pp_collect_merged_issues() {
   local repo_owner="${REPO%%/*}"
   local recent_merged_prs_json
   # 1. is:merged base:$BASE_BRANCH の直近 PR を取得（最新 50 件、Req 5.2 範囲）
+  #    #389: headRefName を取得フィールドに追加（head ブランチ名経路の導出ソース）。
+  #    gh API 呼び出し回数は変えない（Req 3.5）。
   if ! recent_merged_prs_json=$(timeout "$PROMOTE_GIT_TIMEOUT" gh pr list \
       --repo "$REPO" \
       --state merged \
       --base "$BASE_BRANCH" \
-      --json number,headRepositoryOwner,closingIssuesReferences \
+      --json number,headRefName,headRepositoryOwner,closingIssuesReferences \
       --limit 50 2>/dev/null); then
     pp_warn "merged PR の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     return 0
   fi
 
-  # 2. fork PR を除外（NFR 2.4）し、closingIssuesReferences から Issue 番号を抽出
+  # 2. fork PR を除外（NFR 2.4）し、closingIssuesReferences と headRefName 両経路から
+  #    Issue 番号を抽出（#389 Req 1.1, 1.2, 1.4 / 和集合 + 重複排除）
   local linked_issues
-  linked_issues=$(echo "$recent_merged_prs_json" | jq -r \
-    --arg owner "$repo_owner" \
-    '[.[]
-      | select((.headRepositoryOwner.login // "") == $owner)
-      | (.closingIssuesReferences // [])[]
-      | .number
-    ] | unique | .[]')
+  linked_issues=$(pp_extract_linked_issues "$recent_merged_prs_json" "$repo_owner")
 
   # 3. 各 Issue について `staged-for-release` ラベルの有無を確認し、
   #    未付与なら自動付与する（重複付与は抑止 / Req 2.1.1, 2.1.3）
@@ -1122,6 +1164,13 @@ pp_collect_merged_issues() {
   if [ -n "$linked_issues" ]; then
     while IFS= read -r issue_number; do
       [ -n "$issue_number" ] || continue
+      # #389 Req 1.5 / NFR 4.2: 数値 ID を使用直前に再検証する。jq の capture で
+      # `^[0-9]+$` 一致は保証されているが、closingIssuesReferences 側の異常値も含めて
+      # 防御層として bash 側でも `^[0-9]+$` を確認し、不正値は `gh issue edit` 引数や
+      # URL に展開しない。
+      if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+        continue
+      fi
       if pp_issue_has_label "$issue_number" "$LABEL_STAGED_FOR_RELEASE"; then
         # AC 2.1.3: 既付与なら API 再送しない
         skipped=$((skipped + 1))

--- a/local-watcher/test/pp_extract_linked_issues_test.sh
+++ b/local-watcher/test/pp_extract_linked_issues_test.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #389 で追加した `pp_extract_linked_issues`（modules/promote-pipeline.sh）が
+#       merged PR の `closingIssuesReferences` と `headRefName` の両経路から Issue 番号を
+#       和集合 + 重複排除で抽出する純関数として正しく動作することを検証する近接テスト。
+#
+#       対象関数:
+#         - pp_extract_linked_issues (#389 head ブランチ名導出 + closingIssuesReferences 併用)
+#
+#       検証する AC (docs/specs/389-fix-promote-pipeline-staged-for-release/requirements.md):
+#         - Req 1.1: head ブランチ名 `^claude/issue-([0-9]+)-impl-` から Issue 番号導出
+#         - Req 1.2: closingIssuesReferences と head 経路の和集合・重複排除
+#         - Req 1.3: head パターン不一致 PR は head 経路導出しない
+#         - Req 1.4: BASE_BRANCH != default のとき closingIssuesReferences=[] でも head 経路で導出
+#         - Req 1.5 / NFR 4.2: 数値 ID `^[0-9]+$` の検証（jq capture で保証）
+#         - Req 2.3 / NFR 4.1: fork PR 除外を head 経路にも適用
+#         - Req 5.1 / 5.2: 4 ケース + fork PR ケースの観測
+#
+# 配置先: local-watcher/test/pp_extract_linked_issues_test.sh
+# 依存:   bash 4+, awk, jq
+# 実行:   bash local-watcher/test/pp_extract_linked_issues_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PP_MOD="$SCRIPT_DIR/../bin/modules/promote-pipeline.sh"
+
+if [ ! -f "$PP_MOD" ]; then
+  echo "ERROR: cannot find promote-pipeline.sh at $PP_MOD" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for this test" >&2
+  exit 2
+fi
+
+# extract_function イディオム（既存テスト sn_callsite_promote_test.sh と同形式）
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# pp_extract_linked_issues のみを抽出（純関数なので依存関数 stub は不要）
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PP_MOD" "pp_extract_linked_issues")"
+
+if ! declare -F pp_extract_linked_issues >/dev/null; then
+  echo "ERROR: pp_extract_linked_issues not loaded" >&2
+  exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+REPO_OWNER="owner"
+
+# ============================================================
+# Case 1: closingIssuesReferences 単独で導出（既存挙動・base=main 想定）
+# ============================================================
+echo "--- Case 1: closingIssuesReferences 単独（既存挙動の維持 / Req 3.2） ---"
+
+INPUT_C1=$(cat <<'JSON'
+[
+  {
+    "number": 100,
+    "headRefName": "claude/issue-42-impl-foo",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": [ { "number": 42 } ]
+  }
+]
+JSON
+)
+
+ACTUAL_C1=$(pp_extract_linked_issues "$INPUT_C1" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+assert_eq "Case 1: closingIssuesReferences の #42 を抽出" "42" "$ACTUAL_C1"
+
+# ============================================================
+# Case 2: head ブランチ名単独で導出（BASE_BRANCH=develop 想定 / Req 1.4）
+# ============================================================
+echo ""
+echo "--- Case 2: head ブランチ名単独（closingIssuesReferences=[] / Req 1.1, 1.4） ---"
+
+INPUT_C2=$(cat <<'JSON'
+[
+  {
+    "number": 200,
+    "headRefName": "claude/issue-7-impl-bar",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  }
+]
+JSON
+)
+
+ACTUAL_C2=$(pp_extract_linked_issues "$INPUT_C2" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+assert_eq "Case 2: head ブランチ名からの #7 を抽出（base=develop 想定）" "7" "$ACTUAL_C2"
+
+# ============================================================
+# Case 3: 両方から同一 #N → 和集合 + 重複排除（Req 1.2）
+# ============================================================
+echo ""
+echo "--- Case 3: 両経路から同一 #N → 和集合で重複排除（Req 1.2） ---"
+
+INPUT_C3=$(cat <<'JSON'
+[
+  {
+    "number": 300,
+    "headRefName": "claude/issue-99-impl-baz",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": [ { "number": 99 } ]
+  }
+]
+JSON
+)
+
+ACTUAL_C3=$(pp_extract_linked_issues "$INPUT_C3" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+assert_eq "Case 3: 両経路で同じ #99 → unique で 1 件のみ" "99" "$ACTUAL_C3"
+
+# ============================================================
+# Case 4: head パターン不一致 → head 経路は導出されない（Req 1.3）
+# ============================================================
+echo ""
+echo "--- Case 4: head パターン不一致 PR の head 経路除外（Req 1.3） ---"
+
+INPUT_C4=$(cat <<'JSON'
+[
+  {
+    "number": 400,
+    "headRefName": "feature/manual-fix",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  },
+  {
+    "number": 401,
+    "headRefName": "claude/issue-50-design-spec",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  },
+  {
+    "number": 402,
+    "headRefName": "claude/issue-51-impl-good",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  }
+]
+JSON
+)
+
+ACTUAL_C4=$(pp_extract_linked_issues "$INPUT_C4" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+# feature/manual-fix と claude/issue-50-design-spec は除外され、#51 のみ
+assert_eq "Case 4: 不一致 PR を除外、#51 のみ抽出" "51" "$ACTUAL_C4"
+
+# ============================================================
+# Case 5: fork PR は head ブランチ名が `claude/issue-<N>-impl-` でも除外（Req 2.3）
+# ============================================================
+echo ""
+echo "--- Case 5: fork PR の head 経路除外（Req 2.3 / NFR 4.1） ---"
+
+INPUT_C5=$(cat <<'JSON'
+[
+  {
+    "number": 500,
+    "headRefName": "claude/issue-77-impl-fork",
+    "headRepositoryOwner": { "login": "external-fork-user" },
+    "closingIssuesReferences": [ { "number": 77 } ]
+  },
+  {
+    "number": 501,
+    "headRefName": "claude/issue-88-impl-internal",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  }
+]
+JSON
+)
+
+ACTUAL_C5=$(pp_extract_linked_issues "$INPUT_C5" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+# fork PR (#500) の #77 は head 経路でも closingIssuesReferences 経路でも除外、#88 のみ
+assert_eq "Case 5: fork PR を除外、内部 PR の #88 のみ抽出" "88" "$ACTUAL_C5"
+
+# ============================================================
+# Case 6: 複数 PR の混合 → 全 Issue 番号を unique + 昇順で抽出（Req 1.2 包括）
+# ============================================================
+echo ""
+echo "--- Case 6: 複数 PR 混合 → 全 Issue 番号を unique 昇順抽出 ---"
+
+INPUT_C6=$(cat <<'JSON'
+[
+  {
+    "number": 600,
+    "headRefName": "claude/issue-10-impl-a",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": [ { "number": 10 } ]
+  },
+  {
+    "number": 601,
+    "headRefName": "claude/issue-20-impl-b",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  },
+  {
+    "number": 602,
+    "headRefName": "feature/random",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": [ { "number": 30 } ]
+  },
+  {
+    "number": 603,
+    "headRefName": "claude/issue-10-impl-dup",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  }
+]
+JSON
+)
+
+ACTUAL_C6=$(pp_extract_linked_issues "$INPUT_C6" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+# #10 (closing + head + 重複 head), #20 (head), #30 (closing on non-claude head) → 10 20 30
+assert_eq "Case 6: 和集合 + unique で 10/20/30 を昇順抽出" "10 20 30" "$ACTUAL_C6"
+
+# ============================================================
+# Case 7: 空入力 / null フィールド耐性
+# ============================================================
+echo ""
+echo "--- Case 7: 空配列入力で空出力 / null 耐性 ---"
+
+ACTUAL_C7A=$(pp_extract_linked_issues "[]" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+assert_eq "Case 7a: 空配列入力で空出力" "" "$ACTUAL_C7A"
+
+# headRefName が欠落、closingIssuesReferences が欠落しても落ちない
+INPUT_C7B=$(cat <<'JSON'
+[
+  {
+    "number": 700,
+    "headRepositoryOwner": { "login": "owner" }
+  }
+]
+JSON
+)
+ACTUAL_C7B=$(pp_extract_linked_issues "$INPUT_C7B" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+assert_eq "Case 7b: フィールド欠落 PR は空出力（クラッシュしない）" "" "$ACTUAL_C7B"
+
+# ============================================================
+# Case 8: head ブランチ名のサフィックス境界 / 数値 ID 検証
+# ============================================================
+echo ""
+echo "--- Case 8: head パターン境界（hyphen 必須・数値 ID のみ） ---"
+
+INPUT_C8=$(cat <<'JSON'
+[
+  {
+    "number": 800,
+    "headRefName": "claude/issue-1-impl-x",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  },
+  {
+    "number": 801,
+    "headRefName": "claude/issue-abc-impl-x",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  },
+  {
+    "number": 802,
+    "headRefName": "claude/issue-2-implfoo",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  }
+]
+JSON
+)
+
+ACTUAL_C8=$(pp_extract_linked_issues "$INPUT_C8" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+# #800 は `claude/issue-1-impl-x` → #1, #801 は `abc` で不一致, #802 は `-impl-`（hyphen 必須）に
+# 一致しないので不一致 → 結果 #1 のみ
+assert_eq "Case 8: 数値 ID のみ採用、hyphen 必須で #1 のみ抽出" "1" "$ACTUAL_C8"
+
+# ============================================================
+# Case 9: BASE_BRANCH=develop の代表シナリオ（Req 5.4 fail-condition 観測）
+# ============================================================
+echo ""
+echo "--- Case 9: BASE_BRANCH=develop / closingIssuesReferences=[] / head=claude/issue-1-impl-x ---"
+
+INPUT_C9=$(cat <<'JSON'
+[
+  {
+    "number": 900,
+    "headRefName": "claude/issue-1-impl-x",
+    "headRepositoryOwner": { "login": "owner" },
+    "closingIssuesReferences": []
+  }
+]
+JSON
+)
+
+ACTUAL_C9=$(pp_extract_linked_issues "$INPUT_C9" "$REPO_OWNER" | tr '\n' ' ' | sed 's/ $//')
+if [ "$ACTUAL_C9" = "1" ]; then
+  echo "PASS: Case 9: develop 運用 #1 が staged-for-release 対象集合に含まれる"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: Case 9 (#389 Req 5.4): develop 運用で #1 が抽出されない"
+  echo "  PR number       : 900"
+  echo "  headRefName     : claude/issue-1-impl-x"
+  echo "  expected Issue  : 1"
+  echo "  actual          : $(printf '%q' "$ACTUAL_C9")"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=================================================="
+echo "RESULT: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "=================================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Phase B Promote Pipeline の `pp_collect_merged_issues` が Issue 番号の導出に
`closingIssuesReferences` のみを使用しているため、`BASE_BRANCH=develop` 等の
gitflow 運用では GitHub が closing-issue リンクを生成せず `staged-for-release` が
自動付与されない問題を修正する。

`closingIssuesReferences` と head ブランチ名 `^claude/issue-([0-9]+)-impl-` からの
capture を **和集合** で扱う純関数ヘルパー `pp_extract_linked_issues` を新設し、
`pp_collect_merged_issues` の Issue 番号導出をこのヘルパー経由に切り替えた。
`BASE_BRANCH=main` 既存運用・fork PR 除外・opt-in gate 等の既存契約は一切変更しない。

## 対応 Issue

Closes #389

## 関連 PR

なし（設計 PR なし: design-less impl）

## 実装内容

- (Req 1.1 / Req 1.4) `pp_extract_linked_issues` を追加 — head ブランチ名 jq `capture` で
  `BASE_BRANCH=develop` 運用（`closingIssuesReferences=[]`）でも `<N>` を抽出
- (Req 1.2) jq 内で `closingIssuesReferences` 番号と head 導出番号を `+ unique` で和集合化・重複排除
- (Req 1.3) head パターン不一致（`feature/*`、`claude/issue-N-design-*` 等）は `capture // empty` で素通り
- (Req 1.5 / NFR 4.2) jq `capture` の数値保証に加え bash 側 `[[ =~ ^[0-9]+$ ]]` の二重防御
- (Req 2.3 / NFR 4.1) fork PR 除外を head 経路にも適用。headRefName は jq 内 `capture` で完結
- (Req 3.5) `gh pr list` の `--json` フィールドに `headRefName` を追加するのみ（gh API 呼び出し回数は変えない）
- (Req 5) `local-watcher/test/pp_extract_linked_issues_test.sh` を新規追加（10 ケース）

## 受入基準チェック

- [x] Req 1.1: head パターン導出 ← Case 2/4/6/8/9（`pp_extract_linked_issues_test.sh`）
- [x] Req 1.2: 和集合 + 重複排除 ← Case 3/6
- [x] Req 1.3: パターン不一致時の除外 ← Case 4（`feature/manual-fix`、`claude/issue-50-design-spec`）
- [x] Req 1.4: `BASE_BRANCH=develop` 補完 ← Case 2/9（`closingIssuesReferences=[]`）
- [x] Req 1.5: `^[0-9]+$` 検証 ← Case 8（`abc`/`implfoo` 除外）
- [x] Req 2.1–2.5: 既存付与契約維持 ← 後段 `pp_collect_merged_issues` ループ未変更
- [x] Req 2.3: fork PR 除外 ← Case 5（fork owner の impl ブランチを除外）
- [x] Req 3.1–3.5: 後方互換 ← diff 確認、Case 1/3 で main 既存運用の不変を観測
- [x] Req 4.1–4.4: スコープ外不可侵 ← `pp_get_st_state`/`pp_resolve_merge_sha`/`pp_handle_st_*`/`po_*` 未変更
- [x] Req 5.1–5.4: 近接テスト ← `bash local-watcher/test/pp_extract_linked_issues_test.sh` PASS=10 FAIL=0
- [x] NFR 2.1–2.2: `bash -n` OK / `shellcheck` warnings 0

## テスト結果

```
# 近接テスト（新規）
$ bash local-watcher/test/pp_extract_linked_issues_test.sh
... (Case 1–10 すべて OK)
PASS=10 FAIL=0

# 静的解析
$ bash -n local-watcher/bin/modules/promote-pipeline.sh   → OK
$ shellcheck local-watcher/bin/modules/promote-pipeline.sh local-watcher/bin/issue-watcher.sh
  → warnings 0
$ shellcheck local-watcher/test/pp_extract_linked_issues_test.sh
  → warnings 0

# 回帰テスト
$ bash local-watcher/test/sn_callsite_promote_test.sh     → PASS=15 FAIL=0
$ bash local-watcher/test/po_apply_awaiting_slot_test.sh  → PASS=19 FAIL=0
$ bash local-watcher/test/po_sticky_comment_helpers_test.sh → PASS=10 FAIL=0
```

## 実装上の判断

- **jq 1 pass 内処理**: head 経路導出を jq 内 `capture` + 和集合 + `unique` で完結させ、
  `headRefName` を bash に展開させない（NFR 4.1 フラグ注入防止 / Req 3.5 gh API 呼び出し回数不変）
- **helper 切り出し**: `pp_extract_linked_issues` を純関数として分離したことで `gh` stub
  不要の近接テストを簡潔に書ける（Req 5 の `extract_function` イディオム要求に合致）
- **`AUTO_MERGE_HEAD_PATTERN` との関係**: 専用パターン `^claude/issue-([0-9]+)-impl-` を
  helper 内に literal で持つ設計（requirements が「env var 既定値変更はスコープ外」と明示済み）

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため `Closes` を採用
- Reviewer approve 済み（RESULT: approve）。詳細は
  `docs/specs/389-fix-promote-pipeline-staged-for-release/review-notes.md` を参照
- 特に注意して見てほしいファイル:
  - `local-watcher/bin/modules/promote-pipeline.sh`（`pp_extract_linked_issues` 追加 + `pp_collect_merged_issues` 修正箇所）
  - `local-watcher/test/pp_extract_linked_issues_test.sh`（新規 10 ケース）
- base: main / baseRefName: main / OK（PR 作成後に検証済み）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #389 のコメントを参照してください。
