### PR TITLE
fix(#392): dr_log の stdout 出力を stderr へ切り替えて staged-for-release verdict 捕捉汚染を解消

### DIFF
--- a/docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/impl-notes.md
+++ b/docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/impl-notes.md
@@ -1,0 +1,172 @@
+# Implementation Notes — #392
+
+## 修正範囲
+
+中核 fix は `local-watcher/bin/issue-watcher.sh` の `dr_log()` 関数 1 ヶ所のみ
+（L9666-9674 → L9666-9686 にコメントブロック拡張込みで変更）:
+
+- **`dr_log()` (L9680)**: `echo "[$(date '+%F %T')] dr: $*"` → `echo "[$(date '+%F %T')] dr: $*" >&2`
+  - これにより `dr_resolve_one` の OPEN + staged-for-release 解決パス
+    （L9960 `dr_log "issue=#${dep_num} verdict=resolved reason=staged-for-release base=${BASE_BRANCH:-main}"`）
+    の直後にある `echo "resolved"` が、呼び出し側 `verdict=$(dr_resolve_one ...)`
+    （L10417 / `dr_unblock_resolve_one_issue` 内）に **戻り値のみ** を渡せる
+    ようになる。
+  - `dr_warn` (L9669) は本修正前から `>&2`、`dr_error` (L9672) も本修正前から `>&2`
+    （要件 Req 4.3 / NFR 3.2 既存挙動維持）。
+- 関数本体に至る理由・後方互換性・cron.log 集約位置を コメントブロックで説明
+  （L9666-9678 のコメント追加 14 行）。
+
+その他のコード変更なし（`dr_resolve_one` / `dr_unblock_resolve_one_issue` /
+`dr_unblock_sweep` 等の本体ロジックは無変更）。
+
+## 横展開チェック結果
+
+要件 Req 5 / Req 6 の棚卸し:
+
+**Req 5（dr 系 stdout 戻り値関数の棚卸し）**:
+
+- `dr_resolve_one` (L9890): 5 終端パス（OPEN+staged / OPEN+ラベル無し /
+  CLOSED+merged≥1 / CLOSED+merged=0 / api error 5 種）すべて `echo` で
+  verdict 1 行を返す。本修正前は `dr_log` の stdout 汚染で同一実行パスに
+  ログ行混入していたが、本修正で stdout が verdict 文字列のみに純化された。
+- `dr_extract_deps` (L9695): 純粋関数。`dr_log` / `dr_warn` を呼ばない（確認済）。
+- `dr_format_unresolved_comment` (L9751): 純粋関数。`dr_log` / `dr_warn` を呼ばず、
+  内部で呼ぶ `dr_unblock_gate_enabled` も log を出さない（gate 判定のみ）。
+- `dr_gh_graphql_closed_by` (L9809): GraphQL レスポンス JSON を stdout に返す。
+  `dr_log` / `dr_warn` を呼ばない（確認済）。
+
+→ Req 5.1〜5.4 すべて満たす。
+
+**Req 6（他モジュール `*_log` の同型バグ横展開チェック）**: `*_log` 横展開チェック: **同型バグ無し**。
+
+確認したモジュール集合（全 14 ロガー prefix）:
+
+- `qa_log` / `mq_log` / `ar_log` / `pp_log` / `pi_log` / `drr_log` / `pr_log` /
+  `sec_log` / `fr_log` / `sr_log`（`modules/core_utils.sh`）
+- `sh_log`（`modules/scaffolding-health.sh`）
+- `cm_log`（`modules/context-map.sh`）
+- `sav_log`（`modules/stage-a-verify.sh`）
+- `gh_log`（`modules/guard-hook.sh`）
+- `am_log` / `amd_log` / `el_log` / `mqr_log` / `nda_log` / `po_log` / `sn_log`
+  （個別モジュール）
+
+すべて `dr_log` と同じく **stdout に echo する設計**（`*_warn` / `*_error` のみ `>&2`）。
+ただし、`var=$(func ...)` パターンで stdout を機械可読戻り値として捕捉する
+呼び出し箇所を網羅的に grep した結果（`grep -E '=\$\((dr_|qa_|mq_|...)'`）、
+当該関数本体で `*_log`（stderr リダイレクトなし）を呼ぶ箇所は dr_resolve_one
+以外には **存在しなかった**。
+
+具体的に確認した「var=$()` パターンで呼ばれる関数」の本体内 `*_log` 呼び出し検索結果:
+
+- `pr_detect_iteration_keyword` (pr-reviewer.sh L585): `pr_log ... >&2` で
+  **明示的に stderr リダイレクト済み**（同型バグ防止対策が既に施されている）。
+- `pr_build_prompt_file` (pr-reviewer.sh L395): コメントで「stdout に結果を返す
+  契約のため pr_log は使わず pr_warn のみ使用」と明示。`pr_log` を呼ばない設計。
+- その他の `drr_already_processed` / `drr_find_merged_design_pr` /
+  `cm_render_prompt_section` / `po_parse_triage_edit_paths` /
+  `fr_state_path` / `fr_load_state` / `fr_collect_*` / `fr_fetch_*` /
+  `pi_read_last_run` / `pi_collect_*` / `pi_classify_*` / `pi_select_*` /
+  `pi_resolve_max_rounds` / `pi_read_no_progress_streak` /
+  `pi_build_iteration_prompt` / `pi_fetch_candidate_prs` / `pr_build_marker` /
+  `cm_resolve_*`: 関数本体内で `*_log`（stderr リダイレクトなし）を呼んで
+  いない（grep `_log\b` excluding `>&2` で 0 件）。
+
+→ Req 6.1 / 6.3 充足。Req 6.4（Out of Scope）に従い他モジュールの `*_log`
+出力先一括書き換えは **本 PR では行わない**。同型バグが見つかれば別 Issue 切り出し
+する方針だが、今回は 0 件だったため別 Issue 不要。
+
+## 追加テスト / 既存テスト改修
+
+**追加テスト**: `local-watcher/test/dr_resolve_one_stdout_test.sh`（新規 509 行）
+
+- `extract_function` イディオムで `dr_log` / `dr_warn` / `dr_error` /
+  `dr_resolve_one` の **実体** を抽出して読み込み、`dr_gh_graphql_closed_by`
+  のみを stub 化（GraphQL レスポンスを fixture 注入）。
+- 全 9 ケースで 22 件の assert を実行:
+  - Case 1: OPEN + staged-for-release + BASE_BRANCH=develop → stdout 厳密 `resolved`、
+    `dr_log` 行が stderr に出ること / stdout に紛れ込まないこと（本 Issue 根因の直接検証）
+  - Case 2: OPEN + ラベル無し → `open`
+  - Case 2b: OPEN + BASE_BRANCH=main → `open`（既存挙動維持 / Req 3.2）
+  - Case 3: CLOSED + merged≥1 → `resolved`
+  - Case 4: CLOSED + merged=0 → `closed unmerged`（CLOSED node 1 件 / 空配列 2 fixture）
+  - Case 5: GraphQL errors 検知 → `api error`
+  - Case 6: 不正 JSON / state=null → `api error`
+  - Case 7: gh rc!=0 → `api error`、dr_warn が stderr 出力 + stdout 汚染ゼロ
+  - Case 8: `dr_log` / `dr_warn` / `dr_error` 単体の stdout 汚染ゼロ + フォーマット維持
+  - Case 9: REPO env 不正 → `api error`
+
+**Red→Green 確認**: `dr_log` の `>&2` を一時 revert すると 22 件中 6 件 FAIL、
+本修正復元で 22 件全て PASS。本テストが本 Issue (#392) の根因を正しく検知することを確認。
+
+**既存テストの改修**: なし。既存 `dr_unblock_sweep_test.sh` の `dr_log` / `dr_warn`
+stub（L225-227）は本修正後も実害を引き起こさない構成（テスト隔離の都合上 stub する
+こと自体は正当 / Req 7.5）。新規 stdout 純度テストの存在によって実 stdout 汚染を
+検知できる体制になった。
+
+## 検証ログ要約
+
+| 検証項目 | コマンド | 結果 |
+|---------|---------|------|
+| 構文 | `bash -n local-watcher/bin/issue-watcher.sh` | OK |
+| 構文 | `bash -n local-watcher/test/dr_resolve_one_stdout_test.sh` | OK |
+| 静的解析 | `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/*.sh install.sh setup.sh .github/scripts/*.sh` | クリーン（rc=0、baseline 維持） |
+| 静的解析 | `shellcheck local-watcher/test/dr_resolve_one_stdout_test.sh` | クリーン |
+| 新規テスト | `bash local-watcher/test/dr_resolve_one_stdout_test.sh` | 22 PASS / 0 FAIL |
+| 既存回帰 | `bash local-watcher/test/dr_unblock_sweep_test.sh` | 56 PASS / 0 FAIL |
+| 既存回帰 | `bash local-watcher/test/dc_cycle_sweep_test.sh` | 74 PASS / 0 FAIL |
+| 二重管理 | `diff -r .claude/agents repo-template/.claude/agents` | 空（同期維持） |
+| 二重管理 | `diff -r .claude/rules repo-template/.claude/rules` | 空（同期維持） |
+
+## README 反映の判断
+
+本修正は **ユーザー可視仕様の変更ではない**（`dr_log` の挙動はメンテナ向け内部実装
+詳細であり、cron 経由の集約位置は不変。grep 集計 `grep ' dr:'` も従来どおり機能する）。
+要件 Req 8.2 で「必要時のみ追記」と規定されており、本修正は外部観測挙動を変えないため
+README 反映は不要と判断。consumer repo にとっては「2-branch 運用で
+DEP_AUTO_UNBLOCK が正しく動くようになった」というバグ修正の透過的反映であり、
+README の挙動説明文を書き換える必要はない。
+
+## AC Traceability
+
+requirements.md の各 numeric ID に対する担保テスト:
+
+| AC ID | 内容 | 担保 |
+|-------|------|------|
+| 1.1 | `dr_log` 出力先 stderr / stdout 1 文字も書かない | `dr_resolve_one_stdout_test.sh` Case 8 (dr_log 単体) + Case 1 (実経路) |
+| 1.2 | `dr_warn` 出力先 stderr / stdout 1 文字も書かない | Case 8 (dr_warn 単体) + Case 7 (rc!=0 実経路) |
+| 1.3 | OPEN + staged-for-release → stdout 厳密 `resolved` | Case 1 |
+| 1.4 | OPEN + staged-for-release 無し → stdout 厳密 `open` | Case 2 |
+| 1.5 | CLOSED + merged≥1 → stdout 厳密 `resolved` | Case 3 |
+| 1.6 | CLOSED + merged=0 → stdout 厳密 `closed unmerged` | Case 4 (CLOSED node 1 件 / 空配列) |
+| 1.7 | api error 経路 → stdout 厳密 `api error` | Case 5 (GraphQL errors) + Case 6 (不正 JSON / state=null) + Case 7 (gh rc!=0) + Case 9 (REPO 不正) |
+| 1.8 | verdict=$(...) 捕捉が 4 値集合と完全一致 | Case 1 (case 4 値マッチ assert) |
+| 2.1 | 2-branch DEP_AUTO_UNBLOCK 機能復旧 | Case 1 で OPEN + staged-for-release が `resolved` 1 行を返すことを実証 → 既存 `dr_unblock_sweep_test.sh` AT-a シナリオが本修正後も成立することで間接担保 |
+| 2.2 | 構造化ログ `verdict=unblock_cleared` 維持 / `未知の verdict` 残らない | `dr_unblock_sweep_test.sh` 56 件 PASS（既存テストの構造化ログ assert は破壊されていない） |
+| 2.3 | `blocked` 除去後の通常 pickup 合流 | Out of Scope（既存 #346 の動線。本修正で変更なし） |
+| 3.1 | gate `=true` 以外で sweep 本体に到達しない | `dr_unblock_sweep_test.sh` AT-c で既に担保（本修正で破壊されていないことを 56 件 PASS で確認） |
+| 3.2 | BASE_BRANCH=main で挙動一致 | Case 2b |
+| 3.3 | CLOSED 経路 / api error 経路の挙動一致 | Case 3 / 4 / 5 / 6 / 7 |
+| 3.4 | 既存 env var / ラベル / exit code / cron 文字列を変更しない | コード変更が `dr_log` 内 echo の `>&2` 追加のみで完了（env var / ラベル / exit code に触れていない） |
+| 3.5 | `dr_unblock_sweep` 内のクエリ / FIFO / cycle 連携を変更しない | コード変更箇所 1 ヶ所のみ（`dr_unblock_sweep` 本体無変更） |
+| 4.1 | cron.log で従来同じ 1 行フォーマットで観測 | Case 8 で `dr_log` の stderr フォーマット `[YYYY-MM-DD HH:MM:SS] dr: <message>` 維持を assert |
+| 4.2 | メッセージ語彙・キー・prefix `dr:` 維持 | Case 1 で `dr: issue=#117 verdict=resolved reason=staged-for-release base=develop` フォーマット維持を assert |
+| 4.3 | `dr_error` 出力先 stderr 維持 | Case 8 (dr_error 単体) |
+| 5.1 | `dr_resolve_one` 5 終端パスで stdout verdict 1 行のみ | Case 1〜7 + Case 9（5 経路 + 2 buf）全て厳密一致 assert |
+| 5.2 | `dr_extract_deps` stdout が Issue 番号集合のみ | コード review で確認（dr_log/dr_warn 呼び出しなし）。既存 `dr_unblock_sweep_test.sh` の依存抽出シナリオで間接担保 |
+| 5.3 | `dr_format_unresolved_comment` stdout がコメント本文のみ | コード review で確認（dr_log/dr_warn 呼び出しなし）。既存 `dr_unblock_sweep_test.sh` AT-h で文面分岐を担保 |
+| 5.4 | `dr_gh_graphql_closed_by` stdout が GraphQL JSON のみ | コード review で確認（dr_log/dr_warn 呼び出しなし）。Case 1〜9 で fixture 注入を経て dr_resolve_one が正常 verdict を返すことで間接担保 |
+| 6.1〜6.4 | 他モジュール `*_log` 横展開チェック | 上記「横展開チェック結果」節で 0 件、Req 6.4 に従い本 PR では一括書き換えなし |
+| 7.1〜7.5 | 回帰防止テスト | `dr_resolve_one_stdout_test.sh` 22 件全て、特に Red→Green を実証済み |
+| 8.1〜8.3 | root↔repo-template 同期 / README 反映 | `.claude` 変更なし / `diff -r` 空確認済み、README 反映不要の判断を本ノートに記載 |
+| NFR 1.1〜1.2 | `bash -n` / `shellcheck` 警告ゼロ | 検証ログ要約参照 |
+| NFR 2.1〜2.3 | 後方互換性 | Case 2b（main 維持）/ 3.3 担保 / 戻り値語彙 4 値変更なし |
+| NFR 3.1〜3.2 | 可観測性 | Case 8 でフォーマット維持 / Case 1 で staged-for-release 解決時の語彙・キー順序維持 |
+| NFR 4.1 | 未信頼入力リダイレクト破壊なし | 変更は `>&2` 追加のみで未信頼値の取り扱いに影響なし（クォート維持） |
+
+## 確認事項
+
+なし。本 Issue の requirements.md / 対象コード / 横展開チェック / 既存テストとの整合は
+すべてクリア。Out of Scope（他モジュールの `*_log` 一括書き換え等）も Req 6.4 の方針に
+従って本 PR では扱わない。
+
+STATUS: complete

--- a/docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/requirements.md
+++ b/docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/requirements.md
@@ -1,0 +1,272 @@
+# Requirements Document
+
+## Introduction
+
+`local-watcher/bin/issue-watcher.sh` の dependency-resolver (`dr_*`) 系において、`dr_log()`
+が stdout に echo（`>&2` 無し）するため、`dr_resolve_one` の OPEN + `staged-for-release`
+解決パスで `dr_log` を呼んだ直後に `echo "resolved"` で戻り値を返す並びが、呼び出し側
+`dr_unblock_sweep` の `verdict=$(dr_resolve_one ...)` 捕捉に **ログ行と戻り値の両方** を
+混入させる。結果、parser は捕捉文字列を `resolved` でも `open` でも `api error` でもない
+「未知の verdict」と判断し、対象 Issue を `unblock_keep` のまま放置する。`#117` (OPEN +
+`staged-for-release`) に依存する `#115` が `#117` 解決後も `blocked` のまま外れない事象
+として実機再現済みであり、`BASE_BRANCH != main` 環境（2-branch / gitflow）で
+`DEP_AUTO_UNBLOCK` の中核機能が完全に機能しない。CLAUDE.md「標準出力は機械可読な結果用に
+予約・ログは `>&2`」規約とも整合させる必要がある。
+
+本要件は、(1) `dr_log` / `dr_warn` の出力先を stderr に揃えて verdict 捕捉の汚染を解消し、
+(2) dr 系で stdout を「機械可読な戻り値」に使う関数群（特に `dr_resolve_one`）で同一実行
+パスにログを混入しないことを保証する棚卸しを行い、(3) 他モジュールの `*_log` についても
+同型バグ（stdout ログ + 同関数 stdout 戻り値捕捉）が存在しないかを軽く確認する範囲を扱う。
+既存の `BASE_BRANCH=main` 経路・CLOSED→`resolved`/`closed unmerged` 経路・`api error`
+経路・cron.log への可視性を一切壊さないことを要件として明文化する。
+
+## 関連
+
+- Depends on: なし（独立した修正）
+- Related: #346（`DEP_AUTO_UNBLOCK` / blocked 自動解除スイープ） / #316（`staged-for-release`
+  依存の resolved 判定） / #117（実機再現の依存先） / #115（実機再現の被ブロッキング Issue）
+
+## Requirements
+
+### Requirement 1: dr 系ロガーの stderr 化と verdict 捕捉の非汚染
+
+**Objective:** As an idd-claude 運用者, I want `dr_log` / `dr_warn` の出力が stdout を
+汚染しないこと, so that `dr_resolve_one` の stdout を捕捉する呼び出し側
+（`dr_unblock_resolve_one_issue` の `verdict=$(dr_resolve_one ...)`）が常に厳密な戻り値
+だけを受け取れ、`staged-for-release` 解決パスでも対象 Issue が自動 unblock される。
+
+#### Acceptance Criteria
+
+1. The Dependency Resolver shall `dr_log` の出力先を stderr とし、stdout には 1 文字も
+   書き出さない。
+2. The Dependency Resolver shall `dr_warn` の出力先を stderr とし、stdout には 1 文字も
+   書き出さない。
+3. When `dr_resolve_one` が OPEN + `staged-for-release` を resolved として判定した,
+   the Dependency Resolver shall stdout に厳密に `resolved` のみ（末尾改行を除き他文字を
+   含まない）を出力する。
+4. When `dr_resolve_one` が OPEN + `staged-for-release` なしを open として判定した,
+   the Dependency Resolver shall stdout に厳密に `open` のみを出力する。
+5. When `dr_resolve_one` が CLOSED + merged PR 1 件以上 を resolved として判定した,
+   the Dependency Resolver shall stdout に厳密に `resolved` のみを出力する。
+6. When `dr_resolve_one` が CLOSED + merged PR ゼロ件 を closed unmerged として判定した,
+   the Dependency Resolver shall stdout に厳密に `closed unmerged` のみを出力する。
+7. If `dr_resolve_one` が GraphQL 失敗・jq parse 失敗・想定外応答構造のいずれかを検知した,
+   the Dependency Resolver shall stdout に厳密に `api error` のみを出力する。
+8. When `dr_unblock_resolve_one_issue` が `dr_resolve_one` の stdout を `verdict=$(...)`
+   で捕捉した, the Dependency Resolver shall 捕捉文字列が `resolved` / `open` /
+   `closed unmerged` / `api error` のいずれかと完全一致し、`未知の verdict` 分岐に到達
+   しない（OPEN + `staged-for-release` 解決パスを含む）。
+
+### Requirement 2: DEP_AUTO_UNBLOCK の 2-branch 環境での復旧
+
+**Objective:** As an idd-claude 運用者, I want `BASE_BRANCH != main` 環境で全依存が
+`staged-for-release` 経由 resolved になった blocked Issue が自動的に `blocked` 除去
+されること, so that gitflow 運用や 2-branch 運用でも依存チェーンが順送りで進む
+full-auto が止まらない。
+
+#### Acceptance Criteria
+
+1. While `DEP_AUTO_UNBLOCK_ENABLED=true` かつ `FULL_AUTO_ENABLED=true` かつ
+   `BASE_BRANCH != main`, when ある blocked Issue の全依存先が OPEN + `staged-for-release`
+   付与済み状態にある, the Dependency Resolver shall 当該 Issue の `blocked` ラベルを
+   除去し、自動解除コメント（`DR_UNBLOCK_MARKER_CLEARED` マーカー付き）を 1 件投稿する。
+2. When 上記の自動解除が成功した, the Dependency Resolver shall 構造化ログ
+   `issue=#<N> extracted=... resolved=... unresolved= verdict=unblock_cleared` を 1 行
+   残し、`未知の verdict` を含むログを残さない。
+3. While 上記の sweep 後に同一 tick の `_dispatcher_run` メイン候補列挙が走った,
+   the Dependency Resolver shall `blocked` 除去済み Issue が `-label:"blocked"` 除外条件
+   を満たし通常 pickup に合流できる（既存 fall-through 動線 / #346 Req 2.3 を維持）。
+
+### Requirement 3: 後方互換と既存解決経路の温存
+
+**Objective:** As an idd-claude 運用者, I want 本修正によって `BASE_BRANCH=main` 既存運用・
+CLOSED→`resolved` / `closed unmerged` 経路・`api error` 経路・`DEP_AUTO_UNBLOCK_ENABLED`
+未設定環境の外部観測挙動が一切変わらないこと, so that 既存 consumer repo の依存解決・
+ラベル遷移・cron 実行コスト・log 出力の集約位置が無告知で変わらない。
+
+#### Acceptance Criteria
+
+1. While `DEP_AUTO_UNBLOCK_ENABLED` が `=true` 以外（既定 `false` を含む）, the Dependency
+   Resolver shall `dr_unblock_sweep` の本体処理に到達せず、本修正による追加コードパスにも
+   到達しない（既存 opt-in gate の挙動を維持する）。
+2. While `BASE_BRANCH=main`, the Dependency Resolver shall 本修正前後で `dr_resolve_one`
+   が返す verdict 集合・順序・各依存先について発火する gh GraphQL 呼び出し回数を一致させる。
+3. When `dr_resolve_one` が CLOSED + merged PR 1 件以上 / CLOSED + merged PR ゼロ件 /
+   GraphQL 失敗 / `api error` 経路 を辿った, the Dependency Resolver shall 本修正前後で
+   stdout 戻り値・stderr 警告・呼び出し側の verdict 分岐到達結果を一致させる。
+4. The Dependency Resolver shall 既存の env var 名（`DEP_AUTO_UNBLOCK_ENABLED` /
+   `FULL_AUTO_ENABLED` / `BASE_BRANCH` / `LABEL_BLOCKED` / `LABEL_STAGED_FOR_RELEASE`
+   等）・ラベル名・exit code 意味・cron 登録文字列を本修正で変更しない。
+5. The Dependency Resolver shall `dr_unblock_sweep` 内の `gh issue list` 取得件数上限
+   （`--limit 50`）・FIFO 順（`sort:created-asc`）・終端ラベル除外条件・cycle 検出
+   （`dc_cycle_sweep`）連携を本修正で変更しない。
+
+### Requirement 4: cron.log への可観測性の維持
+
+**Objective:** As an idd-claude 運用者, I want `dr_log` / `dr_warn` を stderr 化しても
+従来どおり cron.log で全行が観測できること, so that 既存の障害分析・grep 集計（`grep ' dr:'`
+や `grep 'verdict='` 等）が引き続き機能する。
+
+#### Acceptance Criteria
+
+1. The Dependency Resolver shall 本修正後の `dr_log` / `dr_warn` 出力が cron 経由
+   （cron が `>>cron.log 2>&1` で標準エラーを標準出力にマージする運用前提）で cron.log
+   に従来と同じ 1 行フォーマット（`[YYYY-MM-DD HH:MM:SS] dr: ...` および
+   `[YYYY-MM-DD HH:MM:SS] dr: WARN: ...`）で出現する。
+2. The Dependency Resolver shall `dr_log` / `dr_warn` のメッセージ語彙（`verdict=...` /
+   `extracted=...` / `unresolved=...` / `dep=#<N>` 等のキー）と prefix `dr:` を本修正で
+   変更しない（既存 grep / 集計クエリを破壊しない）。
+3. The Dependency Resolver shall `dr_error` の出力先（stderr）を本修正で変更しない
+   （既存仕様維持）。
+
+### Requirement 5: dr 系 stdout 戻り値関数の棚卸し
+
+**Objective:** As an idd-claude メンテナ, I want dr 系で stdout を「機械可読な戻り値」に
+使っている全関数について、同一実行パスにログを stdout 混入していない状態を確認したい,
+so that 本 Issue と同型のバグ（戻り値捕捉に dr_log/dr_warn 行が紛れ込む）が他の経路で
+潜在しないことを保証する。
+
+#### Acceptance Criteria
+
+1. The Dependency Resolver shall `dr_resolve_one` のすべての終端パス（OPEN+`staged-for-release`
+   / OPEN+ラベル無し / CLOSED+merged 1 件以上 / CLOSED+merged ゼロ件 / `api error` 5 経路）
+   について stdout が verdict 文字列ちょうど 1 行のみであることを満たす。
+2. The Dependency Resolver shall `dr_extract_deps` の stdout が「Issue 番号の改行区切り
+   集合（各行が `^[0-9]+$`）」のみで構成され、ログ文字列を混入しないことを満たす。
+3. The Dependency Resolver shall `dr_format_unresolved_comment` の stdout が
+   エスカレーション markdown 本文のみで構成され、ログ文字列を混入しないことを満たす。
+4. The Dependency Resolver shall `dr_gh_graphql_closed_by` の stdout が GraphQL レスポンス
+   JSON のみで構成され、ログ文字列を混入しないことを満たす。
+
+### Requirement 6: 他モジュール `*_log` の同型バグ横展開チェック
+
+**Objective:** As an idd-claude メンテナ, I want 他モジュール（`qa_` / `mq_` / `pi_` /
+`pr_` / `ar_` / `pp_` / `sec_` / `cm_` / `sh_` / `sav_` / `gh_` / `sr_` / `fr_` / `sc_` /
+`tc_` / `pt_` 等）の `*_log` についても、stdout 出力 + 同関数 stdout 戻り値捕捉という
+同型バグが現存しないことを軽く確認したい, so that 本修正の知見を repo 全体に横展開する
+最小コストの一巡が行われ、潜在バグの早期発見につながる。
+
+#### Acceptance Criteria
+
+1. The Maintainer Audit shall 各モジュールの `*_log` 関数について、呼び出し側が
+   `result=$(<関数名> ...)` 形式で stdout を捕捉する関数を網羅的に列挙し、その関数本体
+   内で `*_log` 系（stdout 出力ロガー）が呼ばれていないことを確認する。
+2. When 横展開チェックで同型バグの候補が 1 件以上見つかった, the Maintainer Audit shall
+   当該候補を本 Issue 内で修正対象に追加するか、別 Issue として切り出すかの判断を
+   `impl-notes.md` または PR 本文に記録する。
+3. When 横展開チェックで同型バグの候補が 0 件であった, the Maintainer Audit shall その旨を
+   `impl-notes.md` または PR 本文に「`*_log` 横展開チェック: 同型バグ無し」として 1 行
+   残し、確認したモジュール集合を明示する。
+4. The Maintainer Audit shall 本 Issue のスコープにおいて他モジュールの `*_log` の
+   stdout/stderr 出力先を一括書き換えしない（Out of Scope を尊重し、必要なら別 Issue に
+   切り出す）。
+
+### Requirement 7: 回帰防止テスト（dr_resolve_one stdout 純度）
+
+**Objective:** As an idd-claude メンテナ, I want `dr_resolve_one` の `staged-for-release`
+解決パスについて、**実際の stdout を厳密一致で検証する** 近接テストを追加したい,
+so that 既存テスト（`dr_unblock_sweep_test.sh`）が `dr_log` / `dr_resolve_one` を stub
+していて本 Issue の汚染を見逃してきた構造欠陥を、実 stdout 捕捉で再現するケースを足す
+ことで補修できる。
+
+#### Acceptance Criteria
+
+1. The Test Suite shall `dr_resolve_one`（および間接的に `dr_log` 実体）を
+   `extract_function` イディオムで隔離抽出し、`gh` のみを stub した状態で
+   `verdict=$(dr_resolve_one <N>)` を実行する近接テストを `local-watcher/test/` 配下に
+   追加する。
+2. The Test Suite shall OPEN + `staged-for-release` 付与済み・`BASE_BRANCH != main` の
+   fixture について、捕捉した `verdict` 変数の値が文字列 `resolved` と **完全一致**
+   （末尾改行を除き他文字を含まない）することを確認する。
+3. The Test Suite shall 上記ケースで `dr_log` の出力が stderr 経由のみで観測される
+   （`{ verdict=$(dr_resolve_one <N>); } 2>captured_stderr` でリダイレクトしたとき、
+   `captured_stderr` に `dr: ... verdict=resolved reason=staged-for-release` 行が含まれ、
+   `verdict` 変数側には含まれない）ことを確認する。
+4. The Test Suite shall OPEN + ラベル無し / CLOSED + merged 1 件以上 / CLOSED + merged
+   ゼロ件 / GraphQL errors 検知 / jq parse 失敗 の 5 経路について、それぞれ stdout が
+   厳密に `open` / `resolved` / `closed unmerged` / `api error` / `api error` のいずれかと
+   完全一致することを確認する。
+5. The Test Suite shall 既存 `dr_unblock_sweep_test.sh` の `dr_log` / `dr_warn` stub が
+   本修正後も実害（戻り値捕捉汚染）を引き起こさない構成であることを、抽出 + 実 stdout
+   捕捉テストの存在によって担保する（既存テストの stub 自体は維持してよい）。
+
+### Requirement 8: root ↔ repo-template 同期と README 反映
+
+**Objective:** As an idd-claude メンテナ, I want 本修正を root `.claude/` / repo-template
+の二重管理規約に従って整合的に反映したい, so that consumer repo に配布される
+`issue-watcher.sh` 系統で同じ修正が同時に有効化される。
+
+#### Acceptance Criteria
+
+1. The Maintainer shall 本修正が `local-watcher/bin/issue-watcher.sh` 単体で完結する場合
+   （`.claude/agents` / `.claude/rules` の変更を伴わない場合）、`diff -r` 同期確認は対象外
+   とする（CLAUDE.md の二重管理鉄則は agents/rules を対象とするため）。
+2. When 修正が consumer 配布対象（`local-watcher/bin/issue-watcher.sh`）に閉じる場合,
+   the Maintainer shall README の挙動説明文に「dr_log / dr_warn は stderr 出力」「cron 経由
+   での集約位置は不変」を必要時のみ追記し、不要なら追記しない（既存挙動の説明を破壊しない
+   範囲）。
+3. While 本修正で `.claude/agents` / `.claude/rules` を変更しない, the Maintainer shall
+   `diff -r .claude/agents repo-template/.claude/agents` および
+   `diff -r .claude/rules repo-template/.claude/rules` が空であることを確認する
+   （現状維持）。
+
+## Non-Functional Requirements
+
+### NFR 1: 静的検査と構文健全性
+
+1. The Dependency Resolver shall 本修正後の `local-watcher/bin/issue-watcher.sh` が
+   `bash -n` で構文エラー 0、`shellcheck` で `.shellcheckrc` を踏まえた baseline 上の
+   警告増加 0 を満たす。
+2. The Test Suite shall 追加した近接テストの bash スクリプトが `bash -n` / `shellcheck`
+   クリーンであることを満たす。
+
+### NFR 2: 後方互換性
+
+1. The Dependency Resolver shall 既存ラベル名 `blocked` / `staged-for-release` /
+   `claude-failed` / `needs-decisions` を本修正で改名・別名追加せず、定数経由の参照を
+   破壊しない。
+2. The Dependency Resolver shall 本修正前後で `DEP_AUTO_UNBLOCK_ENABLED` 未設定 / `false`
+   環境の外部観測挙動（gh API 呼び出しゼロ・log 出力ゼロ・ラベル遷移ゼロ）を一致させる。
+3. The Dependency Resolver shall 本修正前後で `dr_resolve_one` の戻り値語彙集合
+   （`resolved` / `open` / `closed unmerged` / `api error`）を変更しない。
+
+### NFR 3: 可観測性
+
+1. The Dependency Resolver shall 本修正後の `dr_log` 1 行フォーマット
+   `[YYYY-MM-DD HH:MM:SS] dr: <message>` および `dr_warn` 1 行フォーマット
+   `[YYYY-MM-DD HH:MM:SS] dr: WARN: <message>` を変更しない。
+2. The Dependency Resolver shall `staged-for-release` 解決時の構造化ログメッセージ
+   `issue=#<N> verdict=resolved reason=staged-for-release base=<branch>` の語彙とキー順序
+   を本修正で変更しない（既存 grep / 集計クエリを破壊しない）。
+
+### NFR 4: 未信頼入力の取り扱い
+
+1. The Dependency Resolver shall 本修正で新規導入する出力リダイレクト（`>&2`）について、
+   GitHub API レスポンスや Issue 本文に含まれる未信頼文字列を `dr_log` / `dr_warn` 引数
+   としてそのまま流す場合でも、stdout / stderr 区別が破壊されない記述で実装する
+   （変数展開のクォート維持 / リダイレクト先の固定化）。
+
+## Out of Scope
+
+- 他モジュールの `*_log`（`qa_log` / `mq_log` / `pp_log` / `pi_log` / `pr_log` /
+  `ar_log` / `sec_log` / `cm_log` / `sh_log` / `sav_log` / `gh_log` / `sr_log` /
+  `fr_log` / `sc_log` / `tc_log` / `pt_log` 等）の stdout → stderr 一括書き換え
+  （横展開チェックで同型バグが見つからなければ書き換えを行わない。仮に見つかった場合も
+  本 Issue では扱わず別 Issue として切り出す方針）。
+- `dr_resolve_one` の戻り値語彙集合の拡張（`resolved` / `open` / `closed unmerged` /
+  `api error` の 4 種を維持する）。
+- `dr_unblock_sweep` の対象 Issue 列挙クエリ・FIFO 順・上限値の変更。
+- `dc_cycle_sweep` との連携（cycle 検出・除外）ロジックの変更。
+- `DEP_AUTO_UNBLOCK_ENABLED` / `FULL_AUTO_ENABLED` の既定値・正規化ルールの変更。
+- README の挙動説明文の大幅な再構成（必要な差分更新は別途 PR 内で行うが、本要件は外形
+  契約に限定する）。
+- `staged-for-release` ラベルの付与・除去動線そのものの変更（#100 / #389 系統）。
+- cron 設定（`>>cron.log 2>&1` 等のリダイレクト指定）の変更・推奨手順の更新。
+
+## Open Questions
+
+- なし（Issue #392 本文に根本原因（`dr_log` の stdout echo）と修正方針（`>&2` 化 +
+  棚卸し + 横展開チェック + 近接テスト追加）が明示済みで、AC・DoD・スコープ外も整理
+  されている。実装上の選択肢（`dr_log` 本体の `>&2` 追加のみで完結するか、`dr_*` 系
+  すべての出力先を一括正規化するか）は設計レイヤの裁量であり requirements では規定
+  しない）。

--- a/docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/review-notes.md
+++ b/docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/review-notes.md
@@ -1,0 +1,111 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-392-impl-fix-dr-dr-log-stdout-staged-for-release
+- HEAD commit: dd0175800ed3fe158ce7e442ca9eb3797e187cdd
+- Compared to: main..HEAD
+- Changed files: `local-watcher/bin/issue-watcher.sh`（`dr_log` 1 行 + コメントブロック）、
+  `local-watcher/test/dr_resolve_one_stdout_test.sh`（新規 509 行）、
+  `docs/specs/392-.../impl-notes.md`（新規）
+- Feature Flag Protocol: `CLAUDE.md` に `## Feature Flag Protocol` 節（`**採否**:` 行）
+  なし → 通常の 3 カテゴリ判定のみを適用（opt-in 細目は適用せず）
+
+## Verified Requirements
+
+- 1.1 — `dr_log` を `echo ... >&2` に変更（issue-watcher.sh L9680）。
+  `dr_resolve_one_stdout_test.sh` Case 8 で `dr_log` 単体の stdout が空であることを assert
+- 1.2 — `dr_warn` は本修正前から `>&2`（L9683）。Case 7 / 8 で stdout 汚染ゼロを assert
+- 1.3 — Case 1 (OPEN + staged-for-release + BASE_BRANCH=develop) で stdout 厳密 `resolved` を assert
+- 1.4 — Case 2 (OPEN + ラベル無し) で stdout 厳密 `open` を assert
+- 1.5 — Case 3 (CLOSED + merged≥1) で stdout 厳密 `resolved` を assert
+- 1.6 — Case 4 (CLOSED + merged=0、CLOSED node 1 件 / 空配列 2 fixture) で
+  stdout 厳密 `closed unmerged` を assert
+- 1.7 — Case 5 (GraphQL errors) / Case 6 (不正 JSON, issue=null) / Case 7 (gh rc!=0) /
+  Case 9 (REPO 不正) で stdout 厳密 `api error` を assert
+- 1.8 — Case 1 で `verdict=$(dr_resolve_one ...)` 捕捉値が 4 値集合
+  (`resolved` / `open` / `closed unmerged` / `api error`) と完全一致することを case 分岐 assert
+- 2.1 — Case 1 で OPEN + staged-for-release が `resolved` 1 行を返すことを実証。
+  既存 `dr_unblock_sweep_test.sh` AT-a シナリオ（56 件 PASS）で間接担保
+- 2.2 — `dr_unblock_sweep_test.sh` 56 件 PASS で構造化ログ
+  `verdict=unblock_cleared` および「`未知の verdict` 残らない」を間接担保
+- 2.3 — `_dispatcher_run` 経路は無変更（impl-notes に明示）。既存 #346 動線を維持
+- 3.1 — `dr_unblock_sweep_test.sh` AT-c の gate `=true` 以外を 56 件 PASS で維持
+- 3.2 — Case 2b (OPEN + BASE_BRANCH=main + staged-for-release ラベル) で `open` を返す
+  既存挙動を維持することを assert
+- 3.3 — Case 3 / 4 / 5 / 6 / 7 で CLOSED / api error 経路の挙動を維持
+- 3.4 — env var / ラベル / exit code / cron 文字列は変更なし（diff は `dr_log` 1 行 + コメントのみ）
+- 3.5 — `dr_unblock_sweep` 本体・FIFO 順・上限・cycle 連携の変更なし
+- 4.1 — Case 8 で `dr_log` の stderr フォーマット `[YYYY-MM-DD HH:MM:SS] dr: <message>`
+  維持を assert（cron は `>>cron.log 2>&1` で stderr を集約する前提）
+- 4.2 — Case 1 で `dr: issue=#117 verdict=resolved reason=staged-for-release base=develop`
+  の語彙・キー順序・prefix `dr:` 維持を assert
+- 4.3 — Case 8 で `dr_error` の stdout が空 / stderr に `dr: ERROR:` 維持を assert
+- 5.1 — Case 1〜7 + Case 9 の 5 経路すべてで stdout = verdict 1 行のみを厳密一致 assert
+- 5.2 — `dr_extract_deps` は `dr_log` / `dr_warn` を呼ばない純粋関数（コード review 確認 +
+  impl-notes に明記）。既存 `dr_unblock_sweep_test.sh` の依存抽出シナリオで間接担保
+- 5.3 — `dr_format_unresolved_comment` も `dr_log` / `dr_warn` を呼ばない（impl-notes 確認）
+- 5.4 — `dr_gh_graphql_closed_by` も `dr_log` / `dr_warn` を呼ばない（impl-notes 確認 +
+  本テストでは stub 化）
+- 6.1 — impl-notes に全 14 ロガー prefix の grep 結果を明示
+  （`pr_detect_iteration_keyword` は既に `pr_log ... >&2` 対策済、
+  `pr_build_prompt_file` はコメントで `pr_log` 不使用を明示）
+- 6.2 — 横展開チェックで 0 件のため対象外（要件文の condition false）
+- 6.3 — impl-notes に「`*_log` 横展開チェック: 同型バグ無し」と確認モジュール集合を明示
+- 6.4 — 他モジュール `*_log` の一括書き換えなし（diff は `dr_log` 1 行のみ）
+- 7.1 — `dr_resolve_one_stdout_test.sh` で `extract_function` イディオムにより
+  `dr_resolve_one` / `dr_log` / `dr_warn` / `dr_error` の実体を抽出、`dr_gh_graphql_closed_by`
+  のみを stub
+- 7.2 — Case 1 で OPEN + staged-for-release + BASE_BRANCH=develop の捕捉 `verdict` が
+  `resolved` と完全一致することを assert
+- 7.3 — Case 1 で `dr_log` 行が stderr 経由のみで観測され、stdout に紛れ込まないことを
+  両方向 assert（含む / 含まない）
+- 7.4 — Case 2 / 3 / 4 / 5 / 6 の 5 経路で stdout 厳密一致を assert
+- 7.5 — 既存 `dr_unblock_sweep_test.sh` stub を維持しつつ新規テストで実 stdout 純度を担保
+- 8.1 — `local-watcher/bin/issue-watcher.sh` 単体修正で完結
+- 8.2 — README 反映なし（ユーザー可視仕様の変更なし、要件文「必要時のみ追記」を尊重）
+- 8.3 — `diff -r .claude/agents repo-template/.claude/agents` / `.claude/rules` ともに空
+  （impl-notes 検証ログで確認）
+- NFR 1.1 — `bash -n` OK、`shellcheck` baseline 維持（impl-notes 検証ログ）
+- NFR 1.2 — 追加テストも `bash -n` / `shellcheck` クリーン（impl-notes 検証ログ）
+- NFR 2.1 — ラベル名 `blocked` / `staged-for-release` / `claude-failed` / `needs-decisions` 改名なし
+- NFR 2.2 — `DEP_AUTO_UNBLOCK_ENABLED` 未設定 / false 経路は本修正のコードパス対象外
+- NFR 2.3 — 戻り値語彙 4 値集合を維持（Case 1〜9 で各値が出ることを assert）
+- NFR 3.1 — Case 8 で `dr_log` / `dr_warn` の 1 行フォーマット維持を assert
+- NFR 3.2 — Case 1 で `staged-for-release` 解決時の語彙・キー順序維持を assert
+- NFR 4.1 — `>&2` 追加のみで変数展開クォート構造を破壊していない（diff 1 行）
+
+## Boundary 確認
+
+- 変更ファイル: `local-watcher/bin/issue-watcher.sh`（dr 系セクション L9666-9686）、
+  `local-watcher/test/dr_resolve_one_stdout_test.sh`（新規）、impl-notes.md（仕様配下）
+- 要件 Introduction の修正範囲（`dr_log` の `>&2` 化 + 棚卸し + 横展開チェック + 近接テスト追加）
+  と diff が一致。`dr_resolve_one` / `dr_unblock_sweep` 本体・他モジュールの `*_log`
+  には触れていない（Out of Scope を尊重）
+- `tasks.md` は本 spec には存在せず（Triage 経路で Architect スキップ）、
+  `_Boundary:_` アノテーションによる境界制約は提示されていない。要件文の Introduction /
+  Out of Scope に従い境界違反なしと判定
+
+## 検証実行（Reviewer による再実行）
+
+| 検証項目 | 結果 |
+|---------|------|
+| `bash local-watcher/test/dr_resolve_one_stdout_test.sh` | 22 PASS / 0 FAIL |
+| `bash local-watcher/test/dr_unblock_sweep_test.sh` | 56 PASS / 0 FAIL |
+| `bash local-watcher/test/dc_cycle_sweep_test.sh` | 74 PASS / 0 FAIL |
+
+## Findings
+
+なし
+
+## Summary
+
+`dr_log` の 1 行修正 (`echo ... >&2`) + 詳細なコメントブロックで根因を解消し、
+新規 22 assert 回帰テストで全 5 終端パスの stdout 純度と staged-for-release 解決パスの
+verdict 捕捉非汚染を実証。Req 1〜8 / NFR 1〜4 をカバー、既存テスト（dr_unblock_sweep 56 件 /
+dc_cycle_sweep 74 件）も全 PASS で後方互換を維持。Out of Scope の他モジュール `*_log`
+一括書き換えにも踏み込んでいない。境界違反・AC 未カバー・missing test いずれも検出されず。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -9663,8 +9663,21 @@ _resume_branch_assert_slug_match() {
 # 構造化ログ prefix `dr:` で grep 集計できるようにする（Req 6.1〜6.3 / NFR 2.1〜2.2）。
 # helper スクリプト化はせず watcher 単体で完結させる（install.sh の配布対象拡張を
 # 避けるため）。
+#
+# Issue #392 (Req 1.1, 1.2 / NFR 3.1): `dr_log` / `dr_warn` は stderr に書き出す。
+# 理由: `dr_resolve_one` は stdout を「機械可読な戻り値」（`resolved` / `open` /
+# `closed unmerged` / `api error` のいずれか厳密 1 行）に予約しており、その実装中で
+# `dr_log` を呼ぶ経路（OPEN + `staged-for-release` 解決パス）が存在する。`dr_log`
+# が stdout に echo すると、`dr_unblock_resolve_one_issue` 側の
+# `verdict=$(dr_resolve_one ...)` で **ログ行と戻り値の両方** が `$verdict` に
+# 連結捕捉され、未知の verdict と判定されて `BASE_BRANCH != main` 環境の
+# `DEP_AUTO_UNBLOCK` が完全停止する事象が実機再現した（#117 / #115）。`dr_warn` は
+# 既に `>&2` だったが、本意は「stdout 汚染ゼロ」なので `dr_log` も `>&2` に揃える。
+# cron 経由（`>>cron.log 2>&1`）では stderr も cron.log へ集約されるため、既存
+# 集計 grep（`grep ' dr:'` / `grep 'verdict='` 等）は本修正で破壊しない（NFR 3.1）。
+# `dr_error` は本修正前から `>&2`（Req 4.3）。
 dr_log() {
-  echo "[$(date '+%F %T')] dr: $*"
+  echo "[$(date '+%F %T')] dr: $*" >&2
 }
 dr_warn() {
   echo "[$(date '+%F %T')] dr: WARN: $*" >&2

--- a/local-watcher/test/dr_resolve_one_stdout_test.sh
+++ b/local-watcher/test/dr_resolve_one_stdout_test.sh
@@ -1,0 +1,509 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #392 の回帰防止テスト。dr_resolve_one の全 5 経路で stdout が
+#       「resolved / open / closed unmerged / api error の厳密 1 行のみ」で
+#       あること、および dr_log 出力が stdout を汚染しないことを実 stdout 捕捉
+#       で検証する。
+#
+#       既存 dr_unblock_sweep_test.sh は dr_resolve_one / dr_log を stub で
+#       置き換えていたため、本 Issue の根因（dr_log の stdout echo）を見逃して
+#       きた。本テストは実体 dr_resolve_one + 実体 dr_log を extract_function で
+#       隔離抽出して読み込み、gh のみを stub することで実 stdout を観測する。
+#
+#       検証する AC（docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/
+#       requirements.md）:
+#         - Req 1.1: dr_log 出力先が stderr で stdout に 1 文字も書かない
+#         - Req 1.2: dr_warn 出力先が stderr で stdout に 1 文字も書かない
+#         - Req 1.3: OPEN + staged-for-release → stdout が厳密に "resolved\n"
+#         - Req 1.4: OPEN + ラベル無し → stdout が厳密に "open\n"
+#         - Req 1.5: CLOSED + merged PR 1 件以上 → stdout が厳密に "resolved\n"
+#         - Req 1.6: CLOSED + merged PR ゼロ件 → stdout が厳密に "closed unmerged\n"
+#         - Req 1.7: GraphQL errors / jq parse 失敗 → stdout が厳密に "api error\n"
+#         - Req 1.8: 呼び出し側で verdict=$(dr_resolve_one ...) を実行したとき
+#                    捕捉文字列が 4 値のいずれかと完全一致（未知 verdict に落ちない）
+#         - Req 5.1: 全 5 終端パスで stdout = verdict 文字列ちょうど 1 行のみ
+#         - Req 7.2 / 7.3: staged-for-release 解決パスで verdict=resolved、
+#                          dr_log 行は stderr 経由のみで観測される
+#         - Req 7.4: 5 経路の stdout 厳密一致
+#         - NFR 3.1: dr_log フォーマット `[YYYY-MM-DD HH:MM:SS] dr: <message>` 維持
+#
+# 配置先: local-watcher/test/dr_resolve_one_stdout_test.sh
+# 依存:   bash 4+, awk, jq, grep
+# 実行:   bash local-watcher/test/dr_resolve_one_stdout_test.sh
+
+set -euo pipefail
+
+# 本テストは抽出関数（dr_resolve_one / dr_log / dr_warn / dr_error /
+# dr_gh_graphql_closed_by）と stub から indirect 参照される変数を多用するため、
+# static 解析（shellcheck）からは未使用に見える。本ファイル全体で SC2034 を抑止する。
+# shellcheck disable=SC2034
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
+# eval で読み込む。トップレベル副作用は回避する。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# 対象関数群を読み込む。dr_resolve_one が dr_gh_graphql_closed_by / dr_log /
+# dr_warn を呼ぶため、実体を抽出して読み込む（本 Issue の根因は dr_log 実体の
+# stdout echo であり、stub に置き換えると見逃すため）。
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "dr_log")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "dr_warn")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "dr_error")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "dr_resolve_one")"
+
+# dr_gh_graphql_closed_by は stub で置き換える（実 GraphQL は叩かない）。
+# このため本来の関数は読み込まず、後段でテスト stub として再定義する。
+
+for fn in dr_log dr_warn dr_error dr_resolve_one; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# グローバル env（dr_resolve_one が遅延束縛で参照）
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# Req 1.3 では BASE_BRANCH != main で staged-for-release 解決パスを起こすため、
+# デフォルトは develop に設定（個別ケースで override）。
+# shellcheck disable=SC2034
+BASE_BRANCH="develop"
+# shellcheck disable=SC2034
+LABEL_STAGED_FOR_RELEASE="staged-for-release"
+# shellcheck disable=SC2034
+DRR_GH_TIMEOUT="60"
+# shellcheck disable=SC2034
+MERGE_QUEUE_GIT_TIMEOUT="60"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  case "$haystack" in
+    *"$needle"*)
+      echo "PASS: $label"
+      PASS_COUNT=$((PASS_COUNT + 1))
+      ;;
+    *)
+      echo "FAIL: $label"
+      echo "  expected to contain: $(printf '%q' "$needle")"
+      echo "  actual             : $(printf '%q' "$haystack")"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      ;;
+  esac
+}
+
+assert_empty() {
+  local label="$1"
+  local actual="$2"
+  if [ -z "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label (expected empty)"
+    echo "  actual: $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ── stub: dr_gh_graphql_closed_by ──
+# DR_FIXTURE_RESPONSE 変数の内容を stdout にそのまま返し、DR_FIXTURE_RC で
+# 終了コードを制御する。
+# shellcheck disable=SC2317
+dr_gh_graphql_closed_by() {
+  printf '%s' "${DR_FIXTURE_RESPONSE:-}"
+  return "${DR_FIXTURE_RC:-0}"
+}
+
+# ── timeout stub ──
+# dr_resolve_one は dr_gh_graphql_closed_by を内部で `timeout ... gh api graphql`
+# 形式で呼ばないため stub 不要だが、後方互換のためテスト中も timeout は不要。
+# （dr_resolve_one は dr_gh_graphql_closed_by を `response=$(dr_gh_graphql_closed_by ...)`
+# で呼ぶだけ。timeout は dr_gh_graphql_closed_by の **内部** にあり、本テストが
+# それを stub する以上、timeout は起動されない）
+
+# ============================================================
+# Helper: stdout / stderr を別々に捕捉して dr_resolve_one を呼ぶ
+# ============================================================
+# 引数: $1 = 依存 Issue 番号（数字のみ）
+# 戻り値（output vars）:
+#   CAPTURED_STDOUT = dr_resolve_one の stdout
+#   CAPTURED_STDERR = dr_resolve_one の stderr
+capture_dr_resolve_one() {
+  local issue_num="$1"
+  local stderr_file
+  stderr_file=$(mktemp)
+  # dr_resolve_one の stdout を $() で捕捉、stderr は一時ファイルへ
+  CAPTURED_STDOUT=$(dr_resolve_one "$issue_num" 2>"$stderr_file")
+  CAPTURED_STDERR=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+}
+
+# ============================================================
+# Case 1: OPEN + staged-for-release（BASE_BRANCH=develop / Req 1.3, 1.8, 7.2, 7.3）
+# 本 Issue (#392) の根因経路。dr_log が stdout を汚染すれば $verdict が
+# 「ログ行 + resolved」になり厳密一致 assert で失敗する。
+# ============================================================
+echo "--- Case 1: OPEN + staged-for-release (Req 1.3 / 1.8 / 7.2 / 7.3) ---"
+
+BASE_BRANCH="develop"
+DR_FIXTURE_RESPONSE=$(jq -cn '{
+  "data": {
+    "repository": {
+      "issue": {
+        "state": "OPEN",
+        "labels": {
+          "nodes": [
+            {"name": "auto-dev"},
+            {"name": "staged-for-release"}
+          ]
+        },
+        "closedByPullRequestsReferences": {"nodes": []}
+      }
+    }
+  }
+}')
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 117
+
+# Req 1.3 / 7.2 / 7.4: stdout が厳密に "resolved" のみ（末尾改行を除き他文字を含まない）
+assert_eq "Req 1.3 / 7.4: OPEN + staged-for-release stdout 厳密に 'resolved'" \
+  "resolved" "$CAPTURED_STDOUT"
+# Req 1.8: verdict=$(...) で捕捉した値が `unknown verdict` の 4 値以外に落ちない
+case "$CAPTURED_STDOUT" in
+  "resolved"|"open"|"closed unmerged"|"api error")
+    echo "PASS: Req 1.8: verdict が 4 値集合と完全一致"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: Req 1.8: verdict が 4 値集合外 → 未知 verdict 分岐に落ちる"
+    echo "  captured: $(printf '%q' "$CAPTURED_STDOUT")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+# Req 7.3: dr_log 行は stderr 経由のみで観測される
+assert_contains "Req 7.3 / NFR 3.1: dr_log 行が stderr に出ている（フォーマット維持）" \
+  "$CAPTURED_STDERR" "dr: issue=#117 verdict=resolved reason=staged-for-release base=develop"
+# Req 1.1 / 7.2: dr_log 行が stdout に紛れ込まない（汚染ゼロの強い検証）
+case "$CAPTURED_STDOUT" in
+  *"dr:"*|*"reason=staged-for-release"*|*"verdict=resolved"*)
+    echo "FAIL: Req 1.1 / 7.2: dr_log 行が stdout に紛れ込んでいる（汚染ゼロ違反）"
+    echo "  stdout: $(printf '%q' "$CAPTURED_STDOUT")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+  *)
+    echo "PASS: Req 1.1 / 7.2: dr_log 行が stdout に含まれない（stdout 汚染ゼロ）"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+esac
+
+# ============================================================
+# Case 2: OPEN + staged-for-release ラベル無し（Req 1.4 / 7.4）
+# ============================================================
+echo ""
+echo "--- Case 2: OPEN + ラベル無し (Req 1.4 / 7.4) ---"
+
+BASE_BRANCH="develop"
+DR_FIXTURE_RESPONSE=$(jq -cn '{
+  "data": {
+    "repository": {
+      "issue": {
+        "state": "OPEN",
+        "labels": {
+          "nodes": [
+            {"name": "auto-dev"}
+          ]
+        },
+        "closedByPullRequestsReferences": {"nodes": []}
+      }
+    }
+  }
+}')
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 200
+
+assert_eq "Req 1.4 / 7.4: OPEN + ラベル無し stdout 厳密に 'open'" \
+  "open" "$CAPTURED_STDOUT"
+
+# ============================================================
+# Case 2b: OPEN + BASE_BRANCH=main（後方互換 / Req 3.2）
+# BASE_BRANCH=main では staged-for-release ラベルがあっても open を返す（既存挙動維持）
+# ============================================================
+echo ""
+echo "--- Case 2b: OPEN + BASE_BRANCH=main (Req 3.2 後方互換) ---"
+
+BASE_BRANCH="main"
+DR_FIXTURE_RESPONSE=$(jq -cn '{
+  "data": {
+    "repository": {
+      "issue": {
+        "state": "OPEN",
+        "labels": {
+          "nodes": [
+            {"name": "staged-for-release"}
+          ]
+        },
+        "closedByPullRequestsReferences": {"nodes": []}
+      }
+    }
+  }
+}')
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 300
+
+assert_eq "Req 3.2: BASE_BRANCH=main では staged-for-release を読まず 'open'（既存挙動）" \
+  "open" "$CAPTURED_STDOUT"
+
+# ============================================================
+# Case 3: CLOSED + merged PR 1 件以上（Req 1.5 / 7.4）
+# ============================================================
+echo ""
+echo "--- Case 3: CLOSED + merged PR 1 件以上 (Req 1.5 / 7.4) ---"
+
+BASE_BRANCH="develop"
+DR_FIXTURE_RESPONSE=$(jq -cn '{
+  "data": {
+    "repository": {
+      "issue": {
+        "state": "CLOSED",
+        "labels": {"nodes": []},
+        "closedByPullRequestsReferences": {
+          "nodes": [
+            {"number": 1001, "state": "MERGED"}
+          ]
+        }
+      }
+    }
+  }
+}')
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 400
+
+assert_eq "Req 1.5 / 7.4: CLOSED + merged PR 1 件以上 stdout 厳密に 'resolved'" \
+  "resolved" "$CAPTURED_STDOUT"
+
+# ============================================================
+# Case 4: CLOSED + merged PR ゼロ件（Req 1.6 / 7.4）
+# ============================================================
+echo ""
+echo "--- Case 4: CLOSED + merged PR ゼロ件 (Req 1.6 / 7.4) ---"
+
+BASE_BRANCH="develop"
+DR_FIXTURE_RESPONSE=$(jq -cn '{
+  "data": {
+    "repository": {
+      "issue": {
+        "state": "CLOSED",
+        "labels": {"nodes": []},
+        "closedByPullRequestsReferences": {
+          "nodes": [
+            {"number": 1002, "state": "CLOSED"}
+          ]
+        }
+      }
+    }
+  }
+}')
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 500
+
+assert_eq "Req 1.6 / 7.4: CLOSED + merged PR ゼロ件 stdout 厳密に 'closed unmerged'" \
+  "closed unmerged" "$CAPTURED_STDOUT"
+
+# 空配列ケース
+DR_FIXTURE_RESPONSE=$(jq -cn '{
+  "data": {
+    "repository": {
+      "issue": {
+        "state": "CLOSED",
+        "labels": {"nodes": []},
+        "closedByPullRequestsReferences": {"nodes": []}
+      }
+    }
+  }
+}')
+capture_dr_resolve_one 501
+assert_eq "Req 1.6 / 7.4: CLOSED + 空配列 stdout 厳密に 'closed unmerged'" \
+  "closed unmerged" "$CAPTURED_STDOUT"
+
+# ============================================================
+# Case 5: GraphQL errors 検知（Req 1.7 / 7.4）
+# ============================================================
+echo ""
+echo "--- Case 5: GraphQL errors 検知 (Req 1.7 / 7.4) ---"
+
+BASE_BRANCH="develop"
+DR_FIXTURE_RESPONSE=$(jq -cn '{
+  "errors": [
+    {"message": "Issue not found"}
+  ]
+}')
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 600
+
+assert_eq "Req 1.7 / 7.4: GraphQL errors 検知 stdout 厳密に 'api error'" \
+  "api error" "$CAPTURED_STDOUT"
+
+# ============================================================
+# Case 6: jq parse 失敗（不正な JSON 応答 / Req 1.7 / 7.4）
+# ============================================================
+echo ""
+echo "--- Case 6: jq parse 失敗 (Req 1.7 / 7.4) ---"
+
+BASE_BRANCH="develop"
+# 不正な JSON 文字列を返して jq parse 失敗を再現
+DR_FIXTURE_RESPONSE="this is not valid json at all"
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 700
+
+assert_eq "Req 1.7 / 7.4: 不正 JSON 応答 stdout 厳密に 'api error'" \
+  "api error" "$CAPTURED_STDOUT"
+
+# state が null の想定外応答
+DR_FIXTURE_RESPONSE=$(jq -cn '{"data": {"repository": {"issue": null}}}')
+capture_dr_resolve_one 701
+assert_eq "Req 1.7 / 7.4: issue=null の想定外応答 stdout 厳密に 'api error'" \
+  "api error" "$CAPTURED_STDOUT"
+
+# ============================================================
+# Case 7: gh GraphQL 失敗（rc != 0 / Req 1.7）
+# ============================================================
+echo ""
+echo "--- Case 7: gh GraphQL 失敗 rc!=0 (Req 1.7) ---"
+
+BASE_BRANCH="develop"
+DR_FIXTURE_RESPONSE="gh: API rate limit exceeded"
+DR_FIXTURE_RC=1
+
+capture_dr_resolve_one 800
+
+assert_eq "Req 1.7: gh GraphQL rc!=0 stdout 厳密に 'api error'" \
+  "api error" "$CAPTURED_STDOUT"
+# dr_warn が stderr に出ていることも確認（NFR 3.1 既存挙動）
+assert_contains "Req 1.2 / NFR 3.1: gh rc!=0 で dr_warn が stderr に WARN: ... を出力" \
+  "$CAPTURED_STDERR" "dr: WARN:"
+# Req 1.2: dr_warn 行が stdout を汚染しない
+case "$CAPTURED_STDOUT" in
+  *"WARN:"*|*"gh api graphql"*)
+    echo "FAIL: Req 1.2: dr_warn 行が stdout に紛れ込んでいる"
+    echo "  stdout: $(printf '%q' "$CAPTURED_STDOUT")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+  *)
+    echo "PASS: Req 1.2: dr_warn 行が stdout に含まれない（stdout 汚染ゼロ）"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+esac
+
+# ============================================================
+# Case 8: dr_log / dr_warn 直接呼び出しの stdout 汚染ゼロ検証
+# （Req 1.1 / 1.2 ロガー単体の出力先確認）
+# ============================================================
+echo ""
+echo "--- Case 8: dr_log / dr_warn 単体の stdout 汚染ゼロ (Req 1.1 / 1.2) ---"
+
+# dr_log の出力先を厳密に検証する
+log_stderr_file=$(mktemp)
+log_stdout=$(dr_log "test message 1.1" 2>"$log_stderr_file")
+log_stderr=$(cat "$log_stderr_file")
+rm -f "$log_stderr_file"
+
+assert_empty "Req 1.1: dr_log の stdout は厳密に空" "$log_stdout"
+assert_contains "Req 1.1 / NFR 3.1: dr_log の stderr に message が含まれフォーマット維持" \
+  "$log_stderr" "dr: test message 1.1"
+
+# dr_warn の出力先を厳密に検証する
+warn_stderr_file=$(mktemp)
+warn_stdout=$(dr_warn "test warn 1.2" 2>"$warn_stderr_file")
+warn_stderr=$(cat "$warn_stderr_file")
+rm -f "$warn_stderr_file"
+
+assert_empty "Req 1.2: dr_warn の stdout は厳密に空" "$warn_stdout"
+assert_contains "Req 1.2 / NFR 3.1: dr_warn の stderr に WARN: が含まれフォーマット維持" \
+  "$warn_stderr" "dr: WARN: test warn 1.2"
+
+# dr_error の出力先確認（Req 4.3 既存挙動維持）
+err_stderr_file=$(mktemp)
+err_stdout=$(dr_error "test error 4.3" 2>"$err_stderr_file")
+err_stderr=$(cat "$err_stderr_file")
+rm -f "$err_stderr_file"
+
+assert_empty "Req 4.3: dr_error の stdout は厳密に空（既存挙動維持）" "$err_stdout"
+assert_contains "Req 4.3: dr_error の stderr に ERROR: が含まれる（既存挙動維持）" \
+  "$err_stderr" "dr: ERROR: test error 4.3"
+
+# ============================================================
+# Case 9: REPO env 不正で api error（Req 1.7 / 補助）
+# ============================================================
+echo ""
+echo "--- Case 9: REPO env 不正 (Req 1.7) ---"
+
+REPO="invalid-no-slash"
+# shellcheck disable=SC2034
+BASE_BRANCH="develop"
+DR_FIXTURE_RESPONSE=""
+DR_FIXTURE_RC=0
+
+capture_dr_resolve_one 900
+
+assert_eq "Req 1.7: REPO env 不正で stdout 厳密に 'api error'" \
+  "api error" "$CAPTURED_STDOUT"
+
+# REPO を元に戻す（テストはここで終了なので未使用になるが、対象 var が遅延束縛で
+# 必要な場合に備えて明示的に復元する慣行を残す。shellcheck の SC2034 警告は抑止）
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

`dr_log()` が stderr リダイレクト（`>&2`）なしで stdout に echo していたため、
`dr_resolve_one` の OPEN + `staged-for-release` 解決パスで `verdict=$(dr_resolve_one ...)` による
stdout 捕捉にログ行と戻り値の両方が混入し、呼び出し側が「未知の verdict」と判断して
unblock を放置していた。`dr_log()` の echo に `>&2` を 1 行追加することで修正。
`BASE_BRANCH != main`（2-branch / gitflow）運用で `DEP_AUTO_UNBLOCK` が完全に機能しない
実機再現バグ（#117 依存の #115 が解除されない事象）を根本解消し、
回帰防止テスト 22 件を新規追加した。

## 対応 Issue

Closes #392

## 関連 PR

なし（Architect スキップ。設計 PR なし）

## 実装内容

- (Req 1.1 / fix) `dr_log()` の `echo` に `>&2` を追加して stdout 汚染を解消
- (Req 1.2) `dr_warn` は本修正前から `>&2`、変更なし
- (Req 1.3〜1.8) `dr_resolve_one` の 5 終端パスすべてで stdout が verdict 文字列のみになったことを確認
- (Req 2.1〜2.3) `BASE_BRANCH != main` 環境での `DEP_AUTO_UNBLOCK` 自動 unblock 復旧
- (Req 3.1〜3.5) 後方互換維持（`BASE_BRANCH=main` 既存運用・CLOSED 経路・`api error` 経路・env var / ラベル / exit code 不変）
- (Req 4.1〜4.3) cron.log 可観測性維持（フォーマット・語彙・prefix `dr:` 不変）
- (Req 5.1〜5.4) dr 系 stdout 戻り値関数（`dr_extract_deps` / `dr_format_unresolved_comment` / `dr_gh_graphql_closed_by`）の棚卸し確認
- (Req 6.1〜6.4) 他モジュール `*_log` 横展開チェック: 同型バグ無し（全 14 ロガー prefix 確認）
- (Req 7.1〜7.5) `local-watcher/test/dr_resolve_one_stdout_test.sh` 新規追加（22 assert、Red→Green 実証）
- (Req 8.1〜8.3) `.claude/agents` / `.claude/rules` 変更なし、`diff -r` 空を確認

## 受入基準チェック

- [x] Req 1.1: `dr_log` stdout に 1 文字も書き出さない ← `dr_resolve_one_stdout_test.sh` Case 8
- [x] Req 1.3: OPEN + staged-for-release → stdout 厳密 `resolved` ← Case 1
- [x] Req 1.4: OPEN + ラベル無し → stdout 厳密 `open` ← Case 2
- [x] Req 1.5: CLOSED + merged≥1 → stdout 厳密 `resolved` ← Case 3
- [x] Req 1.6: CLOSED + merged=0 → stdout 厳密 `closed unmerged` ← Case 4
- [x] Req 1.7: api error 経路 → stdout 厳密 `api error` ← Case 5/6/7/9
- [x] Req 1.8: verdict 捕捉が 4 値集合と完全一致 ← Case 1 (case 4 値マッチ assert)
- [x] Req 7.2: staged-for-release パスの `verdict` が `resolved` と完全一致 ← Case 1
- [x] Req 7.3: `dr_log` 行が stderr のみ・stdout に混入しない ← Case 1 (両方向 assert)
- [x] NFR 1.1: `bash -n` / `shellcheck` クリーン ← 検証ログ参照
- [x] NFR 1.2: 追加テストも `bash -n` / `shellcheck` クリーン ← 検証ログ参照

## テスト結果

```
bash local-watcher/test/dr_resolve_one_stdout_test.sh
→ 22 PASS / 0 FAIL

bash local-watcher/test/dr_unblock_sweep_test.sh
→ 56 PASS / 0 FAIL

bash local-watcher/test/dc_cycle_sweep_test.sh
→ 74 PASS / 0 FAIL

shellcheck local-watcher/bin/issue-watcher.sh ...（クリーン / rc=0）
bash -n local-watcher/bin/issue-watcher.sh（OK）
```

（Reviewer による独立再実行でも全 PASS 確認済み: `docs/specs/392-.../review-notes.md` 参照）

## 実装上の判断

- 修正は `dr_log()` の `echo` に `>&2` を追加する 1 行変更のみ。`dr_warn` は本修正前から `>&2`。
- `dr_resolve_one` / `dr_unblock_sweep` 本体・他モジュールの `*_log` には触れていない。
- 横展開チェックで全 14 ロガー prefix の `var=$(func ...)` パターンを grep し、同型バグが
  `dr_resolve_one` 以外に存在しないことを確認（Req 6.3 充足）。
- `pr_detect_iteration_keyword` は既に `pr_log ... >&2` で対策済み、`pr_build_prompt_file` は
  `pr_log` を呼ばない設計であることも確認した。
- README 反映は Req 8.2 の「必要時のみ追記」に従い不要と判断（外部観測挙動の変更なし）。

詳細は `docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer の独立レビュー（approve）済み: `docs/specs/392-fix-dr-dr-log-stdout-staged-for-release/review-notes.md` を参照（RESULT: approve）
- base: main / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #392 のコメントを参照してください。
