### PR TITLE
fix(#397): no-progress な design/impl round を needs-iteration 据え置きにし silent deadlock を解消

### DIFF
--- a/docs/specs/397-fix-pr-iteration-no-progress-design-roun/impl-notes.md
+++ b/docs/specs/397-fix-pr-iteration-no-progress-design-roun/impl-notes.md
@@ -1,0 +1,88 @@
+# Implementation Notes (#397)
+
+## 修正方針
+
+`pr-iteration.sh` の `pi_run_iteration` 末尾（round 終了処理）で、`commit_pushed=false`（head branch に新規 commit が push されなかった round）でも `no-progress-streak < PR_ITERATION_NO_PROGRESS_LIMIT` であれば `pi_finalize_labels_design` / `pi_finalize_labels` を呼んで `needs-iteration` を外し、`awaiting-design-review` / `ready-for-review` に遷移して `action=success` で完了扱いしていた defect を修正する。
+
+修正後の挙動:
+
+- **commit_pushed=true**（新規 commit あり）→ 従来通り `pi_finalize_labels_design` / `pi_finalize_labels` を呼んで `awaiting-design-review` / `ready-for-review` に遷移し `action=success` ログを記録（Req 3.1〜3.3 / 4.3 / NFR 1.3）。
+- **commit_pushed=false かつ streak < limit**（no-progress 過渡状態）→ `needs-iteration` を **据え置き** し、`action=no-progress` ログを記録して `return 1`。次サイクルでも `needs-iteration` を起点とする候補抽出に再び含まれる（Req 1.1〜1.3 / 2.1〜2.2 / 4.1〜4.2 / 5.1〜5.2）。
+- **commit_pushed=false かつ streak >= limit**（no-progress 上限到達）→ 従来通り `pi_escalate_to_failed "no-progress"` で `claude-failed` に遷移し `return 2`。Req 5.3 を満たすため、escalate ログに `limit=<値>` を追加（従来は省略されていた）（Req 2.3〜2.4 / 5.3）。
+
+判定ロジックは新規ヘルパー `pi_classify_round_outcome <commit_pushed> <new_streak> <limit>` に切り出し、純粋関数として隔離テスト可能にした（CLAUDE.md「機能追加ガイドライン」§1 / §2 / §7 と整合: `pi_` prefix namespace 維持、副作用なし、近接テスト追加）。
+
+## 変更ファイル
+
+- `local-watcher/bin/modules/pr-iteration.sh`
+  - `pi_classify_round_outcome()` 新規追加（純粋関数 / 3 way 分類: `success` / `escalate` / `no-progress`）
+  - `pi_run_iteration()` 内の round 終了処理（`if [ $rc -eq 0 ]; then` ブロック）を上記ヘルパーの結果で 3 way 分岐に再構成
+  - escalate ログに `limit=<値>` を追記（Req 5.3）
+  - 既存 env var（`PR_ITERATION_NO_PROGRESS_LIMIT` / `PR_ITERATION_DESIGN_ENABLED` / `PR_ITERATION_MAX_ROUNDS*`）の名称・既定値・意味は **不変**（NFR 1.1）
+  - 既存ラベル（`needs-iteration` / `awaiting-design-review` / `ready-for-review` / `claude-failed`）の名称・付与責務・取り外し責務は **不変**（NFR 1.2）
+  - 既存 return code（0=success / 1=fail / 2=escalated / 3=skip）の意味は **不変**
+
+## 追加テスト
+
+- `local-watcher/test/pi_classify_round_outcome_test.sh`（新規 24 ケース）
+  - 正常系 success（4 ケース / Req 3.1〜3.3）: `commit_pushed=true` は streak 値に依らず success
+  - 正常系 no-progress（3 ケース / Req 1.1〜1.3 / 2.1〜2.2 / 4.1〜4.2）: `commit_pushed=false` かつ `streak < limit` は no-progress
+  - 正常系 escalate（3 ケース / Req 2.3〜2.4 / 5.3）: `streak >= limit` は escalate
+  - 累積シナリオ（4 ケース / Req 2.1〜2.3）: 連続 no-progress round で最終的に escalate に到達する
+  - 境界値（3 ケース）: `limit=1` で即時 escalate / `limit=0` で常時 escalate / 極端な大 limit で永続 no-progress
+  - 異常系（6 ケース / NFR 2.1）: 不正値（空文字列 / 非数値 / typo）は安全側で no-progress に倒れる
+  - kind 非依存性（1 ケース / Req 4.1〜4.3）: 同入力で同 outcome（design / impl 区別なし）
+
+## 静的解析結果
+
+- `bash -n local-watcher/bin/modules/pr-iteration.sh` → OK
+- `shellcheck local-watcher/bin/modules/pr-iteration.sh` → 警告ゼロ
+- `shellcheck local-watcher/bin/modules/*.sh local-watcher/bin/issue-watcher.sh install.sh setup.sh` → 警告ゼロ
+- `diff -r .claude/agents repo-template/.claude/agents` → 空（同期維持）
+- `diff -r .claude/rules repo-template/.claude/rules` → 空（同期維持）
+- `repo-template/` 配下に `pr-iteration.sh` は存在せず（`local-watcher/` 配下のみが正本、`install.sh` 経由で `$HOME/bin/modules/` に配布する設計）
+
+## 既存テスト実行結果（リグレッション確認）
+
+- `bash local-watcher/test/pi_classify_round_outcome_test.sh` → 24 PASS / 0 FAIL（新規）
+- `bash local-watcher/test/pi_max_rounds_kind_test.sh` → 24 PASS / 0 FAIL
+- `bash local-watcher/test/pi_detect_quota_soft_fail_test.sh` → 13 PASS / 0 FAIL
+- `bash local-watcher/test/repo_prefix_log_test.sh` → 36 PASS / 0 FAIL
+
+## AC Traceability
+
+| 要件 | テストケース（および inline 修正箇所） |
+|---|---|
+| Req 1.1 (no-progress で `awaiting-design-review` 付与なし) | `pi_classify_round_outcome false 1 3 → no-progress` + 修正後の `case "$outcome" in no-progress) return 1` 分岐（`pi_finalize_labels_design` を呼ばない経路） |
+| Req 1.2 (no-progress を `action=success` で記録しない) | 修正後の `pi_log ... action=no-progress` 出力（`action=success` キーを含まない） |
+| Req 1.3 (次サイクル候補に残る) | `needs-iteration` を据え置く（`pi_finalize_labels*` を呼ばないため `pi_fetch_candidate_prs` の `label:"$LABEL_NEEDS_ITERATION"` フィルタに次サイクルも合致） |
+| Req 2.1 (no-progress streak 加算) | 修正前と同じく `prev_streak+1` を `pi_write_marker` で永続化 / 既存 `pi_max_rounds_kind_test.sh` の no-progress-streak 読み出しテストで読出側の互換性確認 |
+| Req 2.2 (limit 未満なら次 round 進める) | `pi_classify_round_outcome false <streak<limit> <limit> → no-progress`（4 ケース + 累積シナリオ 2 ケース） |
+| Req 2.3 (limit 到達で escalation 発火) | `pi_classify_round_outcome false <streak>=limit> <limit> → escalate`（3 ケース + 累積シナリオ 2 ケース + 境界値 2 ケース） |
+| Req 2.4 (escalation ログに reason/streak/limit) | 修正後の `pi_log ... no-progress-streak=${new_streak} limit=${PR_ITERATION_NO_PROGRESS_LIMIT} reason=no-progress escalate` 出力 |
+| Req 3.1 (commit 有り round の通常 finalize) | `pi_classify_round_outcome true * * → success` + 既存 finalize case 分岐維持（4 ケース） |
+| Req 3.2 (commit 有り round で streak リセット) | `new_streak=0` 既存ロジック維持（修正対象外） |
+| Req 3.3 (commit 有り round の `action=success` ログ維持) | 既存 `pi_log ... action=success (needs-iteration -> awaiting-design-review/ready-for-review)` 維持 |
+| Req 4.1 (impl 種別でも同等制御フロー) | `pi_classify_round_outcome` は kind を引数に取らない（純粋関数 / 1 ケース）+ `pi_run_iteration` 内の case 分岐は finalize 関数選択のみ kind 依存、outcome 判定は kind 非依存 |
+| Req 4.2 (impl no-progress で `ready-for-review` 付与なし) | 修正後の `case "$outcome" in no-progress) return 1` 分岐は `pi_finalize_labels` も呼ばないため impl 側も同様に needs-iteration 据え置き |
+| Req 4.3 (impl commit 有り round の通常 finalize) | 既存 `impl)` case ブロックは outcome=success のときのみ到達するため挙動不変 |
+| Req 5.1 (no-progress 1 行ログに PR/kind/round/streak/limit) | 既存 L1387 ログを温存（design / impl 両 kind で出力 / `pi_log "PR #${pr_number}: kind=${kind} round=${next_round} no-progress-streak=${new_streak} limit=${PR_ITERATION_NO_PROGRESS_LIMIT}"`） |
+| Req 5.2 (`action=success` を含まないログ) | 修正後の `pi_log ... action=no-progress` 出力で `action=success` を含まない |
+| Req 5.3 (escalation 1 行ログに PR/kind/round/reason/streak/limit) | 修正後の escalate ログに `limit=${PR_ITERATION_NO_PROGRESS_LIMIT}` を追加（従来欠落していた） |
+| NFR 1.1 (既存 env var 不変) | env var の参照のみで宣言・既定値は無変更 |
+| NFR 1.2 (既存ラベル不変) | `LABEL_NEEDS_ITERATION` / `LABEL_AWAITING_DESIGN` / `LABEL_READY` / `LABEL_FAILED` の名称・責務は無変更 |
+| NFR 1.3 (commit 有り round の挙動不変) | 既存 finalize case 分岐と success ログを温存（success cases 4 ケース + commit 有り round の return 0 を維持） |
+| NFR 2.1 (判定情報不足時は success に倒さない) | `pi_classify_round_outcome` の不正値処理は no-progress に倒れる（6 ケース） |
+| NFR 2.2 (marker 永続化失敗時の据え置き) | 既存 `pi_write_marker` 失敗時の `pi_error + return 1` ロジック維持（#122 既存挙動） |
+
+## 確認事項
+
+- **`return 1` の意味**: no-progress round 据え置きは `pi_run_iteration` の `return 1`（fail カウンタに加算される）で表現している。要件は「`action=success` として記録しない」のみを要求しているため要件は満たすが、運用観点では `process_pr_iteration` のサマリで「needs-iteration 据え置き = fail カウント増」となる。意図的な挙動だが、将来的に「needs-iteration retry」を独立 return code（例: `4=retry`）に分離してサマリでも区別する設計変更を検討する余地がある（本要件のスコープ外、別 Issue 検討推奨）。
+- **escalate ログの `limit=` 追記**: Req 5.3 を満たすため escalate ログに `limit=` キーを新規追加した。既存運用で `grep 'reason=no-progress escalate'` 形式の集計をしている場合は不変だが、`limit=` を読み取る監視はこれまで存在しなかったため後方互換上の影響はない（ログ文字列に新キー追加のみ、既存キーの順序や名称は不変）。
+
+## 派生タスク候補
+
+- `process_pr_iteration` のサマリで「needs-iteration 据え置き retry round」を `fail` から分離するための return code 追加（運用観測性向上、本 Issue スコープ外）
+- Out of Scope に挙がっている「reopen された PR に残る obsolete な人間コメントを現行指示として解釈する挙動の見直し」は別 Issue 検討事項
+
+STATUS: complete

--- a/docs/specs/397-fix-pr-iteration-no-progress-design-roun/requirements.md
+++ b/docs/specs/397-fix-pr-iteration-no-progress-design-roun/requirements.md
@@ -1,0 +1,155 @@
+# Requirements Document
+
+## Introduction
+
+PR Iteration Processor の design round が新規 commit を生まなかった場合（no-progress round）、
+no-progress 連続カウンタが上限に達していなくても `needs-iteration` を外して
+`awaiting-design-review` に遷移させ、結果として `action=success` 扱いになっている。
+`pr-iteration` の候補抽出は `needs-iteration` ラベル付与 PR を起点に行うため、
+`awaiting-design-review` へ移行した PR は次 round の対象から外れ、no-progress 連続カウンタが
+加算されない。結果として escalation（`claude-failed` 付与）が発火せず、必須 status check が
+FAILED のまま auto-merge も再レビューも進まない silent deadlock が発生している。本要件は
+#122 で導入された no-progress 安全機構を design 遷移経路でも有効化し、no-progress を観測した
+ときに deadlock せず最終的に escalation または retry に収束させることを目的とする。
+
+## Requirements
+
+### Requirement 1: no-progress な design round のラベル据え置き
+
+**Objective:** As an idd-claude 運用者, I want no-progress な design round で
+`needs-iteration` ラベルが据え置かれることを保証してほしい, so that PR が候補プールから外れずに
+次 round で再試行され、no-progress 連続カウンタが加算され続けて最終的に escalation に到達する。
+
+#### Acceptance Criteria
+
+1. When design 種別の PR Iteration round が終了し、当該 round の開始時点から終了時点までに
+   head branch に新規 commit が push されなかった場合、the PR Iteration Processor shall
+   `needs-iteration` ラベルを据え置き、`awaiting-design-review` ラベルを付与しない。
+2. When design 種別の PR Iteration round が終了し、当該 round で新規 commit が push されな
+   かった場合、the PR Iteration Processor shall 当該 round の終了結果を `action=success` として
+   記録しない。
+3. When design 種別の PR Iteration round が終了し、当該 round で新規 commit が push されな
+   かった場合、the PR Iteration Processor shall 当該 PR が次サイクルでも `needs-iteration`
+   ラベルを起点とする候補抽出に再び含まれる状態を維持する。
+
+### Requirement 2: no-progress 連続カウンタの加算と escalation 到達性
+
+**Objective:** As an idd-claude 運用者, I want no-progress な round が観測されたら
+no-progress 連続カウンタが確実に加算され、上限に達した時点で escalation が発火することを
+保証してほしい, so that PR が必須 status check FAILED のまま無期限に停滞することがなくなる。
+
+#### Acceptance Criteria
+
+1. When design 種別の PR Iteration round が新規 commit 無しで終了した場合、
+   the PR Iteration Processor shall 当該 PR の no-progress 連続カウンタを 1 加算した状態で
+   次サイクルから観測可能にする。
+2. While 当該 PR の no-progress 連続カウンタが `PR_ITERATION_NO_PROGRESS_LIMIT` 未満である
+   間、the PR Iteration Processor shall 当該 PR を `needs-iteration` 候補のまま次 round に
+   進められる状態として残す。
+3. When 当該 PR の no-progress 連続カウンタが `PR_ITERATION_NO_PROGRESS_LIMIT` 以上に達した
+   round の終了時点で、the PR Iteration Processor shall escalation を発火させ、当該 PR に
+   `claude-failed` ラベルを付与する。
+4. When escalation が発火した場合、the PR Iteration Processor shall reason=`no-progress` と
+   加算後の連続カウンタ値および limit 値を含む 1 行ログを出力する。
+
+### Requirement 3: 新規 commit がある round の success 遷移は維持
+
+**Objective:** As an idd-claude 運用者, I want 当該 round で実際に新規 commit が push された
+ケースでは従来通り success 遷移する挙動を維持してほしい, so that 本 fix が正常な iteration
+パスを壊さず、design 反復の通常運用が継続できる。
+
+#### Acceptance Criteria
+
+1. When design 種別の PR Iteration round が終了し、当該 round で head branch に新規 commit が
+   push された場合、the PR Iteration Processor shall `needs-iteration` を外して
+   `awaiting-design-review` を付与するラベル遷移を実行する。
+2. When design 種別の PR Iteration round が終了し、当該 round で head branch に新規 commit が
+   push された場合、the PR Iteration Processor shall 当該 PR の no-progress 連続カウンタを 0 に
+   リセットする。
+3. When design 種別の PR Iteration round で新規 commit が push されラベル遷移に成功した場合、
+   the PR Iteration Processor shall 当該 round の終了結果を `action=success` として 1 行
+   ログに記録する。
+
+### Requirement 4: impl 種別 round における同型経路の扱い
+
+**Objective:** As an idd-claude 運用者, I want impl 種別の PR Iteration round で発生し得る
+同型の no-progress→success 経路についても本修正の対象範囲を明確化してほしい, so that
+将来 impl 側で同じ silent deadlock が観測された際の扱いが Issue / PR 内で曖昧にならない。
+
+#### Acceptance Criteria
+
+1. When impl 種別の PR Iteration round が新規 commit 無しで終了した場合、
+   the PR Iteration Processor shall design 種別と同等の制御フロー（`needs-iteration` 据え置き
+   + no-progress 連続カウンタ加算 + 上限到達時 escalation）を適用する。
+2. When impl 種別の PR Iteration round が新規 commit 無しで終了した場合、
+   the PR Iteration Processor shall `needs-iteration` を外して `ready-for-review` を付与する
+   ラベル遷移を実行しない。
+3. When impl 種別の PR Iteration round で実際に新規 commit が push された場合、
+   the PR Iteration Processor shall 従来通り `needs-iteration` を外して `ready-for-review` を
+   付与するラベル遷移を実行する。
+
+### Requirement 5: 観測可能性（ログ）
+
+**Objective:** As an idd-claude 運用者, I want no-progress round と escalation の遷移点を
+ログから機械可読に追跡できるようにしてほしい, so that 本修正が意図通り動作しているか
+（または再回帰していないか）を運用ログから検証できる。
+
+#### Acceptance Criteria
+
+1. When design 種別 round が新規 commit 無しで終了した場合、the PR Iteration Processor shall
+   PR 番号・kind・round 番号・加算後の no-progress 連続カウンタ値・limit 値を含む 1 行を
+   既存のログ出力先に記録する。
+2. When design 種別 round が新規 commit 無しで終了し、かつ連続カウンタが上限未満であった
+   場合、the PR Iteration Processor shall 当該 round の終了結果を `action=success` を含まない
+   ログ表現で記録する。
+3. When escalation が発火した場合、the PR Iteration Processor shall PR 番号・kind・round
+   番号・reason=`no-progress`・連続カウンタ値・limit 値を 1 行ログに記録する。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The PR Iteration Processor shall 既存の env var 名（`PR_ITERATION_NO_PROGRESS_LIMIT` /
+   `PR_ITERATION_DESIGN_ENABLED` / `PR_ITERATION_MAX_ROUNDS*` 等）の名称と既定値の意味を
+   変更しない。
+2. The PR Iteration Processor shall 既存ラベル（`needs-iteration` / `awaiting-design-review` /
+   `ready-for-review` / `claude-failed`）の名称・付与責務・取り外し責務の契約を変更しない
+   （本要件はラベル遷移の発火条件のみを変更する）。
+3. The PR Iteration Processor shall round の正常進行（新規 commit が push された round）に
+   対する観測可能な挙動（ラベル遷移・no-progress 連続カウンタのリセット・ログ出力）を
+   変更しない。
+
+### NFR 2: 安全側のデフォルト挙動
+
+1. If 当該 round で新規 commit が push されたか否かを判定するために必要な情報が取得不能だった
+   場合、the PR Iteration Processor shall 当該 round を success 遷移として扱わず、
+   `needs-iteration` 据え置きで終了させる。
+2. If no-progress 連続カウンタの永続化に失敗した場合、the PR Iteration Processor shall
+   `needs-iteration` を据え置いたまま終了し、ERROR レベルのログを出力する（現行の
+   Issue #122 Req 5.4 の据え置き契約を維持する）。
+
+## Out of Scope
+
+- 「なぜ Architect / Developer / claude CLI が当該 round で commit を作らなかったか」という
+  個別要因（フィードバック未到達 / 誤指示コメント / stale コメントの解釈等）の調査・修正は
+  本要件の対象外。本要件は no-progress round を `action=success` として候補から外し deadlock
+  させる制御フローの修正に限定する。
+- reopen された PR に残る obsolete な人間コメントを現行指示として解釈する挙動の見直しは
+  別 Issue 検討事項として扱い、本要件の対象外とする。
+- `PR_ITERATION_NO_PROGRESS_LIMIT` の既定値変更や、kind 別に上限を分離する設計変更は
+  本要件の対象外（既定値・分離なしの現行設計を前提に挙動を是正する）。
+- design / impl 以外の新しい PR Iteration 種別の導入は本要件の対象外。
+- pr-reviewer / auto-merge-design / design-review-release / promote-pipeline 等、本要件が
+  解消しようとしている下流 processor 側の挙動変更は対象外（本要件の修正が完了すれば
+  これら下流側の処理は既存契約のまま自然に進行する想定）。
+
+## Open Questions
+
+- なし（Issue 本文「受入基準」「スコープ外」が十分に明確で、本要件のスコープと完了条件は
+  Issue 記述のみで一意に定まる）。
+
+## 関連
+
+- Depends on: なし
+- Parent: なし
+- Related: #122 #389 #383

--- a/docs/specs/397-fix-pr-iteration-no-progress-design-roun/review-notes.md
+++ b/docs/specs/397-fix-pr-iteration-no-progress-design-roun/review-notes.md
@@ -1,0 +1,72 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-397-impl-fix-pr-iteration-no-progress-design-roun
+- HEAD commit: cff361e730d40df2fb89da931d326033ece23252
+- Compared to: main..HEAD
+- 変更ファイル:
+  - `local-watcher/bin/modules/pr-iteration.sh`（+88 / -7 行）
+  - `local-watcher/test/pi_classify_round_outcome_test.sh`（新規 +226 行 / 24 ケース）
+  - `docs/specs/397-fix-pr-iteration-no-progress-design-roun/requirements.md`（新規）
+  - `docs/specs/397-fix-pr-iteration-no-progress-design-roun/impl-notes.md`（新規）
+
+CLAUDE.md に `## Feature Flag Protocol` 節の `**採否**:` 宣言は存在しないため、flag 観点の
+追加判定は適用せず、通常の 3 カテゴリ（AC 未カバー / missing test / boundary 逸脱）で判定した。
+
+## Verified Requirements
+
+- 1.1 — `pi_run_iteration` 内 `case "$outcome" in no-progress) ... return 1`（`pr-iteration.sh:1465-1471`）
+  により `pi_finalize_labels_design` を呼ばずに復帰。Test:
+  `pi_classify_round_outcome false 1 3 → no-progress`（`pi_classify_round_outcome_test.sh:68-79`）
+- 1.2 — no-progress 分岐のログは `action=no-progress`（`pr-iteration.sh:1470`）。`action=success` を含まない
+- 1.3 — `needs-iteration` ラベルが据え置かれるため `pi_fetch_candidate_prs` の
+  `label:"$LABEL_NEEDS_ITERATION"` フィルタに次サイクルも合致（implicit / 削除コードなし）
+- 2.1 — `pi_write_marker "$pr_number" "$next_round" "$new_streak"`（`pr-iteration.sh:1444`）が
+  outcome 分類より前に実行されるため streak は永続化される（修正前の挙動を温存）
+- 2.2 — `pi_classify_round_outcome false <streak<limit> <limit> → no-progress`（`return 1` 経路）。
+  Test: 累積シナリオ round=1/2（`pi_classify_round_outcome_test.sh:117-129`）
+- 2.3 — `escalate` 分岐で `pi_escalate_to_failed ... no-progress`（`pr-iteration.sh:1457-1463`）。
+  Test: streak=3/4/10 with limit=3（`pi_classify_round_outcome_test.sh:97-107`）+ 境界値 limit=0/1
+- 2.4 — escalate ログ `... no-progress-streak=${new_streak} limit=${PR_ITERATION_NO_PROGRESS_LIMIT}
+  reason=no-progress escalate`（`pr-iteration.sh:1461`、`limit=` 新規追加）
+- 3.1 — `success) :` で kind dispatch ブロックにフォールスルー（`pr-iteration.sh:1473-1499`）。
+  Test: commit_pushed=true は streak 値に依らず success（4 ケース）
+- 3.2 — 既存ロジック温存（`if [ "$commit_pushed" = "true" ]; then new_streak=0`、`pr-iteration.sh:1430-1431`）
+- 3.3 — 既存 `action=success (needs-iteration -> awaiting-design-review/ready-for-review)` ログを温存
+  （`pr-iteration.sh:1489 / 1495`）
+- 4.1 — `pi_classify_round_outcome` は kind を引数に取らない純粋関数。Test:
+  「同入力で同 outcome」検証（`pi_classify_round_outcome_test.sh:215-220`）
+- 4.2 — no-progress 分岐は `return 1` で kind dispatch に到達しないため `pi_finalize_labels` も呼ばれない
+- 4.3 — 既存 `impl)` case ブロックは outcome=success のときのみ到達するため挙動不変
+- 5.1 — `pi_log "PR #${pr_number}: kind=${kind} round=${next_round} no-progress-streak=${new_streak}
+  limit=${PR_ITERATION_NO_PROGRESS_LIMIT}"`（`pr-iteration.sh:1440`、design/impl 両 kind で出力）
+- 5.2 — no-progress 分岐ログは `action=no-progress`（`pr-iteration.sh:1470`）で `action=success` を含まない
+- 5.3 — escalate ログに `reason=no-progress` + `no-progress-streak=` + `limit=` を含む（`pr-iteration.sh:1461`）
+- NFR 1.1 — `PR_ITERATION_NO_PROGRESS_LIMIT` / `PR_ITERATION_DESIGN_ENABLED` 等の env var の
+  宣言・既定値は無変更
+- NFR 1.2 — ラベル定数（`LABEL_NEEDS_ITERATION` / `LABEL_AWAITING_DESIGN` / `LABEL_READY` /
+  `LABEL_FAILED`）の名称・付与責務は無変更
+- NFR 1.3 — commit 有り round の挙動（finalize 経路・success ログ・return 0）を温存
+- NFR 2.1 — `pi_classify_round_outcome` の不正値（空文字列 / 非数値 / typo）は安全側で
+  `no-progress` に倒れる。Test 6 ケース（`pi_classify_round_outcome_test.sh:163-194`）
+- NFR 2.2 — 既存 `pi_write_marker` 失敗時の `pi_error + return 1`（`pr-iteration.sh:1444-1447`）を温存
+
+## Findings
+
+なし
+
+## Summary
+
+`pi_classify_round_outcome` 純粋関数の新規追加と `pi_run_iteration` 末尾の 3-way 分岐
+（success / no-progress / escalate）により、no-progress design round の silent deadlock を
+解消する変更。全 numeric AC（1.1-1.3 / 2.1-2.4 / 3.1-3.3 / 4.1-4.3 / 5.1-5.3 / NFR 1.1-1.3 /
+NFR 2.1-2.2）が実装または既存挙動温存でカバーされており、新規 24 テストケースが該当ヘルパーを
+網羅検証。boundary は対象モジュール（`local-watcher/bin/modules/pr-iteration.sh`）と
+近接テスト（`local-watcher/test/`）に限定されており、`repo-template/` 配布物・env var 名・
+ラベル名・既存 return code 意味への破壊的変更なし。`shellcheck` / `bash -n` クリーン、新規
+テスト 24 PASS / 0 FAIL を再現確認。
+
+RESULT: approve

--- a/local-watcher/bin/modules/pr-iteration.sh
+++ b/local-watcher/bin/modules/pr-iteration.sh
@@ -1043,6 +1043,58 @@ pi_auto_commit_and_push() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# pi_classify_round_outcome: round 終了時の outcome を 1 単語で分類する純粋関数
+#   入力: $1=commit_pushed ("true" | "false")
+#         $2=new_streak (非負整数。加算済みの no-progress 連続カウンタ値)
+#         $3=limit      (非負整数。PR_ITERATION_NO_PROGRESS_LIMIT 値)
+#   出力: stdout に下記いずれか 1 単語
+#           "success"     - commit 有り → 通常 finalize（needs-iteration を外す）に進む
+#           "escalate"    - commit 無し かつ streak >= limit → claude-failed へ昇格
+#           "no-progress" - commit 無し かつ streak < limit → needs-iteration 据え置き
+#   返り値: 0 固定
+#
+#   設計判断 (#397 fix):
+#     - commit_pushed=false の round は no-progress streak の状態に関わらず、
+#       finalize 経路（needs-iteration → awaiting-design-review / ready-for-review）に
+#       進ませない。streak が limit 未満なら next cycle で再 pickup されるよう
+#       needs-iteration を据え置き、limit 到達時のみ escalate に倒す。
+#     - 旧実装（#122 まで）は no-progress でも streak<limit なら finalize 成功扱いに
+#       なっており、PR が候補プールから外れて no-progress カウンタが二度と加算されない
+#       silent deadlock を起こしていた（#397）。本関数の "no-progress" 分類はその
+#       deadlock を断ち切る分岐点。
+#     - 純粋関数（副作用なし / グローバル参照なし）として実装し、テストで隔離検証可能。
+#     - 不正値の場合（commit_pushed が "true"/"false" 以外、または非数値 streak/limit）は
+#       安全側に倒して "no-progress" を返す（NFR 2.1: 判定情報が取得不能なら success に
+#       倒さない）。
+# ─────────────────────────────────────────────────────────────────────────────
+pi_classify_round_outcome() {
+  local commit_pushed="${1-}"
+  local new_streak="${2-}"
+  local limit="${3-}"
+
+  # commit_pushed=true は最優先（streak は呼び出し元で 0 にリセットされている前提）
+  if [ "$commit_pushed" = "true" ]; then
+    echo "success"
+    return 0
+  fi
+
+  # commit_pushed が "false" でない場合は安全側に no-progress 扱い
+  if [ "$commit_pushed" != "false" ]; then
+    echo "no-progress"
+    return 0
+  fi
+
+  # streak / limit が数値で取れているときのみ escalate 判定。それ以外は no-progress に倒す
+  # （NFR 2.1: 判定情報不足時は finalize=success に進ませない安全側挙動）。
+  if [[ "$new_streak" =~ ^[0-9]+$ ]] && [[ "$limit" =~ ^[0-9]+$ ]] && [ "$new_streak" -ge "$limit" ]; then
+    echo "escalate"
+    return 0
+  fi
+  echo "no-progress"
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # pi_run_iteration: 1 PR 分の iteration を実行（fresh context Claude 起動）
 #   入力: $1=pr_json
 #   戻り値: 0=success(commit+push or reply-only), 1=failure, 2=escalated(round上限到達),
@@ -1383,6 +1435,7 @@ pi_run_iteration() {
 
     # Issue #122 Req 6.2: round 終了時点で no-progress 連続カウンタが加算されたら
     # PR 番号 / kind / 加算後の連続カウンタ / 上限値を 1 行ログに記録
+    # Issue #397 Req 5.1: design / impl 両 kind で同一フォーマットで出力する。
     if [ "$commit_pushed" = "false" ]; then
       pi_log "PR #${pr_number}: kind=${kind} round=${next_round} no-progress-streak=${new_streak} limit=${PR_ITERATION_NO_PROGRESS_LIMIT}"
     fi
@@ -1393,14 +1446,42 @@ pi_run_iteration() {
       return 1
     fi
 
-    # Issue #122 Req 3.3 / 6.3: no-progress 連続カウンタが上限以上に達したら escalate
-    if [ "$new_streak" -ge "$PR_ITERATION_NO_PROGRESS_LIMIT" ]; then
-      pi_log "PR #${pr_number}: kind=${kind} round=${next_round} no-progress-streak=${new_streak} reason=no-progress escalate"
-      pi_escalate_to_failed "$pr_number" "$next_round" "$max_rounds" "no-progress" "$new_streak" || true
-      return 2
-    fi
+    # Issue #397: round 終了時の outcome を 3 way に分類（success / escalate / no-progress）。
+    # 旧実装は commit 無しでも streak < limit なら finalize 成功扱いに倒れていた
+    # （`needs-iteration` を外して `awaiting-design-review` / `ready-for-review` に遷移）。
+    # その結果 PR が候補プールから外れて no-progress streak が永久に加算されず escalation
+    # に到達しない silent deadlock が発生していた。本分岐で no-progress を独立扱いにする。
+    local outcome
+    outcome=$(pi_classify_round_outcome "$commit_pushed" "$new_streak" "$PR_ITERATION_NO_PROGRESS_LIMIT")
+    case "$outcome" in
+      escalate)
+        # Issue #122 Req 3.3 / 6.3 / Issue #397 Req 2.3 / 2.4 / 5.3:
+        # no-progress 連続カウンタが上限以上 → claude-failed 昇格。
+        # ログには PR 番号 / kind / round / reason / streak / limit を含める（Req 5.3）。
+        pi_log "PR #${pr_number}: kind=${kind} round=${next_round} no-progress-streak=${new_streak} limit=${PR_ITERATION_NO_PROGRESS_LIMIT} reason=no-progress escalate"
+        pi_escalate_to_failed "$pr_number" "$next_round" "$max_rounds" "no-progress" "$new_streak" || true
+        return 2
+        ;;
+      no-progress)
+        # Issue #397 Req 1.1〜1.3 / 2.1 / 2.2 / 4.1 / 4.2 / 5.2:
+        # commit が無かった round では finalize（needs-iteration 除去）に進まず、
+        # `needs-iteration` を据え置いて return する。`action=success` ログは出さない。
+        # streak は marker 上で既に加算済み（次サイクルで pi_read_no_progress_streak が拾う）。
+        pi_log "PR #${pr_number}: kind=${kind} round=${next_round} action=no-progress (needs-iteration を残置, streak=${new_streak}/${PR_ITERATION_NO_PROGRESS_LIMIT})"
+        return 1
+        ;;
+      success)
+        : # 通常 finalize に進む
+        ;;
+      *)
+        # 想定外: 安全側に倒して needs-iteration 据え置き
+        pi_warn "PR #${pr_number}: kind=${kind} round=${next_round} unknown round outcome='${outcome}' (needs-iteration を残置)"
+        return 1
+        ;;
+    esac
 
-    # AC 6.2 (#26) / #35 AC 3.1 / 3.2: kind に応じたラベル遷移
+    # AC 6.2 (#26) / #35 AC 3.1 / 3.2 / Issue #397 Req 3.1〜3.3 / 4.3:
+    # commit_pushed=true（outcome=success）のみここに到達する。kind に応じたラベル遷移を実施。
     local finalize_ok=false
     case "$kind" in
       design)

--- a/local-watcher/test/pi_classify_round_outcome_test.sh
+++ b/local-watcher/test/pi_classify_round_outcome_test.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/pr-iteration.sh の Issue #397（PR Iteration の no-progress
+#       design round が `awaiting-design-review` に遷移して silent deadlock する defect）で
+#       導入した round outcome 分類ヘルパーをテストする。
+#
+#       対象関数:
+#         - pi_classify_round_outcome (#397 / Req 1, 2, 3, 4)
+#
+#       本テストは、pi_run_iteration の round 終了処理から切り出された純粋関数を
+#       extract_function で隔離抽出し、入出力のみで AC を網羅検証する。
+#       環境変数や gh / git 呼び出しに依存しない（純粋関数の利点を最大化する）。
+#
+# 配置先: local-watcher/test/pi_classify_round_outcome_test.sh
+# 依存:   bash 4+, awk
+# 実行:   bash local-watcher/test/pi_classify_round_outcome_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_ITERATION_SH="$SCRIPT_DIR/../bin/modules/pr-iteration.sh"
+
+if [ ! -f "$PR_ITERATION_SH" ]; then
+  echo "ERROR: cannot find pr-iteration.sh at $PR_ITERATION_SH" >&2
+  exit 2
+fi
+
+# 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
+# eval で読み込む。トップレベル副作用は回避する。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_ITERATION_SH" "pi_classify_round_outcome")"
+
+if ! declare -F pi_classify_round_outcome >/dev/null; then
+  echo "ERROR: pi_classify_round_outcome not loaded" >&2
+  exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ─── 正常系: commit_pushed=true → success ─────────────────────────────────────
+echo "--- pi_classify_round_outcome: success cases (Req 3.1〜3.3) ---"
+
+# Req 3.1 / 3.2 / 3.3: commit が push された round は streak 値に依らず success
+assert_eq "commit_pushed=true / streak=0 / limit=3 → success" \
+  "success" \
+  "$(pi_classify_round_outcome true 0 3)"
+
+assert_eq "commit_pushed=true / streak=1 / limit=3 → success（streak はリセット済み前提でも success 優先）" \
+  "success" \
+  "$(pi_classify_round_outcome true 1 3)"
+
+assert_eq "commit_pushed=true / streak=99 / limit=3 → success（streak が limit 以上でも commit 有りなら success）" \
+  "success" \
+  "$(pi_classify_round_outcome true 99 3)"
+
+assert_eq "commit_pushed=true / streak=0 / limit=0 → success（境界: limit=0）" \
+  "success" \
+  "$(pi_classify_round_outcome true 0 0)"
+
+echo ""
+
+# ─── 正常系: commit_pushed=false かつ streak<limit → no-progress ──────────────
+echo "--- pi_classify_round_outcome: no-progress cases (Req 1.1〜1.3 / 2.1 / 2.2 / 4.1 / 4.2) ---"
+
+# Req 1.1 / 1.2 / 1.3 / 2.1 / 2.2 / 4.1 / 4.2:
+# commit 無し かつ streak < limit → needs-iteration 据え置き相当（"no-progress" 分類）
+assert_eq "commit_pushed=false / streak=1 / limit=3 → no-progress（初回 no-progress round）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false 1 3)"
+
+assert_eq "commit_pushed=false / streak=2 / limit=3 → no-progress（limit 未満）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false 2 3)"
+
+assert_eq "commit_pushed=false / streak=0 / limit=3 → no-progress（境界: streak=0）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false 0 3)"
+
+echo ""
+
+# ─── 正常系: commit_pushed=false かつ streak>=limit → escalate ────────────────
+echo "--- pi_classify_round_outcome: escalate cases (Req 2.3 / 2.4 / 5.3) ---"
+
+# Req 2.3 / 2.4 / 5.3: limit に達した時点で escalate
+assert_eq "commit_pushed=false / streak=3 / limit=3 → escalate（境界一致）" \
+  "escalate" \
+  "$(pi_classify_round_outcome false 3 3)"
+
+assert_eq "commit_pushed=false / streak=4 / limit=3 → escalate（境界超過）" \
+  "escalate" \
+  "$(pi_classify_round_outcome false 4 3)"
+
+assert_eq "commit_pushed=false / streak=10 / limit=3 → escalate（大きく超過）" \
+  "escalate" \
+  "$(pi_classify_round_outcome false 10 3)"
+
+echo ""
+
+# ─── escalation 到達性の累積シナリオ（Req 2 統合検証） ────────────────────────
+echo "--- 累積シナリオ: 連続 no-progress round で最終的に escalate に到達する（Req 2.1〜2.3） ---"
+
+# limit=3 を仮定し、prev_streak を 0→1→2→3 と進めるシミュレーション
+# 各 round の new_streak（呼び出し元で prev_streak+1 した値）を渡す
+limit=3
+streak=0
+last_outcome=""
+for round in 1 2 3 4; do
+  streak=$((streak + 1))
+  last_outcome=$(pi_classify_round_outcome false "$streak" "$limit")
+  case "$round" in
+    1|2)
+      assert_eq "累積 round=${round}: streak=${streak} → no-progress (limit=${limit} 未満)" \
+        "no-progress" \
+        "$last_outcome"
+      ;;
+    3|4)
+      assert_eq "累積 round=${round}: streak=${streak} → escalate (limit=${limit} 到達/超過)" \
+        "escalate" \
+        "$last_outcome"
+      ;;
+  esac
+done
+
+echo ""
+
+# ─── 境界: limit が極端な値 ───────────────────────────────────────────────────
+echo "--- 境界値: limit=1 や limit=0 のケース ---"
+
+# limit=1: 1 度の no-progress で即 escalate
+assert_eq "limit=1: streak=1 → escalate（最小 limit 設定での即時 escalate）" \
+  "escalate" \
+  "$(pi_classify_round_outcome false 1 1)"
+
+# limit=0: streak がどんな値でも常に escalate
+assert_eq "limit=0: streak=0 / commit=false → escalate（limit=0 は no-progress を一切許さない設定）" \
+  "escalate" \
+  "$(pi_classify_round_outcome false 0 0)"
+
+# limit が極端に大きい: ほぼ no-progress が続く
+assert_eq "limit=999: streak=10 → no-progress" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false 10 999)"
+
+echo ""
+
+# ─── 異常系: 不正値は安全側（no-progress = needs-iteration 据え置き）に倒す ───
+echo "--- 異常系: 不正値の安全側挙動 (NFR 2.1) ---"
+
+# commit_pushed が "true"/"false" 以外
+assert_eq "commit_pushed='' (空) → no-progress（安全側）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome '' 1 3)"
+
+assert_eq "commit_pushed='yes' (typo) → no-progress（安全側）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome 'yes' 1 3)"
+
+# streak が非数値（取得失敗を想定）
+assert_eq "commit_pushed=false / streak='' (空) → no-progress（NFR 2.1 安全側、success/escalate に倒さない）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false '' 3)"
+
+assert_eq "commit_pushed=false / streak='abc' (非数値) → no-progress（安全側）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false abc 3)"
+
+# limit が非数値
+assert_eq "commit_pushed=false / streak=5 / limit='' → no-progress（安全側、誤 escalate を避ける）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false 5 '')"
+
+assert_eq "commit_pushed=false / streak=5 / limit='abc' → no-progress（安全側）" \
+  "no-progress" \
+  "$(pi_classify_round_outcome false 5 abc)"
+
+echo ""
+
+# ─── 統合: design / impl 種別を区別しないことの確認 ─────────────────────────
+# Req 4.1 / 4.2: impl 種別でも design 種別と同じ制御フローが適用される。
+# pi_classify_round_outcome は kind を引数に取らない（pure 関数 / kind 非依存）こと
+# 自体が Req 4.1 の制御フロー統一性を担保する。本テストでは関数のシグネチャを確認する
+# 形で間接的に検証する。
+echo "--- Req 4.1 / 4.2 / 4.3: kind 非依存の制御フロー ---"
+
+# 同じ入力に対して常に同じ outcome を返す（impl/design 区別が無いこと）
+out_impl=$(pi_classify_round_outcome false 1 3)
+out_design=$(pi_classify_round_outcome false 1 3)
+assert_eq "Req 4.1: 同入力で同 outcome（kind 区別なし / 副作用なし）" \
+  "$out_impl" \
+  "$out_design"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

PR Iteration Processor の design round が新規 commit を生まなかった（no-progress）際に、
`needs-iteration` を外して `awaiting-design-review` に遷移させ `action=success` 扱いになっていた
defect を修正する。この defect によって no-progress 連続カウンタが加算されず escalation が
発火しない silent deadlock が発生していた（#397）。

`pi_classify_round_outcome` 純粋関数を新規追加し、`pi_run_iteration` の round 終了処理を
commit_pushed の有無と no-progress 連続カウンタを参照した 3-way 分岐（success / no-progress /
escalate）に再構成することで、no-progress round での `needs-iteration` 据え置きと
最終的な escalation 到達を保証する。

## 対応 Issue

Closes #397

## 関連 PR

なし（Architect による設計 PR は走っていない design-less impl）

## 実装内容

- (Req 1.1〜1.3 / 4.1〜4.2) `pi_run_iteration` に `case "$outcome" in no-progress)` 分岐を追加し、`pi_finalize_labels_design` / `pi_finalize_labels` を呼ばずに `return 1` で返すことで `needs-iteration` を据え置き
- (Req 2.3〜2.4 / 5.3) escalate 分岐のログに `limit=${PR_ITERATION_NO_PROGRESS_LIMIT}` を追記（従来欠落していた観測可能性を補完）
- (Req 3.1〜3.3 / 4.3 / NFR 1.3) 新規 commit があった round の `pi_finalize_labels_design` / `pi_finalize_labels` → `action=success` ログの既存経路を温存
- (Req 4.1 / NFR 2.1) `pi_classify_round_outcome <commit_pushed> <new_streak> <limit>` 純粋関数を新規追加。不正値（空文字列 / 非数値 / typo）は安全側で `no-progress` に倒れる
- (NFR 1.1〜1.2) `PR_ITERATION_NO_PROGRESS_LIMIT` 等の env var 名・既定値、`needs-iteration` 等のラベル名・付与責務は無変更
- 近接テスト `local-watcher/test/pi_classify_round_outcome_test.sh` 新規追加（24 ケース）

## 受入基準チェック

- [x] Req 1.1: no-progress round で `awaiting-design-review` 付与なし ← `case no-progress) return 1`（`pi_finalize_labels_design` を呼ばない）
- [x] Req 1.2: no-progress を `action=success` で記録しない ← `pi_log ... action=no-progress` 出力
- [x] Req 1.3: 次サイクル候補に残る ← `needs-iteration` 据え置きで次サイクルの `label:"$LABEL_NEEDS_ITERATION"` フィルタに合致
- [x] Req 2.1: no-progress streak 加算 ← `pi_write_marker` で `prev_streak+1` を永続化
- [x] Req 2.2: limit 未満なら次 round 進める ← `pi_classify_round_outcome false <streak<limit> <limit> → no-progress`
- [x] Req 2.3: limit 到達で escalation 発火 ← `pi_classify_round_outcome false <streak>=limit> <limit> → escalate`
- [x] Req 2.4: escalation ログに reason/streak/limit ← `pi_log ... reason=no-progress escalate`
- [x] Req 3.1〜3.3: commit 有り round の success 遷移・streak リセット・ログを維持
- [x] Req 4.1〜4.3: impl 種別でも同等制御フロー（`pi_classify_round_outcome` は kind 非依存）
- [x] Req 5.1〜5.3: ログ観測可能性（PR/kind/round/streak/limit/reason を含む 1 行ログ）
- [x] NFR 1.1〜1.3: 既存 env var・ラベル・commit 有り round の挙動不変
- [x] NFR 2.1〜2.2: 不正値は安全側 no-progress / marker 永続化失敗時は据え置き＋ERROR ログ

## テスト結果

```
bash local-watcher/test/pi_classify_round_outcome_test.sh
→ 24 PASS / 0 FAIL（新規）

bash local-watcher/test/pi_max_rounds_kind_test.sh
→ 24 PASS / 0 FAIL

bash local-watcher/test/pi_detect_quota_soft_fail_test.sh
→ 13 PASS / 0 FAIL

bash local-watcher/test/repo_prefix_log_test.sh
→ 36 PASS / 0 FAIL

shellcheck local-watcher/bin/modules/pr-iteration.sh → 警告ゼロ
shellcheck local-watcher/bin/modules/*.sh local-watcher/bin/issue-watcher.sh install.sh setup.sh → 警告ゼロ
bash -n local-watcher/bin/modules/pr-iteration.sh → OK
diff -r .claude/agents repo-template/.claude/agents → 空（同期維持）
diff -r .claude/rules repo-template/.claude/rules → 空（同期維持）
```

## 実装上の判断

- **`return 1` の意味**: no-progress round 据え置きは `pi_run_iteration` の `return 1`（fail カウンタに加算）で表現している。要件は「`action=success` として記録しない」のみを要求しているため要件は満たすが、将来的に `process_pr_iteration` サマリで「needs-iteration retry」を独立 return code（例: `4=retry`）に分離する設計変更を検討する余地がある（本要件スコープ外、別 Issue 検討推奨）。
- **escalate ログの `limit=` 追記**: Req 5.3 を満たすため escalate ログに `limit=` キーを追加。既存の `grep 'reason=no-progress escalate'` 集計は不変。`limit=` を読み取る監視はこれまで存在しなかったため後方互換上の影響なし。
- 詳細は `docs/specs/397-fix-pr-iteration-no-progress-design-roun/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後に検証済み）
- Reviewer の独立レビュー（approve）が完了済み: `docs/specs/397-fix-pr-iteration-no-progress-design-roun/review-notes.md`（RESULT: approve, Findings: なし）
- `return 1` の意味（no-progress retry vs fail）については別 Issue での検討を推奨（impl-notes.md「派生タスク候補」参照）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #397 のコメントを参照してください。
