### PR TITLE
fix(#400): pr-iteration self-filter を idd-claude:pr-iteration prefix のみに限定し PR Reviewer 指摘の除外バグを修正

### DIFF
--- a/docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/impl-notes.md
+++ b/docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/impl-notes.md
@@ -1,0 +1,81 @@
+# Implementation Notes — Issue #400
+
+## 概要
+
+`local-watcher/bin/modules/pr-iteration.sh` の self-filter（`pi_general_filter_self` および
+line-comment 経路）を、`idd-claude:` を含む全コメント一律除外から
+**`idd-claude:pr-iteration` を含むコメントのみ除外** に限定範囲化した。これにより
+PR Reviewer (`idd-claude:pr-reviewer`) / security-review / quota-reset / auto-rebase 等
+他系統の自動投稿が iteration agent の入力に正しく渡るようになる。
+
+## 変更ファイル
+
+- `local-watcher/bin/modules/pr-iteration.sh`
+  - `pi_general_filter_self`: `contains("idd-claude:")` → `contains("idd-claude:pr-iteration")`
+  - line-comment 経路（`pi_build_iteration_prompt` 内の reviews 取得直後 jq projection）:
+    同じ `contains("idd-claude:pr-iteration")` ベースの `select(... | not)` を projection と
+    同時に適用（Req 5.2）。Req 5.1 の通り「`idd-claude:` 含む文字列一律除外」は導入しない。
+- `local-watcher/test/pi_general_filter_self_test.sh`（新規）
+  - `extract_function` で `pi_general_filter_self` / `pi_general_filter_resolved` を抽出して
+    fixture ベースで検証。17 ケース全 PASS。
+
+## repo-template 同期について
+
+`repo-template/local-watcher/bin/modules/` ディレクトリは **存在しない**（grep 結果で確認）。
+CLAUDE.md の二重管理規約は `.claude/{agents,rules}/` のみが byte 一致対象であり、
+`local-watcher/bin/modules/*.sh` は `install.sh` が `local-watcher/bin/modules/` から
+直接 `$HOME/bin/modules/` に配布する単一ソース構成（issue-watcher.sh 行 1359-1360 のコメント
+で明示）。よって本 Issue の修正に「repo-template 側同期」は適用外。
+
+## AC Traceability
+
+| Req | 検証手段 |
+|---|---|
+| 1.1 PR Reviewer marker を self-filter で除外しない | `pi_general_filter_self_test.sh` Req 1.1 / 2.4 / 1.4 ケース |
+| 1.2 last-run TS より後の reviewer は agent 入力に含める | Req 3.2 ケース |
+| 1.3 kind 属性値に依存せず PR Reviewer 投稿を含める | substring 判定で kind 不参照を構造的に保証、Req 1.1 / 1.4 ケースで観測 |
+| 1.4 final カウンタ 0 にならない | Req 1.4 混在ケースで keep=3 件を観測 |
+| 2.1 `idd-claude:pr-iteration` で始まる marker を除外 | Req 2.1 ケース |
+| 2.2 `idd-claude:pr-iteration-processing` 除外 | Req 2.2 ケース |
+| 2.3 `idd-claude:pr-iteration-529-warning` 除外 | Req 2.3 ケース |
+| 2.4 他 prefix を除外しない（reviewer/security/quota-reset/auto-rebase/review 等） | Req 2.4 ケース 5 件（security-review / quota-reset / auto-rebase / review / 混在） |
+| 2.5 `idd-claude:pr-iteration-<suffix>` 形式の前方互換 | Req 2.5 ケース（`-foo` サフィックス） |
+| 3.1 last-run TS 以前（同時刻含む）は除外 | Req 3.1 ケース 2 件 |
+| 3.2 last-run TS より後は agent 入力に含める | Req 3.2 ケース |
+| 3.3 marker 不在（初回 round）は全件採用 | Req 3.3 ケース |
+| 3.4 last-run 比較境界（`==` 除外側）を変更しない | `pi_general_filter_resolved` 未改変（`$last_run == "" or (.created_at // "") > $last_run`） |
+| 4.1〜4.4 サマリログ後方互換 | `pi_collect_general_comments` のログ書式・カウンタ計算式・stderr 出力先を改変しない（修正は filter 1 関数のみ） |
+| 5.1 line-comment に `idd-claude:` 一律除外は導入しない | 実装上 substring `idd-claude:pr-iteration` のみ判定、line_filter テストでも reviewer marker / 通常 line keep を確認 |
+| 5.2 line-comment の `idd-claude:pr-iteration` marker は除外 | line-comment Req 5.2 ケース |
+| 5.3 line-comment の他 prefix / marker 不在は keep | line-comment Req 5.3 ケース 2 件 |
+| NFR 1.1 env / exit code / marker prefix キー名不変 | filter 内部の jq 式 1 行のみ変更、外部契約は同じ |
+| NFR 1.2 既存テスト退行ゼロ | `pi_max_rounds_kind_test.sh` 24/24 PASS、`pi_detect_quota_soft_fail_test.sh` 13/13 PASS |
+| NFR 2.1 / 2.2 filtered_self カウンタの観測性 | `pi_collect_general_comments` の `filtered_self=$((fetched - count_self))` は未変更、カウンタ意味は限定範囲化に追従して更新 |
+| NFR 3.1 近接テスト追加 | `pi_general_filter_self_test.sh` 17 ケース |
+
+## テスト結果サマリ
+
+- `bash local-watcher/test/pi_general_filter_self_test.sh`: 17/17 PASS
+- `bash local-watcher/test/pi_max_rounds_kind_test.sh`: 24/24 PASS (既存退行なし)
+- `bash local-watcher/test/pi_detect_quota_soft_fail_test.sh`: 13/13 PASS (既存退行なし)
+- `bash -n local-watcher/bin/modules/pr-iteration.sh`: OK
+- `shellcheck local-watcher/bin/modules/pr-iteration.sh local-watcher/test/pi_general_filter_self_test.sh`: 警告ゼロ
+
+## 設計判断
+
+- **substring match vs 正規表現 prefix match**: `idd-claude:pr-iteration` の substring 判定で
+  Req 2.1〜2.3（`<空白>` / `-processing` / `-529-warning`）と Req 2.5（`-<suffix>` 前方互換）を
+  同時に満たせる。`pr-iteration` と他 prefix（`pr-reviewer`）は文字列としても包含関係に無いため
+  `pr-iteration` substring が `pr-reviewer` を誤マッチすることはない（jq の `contains` は
+  単純 substring）。シンプルさを優先して `test()` ベースの regex 前方一致は採用しなかった。
+- **line-comment 経路の projection 同時適用**: line_comments_json は 1 箇所でしか作られない
+  ため、projection 直後に `select(... | not)` を同じ jq 式内で繋いで二重パス（filter 関数化）
+  を避けた。一般コメント経路は既に `pi_general_filter_self` 関数として分離されているため
+  単独で扱える（テスト容易性も維持）。
+
+## 確認事項
+
+- なし。要件は Issue 本文と requirements.md で完結しており、design.md / tasks.md は本 Issue
+  では生成されていない（軽量 fix のため triage で needs_architect=false 想定）。
+
+STATUS: complete

--- a/docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/requirements.md
+++ b/docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/requirements.md
@@ -1,0 +1,113 @@
+# Requirements Document
+
+## Introduction
+
+PR Iteration Processor（#26 で導入、#55 で一般コメントの mention 篩い撤廃を実施）の
+self-comment フィルタが、`idd-claude:` 文字列を含む **全コメントを一律除外** する実装に
+なっている。このため、PR Reviewer（#399 で導入された review 自動投稿系、
+`<!-- idd-claude:pr-reviewer sha=<sha> kind=review tool=<tool> -->` 形式の hidden marker
+を本文に持つ）が投稿した review 指摘も "self" として扱われ、iteration agent の入力
+（一般コメント）から取り除かれる。実稼働ログでは `fetched=8, filtered_self=7, final=0`
+のような全除外が発生し、codex 由来の review 指摘を渡せないまま iteration agent が起動
+するため、推測ベースの no-op に陥り PR が `needs-iteration` のまま no-progress 連続で
+ループ → 最終的に codex review ゲートで stuck する。本要件は self-filter の対象を
+「PR Iteration Processor 自身が投稿した marker のみ」に正しく限定し、PR Reviewer 由来の
+review 指摘を iteration agent へ確実に届けることを目的とする。重複処理防止（last-run 境界）
+と self 除外（無限ループ防止）の既存規約は維持する。
+
+## Requirements
+
+### Requirement 1: PR Reviewer 投稿の review 指摘を iteration agent 入力に含める
+
+**Objective:** As a auto-dev 運用者, I want PR Reviewer が投稿した review 指摘（`idd-claude:pr-reviewer ... kind=review` marker 付き）が PR Iteration Processor の入力に渡るようにしたい, so that codex / claude の具体的な指摘内容に基づいて iteration agent が修正できる（推測に頼らない）
+
+#### Acceptance Criteria
+
+1. When PR Iteration Processor が一般コメントを収集する, the PR Iteration Processor shall `<!-- idd-claude:pr-reviewer sha=<sha> kind=review tool=<tool> -->` marker を本文に含むコメントを self-filter で除外せず iteration agent の入力に含める
+2. When PR Reviewer 由来の `kind=review` コメントが last-run TS より後に新規投稿されている, the PR Iteration Processor shall 当該コメントを iteration agent へ渡す一般コメント集合に含める
+3. The PR Iteration Processor shall PR Reviewer の `kind` 属性値（`review` / `reply` / その他）に依存せず、Requirement 2 が定める self-filter 限定範囲に該当しない限りすべての PR Reviewer 投稿コメントを iteration agent 入力に含める
+4. If PR Reviewer 由来の review 指摘が 1 件以上存在し他のフィルタ（last-run / event-style / truncate）で除外されない, the PR Iteration Processor shall iteration agent への最終入力件数（`final` カウンタ）を 0 ではない値で確定させた状態で agent を起動する
+
+### Requirement 2: self-filter の対象を PR Iteration Processor 自身の marker に限定する
+
+**Objective:** As a watcher 運用者, I want self-filter が PR Iteration Processor 自身の自動投稿のみを除外するようにしたい, so that 無限ループ（iteration agent が自己投稿を再処理する事故）を防ぎつつ他系統（PR Reviewer / Security Review / Quota-Aware 等）の自動投稿を誤除外しない
+
+#### Acceptance Criteria
+
+1. When 一般コメント本文に `idd-claude:pr-iteration` で始まる hidden marker が含まれる, the PR Iteration Processor shall 当該コメントを self として除外する
+2. When 一般コメント本文に `idd-claude:pr-iteration-processing` marker が含まれる（着手表明コメント）, the PR Iteration Processor shall 当該コメントを self として除外する
+3. When 一般コメント本文に `idd-claude:pr-iteration-529-warning` marker が含まれる（quota soft-fail 警告コメント）, the PR Iteration Processor shall 当該コメントを self として除外する
+4. The PR Iteration Processor shall `idd-claude:pr-reviewer` / `idd-claude:security-review` / `idd-claude:security-notes` / `idd-claude:quota-reset` / `idd-claude:partial-status` / `idd-claude:edit-paths` / `idd-claude:awaiting-slot` / `idd-claude:busy-wait` / `idd-claude:auto-rebase` / `idd-claude:auto-rebase-semantic` / `idd-claude:dep-cycle-detected` / `idd-claude:design-review-release` / `idd-claude:review` 等、`idd-claude:pr-iteration` 以外の prefix を持つ hidden marker を self として除外しない
+5. Where 将来 PR Iteration Processor 系の新しい marker サブ種別が `idd-claude:pr-iteration<suffix>` 形式（例: `idd-claude:pr-iteration-foo`）で追加される, the PR Iteration Processor shall 当該 marker を self として除外する（前方互換性のため prefix 単位の判定）
+
+### Requirement 3: 重複処理防止（last-run 境界）の維持
+
+**Objective:** As a auto-dev 運用者, I want 過去 round で既に処理済みの review 指摘を再処理しないようにしたい, so that 同じ指摘で iteration が空回りする / コストが暴走することを防ぐ
+
+#### Acceptance Criteria
+
+1. When PR Reviewer の review コメントが last-run TS 以前（同時刻を含む）に投稿されている, the PR Iteration Processor shall 当該コメントを過去 round 既処理として最終入力から除外する
+2. When PR Reviewer の review コメントが last-run TS より後に投稿されている, the PR Iteration Processor shall 当該コメントを iteration agent への最終入力に含める
+3. When PR body 内に PR Iteration Processor の hidden marker が存在しない（初回 round）, the PR Iteration Processor shall 取得した全 PR Reviewer 由来コメントを過去 round 段では除外しない（last-run 不在時の no-op 既存挙動を踏襲）
+4. The PR Iteration Processor shall last-run 比較の境界判定（`==` を除外側に倒す既存挙動）を変更しない
+
+### Requirement 4: フィルタ件数ログの後方互換
+
+**Objective:** As a watcher 運用者, I want 一般コメント収集のサマリログ形式を変えずに監視・障害解析に使えるようにしたい, so that 既存の grep / log 集計ツールや過去ログとの比較が機能する
+
+#### Acceptance Criteria
+
+1. The PR Iteration Processor shall 一般コメント収集のサマリログを `PR #<n> general comments: fetched=<a>, filtered_self=<b>, filtered_resolved=<c>, filtered_event=<d>, truncated=<e> (limit=<L>)?, final=<f>` 形式で出力し、フィールド名（`fetched` / `filtered_self` / `filtered_resolved` / `filtered_event` / `truncated` / `final`）の意味を本要件導入前と一致させる
+2. The PR Iteration Processor shall `filtered_self` のカウントを「Requirement 2 が定める self-filter で除外された件数」として計算する（PR Reviewer 由来コメントは self として数えない）
+3. When 一般コメントが 0 件取得された、または取得失敗で degraded path に倒れた, the PR Iteration Processor shall サマリログのフィールド数を保ったまま該当カウンタを 0 で出力する（既存挙動と一致）
+4. The PR Iteration Processor shall サマリログの出力先を stderr のままとし、JSON 配列の出力先（stdout）と分離する既存契約を変更しない
+
+### Requirement 5: line-comment 経路の挙動整合
+
+**Objective:** As a auto-dev 運用者, I want line-comment（review 行コメント）経路でも reviewer 由来コメントが iteration agent 入力に渡る挙動を維持したい, so that 一般コメント経路と line-comment 経路の両方で「reviewer 指摘を取り込む」という方針が一貫する
+
+#### Acceptance Criteria
+
+1. The PR Iteration Processor shall line-comment 経路（review 行コメント集合）に対して、本 Issue 修正で `idd-claude:` を含む文字列を一律除外する self-filter を新規導入しない
+2. When line-comment 本文に `idd-claude:pr-iteration` で始まる marker が含まれる, the PR Iteration Processor shall 当該 line-comment を iteration agent への最終入力から除外する（一般コメント経路と同じ self-filter 規約を line-comment にも適用、Requirement 2 と整合）
+3. When line-comment 本文に `idd-claude:pr-iteration` 以外の `idd-claude:` prefix を持つ marker が含まれる、または marker を含まない通常の line-comment である, the PR Iteration Processor shall 当該 line-comment を iteration agent への最終入力に含める
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The PR Iteration Processor shall 既存の env var 名 / exit code 意味 / hidden marker prefix `<!-- idd-claude:pr-iteration ` / PR body 内 marker のキー名（`round=` / `last-run=` / `no-progress-streak=`）を変更しない
+2. The local-watcher repo shall 既存テスト（PR Iteration Processor の marker regex / round カウンタ依存テスト）を退行させない
+3. The local-watcher repo shall 本変更を root と repo-template（`repo-template/local-watcher/...` 配下）で byte 一致同期した状態で配布する
+
+### NFR 2: 観測性
+
+1. When self-filter で除外された件数が増減した, the PR Iteration Processor shall `filtered_self=<N>` のカウンタ値で外部観測可能にする（Requirement 4 と整合）
+2. While iteration agent を起動する直前, the PR Iteration Processor shall サマリログを stderr に出力し、`fetched > 0` かつ `final=0` になった場合でも内訳（`filtered_self` / `filtered_resolved` / `filtered_event` / `truncated`）が運用者から判別可能な形にする
+
+### NFR 3: テスト整備
+
+1. The local-watcher repo shall 本要件を検証する近接テストを `local-watcher/test/` 配下に追加し、以下のケースを観測可能な形で最低限含める:
+   - PR Reviewer の `kind=review` コメントが self-filter で除外されないこと
+   - PR Iteration Processor 自身の `idd-claude:pr-iteration-processing` / `idd-claude:pr-iteration-529-warning` コメントが self-filter で除外されること
+   - last-run TS より後の PR Reviewer コメントが最終入力に含まれること
+   - last-run TS 以前（同時刻を含む）の PR Reviewer コメントが除外されること
+
+## Out of Scope
+
+- PR Reviewer 側の review 投稿フォーマット / marker 構造の変更（#399 で確立済み）
+- line-comment 経路で新規 self-filter を実装することそのもの（Requirement 5.1 で除外。仮に line-comment にも `idd-claude:pr-iteration` marker を含むコメントが存在する場合の挙動規約のみ Requirement 5.2 に明記）
+- last-run 境界判定そのもののロジック変更（`==` を除外側に倒す既存挙動を維持、Requirement 3.4）
+- 一般 / line 以外の入力経路（PR body / 差分 / requirements.md）の取り扱い変更
+- `PR_ITERATION_DESIGN_ENABLED` 等の opt-in gate 設計変更
+- iteration agent の prompt template 本文の書き換え（reviewer 指摘を「具体指摘として活用せよ」という指示の追加は #399 で対応済み）
+- PR Iteration Processor 以外の processor（Security Review / Auto-Rebase 等）の self-filter 挙動
+
+## Open Questions
+
+- なし（Issue #400 本文に修正方針・受入基準・DoD が明示されており、要件レベルで追加の人間判断は不要。実装段階で marker prefix 判定の具体的な照合方式（正規表現 / 文字列前方一致など）が必要になるが、それは design.md / impl の領分）
+
+## 関連
+
+- Depends on: #399
+- Related: #26 #55 #397

--- a/docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/review-notes.md
+++ b/docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/review-notes.md
@@ -1,0 +1,98 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-400-impl-fix-pr-iteration-self-filter-pr-reviewer
+- HEAD commit: 5d92d5e6dc17e79052419d80641f3cb6e7c2b1a3
+- Compared to: main..HEAD
+- 変更ファイル:
+  - `local-watcher/bin/modules/pr-iteration.sh`
+  - `local-watcher/test/pi_general_filter_self_test.sh`（新規）
+  - `docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/{requirements.md,impl-notes.md}`
+
+## Verified Requirements
+
+- 1.1 — `pi_general_filter_self` の jq 式が `contains("idd-claude:")` → `contains("idd-claude:pr-iteration")`
+  に限定範囲化（`pr-iteration.sh:248`）。テスト「Req 1.1 / 2.4: PR Reviewer kind=review コメントは
+  self-filter で除外されず keep」PASS で観測可能（`pi_general_filter_self_test.sh`）。
+- 1.2 — `pi_general_filter_self` 通過後 `pi_general_filter_resolved` を経由しても last-run TS
+  より後の reviewer コメントが残ることをテスト「Req 3.2: last-run TS より後の reviewer コメントは
+  最終入力に含める」で確認（PASS）。
+- 1.3 — substring `idd-claude:pr-iteration` 判定は `kind` 属性値を一切参照しない構造保証。
+  `kind=review` / `kind=reply` 等の値に依存せず PR Reviewer 投稿を keep する（混在ケース
+  「Req 1.4 / 4.2」PASS で観測）。
+- 1.4 — 混在入力（reviewer 2 件 + pr-iteration 系 2 件 + security 1 件）で `keep=3` 件残ることを
+  テスト「Req 1.4 / 4.2: 混在入力で reviewer / security は keep、pr-iteration 系のみ除外」で
+  確認（PASS）。final カウンタが 0 にならない経路を観測可能。
+- 2.1 — `idd-claude:pr-iteration round=N last-run=... no-progress-streak=K` marker が除外される
+  ことをテスト「Req 2.1」PASS で観測。
+- 2.2 — `idd-claude:pr-iteration-processing round=N` marker（着手表明）が除外されることを
+  テスト「Req 2.2」PASS で観測。
+- 2.3 — `idd-claude:pr-iteration-529-warning round=N` marker（quota soft-fail）が除外されることを
+  テスト「Req 2.3」PASS で観測。
+- 2.4 — `idd-claude:security-review` / `idd-claude:quota-reset` / `idd-claude:auto-rebase` /
+  `idd-claude:review` が keep されることをテスト 4 件 + 混在 1 件 PASS で観測。jq の `contains`
+  は単純 substring のため `pr-iteration` が `pr-reviewer` 等を誤包含することは構造上ない。
+- 2.5 — `idd-claude:pr-iteration-foo` 形式の前方互換性をテスト「Req 2.5」PASS で観測。substring
+  判定により将来のサブ種別も自動的に self として扱われる。
+- 3.1 — `pi_general_filter_resolved` 未改変（`pr-iteration.sh:263-267`、`$last_run == "" or
+  (.created_at // "") > $last_run` 既存式そのまま）。同時刻 / より前の reviewer コメントが
+  除外されることをテスト「Req 3.1（== 同時刻 / より前）」2 件 PASS で観測。
+- 3.2 — 「Req 3.2: last-run TS より後の reviewer コメントは最終入力に含める」PASS（前述）。
+- 3.3 — `last_run=""`（marker 不在 = 初回 round）で全件採用されることをテスト「Req 3.3」PASS
+  で観測。
+- 3.4 — `pi_general_filter_resolved` の jq 式（`==` を除外側に倒す既存挙動）が改変されていない
+  ことをソース直接確認（`pr-iteration.sh:265-266`）。テスト「Req 3.1: 同時刻除外」で観測も確認。
+- 4.1 — `pi_collect_general_comments`（`pr-iteration.sh:322-417`）のサマリログ書式
+  `PR #${pr_number} general comments: fetched=..., filtered_self=..., filtered_resolved=...,
+  filtered_event=..., truncated=... (limit=${limit})?, final=...` がそのまま温存。フィールド名・順序
+  共に未改変。
+- 4.2 — `filtered_self=$((fetched - count_self))` の計算式（`pr-iteration.sh:402`）が未改変。
+  `count_self` の意味自体は限定範囲化に追従して「Req 2 が定める self-filter で除外された件数」
+  に置き換わる（要件 4.2 の定義と整合）。
+- 4.3 — degraded path（fetch 失敗 / jq 整形失敗等）はすべて `echo "[]"` で空配列返却となり、
+  既存の各カウンタ 0 表現を保持する（`pr-iteration.sh:331-348` 系統を未改変）。
+- 4.4 — サマリログの出力先が `pi_warn` / `pi_log ... >&2` で stderr に揃っている既存契約は未改変
+  （`pr-iteration.sh:410-412`）。JSON 配列の stdout 出力（`pr-iteration.sh:415`）も未改変。
+- 5.1 — line-comment 経路の projection（`pr-iteration.sh:890-893`）は `contains("idd-claude:pr-iteration")`
+  ベースで限定範囲。「`idd-claude:` 一律除外」は新規導入されていない。
+- 5.2 — line-comment 経路の `select((.body // "") | contains("idd-claude:pr-iteration") | not)` を
+  確認（`pr-iteration.sh:893`）。テスト「Req 5.2: line-comment の idd-claude:pr-iteration marker
+  は除外」PASS で観測。
+- 5.3 — line-comment の他 prefix marker / marker 不在 keep をテスト 2 件 PASS で観測。
+- NFR 1.1 — 変更箇所は `pi_general_filter_self` 関数の jq 式 1 行と line-comment projection の
+  `select` 追加のみ。env var 名 / exit code / marker prefix `<!-- idd-claude:pr-iteration ` /
+  PR body 内 marker キー名（`round=` / `last-run=` / `no-progress-streak=`）は未改変
+  （`pr-iteration.sh:452-458` で確認）。
+- NFR 1.2 — `pi_max_rounds_kind_test.sh` 24/24 PASS、`pi_detect_quota_soft_fail_test.sh` 13/13 PASS
+  を reviewer 側でも再実行確認。退行ゼロ。
+- NFR 1.3 — `repo-template/local-watcher/bin/modules/` ディレクトリが存在しないことを reviewer 側で
+  確認（`ls` 結果 `DIR_NOT_FOUND`）。`install.sh:1359-1360` が `local-watcher/bin/modules/` から
+  `$HOME/bin/modules/` へ直接配布する単一ソース構成のため、byte 一致同期対象なし。CLAUDE.md
+  「機能追加ガイドライン § 4」の byte 一致対象（`.claude/{agents,rules}` / workflow / labels）にも
+  抵触しない。
+- NFR 2.1 / 2.2 — `filtered_self` カウンタは `pi_collect_general_comments` でそのまま出力され
+  続け（書式・stderr 出力先未改変）、Req 4 系統で観測可能。
+- NFR 3.1 — `pi_general_filter_self_test.sh` 17 ケース新規追加・全 PASS を reviewer 側で再実行
+  確認。要求 4 ケース（PR Reviewer keep / 自身の `-processing` `-529-warning` 除外 / last-run 後
+  reviewer 含む / last-run 以前 reviewer 除外）が全てカバー済み。
+
+## Findings
+
+なし。
+
+## Summary
+
+Issue #400 の修正方針（self-filter の対象を `idd-claude:pr-iteration` prefix のみに限定）は
+`pi_general_filter_self` の jq 式 1 行差し替えと line-comment projection の `select` 追加で
+最小範囲かつ後方互換に実装されている。Requirement 1〜5 / NFR 1〜3 のすべての AC に対して、
+新規テスト 17 ケースおよびソース直接観測で実装の存在を確認した。既存テスト
+（`pi_max_rounds_kind_test.sh` 24/24、`pi_detect_quota_soft_fail_test.sh` 13/13）も退行ゼロ、
+`shellcheck` 警告ゼロ。`repo-template/local-watcher/bin/modules/` は単一ソース構成のため
+byte 一致同期対象外（impl-notes.md の説明と reviewer 側 `ls` 結果が一致）。境界違反なし
+（tasks.md は本 fix では生成されておらず `_Boundary:_` 制約なし、変更は対象モジュールと
+近接テストに限定）。
+
+RESULT: approve

--- a/local-watcher/bin/modules/pr-iteration.sh
+++ b/local-watcher/bin/modules/pr-iteration.sh
@@ -224,18 +224,28 @@ pi_read_last_run() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# pi_general_filter_self: watcher 自身の自動投稿コメントを除外（marker ベース）
+# pi_general_filter_self: PR Iteration Processor 自身の自動投稿コメントを除外
+#   （prefix `idd-claude:pr-iteration` 単位の判定 / Issue #400 Req 2）
 #   入力: stdin に一般コメント JSON 配列
 #   出力: stdout にフィルタ後の JSON 配列
-#   AC #55 Req 2.1, 2.7
+#   AC #55 Req 2.1, 2.7 / #400 Req 2.1〜2.5
 #
-#   判定: comment.body 中に `idd-claude:` で始まる HTML hidden marker を含むなら
-#   watcher 投稿として除外する。GitHub user 同一性に依存しない（cron 実行ホストが
-#   異なる GitHub user で動いていても確実に除外できる）。`@claude` 文字列には
-#   一切依存しない（Req 2.7）。
+#   判定: comment.body 中に `idd-claude:pr-iteration` を含む HTML hidden marker
+#         （`idd-claude:pr-iteration round=...` / `idd-claude:pr-iteration-processing` /
+#         `idd-claude:pr-iteration-529-warning` 等）を持つコメントを self として除外する。
+#         GitHub user 同一性に依存しない（cron 実行ホストが異なる GitHub user で動いて
+#         いても確実に除外できる）。`@claude` 文字列には一切依存しない（Req 2.7）。
+#
+#   Issue #400: 旧実装は `contains("idd-claude:")` で **全** prefix を除外していたため
+#         PR Reviewer 投稿 (`idd-claude:pr-reviewer`) や他系統 (security-review /
+#         quota-reset / auto-rebase 等) も self として落ちる事故が起きていた。本関数は
+#         `idd-claude:pr-iteration` prefix のみを対象とし、他系統の hidden marker は
+#         keep する。`idd-claude:pr-iteration` という substring 判定は前方一致互換で、
+#         将来 `idd-claude:pr-iteration-foo` 形式の新サブ種別が追加されても自動的に
+#         self として扱われる（#400 Req 2.5 前方互換）。
 # ─────────────────────────────────────────────────────────────────────────────
 pi_general_filter_self() {
-  jq '[.[] | select((.body // "") | contains("idd-claude:") | not)]'
+  jq '[.[] | select((.body // "") | contains("idd-claude:pr-iteration") | not)]'
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -863,6 +873,11 @@ pi_build_iteration_prompt() {
   # `git diff <base>..<head> -- <path>` を Bash ツールで実行して取得する設計に切り替えた）
 
   # AC 3.1: 最新 review の line コメントを取得（reviews 配列の最後の要素 = 時系列で最新）
+  #
+  # Issue #400 Req 5.2 / 5.3: line-comment 経路にも一般コメント経路と同じ self-filter 規約
+  # （`idd-claude:pr-iteration` 含むコメントを除外、他 prefix は keep）を適用する。Req 5.1
+  # の通り「`idd-claude:` を含む文字列を一律除外する self-filter は新規導入しない」原則を守り、
+  # PR Iteration Processor 自身の marker のみを限定除外する。
   local line_comments_json="[]"
   local reviews_json latest_review_id
   if reviews_json=$(timeout "$PR_ITERATION_GIT_TIMEOUT" \
@@ -872,7 +887,10 @@ pi_build_iteration_prompt() {
       local raw_line
       if raw_line=$(timeout "$PR_ITERATION_GIT_TIMEOUT" \
           gh api "/repos/${REPO}/pulls/${pr_number}/reviews/${latest_review_id}/comments" 2>/dev/null); then
-        line_comments_json=$(echo "$raw_line" | jq '[.[] | {id, path, line, user: (.user.login // ""), body}]')
+        line_comments_json=$(echo "$raw_line" \
+          | jq '[.[]
+                | {id, path, line, user: (.user.login // ""), body}
+                | select((.body // "") | contains("idd-claude:pr-iteration") | not)]')
       fi
     fi
   fi

--- a/local-watcher/test/pi_general_filter_self_test.sh
+++ b/local-watcher/test/pi_general_filter_self_test.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #400 で限定範囲化した PR Iteration Processor の self-filter
+#       `pi_general_filter_self` のスモークテスト。
+#
+#       検証する受入基準（docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/requirements.md）:
+#         - Req 1.1〜1.4 PR Reviewer 投稿 (`idd-claude:pr-reviewer ... kind=review`) を keep
+#         - Req 2.1〜2.4 自身の marker (`idd-claude:pr-iteration` / `-processing` / `-529-warning`) を除外
+#         - Req 2.4         他系統 (security-review / quota-reset / auto-rebase 等) は keep
+#         - Req 2.5         `idd-claude:pr-iteration-<suffix>` 形式の前方互換性
+#         - Req 3.1〜3.4 last-run 境界の維持 (== 除外側、後は採用) を `pi_general_filter_resolved`
+#                          と組み合わせて検証
+#         - Req 5.1〜5.3 line-comment 経路にも同じ self-filter 規約が適用される (substring 検証)
+#
+# 配置先: local-watcher/test/pi_general_filter_self_test.sh
+# 依存:   bash 4+, awk, jq
+# 実行:   bash local-watcher/test/pi_general_filter_self_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_ITERATION_SH="$SCRIPT_DIR/../bin/modules/pr-iteration.sh"
+
+if [ ! -f "$PR_ITERATION_SH" ]; then
+  echo "ERROR: cannot find pr-iteration.sh at $PR_ITERATION_SH" >&2
+  exit 2
+fi
+
+# 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_ITERATION_SH" "pi_general_filter_self")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_ITERATION_SH" "pi_general_filter_resolved")"
+
+if ! declare -F pi_general_filter_self >/dev/null; then
+  echo "ERROR: pi_general_filter_self not loaded" >&2
+  exit 2
+fi
+if ! declare -F pi_general_filter_resolved >/dev/null; then
+  echo "ERROR: pi_general_filter_resolved not loaded" >&2
+  exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ─── pi_general_filter_self (Issue #400 Req 1 / Req 2) ───
+
+echo "--- pi_general_filter_self cases (Issue #400 Req 1 / Req 2) ---"
+
+# Req 1.1 / 1.3 / 2.4: PR Reviewer 投稿 (idd-claude:pr-reviewer kind=review) は keep する
+input='[{"id":1,"body":"## :mag: PR Reviewer 自動レビュー\n\n指摘 1: foo\n\n<!-- idd-claude:pr-reviewer sha=abc1234 kind=review tool=codex -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 1.1 / 2.4: PR Reviewer kind=review コメントは self-filter で除外されず keep" "1" "$actual"
+
+# Req 2.1: 自身の marker (round=N last-run=...) を持つコメントは除外
+input='[{"id":2,"body":"<!-- idd-claude:pr-iteration round=1 last-run=2026-06-23T10:00:00Z no-progress-streak=0 -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r 'length')
+assert_eq "Req 2.1: idd-claude:pr-iteration round=N marker は self として除外" "0" "$actual"
+
+# Req 2.2: 着手表明コメント (idd-claude:pr-iteration-processing) は除外
+input='[{"id":3,"body":":robot: PR Iteration Processor が処理を開始しました (round 2/3)。\n<!-- idd-claude:pr-iteration-processing round=2 -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r 'length')
+assert_eq "Req 2.2: idd-claude:pr-iteration-processing は self として除外" "0" "$actual"
+
+# Req 2.3: 529 warning コメント (idd-claude:pr-iteration-529-warning) は除外
+input='[{"id":4,"body":":warning: Claude API 一時混雑エラー\n<!-- idd-claude:pr-iteration-529-warning round=1 -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r 'length')
+assert_eq "Req 2.3: idd-claude:pr-iteration-529-warning は self として除外" "0" "$actual"
+
+# Req 2.4: security-review は keep
+input='[{"id":5,"body":"## Security Review\n<!-- idd-claude:security-review sha=abc kind=review -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 2.4: idd-claude:security-review は keep" "5" "$actual"
+
+# Req 2.4: quota-reset は keep
+input='[{"id":6,"body":"<!-- idd-claude:quota-reset -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 2.4: idd-claude:quota-reset は keep" "6" "$actual"
+
+# Req 2.4: auto-rebase は keep
+input='[{"id":7,"body":"<!-- idd-claude:auto-rebase -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 2.4: idd-claude:auto-rebase は keep" "7" "$actual"
+
+# Req 2.4: idd-claude:review (PR Reviewer の汎用 marker) は keep
+input='[{"id":8,"body":"<!-- idd-claude:review tool=codex -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 2.4: idd-claude:review は keep" "8" "$actual"
+
+# Req 2.5: idd-claude:pr-iteration-<suffix> 形式の前方互換性
+input='[{"id":9,"body":"<!-- idd-claude:pr-iteration-foo round=1 -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r 'length')
+assert_eq "Req 2.5: idd-claude:pr-iteration-foo 形式の新サブ種別も self として除外" "0" "$actual"
+
+# 混在ケース: reviewer keep + self exclude を同時に検証（実稼働の fetched=8, filtered_self=7, final=0 シナリオの逆再現）
+input='[
+  {"id":11,"body":"<!-- idd-claude:pr-reviewer sha=a kind=review tool=codex -->","created_at":"2026-06-23T10:00:00Z"},
+  {"id":12,"body":"<!-- idd-claude:pr-reviewer sha=b kind=review tool=claude -->","created_at":"2026-06-23T10:01:00Z"},
+  {"id":13,"body":"<!-- idd-claude:pr-iteration round=1 last-run=2026-06-23T09:00:00Z -->","created_at":"2026-06-23T09:30:00Z"},
+  {"id":14,"body":"<!-- idd-claude:pr-iteration-processing round=2 -->","created_at":"2026-06-23T10:02:00Z"},
+  {"id":15,"body":"<!-- idd-claude:security-review -->","created_at":"2026-06-23T10:03:00Z"}
+]'
+actual=$(echo "$input" | pi_general_filter_self | jq -r '[.[].id] | join(",")')
+assert_eq "Req 1.4 / 4.2: 混在入力で reviewer / security は keep、pr-iteration 系のみ除外" "11,12,15" "$actual"
+
+# ─── pi_general_filter_resolved (Issue #400 Req 3) との組み合わせ検証 ───
+
+echo "--- pi_general_filter_self + pi_general_filter_resolved 統合 (Issue #400 Req 3) ---"
+
+# Req 3.1: last-run TS と同時刻の reviewer コメントは除外（== は除外側に倒す既存挙動の維持）
+input='[{"id":21,"body":"<!-- idd-claude:pr-reviewer sha=x kind=review -->","created_at":"2026-06-23T10:00:00Z"}]'
+actual=$(echo "$input" \
+  | pi_general_filter_self \
+  | pi_general_filter_resolved "2026-06-23T10:00:00Z" \
+  | jq -r 'length')
+assert_eq "Req 3.1: last-run TS と同時刻の reviewer コメントは除外" "0" "$actual"
+
+# Req 3.2: last-run TS より後の reviewer コメントは最終入力に含める
+input='[{"id":22,"body":"<!-- idd-claude:pr-reviewer sha=y kind=review -->","created_at":"2026-06-23T10:00:01Z"}]'
+actual=$(echo "$input" \
+  | pi_general_filter_self \
+  | pi_general_filter_resolved "2026-06-23T10:00:00Z" \
+  | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 3.2: last-run TS より後の reviewer コメントは最終入力に含める" "22" "$actual"
+
+# Req 3.1: last-run TS より前の reviewer コメントは除外
+input='[{"id":23,"body":"<!-- idd-claude:pr-reviewer sha=z kind=review -->","created_at":"2026-06-23T09:59:59Z"}]'
+actual=$(echo "$input" \
+  | pi_general_filter_self \
+  | pi_general_filter_resolved "2026-06-23T10:00:00Z" \
+  | jq -r 'length')
+assert_eq "Req 3.1: last-run TS より前の reviewer コメントは除外" "0" "$actual"
+
+# Req 3.3: last-run 不在 (初回 round) では reviewer コメント全件が採用される
+input='[
+  {"id":24,"body":"<!-- idd-claude:pr-reviewer sha=p kind=review -->","created_at":"2026-06-23T09:00:00Z"},
+  {"id":25,"body":"<!-- idd-claude:pr-reviewer sha=q kind=review -->","created_at":"2026-06-23T10:00:00Z"}
+]'
+actual=$(echo "$input" \
+  | pi_general_filter_self \
+  | pi_general_filter_resolved "" \
+  | jq -r '[.[].id] | join(",")')
+assert_eq "Req 3.3: last-run 空文字列 (初回 round) は reviewer コメントを除外しない" "24,25" "$actual"
+
+# ─── line-comment 経路の self-filter 規約 (Issue #400 Req 5) ───
+
+echo "--- line-comment 経路の self-filter (Issue #400 Req 5) ---"
+
+# Req 5.2: line-comment にも同じ jq filter で pr-iteration marker を除外する整合（実装と同じ式で検証）
+# 実装側の line-comment projection は `[.[] | {id, path, line, user, body} | select((.body // "") | contains("idd-claude:pr-iteration") | not)]`
+line_filter() {
+  jq '[.[] | {id, path, line, user: (.user.login // ""), body} | select((.body // "") | contains("idd-claude:pr-iteration") | not)]'
+}
+
+# Req 5.2: line-comment に pr-iteration marker が含まれていれば除外
+input='[{"id":31,"path":"foo.sh","line":10,"user":{"login":"bot"},"body":"<!-- idd-claude:pr-iteration round=1 -->"}]'
+actual=$(echo "$input" | line_filter | jq -r 'length')
+assert_eq "Req 5.2: line-comment の idd-claude:pr-iteration marker は除外" "0" "$actual"
+
+# Req 5.3: line-comment に他 prefix の marker が含まれていても keep
+input='[{"id":32,"path":"foo.sh","line":10,"user":{"login":"bot"},"body":"<!-- idd-claude:pr-reviewer sha=x kind=review tool=codex -->\n指摘内容: foo.sh の 10 行目で..."}]'
+actual=$(echo "$input" | line_filter | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 5.3: line-comment の idd-claude:pr-reviewer marker は keep" "32" "$actual"
+
+# Req 5.3: marker を含まない通常の line-comment は keep
+input='[{"id":33,"path":"foo.sh","line":15,"user":{"login":"alice"},"body":"このロジックは redundant です"}]'
+actual=$(echo "$input" | line_filter | jq -r '.[0].id // "MISSING"')
+assert_eq "Req 5.3: marker 不在の通常 line-comment は keep" "33" "$actual"
+
+# ─── サマリ ───
+
+echo ""
+echo "================================"
+echo "PASS: $PASS_COUNT"
+echo "FAIL: $FAIL_COUNT"
+echo "================================"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

PR Iteration Processor の self-filter（`pi_general_filter_self`）が `idd-claude:` を含む **全コメントを一律除外** していたため、PR Reviewer が投稿した review 指摘（`idd-claude:pr-reviewer ... kind=review` marker 付き）も誤って除外され、iteration agent が空入力で no-progress 連続 → codex ゲートで stuck する問題を修正する。

`contains("idd-claude:")` を `contains("idd-claude:pr-iteration")` に限定範囲化することで、PR Reviewer / security-review / quota-reset / auto-rebase 等、他系統の自動投稿が iteration agent の入力に正しく渡るようになる。line-comment 経路も同様に整合させた（Req 5）。

## 対応 Issue

Closes #400

## 関連 PR

- 設計 PR: なし（軽量 fix のため design-less impl）

## 実装内容

- (Req 2.1–2.5 / Task —) `pi_general_filter_self` の jq 式を `contains("idd-claude:")` → `contains("idd-claude:pr-iteration")` に変更し、self-filter の対象を PR Iteration Processor 自身の marker のみに限定
- (Req 5.2) line-comment 経路（`pi_build_iteration_prompt` 内の reviews jq projection）に同じ `contains("idd-claude:pr-iteration")` ベースの `select(... | not)` を追加（`idd-claude:` 一律除外は導入しない）
- (NFR 3.1) `local-watcher/test/pi_general_filter_self_test.sh` を新規追加（17 ケース）— PR Reviewer keep / `idd-claude:pr-iteration-*` 除外 / last-run 境界 / 混在入力を全カバー

## 受入基準チェック

- [x] Req 1.1: `idd-claude:pr-reviewer ... kind=review` marker 付きコメントを self-filter で除外しない ← `pi_general_filter_self_test.sh` 「Req 1.1 / 2.4」ケース PASS
- [x] Req 1.4: final カウンタが 0 にならない（混在入力で keep=3）← 「Req 1.4 / 4.2 混在」ケース PASS
- [x] Req 2.1: `idd-claude:pr-iteration` marker を除外 ← 「Req 2.1」ケース PASS
- [x] Req 2.2: `idd-claude:pr-iteration-processing` を除外 ← 「Req 2.2」ケース PASS
- [x] Req 2.3: `idd-claude:pr-iteration-529-warning` を除外 ← 「Req 2.3」ケース PASS
- [x] Req 2.4: 他 prefix（reviewer / security / quota-reset / auto-rebase / review）を除外しない ← 5 件 PASS
- [x] Req 2.5: `idd-claude:pr-iteration-foo` 形式の前方互換 ← 「Req 2.5」ケース PASS
- [x] Req 3.1: last-run TS 以前（同時刻含む）の reviewer コメントは除外 ← 2 件 PASS
- [x] Req 3.2: last-run TS より後の reviewer コメントは agent 入力に含める ← PASS
- [x] Req 3.3: marker 不在（初回 round）は全件採用 ← PASS
- [x] Req 3.4: last-run 比較境界（`==` 除外側）を変更しない ← `pi_general_filter_resolved` 未改変
- [x] Req 4.1–4.4: サマリログ書式・カウンタ・stderr 出力先が後方互換 ← `pi_collect_general_comments` の書式・計算式未改変
- [x] Req 5.2: line-comment の `idd-claude:pr-iteration` marker を除外 ← PASS
- [x] NFR 1.1: env var 名 / exit code / marker prefix / PR body marker キー名不変 ← filter 内部の jq 式 1 行のみ変更
- [x] NFR 1.2: 既存テスト退行ゼロ ← `pi_max_rounds_kind_test.sh` 24/24、`pi_detect_quota_soft_fail_test.sh` 13/13 PASS

## テスト結果

```
bash local-watcher/test/pi_general_filter_self_test.sh  → 17/17 PASS（新規）
bash local-watcher/test/pi_max_rounds_kind_test.sh      → 24/24 PASS（既存退行なし）
bash local-watcher/test/pi_detect_quota_soft_fail_test.sh → 13/13 PASS（既存退行なし）
bash -n local-watcher/bin/modules/pr-iteration.sh       → OK
shellcheck local-watcher/bin/modules/pr-iteration.sh \
  local-watcher/test/pi_general_filter_self_test.sh     → 警告ゼロ
```

## 実装上の判断

- **substring match の採用**: `contains("idd-claude:pr-iteration")` による substring 判定で Req 2.1〜2.3（` ` / `-processing` / `-529-warning`）と Req 2.5（`-<suffix>` 前方互換）を同時に満たせる。`pr-iteration` は `pr-reviewer` と包含関係になく、誤マッチなし。シンプルさを優先し `test()` ベースの正規表現前方一致は採用しなかった。
- **line-comment 経路の projection 同時適用**: `line_comments_json` は 1 箇所でしか生成されないため、projection 直後の jq 式内で `select(... | not)` を繋いで二重パスを回避した。
- **repo-template 同期対象外**: `repo-template/local-watcher/bin/modules/` ディレクトリは存在しない（`install.sh` が `local-watcher/bin/modules/` から直接 `$HOME/bin/modules/` に配布する単一ソース構成）。byte 一致同期の対象は `.claude/{agents,rules}` のみであり本修正は対象外。

詳細は [`docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/review-notes.md`](docs/specs/400-fix-pr-iteration-self-filter-pr-reviewer/review-notes.md) を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK
- Reviewer（独立レビュー）判定: **RESULT: approve**（review-notes.md 参照）
- `pi_general_filter_self` の jq 式変更箇所（`pr-iteration.sh:248` 付近）を重点確認
- 他 processor への波及なし（変更は `pr-iteration.sh` と近接テストのみ）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #400 のコメントを参照してください。
