### PR TITLE
fix(#411): claude 即時失敗の attempt 除外・専用ログ・worktree 起動・独立エスカレーション

### DIFF
--- a/README.md
+++ b/README.md
@@ -4283,6 +4283,8 @@ sha1sum で hash 化したもの）が **完全一致**し、PR 経路では `he
 | quota 検出（claude rc=99） | 結果コメント 1 件投稿 + `claude-failed` ラベル **据え置き** + state `in-progress` 維持。次サイクル待ち |
 | 通算 attempt 上限到達 (`>= FAILED_RECOVERY_MAX_ATTEMPTS`) | 着手コメント投稿せず終端理由コメント 1 件投稿（通算回数 + 上限値含む）+ `claude-failed` **据え置き** + run-summary `claude-failed` 通知（Req 4.5, 4.6） |
 | no-progress 判定（同 signature 再発 + 無進捗） | 着手コメント投稿せず終端理由コメント 1 件投稿（no-progress 含む）+ `claude-failed` **据え置き** + run-summary `claude-failed` 通知（Req 5.3, 5.4） |
+| **#411 即時失敗（claude rc≠0,99 + tool_use 未観測 + セッション継続秒 < 閾値）** | attempt カウンタを **加算しない / ロールバックする**（quota 燃焼上界保証を壊さない）+ `immediate_failure_streak` を ++ + 結果コメント 1 件投稿（連続回数表示）+ `claude-failed` **据え置き** + 次サイクル再試行 |
+| **#411 即時失敗連続上限到達 (`>= FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK`)** | 着手コメント投稿せず終端理由コメント 1 件投稿（`immediate-failure-streak` 識別子 + 連続回数 + 上限値含む）+ `claude-failed` **据え置き** + run-summary `claude-failed` 通知。**`max-attempts` と区別可能**（運用者が手動レビュー時に「claude が試行した結果ダメだった」と「claude が動かなかった」を即座に切り分け可能） |
 
 **既存 `claude-failed` 手動運用との関係**:
 
@@ -4302,9 +4304,10 @@ sha1sum で hash 化したもの）が **完全一致**し、PR 経路では `he
 
 主なフィールド:
 - `total_attempts` — 通算 attempt カウンタ（cron サイクル跨ぎ・watcher 再起動でも継承）
-- `last_status` — `in-progress` / `succeeded` / `max-attempts` / `no-progress`
+- `last_status` — `in-progress` / `succeeded` / `max-attempts` / `no-progress` / `immediate-failure-streak` (#411)
 - `last_failure_signature` — 直前失敗 log の SHA-1 hex（no-progress 判定用）
 - `last_head_sha` — PR 経路の直前 head（Issue 経路は空文字）
+- `immediate_failure_streak` (#411) — 連続即時失敗回数。通算 attempt budget とは独立カウンタで、quota 燃焼上界保証として機能する。tool_use 観測時 / 通常失敗時 / 成功時に 0 にリセットされる。`FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` 到達で `immediate-failure-streak` 終端理由を発火（#411 導入前の state ファイルは本フィールドを持たないが、`load` 時に `0` fallback して読むため後方互換は維持される）
 - `history` — 直近 8 件の試行履歴（hot-spot 防止）
 
 ### 環境変数
@@ -4319,6 +4322,8 @@ sha1sum で hash 化したもの）が **完全一致**し、PR 経路では `he
 | `FAILED_RECOVERY_GIT_TIMEOUT` | `60`（秒） | network 遅延が大きい環境は調整 | gh / git 呼び出しごとの timeout |
 | `FAILED_RECOVERY_MAX_PRS` | `3` | watcher 間隔と claude-failed 件数で調整 | 1 サイクルで処理する Issue / PR の上限件数 |
 | `FAILED_RECOVERY_STATE_DIR` | `$HOME/.issue-watcher/failed-recovery/<repo-slug>` | 通常変更不要 | state JSON の配置先 |
+| `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` (#411) | `10`（秒） | 通常変更不要 | 即時失敗判定の継続時間閾値。claude session が exit code 非ゼロ（quota sentinel 99 除く）+ stream-json 中に tool_use イベントなし + セッション継続時間が本値未満を満たした場合に「実質作業前の即時失敗」と判定し、attempt budget から除外する（非整数 / `<=0` は既定 10 にフォールバック） |
+| `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` (#411) | `3`（回） | 通常変更不要 | 同一 Issue / PR の **即時失敗連続上限**（通算 attempt budget とは独立カウンタ）。本上限到達時は `immediate-failure-streak` 終端理由で 1 度だけ運用者にエスカレーション。quota 燃焼上界保証（無限リトライ防止）として有限の正の整数値を必ず持つ（非整数 / `<=0` は既定 3 にフォールバック） |
 
 ### cron 例（opt-in する場合）
 
@@ -4358,6 +4363,36 @@ Failed Recovery Processor 導入による後方互換性は以下のとおり保
   優先される
 - **cron / launchd 登録文字列の書き換え必要**: 有効化する場合のみ `FULL_AUTO_ENABLED=true
   FAILED_RECOVERY_ENABLED=true` を cron 行に追記する（既存 watcher 起動行はそのまま）
+
+#### #411 即時失敗除外 / 専用ログ / worktree 起動 / 独立エスカレーション
+
+altpocket-server #119 で観測された「claude セッションが約 2 秒で rc=1 で即時失敗するケース」に
+対応するため、Failed Recovery Processor に以下の挙動が追加されました（後方互換あり / NFR 1.1）:
+
+- **即時失敗の attempt budget 除外**: claude exit code 非ゼロ（quota sentinel 99 除く）+
+  stream-json 中に tool use イベントなし + セッション継続時間が
+  `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS`（既定 10 秒）未満を満たした試行は、通算 attempt
+  budget としてカウントせず（既に加算した値をロールバック）、別カウンタ `immediate_failure_streak`
+  のみ ++ する。決定論的に即死する状況で 4 attempts を空消費して premature に終端する事故を防ぐ
+- **専用ログ保存（discoverable）**: recovery claude session の stdout/stderr を
+  `$LOG_DIR/failed-recovery-<kind>-<number>-<TS>.log` に必ず保存（`LOG` 環境変数が未設定でも
+  `/dev/null` に逃さず自前で保存先を確定）。一次運用ログ（cron.log に転送される
+  `failed-recovery:` prefix 行）にも当該パスを記録するため、運用者は cron.log から該当ログを辿れる
+- **対象 repo 作業ツリーでの起動**: recovery claude を `REPO_DIR` 上で起動する（既存 impl 系プロセッサ
+  と同一起点）。PR の場合は head branch を、Issue の場合は既存 `claude/issue-<N>-*` branch または
+  `BASE_BRANCH` を checkout してから claude を起動。作業ツリー確保失敗時は「即時失敗」扱いに倒して
+  attempt budget から除外する（cwd 不在による rc=1 即死の主要候補を排除）
+- **独立エスカレーション識別子 `immediate-failure-streak`**: 即時失敗連続上限
+  （`FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` / 既定 3）到達時に、既存 `max-attempts` /
+  `no-progress` とは **別の終端理由識別子**で 1 度だけエスカレーション。一次運用ログ
+  `failed-recovery: ... terminated reason=immediate-failure-streak` で grep 抽出可能。
+  `claude-failed` ラベルは据え置きで手動レビューへ
+- **既存 state JSON との後方互換**: `immediate_failure_streak` フィールドを持たない既存 state
+  ファイル（#411 導入前に書かれたもの）は `load` 時に `0` fallback として読まれ、次回 `save` で
+  `0` が永続化される。既存呼出側コード（fr_save_state の 5 引数版）も継続動作する
+- **既存環境変数は不変**: `FAILED_RECOVERY_ENABLED` / `FAILED_RECOVERY_MAX_ATTEMPTS` 等の名前・
+  意味・既定値は変更なし。新規追加の `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` /
+  `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` は未設定時に既定値を採用
 
 ### ⚠️ merge 後の再配置が必要
 

--- a/docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/impl-notes.md
+++ b/docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/impl-notes.md
@@ -1,0 +1,206 @@
+# Implementation Notes — #411 即時失敗除外 / 専用ログ / worktree 起動 / 独立エスカレーション
+
+## サマリ
+
+`local-watcher/bin/modules/failed-recovery.sh` に以下 4 系統を追加した（既定 OFF / 後方互換あり）:
+
+1. **即時失敗 attempt 除外**: rc=98 sentinel + `immediate_failure_streak` カウンタ + attempt ロールバック
+2. **専用ログ保存**: `$LOG_DIR/failed-recovery-<kind>-<number>-<TS>.log` を必ず生成し `LOG` 未設定でも `/dev/null` に逃さない
+3. **対象 repo 作業ツリーでの起動**: `REPO_DIR` で claude branch / PR head branch / BASE_BRANCH を checkout
+4. **独立エスカレーション**: `fr_terminate_immediate_failure_streak` + `immediate-failure-streak` 識別子
+
+## 設計判断
+
+### 閾値選定
+
+- `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` 既定 **10 秒**
+  - altpocket-server #119 で観測された ~2 秒 rc=1 を確実に拾える保守値
+  - 短すぎると正常な失敗を誤分類、長すぎると即時失敗を見逃すバランス
+- `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` 既定 **3 回**
+  - 3 cycle（2 分 cron × 3 ≒ 6 分）連続で claude が起動できなければ手動レビューへ
+  - 通算 attempt 4 回上限とは別カウンタ。quota 燃焼上界保証として有限の正の整数値
+- 両方とも env で上書き可能。非整数 / `<=0` は既定値に正規化
+
+### 即時失敗判定ロジック
+
+`fr_classify_immediate_failure` を純粋関数として切り出した（テスト容易性 + Req 1.2 / 1.3 / 1.8）。
+判定: `rc!=0 AND quota 未検出 AND tool_use 未観測 AND elapsed < threshold`。
+すべてのガード条件は逆順優先で評価し、いずれか「通常扱い」に該当した時点で 1 を返す。
+
+tool_use 観測は stream-json 出力に `"type":"tool_use"` 行が含まれるかを grep で観測。
+2 段 tee 構成で `LOG`（cron.log 互換）と専用ログの両方に append し、専用ログ側を grep 対象にする。
+
+### ログファイル命名
+
+`failed-recovery-<kind>-<number>-<TS>.log` で固定（Req 2.3 識別語必須 + Req 2.2 kind/number/timestamp 必須）。
+
+- `kind`: `issue` / `pr` のみ（`fr_resolve_dedicated_log_path` で sanitize）
+- `<number>`: `^[0-9]+$` のみ
+- `<TS>`: `+%Y%m%dT%H%M%SZ`（ASCII 安全 / Req 2.3 + NFR 3.1）
+
+`LOG_DIR` 未設定時は `$HOME/.issue-watcher/logs/$REPO_SLUG` にフォールバック（Req 2.4 で `/dev/null` 行きを防ぐ）。
+ファイル作成失敗時は警告ログを残しつつ `/dev/null` 行きで recovery 自体は継続（fail-continue / Req 2.6）。
+
+### worktree checkout 戦略
+
+`fr_prepare_repo_worktree` を新規追加（Req 3.1〜3.6）:
+
+- **PR の場合**: `gh pr view --json headRefName` で取得 → `git -C $REPO_DIR checkout -B <ref> origin/<ref> --`
+- **Issue の場合**: `git ls-remote --heads origin "claude/issue-<N>-*"` の先頭、無ければ `BASE_BRANCH`
+- 失敗時は `fr_warn` で原因を残しつつ rc=1（Req 3.4 で即時失敗扱いへ倒す）
+- `-- ` でオプション解釈打ち切り（NFR 3.1 / branch 名で `-` 始まりの誤注入防止）
+- `^claude/` パターンで PR head branch を再検証（fork 巻き込み防止）
+
+`fr_run_recovery_attempt` 内で `( cd "$REPO_DIR"; fr_invoke_claude ... )` の subshell に隔離して
+caller の cwd を変更しない（NFR 1.1 後方互換）。
+
+### attempt rollback と streak カウンタ
+
+`fr_run_recovery_attempt` で:
+
+1. 試行開始時に通常通り `total=prev_total+1` で `in-progress` save（既存挙動）
+2. claude rc=98 を受けたら `total=prev_total`（ロールバック）+ `streak=prev_streak+1` で再 save
+3. `streak >= max_streak` なら return 4（`_fr_dispatch_candidate` が `fr_terminate_immediate_failure_streak` を呼ぶ）
+4. 通常失敗 / success path では `streak=0` リセット（Req 1.7）
+5. prev_streak が既に max_streak >= の状態で再起動した場合は事前判定で return 4（attempt 加算なし）
+
+これにより quota 燃焼上界保証（max-attempts 通算 4 回）は壊さずに、即時失敗の「決定論的な空消費」だけを除外できる。
+
+### 識別子と既存終端の区別可能性
+
+- 既存: `max-attempts` / `no-progress`
+- 追加: `immediate-failure-streak`（Req 4.1）
+
+3 つとも `fr_log` で `[YYYY-MM-DD HH:MM:SS] [$REPO] failed-recovery: <kind>=#<n> terminated reason=<id> ...` 形式（Req 4.2）。
+`grep -E "terminated reason=immediate-failure-streak"` で抽出可能。
+sn_notify の event_type は既存 3 種（recovered / max-attempts / no-progress）に `immediate-failure-streak` を追加（Req 4.6）。
+signature 値は detail に含めない（NFR 3.2）。
+
+## 変更ファイル一覧
+
+| File | 変更内容 |
+|---|---|
+| `local-watcher/bin/issue-watcher.sh` | Config ブロックに `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` / `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` 2 つの env 正規化を追加 |
+| `local-watcher/bin/modules/failed-recovery.sh` | `fr_resolve_dedicated_log_path` / `fr_classify_immediate_failure` / `fr_prepare_repo_worktree` / `fr_terminate_immediate_failure_streak` を新規追加。`fr_save_state` に 6 番目引数（immediate_failure_streak）を追加（後方互換 / 省略時継承）。`fr_invoke_claude` を rewrite（2 段 tee / tool_use 観測 / elapsed 計測 / rc=98 sentinel / dedicated_log_path 受け取り）。`fr_run_recovery_attempt` を rewrite（worktree prep → claude → rc=98 / 0 / 99 / 通常失敗の分岐 + streak ハンドリング）。`_fr_dispatch_candidate` に rc=4 case を追加 |
+| `local-watcher/test/fr_immediate_fail_test.sh` | **新規追加**。Section A〜J で `fr_resolve_dedicated_log_path` / `fr_terminate_immediate_failure_streak` 単体と、`fr_run_recovery_attempt` 内 rc=98 / streak 上限 / worktree 失敗 / dedicated_log 受け渡し / repo_dir + ref ログ を検証 |
+| `local-watcher/test/fr_invoke_test.sh` | Section 9 を tool_use 観測 fixture に書き換え（既存の「rc=7 透過」検証を維持しつつ即時失敗判定との干渉を分離）。Section 10〜14 を新規追加（rc=98 sentinel / tool_use 観測ありで透過 / success path / quota 経路除外 / `fr_classify_immediate_failure` 純粋関数の境界値テスト） |
+| `local-watcher/test/fr_attempt_test.sh` | stub に `fr_prepare_repo_worktree` / `fr_resolve_dedicated_log_path` を追加。`fr_invoke_claude` stub を 3 引数版に更新。`REPO_DIR` / `BASE_BRANCH` / `LOG_DIR` env 追加。success path で fr_save_state 呼び出し回数が 2→3 になる（streak=0 reset save が増えた）ことに合わせ assertion 更新 |
+| `local-watcher/test/fr_state_test.sh` | 末尾に Section #411 追加（streak 明示指定 save → load / 6 番目引数省略時の継承 / 既存 state（streak field 不在）の 0 fallback / 不正値正規化） |
+| `local-watcher/test/fr_process_test.sh` | `TERMINATE_IMMEDIATE_TRACE` + `fr_terminate_immediate_failure_streak` stub 追加。Section 11 で rc=4 → `fr_terminate_immediate_failure_streak` が呼ばれることを検証（PR 経路 + 既存 rc=2/3 では呼ばれないことも） |
+| `README.md` | Failed Recovery Processor の終端動作テーブルに #411 即時失敗 / streak 上限到達の 2 行追加。env 表に 2 行追加。state JSON フィールド説明に `immediate_failure_streak` / 拡張 `last_status` enum 追加。Migration Note の末尾に #411 専用節を追加（後方互換性の明示説明） |
+
+## テスト方針 / 追加テストと通過結果
+
+### テスト方針
+
+- AC 起点（要件番号 → テストケース 1:1 マッピング）
+- 既存テストを壊さず、新テストを追加（fr_immediate_fail_test.sh）+ 既存テストに #411 拡張 section を追加
+- 純粋関数（`fr_classify_immediate_failure`）の境界値を `fr_invoke_test.sh` Section 14 でカバー
+- 統合動作（`fr_run_recovery_attempt` の rc=98 ハンドリング）は `fr_immediate_fail_test.sh` で stub を使い検証
+- dispatcher 配線（rc=4 → `fr_terminate_immediate_failure_streak`）は `fr_process_test.sh` Section 11 で検証
+
+### 通過結果
+
+すべて緑（FAIL=0）:
+
+| Test | PASS |
+|---|---|
+| `fr_attempt_test.sh` | 60 |
+| `fr_fetch_test.sh` | 42 |
+| `fr_immediate_fail_test.sh` (new) | 42 |
+| `fr_invoke_test.sh` | 56 |
+| `fr_is_enabled_test.sh` | 40 |
+| `fr_no_progress_test.sh` | 12 |
+| `fr_process_test.sh` | 71 |
+| `fr_state_test.sh` | 60 |
+| `fr_terminate_test.sh` | 77 |
+
+その他 `local-watcher/test/*_test.sh` 全件も FAIL=0 で通過確認済み（68 ファイル）。
+
+### 静的解析
+
+- `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/*.sh` → 警告ゼロ
+- `shellcheck local-watcher/test/fr_*_test.sh` → 警告ゼロ
+- `bash -n local-watcher/bin/modules/failed-recovery.sh` / `local-watcher/bin/issue-watcher.sh` → OK
+- `diff -r .claude/agents repo-template/.claude/agents` → 空（drift なし）
+- `diff -r .claude/rules repo-template/.claude/rules` → 空（drift なし）
+
+## AC Traceability
+
+| AC ID | 実装箇所 | テスト |
+|---|---|---|
+| Req 1.1（即時失敗の attempt 除外） | `failed-recovery.sh` `fr_run_recovery_attempt` rc=98 case（rollback save） | `fr_immediate_fail_test.sh` Section C, `fr_invoke_test.sh` Section 10 |
+| Req 1.2（判定条件: rc非ゼロ+tool_use無+短時間） | `failed-recovery.sh` `fr_classify_immediate_failure`, `fr_invoke_claude` tool_use 観測 | `fr_invoke_test.sh` Section 14 (A〜G 全条件), Section 10 |
+| Req 1.3（閾値 env 上書き / 既定 安全側） | `issue-watcher.sh` `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` 正規化（既定 10） | `fr_invoke_test.sh` Section 14-F/14-G 境界値（9 < 10 < 10）|
+| Req 1.4（streak の state 永続化） | `failed-recovery.sh` `fr_save_state` 6 番目引数 / JSON schema 拡張 | `fr_state_test.sh` Section #411, `fr_immediate_fail_test.sh` Section C/D |
+| Req 1.5（streak 上限到達で停止 → terminate へ委譲） | `failed-recovery.sh` `fr_run_recovery_attempt` rc=4 return + `_fr_dispatch_candidate` case 4 | `fr_immediate_fail_test.sh` Section D/E, `fr_process_test.sh` Section 11 |
+| Req 1.6（streak 上限 env 上書き / 既定 有限正） | `issue-watcher.sh` `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` 正規化（既定 3） | `fr_immediate_fail_test.sh` Section D（max=3 動作確認） |
+| Req 1.7（実質作業着手時 streak リセット） | `failed-recovery.sh` `fr_run_recovery_attempt` 成功 / 通常失敗 path で streak=0 save | `fr_immediate_fail_test.sh` Section F/G |
+| Req 1.8（quota は判定対象外） | `failed-recovery.sh` `fr_classify_immediate_failure` quota 検出時に 1 を返す + `fr_invoke_claude` 内 quota 早期 return 99 | `fr_invoke_test.sh` Section 13, Section 14-A |
+| Req 2.1（recovery claude の stdout/stderr を専用ログに保存） | `failed-recovery.sh` `fr_invoke_claude` 2 段 tee で `effective_dedicated_log` へ append | `fr_immediate_fail_test.sh` Section I |
+| Req 2.2（$LOG_DIR 配下 / kind + number + timestamp 含む） | `failed-recovery.sh` `fr_resolve_dedicated_log_path` | `fr_immediate_fail_test.sh` Section A |
+| Req 2.3（識別語 `failed-recovery` 必須） | 同上 | `fr_immediate_fail_test.sh` Section A |
+| Req 2.4（LOG 未設定でも /dev/null fallback しない） | `failed-recovery.sh` `fr_resolve_dedicated_log_path` $HOME fallback | `fr_immediate_fail_test.sh` Section A（LOG_DIR unset テスト） |
+| Req 2.5（一次運用ログにパス記録） | `failed-recovery.sh` `fr_invoke_claude` 内 `fr_log "... dedicated_log=$effective_dedicated_log"` | 専用テストなし（fr_log 観測で間接的に / fr_immediate_fail_test.sh Section J で重ねて検証） |
+| Req 2.6（保存失敗時の fail-continue） | `failed-recovery.sh` `fr_invoke_claude` 内 mkdir / truncate 失敗時の warn + `/dev/null` fallback | 静的解析と shellcheck で確認（カバー困難な i/o エラー path） |
+| Req 3.1（対象 repo の作業ツリーで claude 起動） | `failed-recovery.sh` `fr_prepare_repo_worktree` + `( cd $REPO_DIR; fr_invoke_claude )` | `fr_immediate_fail_test.sh` Section J（ref + repo_dir ログ） |
+| Req 3.2（PR head branch を checkout） | `failed-recovery.sh` `fr_prepare_repo_worktree` kind=pr 分岐 | `fr_immediate_fail_test.sh`（PR_HEAD_REF stub）/ shellcheck |
+| Req 3.3（Issue は claude/issue-N-* / 無ければ BASE_BRANCH） | `failed-recovery.sh` `fr_prepare_repo_worktree` kind=issue 分岐 | `fr_immediate_fail_test.sh` Section J（採用 ref を出力に観測） |
+| Req 3.4（worktree 失敗 → 即時失敗扱い） | `failed-recovery.sh` `fr_run_recovery_attempt` worktree_ok=0 → claude_rc=98 | `fr_immediate_fail_test.sh` Section H |
+| Req 3.5（REPO_DIR を起点に採用） | `failed-recovery.sh` `fr_prepare_repo_worktree` `repo_dir="${REPO_DIR:-}"` | `fr_immediate_fail_test.sh` Section J |
+| Req 3.6（起点パスと ref をログ記録） | `failed-recovery.sh` `fr_log "... repo_dir=$REPO_DIR ref=$checkout_ref"` | `fr_immediate_fail_test.sh` Section J |
+| Req 4.1（識別子 `immediate-failure-streak`） | `failed-recovery.sh` `fr_terminate_immediate_failure_streak` 本文 + fr_log + sn_notify | `fr_immediate_fail_test.sh` Section B |
+| Req 4.2（一次運用ログで grep 抽出可能） | `failed-recovery.sh` `fr_log "${kind}=#${number} terminated reason=immediate-failure-streak ..."` | `fr_immediate_fail_test.sh` Section B |
+| Req 4.3（Issue/PR にコメント 1 件 / 識別子 + 回数含む） | `failed-recovery.sh` `fr_terminate_immediate_failure_streak` 内の `fr_post_attempt_comment` 1 回 | `fr_immediate_fail_test.sh` Section B |
+| Req 4.4（claude-failed ラベル据え置き） | `fr_terminate_immediate_failure_streak` で `--remove-label` を呼ばない | `fr_immediate_fail_test.sh` Section B |
+| Req 4.5（rs_set_result claude-failed が 1 度だけ） | `fr_terminate_immediate_failure_streak` 内 `rs_set_result "claude-failed"` 1 回 | `fr_immediate_fail_test.sh` Section B |
+| Req 4.6（Slack 通知に識別子 + 回数 / 機微値なし） | `fr_terminate_immediate_failure_streak` 内 `sn_notify failed-recovery ... immediate-failure-streak ...` | `fr_immediate_fail_test.sh` Section B（NFR 3.2 signature 含めないも検証） |
+| NFR 1.1（既存 env / 既定値 不変） | `issue-watcher.sh` Config ブロック既存行は無変更（新規追加のみ） | 既存 `fr_state_test.sh` Section 7 等が通る（PASS=60） |
+| NFR 1.2（新規 env は安全側既定） | `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10` / `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK=3` | env 表 + `fr_state_test.sh` normalize テスト相当のロジック |
+| NFR 1.3（既存終端識別子と区別可能 / 既存文字列変更なし） | `max-attempts` / `no-progress` の文字列は無変更 | `fr_terminate_test.sh` PASS=77（既存挙動） |
+| NFR 1.4（二重 opt-in 維持） | `fr_is_enabled` は無変更 | `fr_is_enabled_test.sh` PASS=40 |
+| NFR 2.1（判定根拠を一次運用ログ） | `fr_invoke_claude` 内 `fr_log "... immediate-failure label=... rc=... tool_use=... elapsed=...s ..."` | `fr_invoke_test.sh` Section 10 |
+| NFR 2.2（dedicated log path / 作業ツリー起点 / ref をログ） | `fr_invoke_claude` start log + `fr_run_recovery_attempt` worktree log | `fr_immediate_fail_test.sh` Section J |
+| NFR 3.1（kind / number / timestamp 入力検証維持） | `fr_resolve_dedicated_log_path` / `fr_prepare_repo_worktree` / `fr_terminate_immediate_failure_streak` で `^[0-9]+$` 検証 + `issue/pr` のみ受理 | `fr_immediate_fail_test.sh` Section A / B 不正値ケース |
+| NFR 3.2（secrets / signature を comment / Slack に含めない） | `fr_terminate_immediate_failure_streak` 本文 + sn_notify detail に signature を含めない | `fr_immediate_fail_test.sh` Section B `assert_not_grep "aaaa..."` |
+
+## 確認事項（Reviewer / 人間判断で確定すべき項目）
+
+- **`FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` の既定値 10 秒**: altpocket-server #119 で観測された ~2 秒
+  rc=1 + 安全マージンで設定したが、運用ログ蓄積後に再評価する余地あり。閾値を 5 秒程度に下げると
+  「2 秒 rc=1」と「8 秒で API エラーで failed」をより厳密に区別できる
+- **`FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` の既定値 3**: 2 分 cron で 6 分後にエスカレーション
+  という想定。watcher が短い間隔（例: 30 秒）で動く環境では値を上げる必要があるかもしれない
+- **stream-json `"type":"tool_use"` 検出パターン**: 現在の grep パターン
+  `"type"[[:space:]]*:[[:space:]]*"tool_use"` は claude CLI の現行 stream 形式に依存する。
+  CLI の出力形式が変わった場合（例: `"type":"tool_call"`）は検出ロジック更新が必要
+- **専用ログのローテーション / 削除**: 現状は無制限に蓄積する。`$LOG_DIR` 配下なので既存 watcher
+  ログのローテーション運用（手動 `find -mtime` 等）と同じ扱いで良いはずだが、failed-recovery 専用
+  のローテーション方針が要件として明示されていない（Out of Scope に該当する可能性）
+- **worktree checkout でのコンフリクト**: `git checkout -B` で local branch を強制リセットする。
+  watcher 自身が他 processor で同じ branch を編集中の場合の挙動（cron は flock で逐次化されている
+  が念のため）は未テスト。Out of Scope の「実装上の判断」として、既存 impl 系プロセッサと同じく
+  「watcher 単一プロセスが flock で逐次化される」前提を踏襲している
+- **`fr_resolve_dedicated_log_path` の `$HOME` fallback でディレクトリが無いケース**: `fr_invoke_claude`
+  内で `mkdir -p` するため新規環境でも自動作成されるが、`$HOME/.issue-watcher/logs/` 配下の
+  permission が異常な環境（例: cron ユーザーが書き込めない）では fail-continue で `/dev/null`
+  fallback する設計。Req 2.6 と整合
+- **claude exit code 99 と 98 の使い分け**: 既存の quota sentinel 99 と新規の即時失敗 sentinel 98 が
+  別経路として `fr_invoke_claude` から返る。`_fr_dispatch_candidate` は rc=99 と rc=4 を別経路で
+  扱うため衝突は無いが、将来追加する sentinel は 97 以下 / 100 以上の範囲で割り当てる必要がある
+- **テストカバレッジの境界**: i/o エラー path（`mkdir -p` 失敗 / `tee` の disk full 等）は通常の
+  unit test では再現困難。Req 2.6 の fail-continue 挙動は shellcheck + コードレビューで担保している
+
+## 補足: 既存挙動との互換性検証
+
+- gate OFF（既定）では `fr_is_enabled` が rc=1 を返し `process_failed_recovery` 冒頭で `return 0`
+  → 本機能導入前と完全に等価（gh API 呼び出しゼロ・state 書き込みゼロ）
+- gate ON で claude が tool_use 観測 + 閾値以上の時間継続して失敗するケース（既存挙動）→
+  `fr_classify_immediate_failure` が 1 を返し、`fr_invoke_claude` は通常通り `claude_rc` を透過。
+  既存の `fr_run_recovery_attempt` の通常失敗 path（rc=1 で再試行）と同一の挙動
+- gate ON で claude が success（rc=0）するケース → 即時失敗判定経路を通らず既存 success path
+  （fr_finalize_success）に直行。`streak=0` リセットを追加で 1 回 save するが結果は同等
+- 既存 state ファイル（`immediate_failure_streak` フィールド不在）の load → `// 0` で 0 fallback。
+  以降の save で field が追加されるが、既存 reader（読み出し側）は新フィールドを単に無視する
+
+STATUS: complete

--- a/docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/requirements.md
+++ b/docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/requirements.md
@@ -1,0 +1,110 @@
+# Requirements Document
+
+## Introduction
+
+`FAILED_RECOVERY` Processor（#359）は `claude-failed` Issue / auto-merge 待ち PR を fresh Claude
+session で復旧する仕組みだが、altpocket-server #119（2026-06-26 JST）で **claude セッションが
+約 2 秒で rc=1 で即時失敗するケース** が観測された。現状の実装は試行開始時に attempt カウンタを
+加算しており、決定論的に即死する状況では既定 4 attempts を 8 分で空消費して `claude-failed` を
+premature に確定させる。さらに dispatch 経路で `LOG` が未設定のため claude の stdout/stderr が
+`/dev/null` に捨てられ、即時失敗の真因（cwd / branch checkout 不在の疑い）が事後診断できない。
+本要件はこれらを「即時失敗の attempt 除外」「discoverable な専用ログ保存」「対象 repo の作業
+ツリーでの起動保証」「起動不能上限による独立エスカレーション」の 4 系統で解消し、quota 燃焼上界
+保証（無限リトライ防止）は壊さずに recovery の実効性と診断可能性を回復する。
+
+関連: #410（同インシデントで併発した impl-resume の fixture 追従盲点）と本 Issue は altpocket-server
+#119 stuck の二段構成。本要件は recovery 側のみを対象とする。
+
+## Requirements
+
+### Requirement 1: 即時失敗の attempt budget 除外
+
+**Objective:** As an idd-claude 運用者, I want claude が実質作業前に即時失敗した試行を attempt budget から除外できる, so that 決定論的に即死する状況で budget を空消費して `claude-failed` を premature 終端させずに済む
+
+#### Acceptance Criteria
+
+1. If recovery claude session が「実質作業前の即時失敗」と判定された場合, the Failed Recovery Processor shall 当該試行を通算 attempt budget としてカウントしない（カウンタを巻き戻す、または増分自体を保留する）
+2. The Failed Recovery Processor shall 「実質作業前の即時失敗」を、claude exit code が非ゼロ（quota sentinel 99 を除く）かつ stream-json 中に tool use イベントが 1 件も観測されず、かつセッション継続時間が即時失敗閾値未満であった場合と定義する
+3. The Failed Recovery Processor shall 即時失敗の継続時間閾値を環境変数で上書き可能にし、既定値は安全側（無限リトライにならない側）に倒した正の秒数とする
+4. While 同一 Issue / PR に対する即時失敗が連続している間, the Failed Recovery Processor shall 即時失敗連続回数を別カウンタとして state に永続化する
+5. If 同一 Issue / PR の即時失敗連続回数が独立上限に到達した場合, the Failed Recovery Processor shall 当該 Issue / PR の処理を停止し、`claude-failed` ラベルを据え置いた上で運用者に手動レビューを促す（Requirement 4 のエスカレーション経路に委譲する）
+6. The Failed Recovery Processor shall 即時失敗連続回数の独立上限を環境変数で上書き可能にし、既定値を有限の正の整数値とする（quota 燃焼上界保証として無限リトライを防止する）
+7. When recovery claude session が tool use イベントを 1 件以上観測した、または即時失敗閾値以上の時間継続した場合, the Failed Recovery Processor shall 当該試行を「実質作業に着手した試行」として通算 attempt budget に加算し、即時失敗連続回数カウンタをリセットする
+8. When recovery claude session が quota 検出 sentinel（exit code 99）で終了した場合, the Failed Recovery Processor shall 既存挙動を維持し、本要件の即時失敗判定経路を適用しない
+
+### Requirement 2: recovery claude 出力の discoverable な専用ログ保存
+
+**Objective:** As an idd-claude 運用者, I want recovery claude セッションの stdout/stderr を専用ログファイルに保存してほしい, so that 即時失敗の事後診断（rc=1 の真因切り分け）が cron.log だけに頼らずに行える
+
+#### Acceptance Criteria
+
+1. When Failed Recovery Processor が recovery claude session を起動する, the Failed Recovery Processor shall 当該セッションの stdout と stderr を専用ログファイルに必ず保存する
+2. The Failed Recovery Processor shall 専用ログファイルを `$LOG_DIR` 配下に配置し、ファイル名に kind（`issue` / `pr`）と対象番号とタイムスタンプを含める
+3. The Failed Recovery Processor shall 専用ログファイルのファイル名に識別語 `failed-recovery` を含め、運用者が他プロセッサのログと文字列マッチで区別できる命名規約に従う
+4. If 呼出側コンテキストで `LOG` 環境変数が未設定であった場合, the Failed Recovery Processor shall 専用ログファイルへの保存を `/dev/null` 行きにフォールバックさせず、Requirement 2.1〜2.3 を満たす保存先を自前で確定する
+5. The Failed Recovery Processor shall 専用ログファイル名と保存先を一次運用ログ（cron.log に転送される `failed-recovery:` prefix 付きの行）にも記録し、運用者が該当ログを辿れる導線を残す
+6. If 専用ログファイルの作成・書き込みに失敗した場合, the Failed Recovery Processor shall 警告ログを残しつつ recovery 試行自体は継続する（fail-continue / 後方互換）
+
+### Requirement 3: 対象 repo の作業ツリーでの起動保証
+
+**Objective:** As an idd-claude 運用者, I want recovery claude を対象 repo の作業ツリー上で起動してほしい, so that ファイル編集や git 操作が対象 repo に対して効くようになり、rc=1 即時死の真因の主要候補（cwd / branch checkout 不在）を排除できる
+
+#### Acceptance Criteria
+
+1. When Failed Recovery Processor が recovery claude session を起動する, the Failed Recovery Processor shall 対象 repo の作業ツリーがチェックアウトされた状態でセッションを開始する
+2. When kind が `pr` の場合, the Failed Recovery Processor shall PR の head branch をチェックアウトした作業ツリーで recovery claude を起動する
+3. When kind が `issue` の場合, the Failed Recovery Processor shall 対象 Issue に紐づく既存 claude branch が存在すればそれを、存在しなければ base branch を、チェックアウトした作業ツリーで recovery claude を起動する
+4. If 作業ツリーの確保・チェックアウトに失敗した場合, the Failed Recovery Processor shall 警告ログで原因を残した上で当該試行を「実質作業前の即時失敗」と同等に扱い、Requirement 1.1 に従って attempt budget から除外する
+5. The Failed Recovery Processor shall 作業ツリーの起点パスを既存の `REPO_DIR` 環境変数で取得し、impl 系プロセッサが使用する作業ツリーと同一の起点を採用する
+6. The Failed Recovery Processor shall 作業ツリー上で recovery claude を起動した事実（起点パスと checkout した参照名）を専用ログまたは一次運用ログに記録する
+
+### Requirement 4: 起動不能の独立エスカレーションと区別可能なログ
+
+**Objective:** As an idd-claude 運用者, I want 「max-attempts 到達」と「起動不能（即時失敗連続）」を別の終端理由として区別したい, so that 手動レビュー時に「claude が試行した結果ダメだった」と「claude が動かなかった」を即座に切り分けられる
+
+#### Acceptance Criteria
+
+1. When Requirement 1.5 の独立上限に到達して終端する場合, the Failed Recovery Processor shall 終端理由として `max-attempts` とは異なる識別子（例: `immediate-failure-streak`）を用いる
+2. The Failed Recovery Processor shall 当該終端理由を一次運用ログの終端行（`failed-recovery: ... terminated reason=<id>`）に含め、運用者が `grep` で抽出可能にする
+3. When Requirement 4.1 の終端が発火した場合, the Failed Recovery Processor shall Issue / PR に終端理由コメントを 1 件だけ投稿し、本文に終端理由識別子と連続即時失敗回数を含める
+4. When Requirement 4.1 の終端が発火した場合, the Failed Recovery Processor shall `claude-failed` ラベルを据え置き、手動レビューを促す
+5. When Requirement 4.1 の終端が発火した場合, the Failed Recovery Processor shall run-summary の最終結果を `claude-failed` として 1 度だけ確定させ、既存 `max-attempts` / `no-progress` 終端と同じく多重発火を起こさない
+6. Where Slack 通知連携が opt-in で有効化されている, the Failed Recovery Processor shall 本終端理由の通知 detail に kind と連続即時失敗回数を含め、failure signature 等の機微値は含めない
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Failed Recovery Processor shall 既存の環境変数名（`FAILED_RECOVERY_ENABLED` / `FAILED_RECOVERY_MAX_ATTEMPTS` / `FAILED_RECOVERY_MAX_TURNS` / `FAILED_RECOVERY_DEV_MODEL` / `FAILED_RECOVERY_GIT_TIMEOUT` / `FAILED_RECOVERY_MAX_PRS` / `FAILED_RECOVERY_STATE_DIR` / `LOG_DIR` / `REPO_DIR`）の意味と既定値を維持する
+2. The Failed Recovery Processor shall 新たに導入する閾値（即時失敗の継続時間閾値、即時失敗連続上限）を新しい環境変数として追加し、未設定時は安全側（過剰除外で無限リトライにならない側）の既定値を採る
+3. The Failed Recovery Processor shall 既存の終端理由識別子（`max-attempts` / `no-progress`）と区別可能な新しい識別子を追加し、既存識別子の文字列は変更しない
+4. The Failed Recovery Processor shall 既存の二重 opt-in gate（`FAILED_RECOVERY_ENABLED` AND `FULL_AUTO_ENABLED`）を維持し、本変更で起動条件を緩めない
+
+### NFR 2: 可観測性
+
+1. The Failed Recovery Processor shall 「実質作業前の即時失敗」と判定した試行ごとに、判定根拠（exit code / tool use 観測有無 / 経過秒数）と現在の即時失敗連続回数を一次運用ログ（`failed-recovery:` prefix 付きの行）に記録する
+2. The Failed Recovery Processor shall 専用ログファイル名・保存先・recovery claude 起動時の作業ツリー起点パス・checkout した参照名を、運用者が cron.log から該当ログを辿れる粒度で一次運用ログに出力する
+
+### NFR 3: セキュリティ
+
+1. The Failed Recovery Processor shall 専用ログファイル名に含める kind / number / timestamp について、既存の入力検証規約（kind は `issue` / `pr` のみ、number は `^[0-9]+$`、timestamp は ASCII の安全文字のみ）を維持する
+2. The Failed Recovery Processor shall 終端理由コメント本文・Slack 通知 detail に GH_TOKEN 等の secrets / failure signature の全文を含めない
+
+## Out of Scope
+
+- claude セッションが rc=1 になる **真因そのものの特定**（CLI バグ・OS 環境差・依存ツール不在等）は本要件の対象外。Requirement 3 で作業ツリーを保証することで「最有力候補」を排除するに留め、それでも再発する場合は別途 Issue で追跡する
+- `impl` / `impl-resume` プロセッサ側の `LOG` 設定経路の見直しは本要件の対象外。failed-recovery dispatch 経路のみで `LOG` 未設定問題を自前解決する
+- #410（fixture 追従盲点）の修正は別 Issue。altpocket-server #119 の再現ログは検証材料として用いるが、本要件で fixture 側を扱わない
+- quota 系の即時失敗（weekly-limit を 529 と誤分類する系統）の網羅性点検は別 Issue（quota-aware の責務）
+- recovery claude のプロンプト改善・修正方針改善は本要件の対象外
+- 既存の no-progress / max-attempts 判定ロジック自体の変更は本要件の対象外（即時失敗判定は両者の前段に位置付ける）
+
+## Open Questions
+
+- なし（即時失敗の判定基準は Requirement 1.2 / 1.3 / 1.6 で「閾値は env で上書き可能・既定は安全側」として、具体値は Architect / Developer 側の調整事項に委ねる）
+
+## 関連
+
+- Depends on: なし
+- Parent: #359
+- Related: #410 #119

--- a/docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/review-notes.md
+++ b/docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/review-notes.md
@@ -1,0 +1,112 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-26T22:15:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-411-impl-fix-failed-recovery-claude-rc-1-2s-attem
+- HEAD commit: 7eb054c6de8ebdac01526b1508e52bad518483da
+- Compared to: main..HEAD
+- 変更ファイル: `local-watcher/bin/issue-watcher.sh`, `local-watcher/bin/modules/failed-recovery.sh`,
+  `local-watcher/test/fr_attempt_test.sh`, `local-watcher/test/fr_immediate_fail_test.sh` (new),
+  `local-watcher/test/fr_invoke_test.sh`, `local-watcher/test/fr_process_test.sh`,
+  `local-watcher/test/fr_state_test.sh`, `README.md`, `docs/specs/411-.../requirements.md`,
+  `docs/specs/411-.../impl-notes.md`
+
+## Verified Requirements
+
+- 1.1 — `fr_run_recovery_attempt` rc=98 case で `fr_save_state` を prev_total へロールバック。
+  `fr_immediate_fail_test.sh` Section C で `^fr_save_state 42 1 in-progress .* 1$` を検証
+- 1.2 — `fr_classify_immediate_failure` 純粋関数で `rc!=0 AND quota 未検出 AND tool_use 未観測
+  AND elapsed < threshold` を判定 + `fr_invoke_claude` が tool_use を `"type":"tool_use"` grep
+  で観測。`fr_invoke_test.sh` Section 14 (A〜G) と Section 10/11/12 でカバー
+- 1.3 — `issue-watcher.sh` で `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` を既定 10 秒に正規化、
+  非整数/0 以下を既定値に丸める。境界値テスト `fr_invoke_test.sh` Section 14-F (elapsed=9) /
+  14-G (elapsed=10)
+- 1.4 — `fr_save_state` 6 番目引数 `immediate_failure_streak` + JSON schema 拡張。
+  `fr_state_test.sh` Section #411 で明示指定 save、継承、legacy state 0 fallback、不正値正規化
+  を検証
+- 1.5 — `fr_run_recovery_attempt` rc=98 時 streak ++ 後 `streak >= max_streak` で return 4 +
+  事前判定で `prev_streak >= max_streak` も return 4。`fr_immediate_fail_test.sh` Section D/E、
+  `fr_process_test.sh` Section 11 で dispatch 配線（rc=4 → `fr_terminate_immediate_failure_streak`）
+  を検証
+- 1.6 — `issue-watcher.sh` で `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` 既定 3 / 非整数・0 以下
+  を既定値に丸める。`fr_immediate_fail_test.sh` Section D で max=3 動作確認
+- 1.7 — success path で `fr_save_state ... 0` を追加保存、通常失敗 path でも streak=0 reset save。
+  `fr_immediate_fail_test.sh` Section F/G で検証
+- 1.8 — `fr_classify_immediate_failure` 内 quota_detected==1 で `return 1`（通常扱い）+
+  `fr_invoke_claude` の quota 早期 return 99 path は判定経路を通らない。
+  `fr_invoke_test.sh` Section 13、Section 14-A
+- 2.1 — `fr_invoke_claude` 2 段 tee (`primary_log` + `secondary_log`) で stdout/stderr を必ず
+  専用ログに append。`fr_immediate_fail_test.sh` Section I で fr_invoke_claude に dedicated
+  log path が渡されることを検証
+- 2.2 — `fr_resolve_dedicated_log_path` が `$LOG_DIR/failed-recovery-<kind>-<number>-<TS>.log`
+  を返す。`fr_immediate_fail_test.sh` Section A で `failed-recovery` / `issue` / `42` / `$LOG_DIR`
+  を含むことを検証 + pr/100 ケース
+- 2.3 — `failed-recovery-` プレフィックスを必ず含めることを Section A で検証
+- 2.4 — `LOG_DIR` 未設定時 `$HOME/.issue-watcher/logs/$REPO_SLUG` フォールバック実装 +
+  Section A で `LOG_DIR` unset 時に `/.issue-watcher/logs/` を含み `/dev/null` を含まないことを検証
+- 2.5 — `fr_invoke_claude` start log に `dedicated_log=$effective_dedicated_log` を含めて
+  fr_log 出力（impl-notes Section J で `repo_dir=` / `ref=` を併せて記録経路として検証）
+- 2.6 — `fr_invoke_claude` 内 mkdir / truncate 失敗時 `fr_warn` + `effective_dedicated_log=""`
+  fallback で /dev/null 行きにして recovery 自体は継続する fail-continue 実装（i/o エラー path
+  は impl-notes 通り unit test 困難で shellcheck + 静的解析で担保）
+- 3.1 — `fr_run_recovery_attempt` で `( cd "$REPO_DIR"; fr_invoke_claude ... )` の subshell
+  isolation 経由で対象 repo の作業ツリー上で claude 起動。`fr_immediate_fail_test.sh` Section J
+- 3.2 — `gh pr view --json headRefName` で head branch 解決 → `fr_prepare_repo_worktree` kind=pr
+  分岐で `^claude/` 検証付き checkout
+- 3.3 — `fr_prepare_repo_worktree` kind=issue 分岐: `git ls-remote --heads origin
+  "claude/issue-<N>-*"` 先頭、無ければ `BASE_BRANCH` fallback。Section J で採用 ref を観測
+- 3.4 — `fr_run_recovery_attempt` で worktree_ok=0 → `claude_rc=98` に倒し、即時失敗扱い経路へ。
+  `fr_immediate_fail_test.sh` Section H で `fr_invoke_claude` 不呼出 + rollback save 検証
+- 3.5 — `fr_prepare_repo_worktree` 冒頭 `repo_dir="${REPO_DIR:-}"` + `.git` 存在確認
+- 3.6 — `fr_run_recovery_attempt` で `fr_log "... repo_dir=$REPO_DIR ref=$checkout_ref"`。
+  Section J で `repo_dir=/tmp/fr-imm-test-stub-repo` / `ref=claude/issue-42-impl-test` 観測
+- 4.1 — 新規 `fr_terminate_immediate_failure_streak` + 識別子 `immediate-failure-streak`。
+  `fr_immediate_fail_test.sh` Section B で識別子を含むコメントと fr_log を検証
+- 4.2 — `fr_log "${kind}=#${number} terminated reason=immediate-failure-streak ..."` で
+  `grep` 抽出可能。Section B で `terminated reason=immediate-failure-streak` を検証
+- 4.3 — `fr_post_attempt_comment` 1 回呼出 + body に streak_count（連続 3 回）と識別子を含む。
+  Section B
+- 4.4 — `fr_terminate_immediate_failure_streak` で `--remove-label` を呼ばない。Section B で
+  `assert_not_grep "--remove-label"` 検証
+- 4.5 — `rs_set_result "claude-failed"` 1 回呼出。Section B で `rs_set_result` が 1 回のみ呼ばれ
+  内容が `claude-failed` であることを検証
+- 4.6 — `sn_notify failed-recovery <num> <url> immediate-failure-streak "kind=... streak=..."`
+  + signature 値を detail に含めない。Section B で `streak=3` 含む + `aaaa...` 不含を検証
+- NFR 1.1 — 既存 env var / 既定値・ラベル名・終端識別子 (`max-attempts` / `no-progress`) は無変更。
+  `fr_save_state` の 6 番目引数も省略時継承で既存呼出側互換。`fr_state_test.sh` Section #411
+  「6 番目引数省略 → 既存 state から streak 継承」「legacy state (streak field 不在) を 0 fallback」
+  で検証 + `fr_process_test.sh` Section 11-C で rc=2/3 経路に影響なし
+- NFR 1.2 — `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10` / `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK=3`
+  既定値 + 不正値 fallback
+- NFR 1.3 — `max-attempts` / `no-progress` 文字列無変更（`fr_terminate_test.sh` PASS=77 既存挙動維持）
+- NFR 1.4 — `fr_is_enabled` 無変更（二重 opt-in gate 維持）
+- NFR 2.1 — `fr_log "claude session immediate-failure label=... rc=... tool_use=... elapsed=...s
+  threshold=...s"` で判定根拠を一次運用ログに記録。`fr_invoke_test.sh` Section 10 で
+  `immediate-failure` / `rc=1` / `tool_use=0` 観測を検証
+- NFR 2.2 — dedicated_log path / repo_dir / checkout ref を一次運用ログに出力（Section J）
+- NFR 3.1 — `fr_resolve_dedicated_log_path` / `fr_prepare_repo_worktree` /
+  `fr_terminate_immediate_failure_streak` で kind は `issue|pr` のみ、number は `^[0-9]+$`、
+  git checkout は `--` でオプション解釈打ち切り、`^claude/` 再検証。Section A / B で不正値ケース
+- NFR 3.2 — `fr_terminate_immediate_failure_streak` のコメント本文 / sn_notify detail に signature
+  を含めない。Section B で `assert_not_grep "aaaa..."` 検証
+
+## Findings
+
+なし
+
+## Summary
+
+`requirements.md` の全 numeric AC（Req 1.1〜1.8 / 2.1〜2.6 / 3.1〜3.6 / 4.1〜4.6 / NFR 1.1〜1.4 /
+NFR 2.1〜2.2 / NFR 3.1〜3.2）について、`local-watcher/bin/modules/failed-recovery.sh` と
+`local-watcher/bin/issue-watcher.sh` に対応実装が確認でき、`fr_immediate_fail_test.sh` (new) /
+`fr_invoke_test.sh` Section 9〜14 / `fr_attempt_test.sh` / `fr_state_test.sh` Section #411 /
+`fr_process_test.sh` Section 11 で各 AC に対応するテストが追加・通過している（PASS=42/56/60/60/71、
+FAIL=0）。Req 2.5（dedicated_log= 文字列の専用テスト）と Req 2.6（i/o エラー fail-continue path）
+については impl-notes に直接 unit test 困難な i/o path であり間接的に観測している旨明記された
+上で実装は揃っており、missing test として reject するには弱い。境界面では failed-recovery
+module / Config ブロック / 関連 test / README / spec 文書に限定され、他 processor / 既存
+env / 既存終端識別子・ラベルへの影響なし。shellcheck / root↔repo-template の drift も clean。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -924,6 +924,37 @@ FAILED_RECOVERY_MAX_PRS="${FAILED_RECOVERY_MAX_PRS:-3}"
 # 状態ファイル（通算カウンタ + 直前試行情報の JSON）の配置先。既定 $HOME/.issue-watcher/
 # failed-recovery/$REPO_SLUG。LOG_DIR と同じ repo-slug 分離方針（NFR 2.2, NFR 2.3）。
 FAILED_RECOVERY_STATE_DIR="${FAILED_RECOVERY_STATE_DIR:-$HOME/.issue-watcher/failed-recovery/$REPO_SLUG}"
+# ─── Failed Recovery 即時失敗判定の閾値 (#411) ───
+# recovery claude session が「実質作業前に即時失敗した試行」を attempt budget から
+# 除外するための判定閾値（Req 1.2 / 1.3）。判定条件は:
+#   (a) claude exit code が非ゼロ かつ quota sentinel 99 ではない
+#   (b) stream-json 中に tool use イベントが 1 件も観測されていない
+#   (c) セッション継続時間（end - start 秒）が即時失敗閾値未満
+# 既定 10 秒は altpocket-server #119 で観測された ~2 秒 rc=1 を確実に拾える保守値。
+# 上書き可能（未設定 / 非整数 / 0 以下 / 負値は既定 10 に正規化、安全側 = リトライ過剰
+# 除外による無限ループにならない側 / NFR 1.2）。
+FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS="${FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS:-10}"
+case "$FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS" in
+  ''|*[!0-9]*) FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10 ;;
+  *)
+    if [ "$FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS" -le 0 ]; then
+      FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10
+    fi
+    ;;
+esac
+# 同一 Issue / PR の即時失敗連続上限（Req 1.5 / 1.6）。通算 attempt budget とは独立した
+# カウンタで、上限到達時は `claude-failed` を据え置いたまま `immediate-failure-streak`
+# 終端理由で 1 度だけ運用者にエスカレーションする（quota 燃焼上界保証 / 無限リトライ防止）。
+# 既定 3 = 「3 cycle 連続で claude が起動できなければ手動レビュー」運用前提。上書き可能。
+FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK="${FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK:-3}"
+case "$FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK" in
+  ''|*[!0-9]*) FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK=3 ;;
+  *)
+    if [ "$FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK" -le 0 ]; then
+      FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK=3
+    fi
+    ;;
+esac
 
 # ─── Stale Pickup Reaper 設定 (#379) ───
 # セッション喪失で `claude-picked-up` / `claude-claimed` ラベルが取り残された Issue を

--- a/local-watcher/bin/modules/failed-recovery.sh
+++ b/local-watcher/bin/modules/failed-recovery.sh
@@ -69,19 +69,23 @@ fr_is_enabled() {
 # サイクル跨ぎ・watcher プロセスの再起動でもカウンタを継承する（Req 4.1, 4.7, 6.2 /
 # NFR 2.2, NFR 2.3）。
 #
-# JSON schema (design.md Data Model 節):
+# JSON schema (design.md Data Model 節 + #411 拡張):
 #   {
 #     "issue": <int>,
 #     "total_attempts": <int>,
-#     "last_status": "in-progress" | "succeeded" | "max-attempts" | "no-progress",
+#     "last_status": "in-progress" | "succeeded" | "max-attempts" | "no-progress" | "immediate-failure-streak",
 #     "last_failure_signature": "<sha-1 hex>",
 #     "last_head_sha": "<commit sha or empty string>",
 #     "last_attempt_at": "<ISO 8601 UTC>",
+#     "immediate_failure_streak": <int>,  // #411 Req 1.4 で追加（連続即時失敗回数）
 #     "history": [
 #       {"attempt": <int>, "at": "<ISO 8601>", "signature": "<hex>", "head_sha": "<sha>", "outcome": "<status>"},
 #       ...  // append-only、古いものから 8 件で truncate
 #     ]
 #   }
+# 後方互換: 既存 state ファイル（#411 導入前に書かれたもの）は immediate_failure_streak
+# フィールドを持たない。fr_load_state は内容をそのまま返し、呼出側で `.immediate_failure_streak
+# // 0` で 0 fallback して読む（#411 NFR 1.1）。
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 # Args: $1 = issue number
@@ -127,21 +131,29 @@ fr_load_state() {
 # Args:
 #   $1 = issue number (int)
 #   $2 = total_attempts (int)
-#   $3 = last_status (enum: "in-progress" | "succeeded" | "max-attempts" | "no-progress")
+#   $3 = last_status (enum: "in-progress" | "succeeded" | "max-attempts" | "no-progress" |
+#                          "immediate-failure-streak")
 #   $4 = last_failure_signature (hex string、空可)
 #   $5 = last_head_sha (sha string、空可)
+#   $6 = immediate_failure_streak (int / #411 Req 1.4. 省略時は既存 state から継承)
 #
 # 副作用:
 #   - $FAILED_RECOVERY_STATE_DIR を mkdir -p で作成（既存なら no-op）
 #   - 状態 JSON ファイルを atomic に書き換える
 #
 # Returns: 0 = persisted, 1 = failure (呼出側を落とさない / fr_warn で警告)
+#
+# 後方互換: $6 を省略した呼び出し（#411 導入前の既存呼出側コード）は、prev_state から
+# `.immediate_failure_streak // 0` を継承して保存する。これにより既存呼出側を変更せずに
+# streak フィールドだけが追加で永続化される（#411 NFR 1.1）。
 fr_save_state() {
   local issue_number="$1"
   local total_attempts="$2"
   local last_status="$3"
   local last_failure_signature="$4"
   local last_head_sha="$5"
+  # #411: 6 番目の引数は immediate_failure_streak（省略時は既存 state から継承）。
+  local immediate_failure_streak="${6-}"
 
   # state_dir を冪等確保（既存なら no-op、所有者は cron 実行ユーザー）
   if ! mkdir -p "$FAILED_RECOVERY_STATE_DIR" 2>/dev/null; then
@@ -163,6 +175,17 @@ fr_save_state() {
   local prev_history
   if ! prev_history=$(printf '%s' "$prev_state" | jq -c '.history // []' 2>/dev/null); then
     prev_history="[]"
+  fi
+
+  # #411: immediate_failure_streak は省略時に既存 state から継承する（NFR 1.1 後方互換）。
+  # 既存 state が当該フィールドを持たないなら 0 fallback。明示指定の場合は数値検証する。
+  if [ -z "$immediate_failure_streak" ]; then
+    if ! immediate_failure_streak=$(printf '%s' "$prev_state" | jq -r '.immediate_failure_streak // 0' 2>/dev/null); then
+      immediate_failure_streak=0
+    fi
+  fi
+  if ! [[ "$immediate_failure_streak" =~ ^[0-9]+$ ]]; then
+    immediate_failure_streak=0
   fi
 
   # 新規 history エントリを append し、古いものから 8 件で truncate。
@@ -194,6 +217,7 @@ fr_save_state() {
       --arg last_failure_signature "$last_failure_signature" \
       --arg last_head_sha "$last_head_sha" \
       --arg last_attempt_at "$now_iso" \
+      --argjson immediate_failure_streak "$immediate_failure_streak" \
       --argjson history "$new_history" \
       '{
         issue: $issue,
@@ -202,6 +226,7 @@ fr_save_state() {
         last_failure_signature: $last_failure_signature,
         last_head_sha: $last_head_sha,
         last_attempt_at: $last_attempt_at,
+        immediate_failure_streak: $immediate_failure_streak,
         history: $history
       }' 2>/dev/null); then
     fr_warn "fr_save_state: JSON 組み立て失敗 issue=$issue_number"
@@ -710,32 +735,240 @@ fr_collect_pr_ci_context() {
 #   - NFR 3.1: prompt は printf '%s' で値埋め込み、claude には引数として個別に渡す
 #   - NFR 3.2: secrets を prompt 本文に埋め込まない（GH_TOKEN 等を直接展開しない）
 #   - NFR 5.2: claude 実行失敗を fail-continue で扱う（quota 検出は別経路 exit 99）
+#
+# #411 拡張:
+#   - 専用ログファイル（`$LOG_DIR/failed-recovery-<kind>-<number>-<TS>.log`）への保存を
+#     必ず行う（Req 2.1〜2.5）。LOG が未設定でも /dev/null に捨てず自前で確定する
+#   - stream-json 中の tool_use イベントを観測し、セッション継続時間と合わせて即時失敗
+#     を判定する（Req 1.2）。即時失敗時は exit 98 sentinel を返す（Req 1.1）
+#   - 対象 repo の作業ツリーで claude を起動する（Req 3.1〜3.3 / `fr_prepare_repo_worktree`）
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+# fr_resolve_dedicated_log_path: failed-recovery 専用ログファイルのパスを返す純粋関数。
+#
+# Args:
+#   $1 = kind ("issue" | "pr")
+#   $2 = number (^[0-9]+$ で使用前検証)
+#
+# Stdout: 絶対パス（`$LOG_DIR/failed-recovery-<kind>-<number>-<TS>.log`）
+# Returns:
+#   0 = 成功
+#   1 = kind / number が不正（caller は /dev/null fallback または fail）
+#
+# 仕様:
+#   - 識別語 `failed-recovery` を必ず含める（Req 2.3 / NFR 2.2）
+#   - kind は `issue` / `pr` のみ受理、number は `^[0-9]+$` のみ受理（NFR 3.1）
+#   - timestamp は ASCII 安全文字（`+%Y%m%dT%H%M%SZ` 互換 UTC）のみで構成
+#   - $LOG_DIR が未設定なら $HOME/.issue-watcher/logs/$REPO_SLUG にフォールバック
+#     （issue-watcher.sh Config ブロックの default と同じ規約 / Req 2.4）
+fr_resolve_dedicated_log_path() {
+  local kind="$1"
+  local number="$2"
+
+  # kind / number の sanitize（NFR 3.1）
+  case "$kind" in
+    issue|pr) : ;;
+    *) return 1 ;;
+  esac
+  if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+
+  # LOG_DIR fallback: 未設定なら $HOME/.issue-watcher/logs/$REPO_SLUG（NFR 1.1 / Req 2.4）
+  local log_dir="${LOG_DIR:-}"
+  if [ -z "$log_dir" ]; then
+    local repo_slug="${REPO_SLUG:-${REPO//\//-}}"
+    log_dir="${HOME}/.issue-watcher/logs/${repo_slug}"
+  fi
+
+  # ASCII 安全な UTC タイムスタンプ（`date -u` 失敗時は epoch を fallback として使用）
+  local ts
+  ts=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || date -u +%s 2>/dev/null || echo "unknown")
+  # timestamp が想定外形式（ASCII 安全文字以外）を含まないよう保険で sanitize
+  ts=$(printf '%s' "$ts" | tr -cd '[:alnum:]')
+
+  printf '%s/failed-recovery-%s-%s-%s.log' "$log_dir" "$kind" "$number" "$ts"
+  return 0
+}
+
+# fr_classify_immediate_failure: claude session の終了情報から即時失敗を判定する純粋関数。
+#
+# Args:
+#   $1 = claude_rc (int / claude 本体の exit code)
+#   $2 = quota_detected ("1" = quota 検出済 / "0" = 検出なし)
+#   $3 = tool_use_observed ("1" = tool_use 観測済 / "0" = 未観測)
+#   $4 = elapsed_seconds (int / セッション継続時間)
+#   $5 = threshold_seconds (int / 即時失敗判定の継続時間閾値)
+#
+# Returns:
+#   0 = 即時失敗（attempt budget から除外すべき）
+#   1 = 通常の試行（attempt budget に加算する）
+#
+# 判定ロジック（Req 1.2 / 1.8）:
+#   - quota 検出（exit 99 sentinel）は本判定経路を適用しない → 1 (通常扱い)
+#   - claude_rc == 0（success） → 1 (通常扱い)
+#   - tool_use_observed == 1（実質作業に着手） → 1 (通常扱い)
+#   - elapsed_seconds >= threshold（一定時間経過） → 1 (通常扱い)
+#   - 上記いずれにも該当しない（rc != 0 かつ quota 以外 かつ tool_use 無し かつ短時間）
+#     → 0 (即時失敗)
+fr_classify_immediate_failure() {
+  local claude_rc="$1"
+  local quota_detected="$2"
+  local tool_use_observed="$3"
+  local elapsed_seconds="$4"
+  local threshold_seconds="$5"
+
+  # quota 検出経路は適用しない（Req 1.8）
+  if [ "$quota_detected" = "1" ]; then
+    return 1
+  fi
+  # claude が正常終了した場合は即時失敗ではない（Req 1.7）
+  if [ "$claude_rc" = "0" ]; then
+    return 1
+  fi
+  # tool_use を観測した場合は実質作業に着手しているため通算 attempt に加算（Req 1.7）
+  if [ "$tool_use_observed" = "1" ]; then
+    return 1
+  fi
+  # 閾値以上の時間継続していたら通常の試行として扱う（Req 1.7）
+  if ! [[ "$elapsed_seconds" =~ ^[0-9]+$ ]]; then
+    elapsed_seconds=0
+  fi
+  if ! [[ "$threshold_seconds" =~ ^[0-9]+$ ]]; then
+    threshold_seconds=10
+  fi
+  if [ "$elapsed_seconds" -ge "$threshold_seconds" ]; then
+    return 1
+  fi
+  # rc != 0 かつ quota 以外 かつ tool_use 無し かつ短時間 = 即時失敗
+  return 0
+}
+
+# fr_prepare_repo_worktree: 対象 repo の作業ツリーを recovery claude 起動可能な状態に
+# checkout する（Req 3.1〜3.3 / 3.5）。
+#
+# Args:
+#   $1 = kind ("issue" | "pr")
+#   $2 = number (^[0-9]+$)
+#   $3 = pr_head_ref (PR の headRefName / kind=pr の時のみ使用、空文字可)
+#
+# Stdout: 採用した checkout 参照名（Req 3.6 のログ記録に使う）
+# Returns:
+#   0 = checkout 成功
+#   1 = checkout 失敗（caller は即時失敗扱いに倒す / Req 3.4）
+#
+# 仕様:
+#   - $REPO_DIR を作業ツリー起点として採用（Req 3.5 / 既存 impl 系プロセッサと同一起点）
+#   - kind=pr の場合: pr_head_ref を `origin/<ref>` から checkout
+#   - kind=issue の場合:
+#       既存 `claude/issue-<number>-*` branch があればその先頭を、無ければ
+#       `origin/$BASE_BRANCH` を checkout
+#   - すべての git 操作は `timeout` + `git -C` で REPO_DIR に対して実行（NFR 3.1）
+#   - 失敗時は fr_warn で原因を残しつつ rc=1 で caller に通知（fail-continue / Req 3.4）
+fr_prepare_repo_worktree() {
+  local kind="$1"
+  local number="$2"
+  local pr_head_ref="${3-}"
+
+  # kind / number の sanitize（NFR 3.1）
+  case "$kind" in
+    issue|pr) : ;;
+    *)
+      fr_warn "fr_prepare_repo_worktree: 不正な kind=$(printf '%s' "$kind" | tr -cd '[:alnum:]_-' | head -c 16)"
+      return 1
+      ;;
+  esac
+  if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+    fr_warn "fr_prepare_repo_worktree: 不正な ${kind} 番号 number=$(printf '%s' "$number" | tr -cd '[:alnum:]_-' | head -c 32)"
+    return 1
+  fi
+
+  # REPO_DIR の存在確認（Req 3.5 / NFR 3.1）
+  local repo_dir="${REPO_DIR:-}"
+  if [ -z "$repo_dir" ] || [ ! -d "$repo_dir/.git" ]; then
+    fr_warn "fr_prepare_repo_worktree: REPO_DIR が未設定または git repo ではない repo_dir=${repo_dir:-<unset>}"
+    return 1
+  fi
+
+  # base branch（fetch / fallback 用）
+  local base_branch="${BASE_BRANCH:-main}"
+  local git_timeout="${FAILED_RECOVERY_GIT_TIMEOUT:-60}"
+
+  # まず origin の最新を取得（fetch 失敗時は既存 cache で続行 / Req 3.4 の fail-continue）
+  timeout "$git_timeout" git -C "$repo_dir" fetch --prune origin >/dev/null 2>&1 || \
+    fr_warn "fr_prepare_repo_worktree: git fetch origin 失敗（既存 cache で続行）"
+
+  local target_ref=""
+  if [ "$kind" = "pr" ]; then
+    # PR head branch を checkout（Req 3.2 / NFR 3.1: head_ref は -- でオプション解釈打ち切り）
+    if [ -z "$pr_head_ref" ]; then
+      fr_warn "fr_prepare_repo_worktree: pr=#${number} の headRefName が空"
+      return 1
+    fi
+    # head_ref を `^claude/` で再検証（既存 fetch 結果との整合性確認）
+    if ! [[ "$pr_head_ref" =~ ^claude/ ]]; then
+      fr_warn "fr_prepare_repo_worktree: pr=#${number} の headRefName が ^claude/ パターン外 head_ref=$(printf '%s' "$pr_head_ref" | tr -cd '[:alnum:]/_.-' | head -c 64)"
+      return 1
+    fi
+    target_ref="$pr_head_ref"
+  else
+    # kind=issue: `claude/issue-<number>-*` 既存 branch を origin から検索（Req 3.3）
+    local found_ref=""
+    found_ref=$(timeout "$git_timeout" git -C "$repo_dir" ls-remote --heads origin "claude/issue-${number}-*" 2>/dev/null | head -n 1 | awk '{print $2}' | sed 's|^refs/heads/||')
+    if [ -n "$found_ref" ]; then
+      target_ref="$found_ref"
+    else
+      # 既存 claude branch 無し → base branch を採用（Req 3.3）
+      target_ref="$base_branch"
+    fi
+  fi
+
+  # `--` でオプション解釈打ち切り（NFR 3.1）
+  if ! timeout "$git_timeout" git -C "$repo_dir" checkout -B "$target_ref" "origin/$target_ref" -- >/dev/null 2>&1; then
+    # origin/$target_ref が無い場合は target_ref そのものを試す（local-only branch / fallback）
+    if ! timeout "$git_timeout" git -C "$repo_dir" checkout "$target_ref" -- >/dev/null 2>&1; then
+      fr_warn "fr_prepare_repo_worktree: git checkout 失敗 ${kind}=#${number} target_ref=$(printf '%s' "$target_ref" | tr -cd '[:alnum:]/_.-' | head -c 64)"
+      return 1
+    fi
+  fi
+
+  printf '%s' "$target_ref"
+  return 0
+}
+
 # fr_invoke_claude: fresh claude session を起動し stream-json を qa_detect_rate_limit
-# で fold する。
+# で fold + tool_use 観測 + 経過時間計測する。
 #
 # Args:
 #   $1 = prompt（claude へ -p で渡す本文。secrets を含めないこと / NFR 3.2）
 #   $2 = stage_label（ログ識別用ラベル。例: "failed-recovery-issue-42"）
+#   $3 = dedicated_log_path（専用ログ保存先パス / 空文字なら $LOG fallback）
 #
 # Returns:
 #   0     = claude 正常終了 + quota 検出なし
+#   98    = 即時失敗判定（attempt budget から除外すべき / #411 Req 1.1）
 #   99    = quota 検出（caller は qa_handle_quota_exceeded 経路に流す / Req 3.x）
-#   N≠0,99 = claude 自体の非ゼロ exit（quota 以外の失敗、fail-continue で caller に透過）
+#   N≠0,98,99 = claude 自体の非ゼロ exit（quota 以外 / 即時失敗以外の失敗、fail-continue）
 #
 # 副作用:
-#   - $LOG（caller 側で設定済みの実行ログ）に stream-json を tee で append
+#   - dedicated_log_path（または $LOG fallback）に stream-json を tee で append
+#   - $LOG（caller 側で設定済みの実行ログ）にも tee で append（cron.log 観測の互換維持）
 #   - prompt 本文を bash 引数として claude に渡す（環境変数経由ではなく引数）
+#   - 専用ログファイル作成失敗時は fr_warn で警告しつつセッション自体は継続（Req 2.6）
 #
 # 実装メモ:
 #   quota-aware.sh の qa_run_claude_stage と同じ tee + qa_detect_rate_limit 構成を
 #   採用するが、本機能は QUOTA_AWARE_ENABLED gate を**経由しない**（Failed Recovery
 #   は claude-failed 復旧の核となる処理なので、quota 検出のみは常時必要）。
 #   そのため qa_run_claude_stage を呼ばず独自 wrapper として実装する。
+#
+#   #411 で stream-json の tool_use 検出 + セッション継続時間計測を追加。tool_use 検出は
+#   stream-json 1 行に `"type":"tool_use"` を含む grep で観測する（grep -q で stream を
+#   早期短絡せず最後まで読む必要があるため、tee 出力先 file を後段で 1 度だけ grep する）。
 fr_invoke_claude() {
   local prompt="$1"
   local stage_label="$2"
+  local dedicated_log_path="${3-}"
 
   # quota 検出用の中間 TSV ファイル（同一 cycle 内の他 stage と衝突しないよう mktemp）
   local detect_file
@@ -745,11 +978,40 @@ fr_invoke_claude() {
   fi
   : > "$detect_file"
 
-  fr_log "claude session start label=$stage_label model=${FAILED_RECOVERY_DEV_MODEL} max_turns=${FAILED_RECOVERY_MAX_TURNS}"
+  # 専用ログファイルの確保（Req 2.1 / 2.4 / 2.6）。
+  # 親ディレクトリ作成 + touch を試行し、失敗したら警告して /dev/null fallback で続行
+  # （fail-continue / Req 2.6）。dedicated_log_path が空文字なら最初から fallback。
+  local effective_dedicated_log="${dedicated_log_path:-}"
+  if [ -n "$effective_dedicated_log" ]; then
+    local _ded_dir
+    _ded_dir=$(dirname "$effective_dedicated_log")
+    if ! mkdir -p "$_ded_dir" 2>/dev/null; then
+      fr_warn "fr_invoke_claude: 専用ログ親 dir 作成失敗 path=$_ded_dir（/dev/null fallback）"
+      effective_dedicated_log=""
+    elif ! : > "$effective_dedicated_log" 2>/dev/null; then
+      fr_warn "fr_invoke_claude: 専用ログファイル truncate 失敗 path=$effective_dedicated_log（/dev/null fallback）"
+      effective_dedicated_log=""
+    fi
+  fi
 
-  # tee で 2 系統に分岐:
-  #   系統 1: $LOG への append（観測ログ。caller 側で LOG を設定済みの前提）
-  #   系統 2: qa_detect_rate_limit → detect_file へ TSV
+  # $LOG（呼出側 cron.log への観測互換）と dedicated_log の両方に append するため、
+  # tee 1 段だけでは賄えない場合は 2 段 tee する。effective_dedicated_log が空文字なら
+  # $LOG のみへ append（既存挙動互換）、$LOG も空文字なら /dev/null へ捨てる。
+  local primary_log="${LOG:-/dev/null}"
+  local secondary_log="${effective_dedicated_log:-/dev/null}"
+
+  # NFR 2.2 / Req 2.5: 専用ログ名と保存先を一次運用ログ（cron.log）にも記録
+  if [ -n "$effective_dedicated_log" ]; then
+    fr_log "claude session start label=$stage_label model=${FAILED_RECOVERY_DEV_MODEL} max_turns=${FAILED_RECOVERY_MAX_TURNS} dedicated_log=$effective_dedicated_log"
+  else
+    fr_log "claude session start label=$stage_label model=${FAILED_RECOVERY_DEV_MODEL} max_turns=${FAILED_RECOVERY_MAX_TURNS}"
+  fi
+
+  # セッション継続時間計測（#411 Req 1.2）
+  local session_start_epoch
+  session_start_epoch=$(date +%s 2>/dev/null || echo "0")
+
+  # 2 段 tee: claude → tee primary_log → tee secondary_log → qa_detect_rate_limit
   # set +e/-e で囲って pipefail 起因の即時 exit を一時抑止し、PIPESTATUS[0] で
   # claude 本体の exit code を取り出す（quota-aware の同型ロジックを踏襲）。
   local claude_rc=0
@@ -758,16 +1020,29 @@ fr_invoke_claude() {
     --model "$FAILED_RECOVERY_DEV_MODEL" \
     --max-turns "$FAILED_RECOVERY_MAX_TURNS" \
     --permission-mode bypassPermissions \
-    --output-format stream-json 2>&1 | tee -a "${LOG:-/dev/null}" | qa_detect_rate_limit > "$detect_file"
+    --output-format stream-json 2>&1 \
+    | tee -a "$primary_log" \
+    | tee -a "$secondary_log" \
+    | qa_detect_rate_limit > "$detect_file"
   local _fr_pipestatus=("${PIPESTATUS[@]}")
   set -e
   claude_rc="${_fr_pipestatus[0]:-0}"
 
+  # セッション継続時間（end - start）
+  local session_end_epoch
+  session_end_epoch=$(date +%s 2>/dev/null || echo "$session_start_epoch")
+  local elapsed_seconds=$((session_end_epoch - session_start_epoch))
+  if [ "$elapsed_seconds" -lt 0 ]; then
+    elapsed_seconds=0
+  fi
+
   # quota 検出（epoch 付き行が 1 行でもあれば exit 99 sentinel）
+  local quota_detected=0
   if [ -s "$detect_file" ]; then
     local epoch_line
     epoch_line=$(awk -F '\t' 'NF >= 2 && $2 ~ /^[0-9]+$/ { last = $0 } END { print last }' "$detect_file")
     if [ -n "$epoch_line" ]; then
+      quota_detected=1
       local path_field
       path_field="${epoch_line%%$'\t'*}"
       fr_log "claude session quota detected label=$stage_label path=$path_field"
@@ -777,7 +1052,31 @@ fr_invoke_claude() {
   fi
   rm -f "$detect_file"
 
-  fr_log "claude session end label=$stage_label rc=$claude_rc"
+  # #411 Req 1.2: stream-json 中の tool_use イベント観測。
+  # primary_log / secondary_log 双方の末尾を grep する（どちらか可読な方で十分）。
+  # claude --output-format stream-json は tool_use を `"type":"tool_use"` JSON 行で出力する。
+  local tool_use_observed=0
+  local _grep_source=""
+  if [ -n "$effective_dedicated_log" ] && [ -r "$effective_dedicated_log" ]; then
+    _grep_source="$effective_dedicated_log"
+  elif [ -n "${LOG:-}" ] && [ -r "${LOG:-}" ]; then
+    _grep_source="$LOG"
+  fi
+  if [ -n "$_grep_source" ]; then
+    if grep -qE '"type"[[:space:]]*:[[:space:]]*"tool_use"' "$_grep_source" 2>/dev/null; then
+      tool_use_observed=1
+    fi
+  fi
+
+  # 即時失敗判定（#411 Req 1.2 / 1.7）
+  local threshold_seconds="${FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS:-10}"
+  if fr_classify_immediate_failure "$claude_rc" "$quota_detected" "$tool_use_observed" "$elapsed_seconds" "$threshold_seconds"; then
+    # NFR 2.1: 判定根拠を一次運用ログに残す（exit code / tool_use 観測有無 / 経過秒）
+    fr_log "claude session immediate-failure label=$stage_label rc=$claude_rc tool_use=$tool_use_observed elapsed=${elapsed_seconds}s threshold=${threshold_seconds}s"
+    return 98
+  fi
+
+  fr_log "claude session end label=$stage_label rc=$claude_rc tool_use=$tool_use_observed elapsed=${elapsed_seconds}s"
   return "$claude_rc"
 }
 
@@ -947,8 +1246,9 @@ fr_finalize_success() {
 # Returns:
 #   0  = success path（claude が修正を完了し fr_finalize_success まで実行）
 #   1  = claude session 失敗（attempt 加算済み、次サイクルで resume）
-#   2  = max-attempts 到達（fr_terminate_max_attempts は task 7 で追加 / 本 task は return 2 stub）
-#   3  = no-progress 判定（fr_terminate_no_progress は task 7 で追加 / 本 task は return 3 stub）
+#   2  = max-attempts 到達
+#   3  = no-progress 判定
+#   4  = #411 即時失敗連続上限到達（fr_terminate_immediate_failure_streak に委譲）
 #   99 = quota 検出（fr_invoke_claude からの sentinel 伝播。caller は次サイクル待ち）
 #
 # 副作用:
@@ -956,10 +1256,12 @@ fr_finalize_success() {
 #   - claude session 起動（fr_invoke_claude 経由）
 #   - state JSON 上書き（試行終了時に 1 回 / Req 4.2）
 #   - 成功時のみ claude-failed ラベル除去 + FR_PROCESSED_THIS_CYCLE 反映
+#   - #411 即時失敗時は attempt 加算をロールバックし、immediate_failure_streak のみ ++
 #
 # 重要な不変条件:
 #   - 重複起動防止: FR_PROCESSED_THIS_CYCLE に "<kind>:<number>" が既存なら即 0 return
 #   - 試行開始時 attempt++ （Req 4.2 / quota 燃焼上界保証）。途中失敗でも加算は確定
+#   - **#411 例外**: rc=98（即時失敗）の場合のみ attempt をロールバックする（Req 1.1）
 #   - Reviewer marker / pr-iteration marker（`idd-claude:pr-iteration round=N`）を
 #     **読まない**（Req 4.3 / D-19b の独立カウンタ規約）
 fr_run_recovery_attempt() {
@@ -1004,8 +1306,28 @@ fr_run_recovery_attempt() {
     prev_total=0
   fi
 
-  # 上限判定（Req 4.4 / 4.5）。上限到達時は terminate 関数（task 7）に委譲する
-  # ため return 2 で caller に通知（本 task では terminate 未実装のため stub）。
+  # #411 Req 1.4: 直前の immediate_failure_streak を読み出す（不在なら 0 fallback）。
+  local prev_streak
+  if ! prev_streak=$(printf '%s' "$prev_state" | jq -r '.immediate_failure_streak // 0' 2>/dev/null); then
+    prev_streak=0
+  fi
+  if ! [[ "$prev_streak" =~ ^[0-9]+$ ]]; then
+    prev_streak=0
+  fi
+
+  # #411 Req 1.5 / 1.6: 即時失敗連続上限の事前チェック（attempt 上限とは独立した経路）。
+  # 既に上限到達していたら、attempt budget を消費せず即 terminate 経路（rc=4）へ。
+  local streak_max="${FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK:-3}"
+  if ! [[ "$streak_max" =~ ^[0-9]+$ ]] || [ "$streak_max" -le 0 ]; then
+    streak_max=3
+  fi
+  if [ "$prev_streak" -ge "$streak_max" ]; then
+    fr_log "fr_run_recovery_attempt: ${kind}=#${number} 即時失敗連続上限到達 streak=$prev_streak max=$streak_max"
+    return 4
+  fi
+
+  # 上限判定（Req 4.4 / 4.5）。上限到達時は terminate 関数に委譲するため return 2 で
+  # caller に通知。
   if ! fr_should_recover "$prev_total"; then
     fr_log "fr_run_recovery_attempt: ${kind}=#${number} 通算 attempt 上限到達 total=$prev_total"
     return 2
@@ -1061,21 +1383,65 @@ fr_run_recovery_attempt() {
   # 試行開始時の attempt++ 確定（Req 4.2 / quota 燃焼上界保証）。
   # ここで一度 in-progress を永続化することで、claude が exit する前に
   # cron が中断しても次サイクルで total_attempts=new_total から resume できる。
-  if ! fr_save_state "$number" "$new_total" "in-progress" "$signature" "$head_sha"; then
+  # streak は前回値をそのまま継承（即時失敗判定後にロールバック / 加算）。
+  if ! fr_save_state "$number" "$new_total" "in-progress" "$signature" "$head_sha" "$prev_streak"; then
     fr_warn "fr_run_recovery_attempt: 開始時 fr_save_state 失敗 ${kind}=#${number}"
   fi
 
-  # claude session を起動（Req 3.1 / 3.2）。prompt は context + 修正指示 +
-  # attempt 回数を平文で組み立てる。secrets を含めない（NFR 3.2 / fr_invoke_claude
-  # は値を引数として claude に渡す）。
-  local prompt
-  prompt=$(printf 'Failed Recovery Processor: claude-failed %s #%s の修正試行 (通算 %s 回目 / 上限 %s)\n\n以下の context から失敗原因を分析し、修正コミットを push してください。\n修正完了したら通常の Reviewer / pr-iteration フローに復帰させるため、本コメントへの追記応答は不要です。\n\n=== Context ===\n%s\n=== End of Context ===\n' \
-      "$kind" "$number" "$new_total" "$FAILED_RECOVERY_MAX_ATTEMPTS" "$context")
+  # #411 Req 3.1〜3.5: 作業ツリーを対象 repo の REPO_DIR に checkout してから claude を起動。
+  # PR の場合は headRefName を取得して PR head branch を、Issue の場合は claude/issue-<N>-*
+  # 既存 branch または BASE_BRANCH を採用する。失敗時は即時失敗扱い（Req 3.4）。
+  local pr_head_ref=""
+  if [ "$kind" = "pr" ]; then
+    if ! pr_head_ref=$(timeout "$FAILED_RECOVERY_GIT_TIMEOUT" gh pr view "$number" \
+        --repo "$REPO" \
+        --json headRefName \
+        --jq '.headRefName' 2>/dev/null); then
+      fr_warn "fr_run_recovery_attempt: gh pr view --json headRefName 失敗 pr=#${number}"
+      pr_head_ref=""
+    fi
+    pr_head_ref="${pr_head_ref%$'\n'}"
+  fi
 
-  local stage_label="failed-recovery-${kind}-${number}"
+  local checkout_ref=""
+  local worktree_ok=0
+  if checkout_ref=$(fr_prepare_repo_worktree "$kind" "$number" "$pr_head_ref" 2>/dev/null); then
+    worktree_ok=1
+    fr_log "fr_run_recovery_attempt: ${kind}=#${number} 作業ツリー checkout 完了 repo_dir=${REPO_DIR:-<unset>} ref=$checkout_ref"
+  else
+    # Req 3.4: 作業ツリー確保失敗を即時失敗扱いに倒す（attempt budget からは除外）
+    fr_warn "fr_run_recovery_attempt: ${kind}=#${number} 作業ツリー checkout 失敗（即時失敗扱い）"
+  fi
+
+  # #411 Req 2.1〜2.5: 専用ログ保存先を確定（LOG 未設定でも /dev/null に逃さない）
+  local dedicated_log_path=""
+  if ! dedicated_log_path=$(fr_resolve_dedicated_log_path "$kind" "$number" 2>/dev/null); then
+    fr_warn "fr_run_recovery_attempt: 専用ログパス解決失敗 ${kind}=#${number}（/dev/null fallback）"
+    dedicated_log_path=""
+  fi
+
   local claude_rc=0
-  # fr_invoke_claude は内部で set +e/-e を toggle するため subshell で隔離
-  ( fr_invoke_claude "$prompt" "$stage_label" ) || claude_rc=$?
+  if [ "$worktree_ok" = "1" ]; then
+    # claude session を起動（Req 3.1 / 3.2）。prompt は context + 修正指示 +
+    # attempt 回数を平文で組み立てる。secrets を含めない（NFR 3.2 / fr_invoke_claude
+    # は値を引数として claude に渡す）。
+    local prompt
+    prompt=$(printf 'Failed Recovery Processor: claude-failed %s #%s の修正試行 (通算 %s 回目 / 上限 %s)\n\n以下の context から失敗原因を分析し、修正コミットを push してください。\n修正完了したら通常の Reviewer / pr-iteration フローに復帰させるため、本コメントへの追記応答は不要です。\n\n=== Context ===\n%s\n=== End of Context ===\n' \
+        "$kind" "$number" "$new_total" "$FAILED_RECOVERY_MAX_ATTEMPTS" "$context")
+
+    local stage_label="failed-recovery-${kind}-${number}"
+    # fr_invoke_claude は内部で set +e/-e を toggle するため subshell で隔離。
+    # subshell 内で REPO_DIR に cd して claude を起動することで、claude が当該 worktree
+    # 上で git 操作・ファイル編集を行えるようにする（Req 3.1）。subshell が exit すれば
+    # cd は caller に波及しない（NFR 1.1 後方互換）。
+    (
+      cd "$REPO_DIR" 2>/dev/null || true
+      fr_invoke_claude "$prompt" "$stage_label" "$dedicated_log_path"
+    ) || claude_rc=$?
+  else
+    # 作業ツリー確保失敗 → claude を起動せず即時失敗 sentinel に倒す（Req 3.4）
+    claude_rc=98
+  fi
 
   if [ "$claude_rc" = "99" ]; then
     # quota 検出: 結果コメント投稿 + state in-progress 維持 + caller は次サイクル待ち
@@ -1089,10 +1455,14 @@ fr_run_recovery_attempt() {
 
   if [ "$claude_rc" = "0" ]; then
     # success path: 結果コメント投稿 → fr_finalize_success（ラベル除去 + state succeeded）
+    # 成功時は immediate_failure_streak を 0 にリセット（Req 1.7）。
     local success_body
     success_body=$(printf 'Failed Recovery Processor (#359): 修正試行が完了しました（通算 %s 回目）。\n\nclaude-failed ラベルを除去し、通常の処理フローに復帰させます。\n適用した修正の概要は本 %s の最新コミット / PR 差分を参照してください。' \
         "$new_total" "$kind")
     fr_post_attempt_comment "$kind" "$number" "$success_body" || true
+    # streak リセット用に state を 1 度書く（fr_finalize_success が succeeded を上書きする
+    # 前に streak=0 を確定させておく）。
+    fr_save_state "$number" "$new_total" "in-progress" "$signature" "$head_sha" "0" || true
     if ! fr_finalize_success "$kind" "$number" "$new_total" "$signature" "$head_sha"; then
       fr_warn "fr_run_recovery_attempt: fr_finalize_success が部分失敗 ${kind}=#${number}"
       return 1
@@ -1100,7 +1470,36 @@ fr_run_recovery_attempt() {
     return 0
   fi
 
-  # その他の失敗 (rc != 0, 99): 結果コメント投稿 + state in-progress 維持
+  if [ "$claude_rc" = "98" ]; then
+    # #411 Req 1.1 / 1.4 即時失敗判定: attempt を prev_total へロールバックし、
+    # immediate_failure_streak のみ ++ する。Req 1.5 上限到達時は caller (_fr_dispatch_candidate)
+    # が terminate 経路に流すため return 4 を返す。
+    local new_streak=$((prev_streak + 1))
+    fr_log "fr_run_recovery_attempt: ${kind}=#${number} 即時失敗 → attempt ロールバック new_streak=$new_streak max=$streak_max"
+    # state を上書き（total を prev_total へ巻き戻し + streak を加算）。
+    if ! fr_save_state "$number" "$prev_total" "in-progress" "$signature" "$head_sha" "$new_streak"; then
+      fr_warn "fr_run_recovery_attempt: 即時失敗時の fr_save_state 失敗 ${kind}=#${number}"
+    fi
+
+    if [ "$new_streak" -ge "$streak_max" ]; then
+      # 上限到達: caller が fr_terminate_immediate_failure_streak を呼ぶ。コメントはそちらに委譲。
+      return 4
+    fi
+
+    # 上限未到達: 結果コメント投稿 + 次サイクル待ち
+    local imm_body
+    imm_body=$(printf 'Failed Recovery Processor (#411): claude セッションが実質作業前に即時失敗しました（連続即時失敗 %s 回目 / 上限 %s / 通算 attempt は加算せず %s 回のまま）。\n\nclaude-failed ラベルは据え置きます。次サイクルで再試行されます。' \
+        "$new_streak" "$streak_max" "$prev_total")
+    fr_post_attempt_comment "$kind" "$number" "$imm_body" || true
+    return 1
+  fi
+
+  # その他の失敗 (rc != 0, 98, 99): 結果コメント投稿 + state in-progress 維持
+  # 通常の失敗（claude が tool_use を観測した、あるいは閾値時間を超えた）の場合は
+  # streak を 0 にリセットする（Req 1.7）。
+  if ! fr_save_state "$number" "$new_total" "in-progress" "$signature" "$head_sha" "0"; then
+    fr_warn "fr_run_recovery_attempt: 通常失敗時の fr_save_state 失敗 ${kind}=#${number}"
+  fi
   local failure_body
   failure_body=$(printf 'Failed Recovery Processor (#359): 修正試行が失敗しました（通算 %s 回目 / 上限 %s / claude rc=%s）。\n\nclaude-failed ラベルは据え置きます。次サイクルで再試行されます（上限到達時は手動レビューへエスカレーション）。' \
       "$new_total" "$FAILED_RECOVERY_MAX_ATTEMPTS" "$claude_rc")
@@ -1251,6 +1650,68 @@ fr_terminate_no_progress() {
   return 0
 }
 
+# fr_terminate_immediate_failure_streak: 即時失敗連続上限到達時の終端処理 (#411 Req 4.1)。
+#
+# Args:
+#   $1 = kind ("issue" | "pr")
+#   $2 = number (^[0-9]+$ で使用前検証)
+#   $3 = streak_count (int / 直近の即時失敗連続回数。コメント本文に表示)
+#
+# 副作用:
+#   - 終端理由コメント 1 件を投稿（Req 4.3。本文に streak_count と識別子を含む）
+#   - rs_set_result "claude-failed" を呼ぶ（Req 4.5 / run-summary 連携）
+#   - fr_log で終端理由 `immediate-failure-streak` をログ出力（Req 4.2 / NFR 4.1）
+#   - claude-failed ラベルは **除去しない**（Req 4.4 / 手動介入待ち）
+#   - sn_notify でも識別子と回数を detail に含めて Slack 通知（Req 4.6 / NFR 3.2 で
+#     failure signature 等の機微値は含めない）
+#
+# Returns:
+#   0 = fail-continue（コメント投稿失敗時も 0 を返す）
+#   1 = 不正な引数（kind が issue/pr 以外 or number が非数値）
+fr_terminate_immediate_failure_streak() {
+  local kind="$1"
+  local number="$2"
+  local streak_count="${3:-0}"
+
+  # kind の不正値ガード（issue / pr のみ受理）
+  case "$kind" in
+    issue|pr) : ;;
+    *)
+      fr_warn "fr_terminate_immediate_failure_streak: 不正な kind=$(printf '%s' "$kind" | tr -cd '[:alnum:]_-' | head -c 16)"
+      return 1
+      ;;
+  esac
+
+  # NFR 3.1: 番号の形式検証（^[0-9]+$）
+  if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+    fr_warn "fr_terminate_immediate_failure_streak: 不正な ${kind} 番号 number=$(printf '%s' "$number" | tr -cd '[:alnum:]_-' | head -c 32)"
+    return 1
+  fi
+  if ! [[ "$streak_count" =~ ^[0-9]+$ ]]; then
+    streak_count=0
+  fi
+
+  # 終端理由コメント 1 件を投稿（Req 4.3）。本文に streak_count と識別子
+  # `immediate-failure-streak` を含めて、運用者が手動レビュー時に max-attempts と区別可能にする。
+  local body
+  # shellcheck disable=SC2016  # 単一引用符内のバッククォートは markdown コードフェンスのリテラル
+  body=$(printf 'Failed Recovery Processor (#411): claude セッションが連続 %s 回、実質作業前の即時失敗を起こしました（終端理由: `immediate-failure-streak` / 上限 %s）。\n\nrecovery claude が起動不能の可能性があります（cwd / branch checkout / CLI 環境差など）。`claude-failed` ラベルは据え置きます。手動レビューに移行してください。' \
+      "$streak_count" "${FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK:-3}")
+  fr_post_attempt_comment "$kind" "$number" "$body" || true
+
+  # run-summary 連携（Req 4.5 / 既存 max-attempts / no-progress と同様 1 度だけ確定）
+  rs_set_result "claude-failed" || true
+
+  # NFR 4.1 / Req 4.2: `failed-recovery:` prefix + 識別子で `grep` 抽出可能にする。
+  fr_log "${kind}=#${number} terminated reason=immediate-failure-streak streak=${streak_count} max=${FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK:-3}"
+
+  # Req 4.6: Slack 通知 emitter（fail-open / gate OFF 時は no-op）。
+  # detail には kind / streak のみ含め、failure signature 等の機微値は含めない（NFR 3.2）。
+  sn_notify failed-recovery "$number" "https://github.com/$REPO/${kind}s/$number" immediate-failure-streak "kind=${kind} streak=${streak_count} max=${FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK:-3}" || true
+
+  return 0
+}
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Orchestrator Entry Point
 #
@@ -1284,6 +1745,8 @@ fr_terminate_no_progress() {
 #   1  = claude session 失敗。次サイクル再試行（fr_run_recovery_attempt 内で結果コメント済み）
 #   2  = max-attempts 到達 → fr_terminate_max_attempts に委譲（state から total を再読み込み）
 #   3  = no-progress 判定 → fr_terminate_no_progress に委譲（state から signature を再読み込み）
+#   4  = #411 即時失敗連続上限到達 → fr_terminate_immediate_failure_streak に委譲
+#        （state から immediate_failure_streak を再読み込み）
 #   99 = quota 検出 → 次サイクル待ち（fr_run_recovery_attempt 内で結果コメント済み）
 #   その他 = 未知 rc 警告 + 次候補へ
 _fr_dispatch_candidate() {
@@ -1324,6 +1787,18 @@ _fr_dispatch_candidate() {
         signature=""
       fi
       fr_terminate_no_progress "$kind" "$number" "$total" "$signature" || true
+      ;;
+    4)
+      # #411 即時失敗連続上限到達: streak は state JSON から再読み込み
+      local prev_state streak
+      prev_state=$(fr_load_state "$number")
+      if ! streak=$(printf '%s' "$prev_state" | jq -r '.immediate_failure_streak // 0' 2>/dev/null); then
+        streak=0
+      fi
+      if ! [[ "$streak" =~ ^[0-9]+$ ]]; then
+        streak=0
+      fi
+      fr_terminate_immediate_failure_streak "$kind" "$number" "$streak" || true
       ;;
     *)
       fr_warn "_fr_dispatch_candidate: 未知の rc=$rc ${kind}=#${number}（skip）"

--- a/local-watcher/test/fr_attempt_test.sh
+++ b/local-watcher/test/fr_attempt_test.sh
@@ -92,6 +92,17 @@ FAILED_RECOVERY_DEV_MODEL="claude-opus-4-7"
 FAILED_RECOVERY_MAX_TURNS=20
 # shellcheck disable=SC2034
 FAILED_RECOVERY_MAX_ATTEMPTS=4
+# #411: 即時失敗連続上限（テスト中はデフォルト 3 で OK / 既存 success path テストでは streak=0 のまま）
+# shellcheck disable=SC2034
+FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK=3
+# shellcheck disable=SC2034
+FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10
+# shellcheck disable=SC2034
+REPO_DIR="/tmp/fr-attempt-test-stub-repo"
+# shellcheck disable=SC2034
+BASE_BRANCH="main"
+# shellcheck disable=SC2034
+LOG_DIR="/tmp/fr-attempt-test-stub-logs"
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -239,6 +250,7 @@ reset_stub_state() {
   LOAD_STATE_TRACE="$(mktemp)"
   INVOKE_CLAUDE_TRACE="$(mktemp)"
   FINALIZE_TRACE="$(mktemp)"
+  PREPARE_WORKTREE_TRACE="$(mktemp)"
   LOAD_STATE_RESPONSE='{}'
   INVOKE_CLAUDE_RC=0
   DETECT_NO_PROGRESS_RC=1
@@ -246,6 +258,9 @@ reset_stub_state() {
   COLLECT_PR_CI_CONTEXT_RESPONSE="dummy pr ci context"
   GH_PR_VIEW_HEAD_SHA="0123456789abcdef0123456789abcdef01234567"
   GH_RC=0
+  # #411: 作業ツリー stub を成功側に倒す（success path の既存テスト互換）
+  PREPARE_WORKTREE_RC=0
+  PREPARE_WORKTREE_OUTPUT="main"
   # FR_PROCESSED_THIS_CYCLE を section ごとに reset
   FR_PROCESSED_THIS_CYCLE=""
   export FR_PROCESSED_THIS_CYCLE
@@ -253,7 +268,8 @@ reset_stub_state() {
 
 cleanup_stub_state() {
   rm -f "$GH_CALL_LOG" "$CLAUDE_CALL_LOG" "$FR_WARN_TRACE" "$FR_LOG_TRACE" \
-        "$SAVE_STATE_TRACE" "$LOAD_STATE_TRACE" "$INVOKE_CLAUDE_TRACE" "$FINALIZE_TRACE" 2>/dev/null || true
+        "$SAVE_STATE_TRACE" "$LOAD_STATE_TRACE" "$INVOKE_CLAUDE_TRACE" "$FINALIZE_TRACE" \
+        "$PREPARE_WORKTREE_TRACE" 2>/dev/null || true
 }
 
 # ── 内部関数 stub 群 ──
@@ -338,12 +354,35 @@ fr_collect_pr_ci_context() {
 }
 
 # fr_invoke_claude stub: INVOKE_CLAUDE_TRACE に引数を記録し、INVOKE_CLAUDE_RC を返す
+# 第 3 引数は #411 で追加した dedicated_log_path（テストでは観測のみ）
 # shellcheck disable=SC2317
 fr_invoke_claude() {
-  echo "fr_invoke_claude prompt_len=${#1} stage=$2" >> "$INVOKE_CLAUDE_TRACE"
+  echo "fr_invoke_claude prompt_len=${#1} stage=$2 ded_log=$3" >> "$INVOKE_CLAUDE_TRACE"
   # claude 呼び出し記録の補助として CLAUDE_CALL_LOG にも記録
   echo "claude -p ... stage=$2" >> "$CLAUDE_CALL_LOG"
   return "$INVOKE_CLAUDE_RC"
+}
+
+# #411: fr_prepare_repo_worktree stub。テストでは常に成功（stdout に checkout 参照名）。
+# 観測用に PREPARE_WORKTREE_TRACE に記録する。
+PREPARE_WORKTREE_TRACE=""
+PREPARE_WORKTREE_RC=0
+PREPARE_WORKTREE_OUTPUT="main"
+# shellcheck disable=SC2317
+fr_prepare_repo_worktree() {
+  echo "fr_prepare_repo_worktree kind=$1 number=$2 pr_head=$3" >> "${PREPARE_WORKTREE_TRACE:-/dev/null}"
+  if [ "$PREPARE_WORKTREE_RC" != "0" ]; then
+    return "$PREPARE_WORKTREE_RC"
+  fi
+  printf '%s' "$PREPARE_WORKTREE_OUTPUT"
+  return 0
+}
+
+# #411: fr_resolve_dedicated_log_path stub。固定パスを返す。
+# shellcheck disable=SC2317
+fr_resolve_dedicated_log_path() {
+  printf '/tmp/fr-attempt-test-dedicated-%s-%s.log' "$1" "$2"
+  return 0
 }
 
 # ============================================================
@@ -397,14 +436,15 @@ assert_rc "observation: success path → rc=0" "0" "$rc"
 # 開始時 save が呼ばれること: total_attempts=3 (prev=2+1), last_status=in-progress
 assert_grep "観点 a: 開始時 fr_save_state(42, 3, in-progress, ...) が呼ばれる" "^fr_save_state 42 3 in-progress " "$SAVE_STATE_TRACE"
 
-# fr_save_state が in-progress 1 件 + finalize 経由 succeeded 1 件 = 計 2 件
+# #411: success path で fr_save_state が in-progress 1 件 + streak=0 reset 1 件 +
+# finalize 経由 succeeded 1 件 = 計 3 件
 save_count=$(wc -l < "$SAVE_STATE_TRACE" 2>/dev/null || echo "0")
 save_count="${save_count//[[:space:]]/}"
-if [ "$save_count" = "2" ]; then
-  echo "PASS: 観点 a: fr_save_state が 2 件呼ばれる (in-progress + succeeded)"
+if [ "$save_count" = "3" ]; then
+  echo "PASS: 観点 a: fr_save_state が 3 件呼ばれる (in-progress + streak-reset + succeeded)"
   PASS_COUNT=$((PASS_COUNT + 1))
 else
-  echo "FAIL: 観点 a: fr_save_state が 2 件呼ばれる (actual=$save_count)"
+  echo "FAIL: 観点 a: fr_save_state が 3 件呼ばれる (actual=$save_count)"
   cat "$SAVE_STATE_TRACE"
   FAIL_COUNT=$((FAIL_COUNT + 1))
 fi

--- a/local-watcher/test/fr_immediate_fail_test.sh
+++ b/local-watcher/test/fr_immediate_fail_test.sh
@@ -1,0 +1,632 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/failed-recovery.sh の Issue #411（即時失敗除外）で
+#       追加した即時失敗除外 / 専用ログ / worktree 起動 / 独立エスカレーション を
+#       関数単体 / 統合 stub で検証するスモークテスト。
+#
+#       対象関数（#411 で新規追加 / 拡張）:
+#         - fr_resolve_dedicated_log_path        (Req 2.1〜2.5 / NFR 2.2)
+#         - fr_prepare_repo_worktree              (Req 3.1〜3.6)
+#         - fr_terminate_immediate_failure_streak (Req 4.1〜4.6 / NFR 4.1)
+#         - fr_run_recovery_attempt 内の rc=98 ハンドリング（Req 1.1 / 1.4 / 1.5 / 1.7）
+#         - fr_save_state の immediate_failure_streak 6 番目引数（Req 1.4）
+#
+#       検証する AC（docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/requirements.md）:
+#         - Req 1.1: rc=98 時に attempt budget からロールバック
+#         - Req 1.4: immediate_failure_streak の state 永続化
+#         - Req 1.5: streak 上限到達時に rc=4 を caller に返す
+#         - Req 1.7: tool_use 観測時 / 通常失敗時に streak=0 リセット
+#         - Req 2.1〜2.3: ログ名に `failed-recovery` / kind / number / timestamp を含む
+#         - Req 2.4: LOG 未設定でも /dev/null fallback せず自前で保存先を確定
+#         - Req 3.5: REPO_DIR を作業ツリー起点に採用
+#         - Req 4.1: 終端理由識別子 `immediate-failure-streak` を使用
+#         - Req 4.2: 一次運用ログ `terminated reason=immediate-failure-streak` で grep 抽出可能
+#         - Req 4.4: claude-failed ラベルは据え置き（除去しない）
+#         - Req 4.5: rs_set_result claude-failed が 1 回だけ呼ばれる
+#
+# 配置先: local-watcher/test/fr_immediate_fail_test.sh
+# 依存:   bash 4+, awk, jq, mktemp
+# 実行:   bash local-watcher/test/fr_immediate_fail_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery.sh"
+
+if [ ! -f "$MODULE_SH" ]; then
+  echo "ERROR: cannot find failed-recovery.sh at $MODULE_SH" >&2
+  exit 2
+fi
+
+# 既存テストと同じ extract_function イディオム
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# 抽出: #411 で追加 / 既存利用の関数
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_resolve_dedicated_log_path")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_prepare_repo_worktree")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_terminate_immediate_failure_streak")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_post_attempt_comment")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_run_recovery_attempt")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_should_recover")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_finalize_success")"
+
+for fn in fr_resolve_dedicated_log_path fr_prepare_repo_worktree \
+          fr_terminate_immediate_failure_streak fr_post_attempt_comment \
+          fr_run_recovery_attempt fr_should_recover fr_finalize_success; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# ── グローバル env ──
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# shellcheck disable=SC2034
+REPO_SLUG="owner-test-repo"
+# shellcheck disable=SC2034
+LABEL_FAILED="claude-failed"
+# shellcheck disable=SC2034
+FAILED_RECOVERY_GIT_TIMEOUT=60
+# shellcheck disable=SC2034
+FAILED_RECOVERY_DEV_MODEL="claude-opus-4-7"
+# shellcheck disable=SC2034
+FAILED_RECOVERY_MAX_TURNS=20
+# shellcheck disable=SC2034
+FAILED_RECOVERY_MAX_ATTEMPTS=4
+# shellcheck disable=SC2034
+FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10
+# shellcheck disable=SC2034
+FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK=3
+# shellcheck disable=SC2034
+LOG_DIR="/tmp/fr-imm-test-logs"
+# shellcheck disable=SC2034
+BASE_BRANCH="main"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+assert_rc() {
+  local label="$1" expected_rc="$2" actual_rc="$3"
+  if [ "$expected_rc" = "$actual_rc" ]; then
+    echo "PASS: $label (rc=$actual_rc)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label expected_rc=$expected_rc actual_rc=$actual_rc"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+assert_grep() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -qE -- "$pattern" "$file" 2>/dev/null; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label pattern=$pattern"
+    [ -f "$file" ] && { echo "--- $file ---"; cat "$file"; echo "--- /$file ---"; }
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+assert_not_grep() {
+  local label="$1" pattern="$2" file="$3"
+  if grep -qE -- "$pattern" "$file" 2>/dev/null; then
+    echo "FAIL: $label unexpected pattern=$pattern"
+    [ -f "$file" ] && { echo "--- $file ---"; cat "$file"; echo "--- /$file ---"; }
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+# ── stub state ──
+GH_CALL_LOG=""
+FR_WARN_TRACE=""
+FR_LOG_TRACE=""
+SAVE_STATE_TRACE=""
+LOAD_STATE_TRACE=""
+INVOKE_CLAUDE_TRACE=""
+PREPARE_WORKTREE_TRACE=""
+SN_NOTIFY_TRACE=""
+RS_SET_RESULT_TRACE=""
+
+LOAD_STATE_RESPONSE='{}'
+INVOKE_CLAUDE_RC=0
+DETECT_NO_PROGRESS_RC=1
+COLLECT_ISSUE_CONTEXT_RESPONSE="dummy issue context"
+COLLECT_PR_CI_CONTEXT_RESPONSE="dummy pr ci context"
+GH_PR_VIEW_HEAD_SHA="0123456789abcdef0123456789abcdef01234567"
+GH_PR_VIEW_HEAD_REF="claude/issue-42-impl-test"
+GH_RC=0
+PREPARE_WORKTREE_RC=0
+PREPARE_WORKTREE_OUTPUT="claude/issue-42-impl-test"
+
+reset_stub_state() {
+  GH_CALL_LOG="$(mktemp)"
+  FR_WARN_TRACE="$(mktemp)"
+  FR_LOG_TRACE="$(mktemp)"
+  SAVE_STATE_TRACE="$(mktemp)"
+  LOAD_STATE_TRACE="$(mktemp)"
+  INVOKE_CLAUDE_TRACE="$(mktemp)"
+  PREPARE_WORKTREE_TRACE="$(mktemp)"
+  SN_NOTIFY_TRACE="$(mktemp)"
+  RS_SET_RESULT_TRACE="$(mktemp)"
+  LOAD_STATE_RESPONSE='{}'
+  INVOKE_CLAUDE_RC=0
+  DETECT_NO_PROGRESS_RC=1
+  COLLECT_ISSUE_CONTEXT_RESPONSE="dummy issue context"
+  COLLECT_PR_CI_CONTEXT_RESPONSE="dummy pr ci context"
+  GH_PR_VIEW_HEAD_SHA="0123456789abcdef0123456789abcdef01234567"
+  GH_PR_VIEW_HEAD_REF="claude/issue-42-impl-test"
+  GH_RC=0
+  PREPARE_WORKTREE_RC=0
+  PREPARE_WORKTREE_OUTPUT="claude/issue-42-impl-test"
+  FR_PROCESSED_THIS_CYCLE=""
+  export FR_PROCESSED_THIS_CYCLE
+  # shellcheck disable=SC2034  # REPO_DIR は遅延束縛で fr_run_recovery_attempt から参照される
+  REPO_DIR="/tmp/fr-imm-test-stub-repo"
+}
+cleanup_stub_state() {
+  rm -f "$GH_CALL_LOG" "$FR_WARN_TRACE" "$FR_LOG_TRACE" "$SAVE_STATE_TRACE" \
+        "$LOAD_STATE_TRACE" "$INVOKE_CLAUDE_TRACE" "$PREPARE_WORKTREE_TRACE" \
+        "$SN_NOTIFY_TRACE" "$RS_SET_RESULT_TRACE" 2>/dev/null || true
+}
+
+# ── 内部関数 stub 群 ──
+# shellcheck disable=SC2317
+fr_warn() { echo "$*" >> "$FR_WARN_TRACE"; }
+# shellcheck disable=SC2317
+fr_log() { echo "$*" >> "$FR_LOG_TRACE"; }
+# shellcheck disable=SC2317
+fr_error() { echo "$*" >> "$FR_WARN_TRACE"; }
+# shellcheck disable=SC2317
+timeout() { shift; "$@"; }
+# shellcheck disable=SC2317
+gh() {
+  echo "gh $*" >> "$GH_CALL_LOG"
+  case "${1:-}" in
+    pr)
+      case "${2:-}" in
+        view)
+          # 引数の `--json` を見て応答を切り替え
+          local args=("$@")
+          local i
+          for ((i=0; i<${#args[@]}; i++)); do
+            if [ "${args[i]:-}" = "--json" ] && [ "${args[i+1]:-}" = "headRefOid" ]; then
+              printf '%s' "$GH_PR_VIEW_HEAD_SHA"
+              return "$GH_RC"
+            fi
+            if [ "${args[i]:-}" = "--json" ] && [ "${args[i+1]:-}" = "headRefName" ]; then
+              printf '%s' "$GH_PR_VIEW_HEAD_REF"
+              return "$GH_RC"
+            fi
+          done
+          return "$GH_RC"
+          ;;
+      esac
+      ;;
+  esac
+  return "$GH_RC"
+}
+# shellcheck disable=SC2317
+fr_load_state() {
+  echo "fr_load_state $*" >> "$LOAD_STATE_TRACE"
+  printf '%s' "$LOAD_STATE_RESPONSE"
+}
+# shellcheck disable=SC2317
+fr_save_state() {
+  echo "fr_save_state $*" >> "$SAVE_STATE_TRACE"
+  return 0
+}
+# shellcheck disable=SC2317
+fr_compute_failure_signature() {
+  cat >/dev/null
+  printf '%s' "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+}
+# shellcheck disable=SC2317
+fr_detect_no_progress() { return "$DETECT_NO_PROGRESS_RC"; }
+# shellcheck disable=SC2317
+fr_collect_issue_context() { printf '%s' "$COLLECT_ISSUE_CONTEXT_RESPONSE"; }
+# shellcheck disable=SC2317
+fr_collect_pr_ci_context() { printf '%s' "$COLLECT_PR_CI_CONTEXT_RESPONSE"; }
+# shellcheck disable=SC2317
+fr_invoke_claude() {
+  echo "fr_invoke_claude prompt_len=${#1} stage=$2 ded_log=$3" >> "$INVOKE_CLAUDE_TRACE"
+  return "$INVOKE_CLAUDE_RC"
+}
+# shellcheck disable=SC2317
+fr_prepare_repo_worktree() {
+  echo "fr_prepare_repo_worktree kind=$1 number=$2 pr_head=$3" >> "$PREPARE_WORKTREE_TRACE"
+  if [ "$PREPARE_WORKTREE_RC" != "0" ]; then
+    return "$PREPARE_WORKTREE_RC"
+  fi
+  printf '%s' "$PREPARE_WORKTREE_OUTPUT"
+  return 0
+}
+# shellcheck disable=SC2317
+fr_resolve_dedicated_log_path() {
+  printf '/tmp/fr-imm-test-dedicated-%s-%s.log' "$1" "$2"
+  return 0
+}
+# shellcheck disable=SC2317
+sn_notify() { echo "sn_notify $*" >> "$SN_NOTIFY_TRACE"; return 0; }
+# shellcheck disable=SC2317
+rs_set_result() { echo "rs_set_result $*" >> "$RS_SET_RESULT_TRACE"; return 0; }
+
+# ============================================================
+# Section A: fr_resolve_dedicated_log_path（Req 2.1〜2.4 / NFR 2.2 / NFR 3.1）
+# ============================================================
+echo "--- Section A: fr_resolve_dedicated_log_path ---"
+
+reset_stub_state
+trap 'cleanup_stub_state' EXIT
+
+# 正常 path: kind=issue + number=42 → `failed-recovery` / `issue` / `42` を含む
+unset -f fr_resolve_dedicated_log_path  # stub を外して本物を呼ぶ
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_resolve_dedicated_log_path")"
+out=$(fr_resolve_dedicated_log_path "issue" "42")
+rc=$?
+assert_rc "Req 2.1: 正常 path → rc=0" "0" "$rc"
+case "$out" in
+  *"failed-recovery"*) echo "PASS: Req 2.3: 識別語 failed-recovery を含む"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
+  *) echo "FAIL: Req 2.3: 識別語 failed-recovery を含む actual=$out"; FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+esac
+case "$out" in
+  *"issue"*) echo "PASS: Req 2.2: kind=issue を含む"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
+  *) echo "FAIL: Req 2.2: kind=issue を含む actual=$out"; FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+esac
+case "$out" in
+  *"42"*) echo "PASS: Req 2.2: number=42 を含む"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
+  *) echo "FAIL: Req 2.2: number=42 を含む actual=$out"; FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+esac
+case "$out" in
+  *"$LOG_DIR"*) echo "PASS: Req 2.2: $LOG_DIR 配下"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
+  *) echo "FAIL: Req 2.2: $LOG_DIR 配下 actual=$out"; FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+esac
+
+# kind=pr
+out=$(fr_resolve_dedicated_log_path "pr" "100")
+case "$out" in
+  *"-pr-100-"*) echo "PASS: Req 2.2: kind=pr / number=100 が含まれる"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
+  *) echo "FAIL: Req 2.2: kind=pr / number=100 actual=$out"; FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+esac
+
+# 不正な kind → rc=1
+set +e
+out=$(fr_resolve_dedicated_log_path "design" "42"); rc=$?
+set -e
+assert_rc "NFR 3.1: 不正な kind=design → rc=1" "1" "$rc"
+
+# 不正な number → rc=1
+set +e
+out=$(fr_resolve_dedicated_log_path "issue" "abc"); rc=$?
+set -e
+assert_rc "NFR 3.1: 非数値 number → rc=1" "1" "$rc"
+
+# Req 2.4: LOG_DIR 未設定でも自前で fallback パスを生成（/dev/null fallback ではない）
+saved_log_dir="$LOG_DIR"
+unset LOG_DIR
+out=$(fr_resolve_dedicated_log_path "issue" "42")
+case "$out" in
+  *"/.issue-watcher/logs/"*"failed-recovery-issue-42-"*)
+    echo "PASS: Req 2.4: LOG_DIR 未設定でも \$HOME/.issue-watcher/logs にフォールバック"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: Req 2.4: LOG_DIR 未設定 fallback actual=$out"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+case "$out" in
+  */dev/null*) echo "FAIL: Req 2.4: /dev/null に倒さない"; FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
+  *) echo "PASS: Req 2.4: /dev/null fallback ではない"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
+esac
+LOG_DIR="$saved_log_dir"
+
+# stub を戻す
+# shellcheck disable=SC2317
+fr_resolve_dedicated_log_path() {
+  printf '/tmp/fr-imm-test-dedicated-%s-%s.log' "$1" "$2"
+  return 0
+}
+cleanup_stub_state
+
+# ============================================================
+# Section B: fr_terminate_immediate_failure_streak（Req 4.1〜4.6 / NFR 4.1 / 4.2）
+# ============================================================
+echo ""
+echo "--- Section B: fr_terminate_immediate_failure_streak ---"
+
+reset_stub_state
+
+set +e
+fr_terminate_immediate_failure_streak "issue" "411" "3"
+rc=$?
+set -e
+assert_rc "Req 4.1〜4.5: 正常 path → rc=0" "0" "$rc"
+
+# Req 4.1 / 4.3: 終端理由コメントに識別子と連続回数が含まれる
+assert_grep "Req 4.1: コメントに identifier immediate-failure-streak が含まれる" "immediate-failure-streak" "$GH_CALL_LOG"
+assert_grep "Req 4.3: コメントに streak 回数 3 が含まれる" "連続 3 回" "$GH_CALL_LOG"
+
+# Req 4.2: 一次運用ログに terminated reason=immediate-failure-streak が記録される
+assert_grep "Req 4.2: fr_log に terminated reason=immediate-failure-streak" "terminated reason=immediate-failure-streak" "$FR_LOG_TRACE"
+assert_grep "Req 4.2: fr_log に issue=#411" "issue=#411" "$FR_LOG_TRACE"
+
+# Req 4.4: claude-failed ラベルを除去しない
+assert_not_grep "Req 4.4: --remove-label claude-failed が呼ばれない" "--remove-label" "$GH_CALL_LOG"
+
+# Req 4.5: rs_set_result claude-failed が 1 回だけ呼ばれる
+rs_count=$(wc -l < "$RS_SET_RESULT_TRACE" 2>/dev/null || echo "0")
+rs_count="${rs_count//[[:space:]]/}"
+assert_eq "Req 4.5: rs_set_result が 1 回だけ呼ばれる" "1" "$rs_count"
+assert_grep "Req 4.5: rs_set_result claude-failed" "claude-failed" "$RS_SET_RESULT_TRACE"
+
+# Req 4.6: Slack 通知に identifier と streak が含まれ、signature 等の機微値を含めない
+assert_grep "Req 4.6: sn_notify に immediate-failure-streak" "immediate-failure-streak" "$SN_NOTIFY_TRACE"
+assert_grep "Req 4.6: sn_notify に streak=3" "streak=3" "$SN_NOTIFY_TRACE"
+assert_not_grep "NFR 3.2: signature 値が sn_notify に含まれない" "aaaaaaaaaaaaaaaa" "$SN_NOTIFY_TRACE"
+
+# NFR 3.1: 不正な kind / number → rc=1
+set +e
+fr_terminate_immediate_failure_streak "design" "411" "3"; rc=$?
+set -e
+assert_rc "NFR 3.1: 不正な kind → rc=1" "1" "$rc"
+
+set +e
+fr_terminate_immediate_failure_streak "issue" "abc" "3"; rc=$?
+set -e
+assert_rc "NFR 3.1: 非数値 number → rc=1" "1" "$rc"
+
+cleanup_stub_state
+
+# ============================================================
+# Section C: fr_run_recovery_attempt 内 rc=98 → attempt ロールバック + streak ++
+# （Req 1.1 / 1.4）
+# ============================================================
+echo ""
+echo "--- Section C: rc=98 → attempt rollback + streak ++ ---"
+
+reset_stub_state
+
+# prev_total=1, prev_streak=0、claude が rc=98 を返す
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":1,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":0,"history":[]}'
+INVOKE_CLAUDE_RC=98
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+rc=$?
+set -e
+
+# 上限未到達なので caller には rc=1（次サイクル再試行）を返す
+assert_rc "Req 1.1: 上限未到達の即時失敗 → caller には rc=1" "1" "$rc"
+
+# fr_save_state は計 2 回呼ばれる:
+#   1) 開始時 in-progress save (total=2, streak=0)  ← prev_total + 1
+#   2) 即時失敗 rollback save (total=1, streak=1)
+save_count=$(wc -l < "$SAVE_STATE_TRACE" 2>/dev/null || echo "0")
+save_count="${save_count//[[:space:]]/}"
+assert_eq "Req 1.1 / 1.4: fr_save_state が 2 回呼ばれる" "2" "$save_count"
+
+# Req 1.1: rollback save が total=1（prev_total に戻す）+ streak=1
+assert_grep "Req 1.1: rollback save total=1（巻き戻し）+ streak=1" "^fr_save_state 42 1 in-progress .* 1$" "$SAVE_STATE_TRACE"
+
+# 上限未到達なので rc != 4
+if [ "$rc" = "4" ]; then
+  echo "FAIL: Req 1.5: streak=1 < max=3 で rc=4 は出してはならない"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+  echo "PASS: Req 1.5: streak=1 < max=3 で rc=4 を返さない"
+  PASS_COUNT=$((PASS_COUNT + 1))
+fi
+
+cleanup_stub_state
+
+# ============================================================
+# Section D: rc=98 + streak が上限到達 → rc=4 を caller に返す（Req 1.5）
+# ============================================================
+echo ""
+echo "--- Section D: rc=98 + streak 上限到達 → rc=4 ---"
+
+reset_stub_state
+
+# prev_streak=2、claude が rc=98 → new_streak=3 == max=3
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":1,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":2,"history":[]}'
+INVOKE_CLAUDE_RC=98
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+rc=$?
+set -e
+assert_rc "Req 1.5: streak max 到達 → rc=4（terminate へ委譲）" "4" "$rc"
+
+# 即時失敗 rollback save: total=1, streak=3
+assert_grep "Req 1.4: rollback save streak=3" "^fr_save_state 42 1 in-progress .* 3$" "$SAVE_STATE_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Section E: rc=98 + prev_streak が既に上限 → 事前判定で rc=4（attempt 加算なし）
+# （Req 1.5 / 1.6）
+# ============================================================
+echo ""
+echo "--- Section E: 事前判定で prev_streak が上限 → rc=4 ---"
+
+reset_stub_state
+
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":1,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":3,"history":[]}'
+INVOKE_CLAUDE_RC=0  # ここまで来ないはず
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+rc=$?
+set -e
+assert_rc "Req 1.5: prev_streak >= max → 事前判定で rc=4" "4" "$rc"
+
+# attempt 加算もしない / claude も起動しない
+invoke_count=$(wc -l < "$INVOKE_CLAUDE_TRACE" 2>/dev/null || echo "0")
+invoke_count="${invoke_count//[[:space:]]/}"
+assert_eq "Req 1.5: 事前判定では fr_invoke_claude が呼ばれない" "0" "$invoke_count"
+
+save_count=$(wc -l < "$SAVE_STATE_TRACE" 2>/dev/null || echo "0")
+save_count="${save_count//[[:space:]]/}"
+assert_eq "Req 1.5: 事前判定では fr_save_state も呼ばれない" "0" "$save_count"
+
+cleanup_stub_state
+
+# ============================================================
+# Section F: 通常失敗（rc!=0,98,99）→ streak=0 リセット（Req 1.7）
+# ============================================================
+echo ""
+echo "--- Section F: 通常失敗で streak=0 リセット ---"
+
+reset_stub_state
+
+# prev_streak=2、claude が rc=7（通常失敗）→ new_streak リセット
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":1,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":2,"history":[]}'
+INVOKE_CLAUDE_RC=7
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+rc=$?
+set -e
+assert_rc "Req 1.7: 通常失敗 → caller には rc=1（次サイクル再試行）" "1" "$rc"
+
+# 開始時 in-progress save: total=2, streak=2 (継承)
+# 通常失敗時 in-progress save: total=2, streak=0 (リセット)
+assert_grep "Req 1.7: 通常失敗時の save で streak=0 にリセット" "^fr_save_state 42 2 in-progress .* 0$" "$SAVE_STATE_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Section G: success path で streak=0 リセット（Req 1.7）
+# ============================================================
+echo ""
+echo "--- Section G: success path で streak=0 リセット ---"
+
+reset_stub_state
+
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":1,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":2,"history":[]}'
+INVOKE_CLAUDE_RC=0
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+rc=$?
+set -e
+assert_rc "Req 1.7: success path → rc=0" "0" "$rc"
+
+# success 経由の追加 save で streak=0 にリセット
+assert_grep "Req 1.7: success 経由の save で streak=0 にリセット" "^fr_save_state 42 2 in-progress .* 0$" "$SAVE_STATE_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Section H: 作業ツリー checkout 失敗 → 即時失敗扱い（Req 3.4）
+# ============================================================
+echo ""
+echo "--- Section H: 作業ツリー checkout 失敗 → 即時失敗扱い ---"
+
+reset_stub_state
+
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":1,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":0,"history":[]}'
+PREPARE_WORKTREE_RC=1
+INVOKE_CLAUDE_RC=0  # ここに来ないはず
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+rc=$?
+set -e
+assert_rc "Req 3.4: 作業ツリー失敗 → 即時失敗扱い → 上限未到達なら rc=1" "1" "$rc"
+
+# claude は起動しない
+invoke_count=$(wc -l < "$INVOKE_CLAUDE_TRACE" 2>/dev/null || echo "0")
+invoke_count="${invoke_count//[[:space:]]/}"
+assert_eq "Req 3.4: 作業ツリー失敗時に fr_invoke_claude が呼ばれない" "0" "$invoke_count"
+
+# rollback save が呼ばれる（streak=1 加算）
+assert_grep "Req 3.4: 作業ツリー失敗時も rollback save streak=1" "^fr_save_state 42 1 in-progress .* 1$" "$SAVE_STATE_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Section I: dedicated log path が fr_invoke_claude に渡される（Req 2.1）
+# ============================================================
+echo ""
+echo "--- Section I: dedicated log path が fr_invoke_claude に渡される ---"
+
+reset_stub_state
+
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":0,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":0,"history":[]}'
+INVOKE_CLAUDE_RC=0
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+set -e
+
+# fr_invoke_claude の trace に dedicated log path が含まれる
+assert_grep "Req 2.1: fr_invoke_claude に専用ログパスが渡される" "ded_log=/tmp/fr-imm-test-dedicated-issue-42.log" "$INVOKE_CLAUDE_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Section J: 作業ツリー起点パスと checkout 参照名がログ記録される（Req 3.6）
+# ============================================================
+echo ""
+echo "--- Section J: 作業ツリー起点と参照名のログ記録 ---"
+
+reset_stub_state
+
+LOAD_STATE_RESPONSE='{"issue":42,"total_attempts":0,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"","immediate_failure_streak":0,"history":[]}'
+INVOKE_CLAUDE_RC=0
+PREPARE_WORKTREE_OUTPUT="claude/issue-42-impl-test"
+
+set +e
+fr_run_recovery_attempt "issue" "42"
+set -e
+
+# REPO_DIR と checkout した参照名（claude/issue-42-impl-test）がログに記録される
+assert_grep "Req 3.6: REPO_DIR がログに記録される" "repo_dir=/tmp/fr-imm-test-stub-repo" "$FR_LOG_TRACE"
+assert_grep "Req 3.6: checkout 参照名がログに記録される" "ref=claude/issue-42-impl-test" "$FR_LOG_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=================================================="
+echo "RESULT: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "=================================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/local-watcher/test/fr_invoke_test.sh
+++ b/local-watcher/test/fr_invoke_test.sh
@@ -51,7 +51,9 @@ extract_function() {
   ' "$script"
 }
 
-# 抽出: failed-recovery.sh から 3 関数 + quota-aware.sh から qa_detect_rate_limit
+# 抽出: failed-recovery.sh から 4 関数 + quota-aware.sh から qa_detect_rate_limit
+# #411: fr_invoke_claude が fr_classify_immediate_failure を呼ぶため、同 module から
+# 当該関数も抽出して同セッションに load する。
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_collect_issue_context")"
 # shellcheck disable=SC1090,SC2086
@@ -59,9 +61,11 @@ eval "$(extract_function "$MODULE_SH" "fr_collect_pr_ci_context")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_invoke_claude")"
 # shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_classify_immediate_failure")"
+# shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$QUOTA_AWARE_SH" "qa_detect_rate_limit")"
 
-for fn in fr_collect_issue_context fr_collect_pr_ci_context fr_invoke_claude qa_detect_rate_limit; do
+for fn in fr_collect_issue_context fr_collect_pr_ci_context fr_invoke_claude fr_classify_immediate_failure qa_detect_rate_limit; do
   if ! declare -F "$fn" >/dev/null; then
     echo "ERROR: $fn not loaded" >&2
     exit 2
@@ -77,6 +81,9 @@ FAILED_RECOVERY_GIT_TIMEOUT=60
 FAILED_RECOVERY_DEV_MODEL="claude-opus-4-7"
 # shellcheck disable=SC2034
 FAILED_RECOVERY_MAX_TURNS=20
+# #411: 即時失敗閾値（テストでは短時間でテストするため小さめに / 既存テストは tool_use 観測あり）
+# shellcheck disable=SC2034
+FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10
 
 PASS_COUNT=0
 FAIL_COUNT=0
@@ -483,23 +490,177 @@ fi
 cleanup_stub_state
 
 # ============================================================
-# Section 9: fr_invoke_claude — claude 非ゼロ exit（quota 以外）を透過
+# Section 9: fr_invoke_claude — claude 非ゼロ exit（quota 以外 / tool_use 観測あり）を透過
+# #411 で即時失敗判定が追加されたため、tool_use 観測ありの fixture を使うことで
+# 「実質作業着手済」扱いになり rc=7 が透過する（quota 以外 / 即時失敗以外の経路）。
 # ============================================================
 echo ""
-echo "--- Section 9: fr_invoke_claude claude 非ゼロ exit 透過 ---"
+echo "--- Section 9: fr_invoke_claude claude 非ゼロ exit 透過（tool_use 観測あり） ---"
 
 reset_stub_state
 
-CLAUDE_STREAM_FIXTURE='{"type":"result","is_error":true,"api_error_status":500}
+# tool_use イベントを 1 件含めることで即時失敗判定（rc=98）を回避する。
+CLAUDE_STREAM_FIXTURE='{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_1","name":"Read","input":{"file_path":"/tmp/x"}}]}}
+{"type":"result","is_error":true,"api_error_status":500}
 '
 CLAUDE_RC=7
 
 rc=0
-( fr_invoke_claude "prompt" "test-stage-fail" ) || rc=$?
-# quota 検出（429）ではなく 500 + claude rc=7 なので rc=7 が透過する
-assert_rc "NFR 5.2: claude 非ゼロ exit（quota 以外）は透過（rc=7）" "7" "$rc"
+( fr_invoke_claude "prompt" "test-stage-fail" "" ) || rc=$?
+# tool_use 観測あり + 500 + claude rc=7 → 即時失敗ではないので rc=7 が透過する
+assert_rc "NFR 5.2: claude 非ゼロ exit（quota 以外 / tool_use 観測あり）は透過（rc=7）" "7" "$rc"
 
 cleanup_stub_state
+
+# ============================================================
+# Section 10: #411 即時失敗判定 — tool_use 無し + 短時間 + rc!=0 → rc=98
+# ============================================================
+echo ""
+echo "--- Section 10: #411 即時失敗判定 → rc=98 ---"
+
+reset_stub_state
+
+# tool_use を含まない result 行のみ。CLAUDE_RC=1（claude 即時失敗を模擬）
+CLAUDE_STREAM_FIXTURE='{"type":"system","subtype":"init"}
+{"type":"result","is_error":true}
+'
+CLAUDE_RC=1
+
+rc=0
+( fr_invoke_claude "prompt" "test-stage-immediate-fail" "" ) || rc=$?
+# tool_use 無し + rc=1 + 即座に終了（テスト fixture は数秒以内）→ rc=98
+assert_rc "#411 Req 1.1: 即時失敗 → rc=98 sentinel" "98" "$rc"
+
+# NFR 2.1: 一次運用ログに判定根拠が記録されること
+if grep -qE 'immediate-failure' "$FR_LOG_TRACE" 2>/dev/null; then
+  echo "PASS: #411 NFR 2.1: 一次運用ログに immediate-failure 識別子が記録される"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: #411 NFR 2.1: 一次運用ログに immediate-failure 識別子が記録される"
+  cat "$FR_LOG_TRACE"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# rc / tool_use / elapsed の判定根拠が含まれていること（rc=1 / tool_use=0）
+if grep -qE 'rc=1' "$FR_LOG_TRACE" 2>/dev/null && \
+   grep -qE 'tool_use=0' "$FR_LOG_TRACE" 2>/dev/null; then
+  echo "PASS: #411 NFR 2.1: 判定根拠（rc / tool_use）がログに含まれる"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: #411 NFR 2.1: 判定根拠（rc / tool_use）がログに含まれる"
+  cat "$FR_LOG_TRACE"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+cleanup_stub_state
+
+# ============================================================
+# Section 11: #411 即時失敗判定 — tool_use 観測あり → rc=98 にならない（短時間でも）
+# ============================================================
+echo ""
+echo "--- Section 11: #411 tool_use 観測ありで即時失敗扱いにならない ---"
+
+reset_stub_state
+
+# tool_use を含む。CLAUDE_RC=2 で非ゼロだが実質作業着手済扱い
+CLAUDE_STREAM_FIXTURE='{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_2","name":"Bash","input":{"command":"ls"}}]}}
+{"type":"result","is_error":true}
+'
+CLAUDE_RC=2
+
+rc=0
+( fr_invoke_claude "prompt" "test-stage-tooluse" "" ) || rc=$?
+# tool_use 観測ありなので rc=2 が透過（rc=98 にならない）
+assert_rc "#411 Req 1.7: tool_use 観測あり → rc=2 透過（即時失敗扱いにならない）" "2" "$rc"
+
+cleanup_stub_state
+
+# ============================================================
+# Section 12: #411 即時失敗判定 — claude rc=0（success）は適用しない
+# ============================================================
+echo ""
+echo "--- Section 12: #411 success path は即時失敗判定対象外 ---"
+
+reset_stub_state
+
+CLAUDE_STREAM_FIXTURE='{"type":"result","is_error":false}
+'
+CLAUDE_RC=0
+
+rc=0
+( fr_invoke_claude "prompt" "test-stage-success" "" ) || rc=$?
+assert_rc "#411 Req 1.2 (a): claude rc=0 → rc=0（即時失敗扱いではない）" "0" "$rc"
+
+cleanup_stub_state
+
+# ============================================================
+# Section 13: #411 即時失敗判定 — quota 検出時は適用しない（Req 1.8）
+# ============================================================
+echo ""
+echo "--- Section 13: #411 quota 検出は即時失敗扱いではない（Req 1.8） ---"
+
+reset_stub_state
+
+# quota fixture + tool_use 無し + 短時間 + claude_rc 非ゼロ。Req 1.8 で quota 経路は
+# 即時失敗判定を適用しないため rc=99 が返るべき。
+CLAUDE_STREAM_FIXTURE='{"type":"rate_limit_event","status":"exceeded","resetsAt":1750000000}
+{"type":"result","is_error":true}
+'
+CLAUDE_RC=1
+
+rc=0
+( fr_invoke_claude "prompt" "test-stage-quota-then-imm" "" ) || rc=$?
+assert_rc "#411 Req 1.8: quota 検出時は即時失敗判定を適用しない → rc=99" "99" "$rc"
+
+cleanup_stub_state
+
+# ============================================================
+# Section 14: #411 fr_classify_immediate_failure 純粋関数の境界値
+# ============================================================
+echo ""
+echo "--- Section 14: #411 fr_classify_immediate_failure 純粋関数 ---"
+
+# 14-A: quota 検出時は 1（通常扱い）
+set +e
+fr_classify_immediate_failure 1 1 0 1 10; rc=$?
+set -e
+assert_rc "#411 Req 1.8: quota 検出 → rc=1（通常扱い）" "1" "$rc"
+
+# 14-B: rc=0 は 1（通常扱い）
+set +e
+fr_classify_immediate_failure 0 0 0 1 10; rc=$?
+set -e
+assert_rc "#411 Req 1.2 (a): rc=0 → rc=1（通常扱い）" "1" "$rc"
+
+# 14-C: tool_use 観測あり → 1（通常扱い）
+set +e
+fr_classify_immediate_failure 1 0 1 1 10; rc=$?
+set -e
+assert_rc "#411 Req 1.7: tool_use 観測あり → rc=1（通常扱い）" "1" "$rc"
+
+# 14-D: elapsed >= threshold → 1（通常扱い）
+set +e
+fr_classify_immediate_failure 1 0 0 15 10; rc=$?
+set -e
+assert_rc "#411 Req 1.7: elapsed >= threshold → rc=1（通常扱い）" "1" "$rc"
+
+# 14-E: 即時失敗（rc!=0 + quota 無し + tool_use 無し + 短時間）→ 0
+set +e
+fr_classify_immediate_failure 1 0 0 2 10; rc=$?
+set -e
+assert_rc "#411 Req 1.2: 全条件満たす → rc=0（即時失敗）" "0" "$rc"
+
+# 14-F: 境界値 elapsed = threshold-1 → 0（即時失敗）
+set +e
+fr_classify_immediate_failure 1 0 0 9 10; rc=$?
+set -e
+assert_rc "#411 Req 1.3: 境界 elapsed=9 < threshold=10 → rc=0（即時失敗）" "0" "$rc"
+
+# 14-G: 境界値 elapsed = threshold → 1（通常扱い）
+set +e
+fr_classify_immediate_failure 1 0 0 10 10; rc=$?
+set -e
+assert_rc "#411 Req 1.3: 境界 elapsed=10 == threshold=10 → rc=1（通常扱い）" "1" "$rc"
 
 # ============================================================
 # Summary

--- a/local-watcher/test/fr_process_test.sh
+++ b/local-watcher/test/fr_process_test.sh
@@ -158,6 +158,7 @@ FETCH_PRS_TRACE=""
 RUN_ATTEMPT_TRACE=""
 TERMINATE_MAX_TRACE=""
 TERMINATE_NO_PROGRESS_TRACE=""
+TERMINATE_IMMEDIATE_TRACE=""
 LOAD_STATE_TRACE=""
 FR_WARN_TRACE=""
 FR_LOG_TRACE=""
@@ -183,6 +184,7 @@ reset_stub_state() {
   RUN_ATTEMPT_TRACE="$(mktemp)"
   TERMINATE_MAX_TRACE="$(mktemp)"
   TERMINATE_NO_PROGRESS_TRACE="$(mktemp)"
+  TERMINATE_IMMEDIATE_TRACE="$(mktemp)"
   LOAD_STATE_TRACE="$(mktemp)"
   FR_WARN_TRACE="$(mktemp)"
   FR_LOG_TRACE="$(mktemp)"
@@ -192,13 +194,13 @@ reset_stub_state() {
   FETCH_PRS_RESPONSE='[]'
   RUN_ATTEMPT_RC_QUEUE=()
   RUN_ATTEMPT_RC_INDEX=0
-  LOAD_STATE_RESPONSE='{"issue":0,"total_attempts":4,"last_failure_signature":"abc123def456"}'
+  LOAD_STATE_RESPONSE='{"issue":0,"total_attempts":4,"last_failure_signature":"abc123def456","immediate_failure_streak":3}'
 }
 
 cleanup_stub_state() {
   rm -f "$FETCH_ISSUES_TRACE" "$FETCH_PRS_TRACE" "$RUN_ATTEMPT_TRACE" \
-        "$TERMINATE_MAX_TRACE" "$TERMINATE_NO_PROGRESS_TRACE" "$LOAD_STATE_TRACE" \
-        "$FR_WARN_TRACE" "$FR_LOG_TRACE" "$IS_ENABLED_TRACE" 2>/dev/null || true
+        "$TERMINATE_MAX_TRACE" "$TERMINATE_NO_PROGRESS_TRACE" "$TERMINATE_IMMEDIATE_TRACE" \
+        "$LOAD_STATE_TRACE" "$FR_WARN_TRACE" "$FR_LOG_TRACE" "$IS_ENABLED_TRACE" 2>/dev/null || true
 }
 
 trap 'cleanup_stub_state' EXIT
@@ -244,6 +246,13 @@ fr_terminate_max_attempts() {
 # shellcheck disable=SC2317
 fr_terminate_no_progress() {
   echo "fr_terminate_no_progress $*" >> "$TERMINATE_NO_PROGRESS_TRACE"
+  return 0
+}
+
+# #411: fr_terminate_immediate_failure_streak stub
+# shellcheck disable=SC2317
+fr_terminate_immediate_failure_streak() {
+  echo "fr_terminate_immediate_failure_streak $*" >> "$TERMINATE_IMMEDIATE_TRACE"
   return 0
 }
 
@@ -589,6 +598,59 @@ set -e
 assert_rc "rc=99 → dispatch は rc=0" "0" "$rc"
 assert_eq "rc=99 で terminate 関数が一切呼ばれない" "0" "$(count_pattern "." "$TERMINATE_MAX_TRACE")"
 assert_eq "rc=99 で terminate_no_progress も呼ばれない" "0" "$(count_pattern "." "$TERMINATE_NO_PROGRESS_TRACE")"
+cleanup_stub_state
+
+# ============================================================
+# Section 11: #411 rc=4 → fr_terminate_immediate_failure_streak が呼ばれる
+# （Req 4.1〜4.5 / 既存 max-attempts / no-progress と独立した終端経路）
+# ============================================================
+echo ""
+echo "--- Section 11: #411 rc=4 → fr_terminate_immediate_failure_streak ---"
+
+# 11-A: rc=4 (immediate-failure-streak) → 専用の terminate 関数が呼ばれる
+reset_stub_state
+RUN_ATTEMPT_RC_QUEUE=(4)
+LOAD_STATE_RESPONSE='{"issue":800,"total_attempts":1,"last_failure_signature":"sigsig","immediate_failure_streak":3}'
+set +e
+_fr_dispatch_candidate "issue" "800"
+rc=$?
+set -e
+assert_rc "#411 Req 1.5: rc=4 → dispatch は rc=0（fail-continue）" "0" "$rc"
+assert_grep "#411 Req 4.1: rc=4 → fr_terminate_immediate_failure_streak が呼ばれる" \
+  "^fr_terminate_immediate_failure_streak issue 800 3$" "$TERMINATE_IMMEDIATE_TRACE"
+assert_eq "#411 rc=4 で fr_terminate_max_attempts が呼ばれない" "0" "$(count_pattern "." "$TERMINATE_MAX_TRACE")"
+assert_eq "#411 rc=4 で fr_terminate_no_progress が呼ばれない" "0" "$(count_pattern "." "$TERMINATE_NO_PROGRESS_TRACE")"
+assert_grep "#411 rc=4 経路で fr_load_state が呼ばれる" "^fr_load_state 800$" "$LOAD_STATE_TRACE"
+cleanup_stub_state
+
+# 11-B: rc=4 で PR 経路も対応
+reset_stub_state
+RUN_ATTEMPT_RC_QUEUE=(4)
+LOAD_STATE_RESPONSE='{"issue":900,"total_attempts":2,"last_failure_signature":"sigsig","immediate_failure_streak":5}'
+set +e
+_fr_dispatch_candidate "pr" "900"
+rc=$?
+set -e
+assert_rc "#411 Req 4.1: PR 経路でも rc=4 で dispatch は rc=0" "0" "$rc"
+assert_grep "#411 Req 4.1: PR 経路で fr_terminate_immediate_failure_streak が呼ばれる" \
+  "^fr_terminate_immediate_failure_streak pr 900 5$" "$TERMINATE_IMMEDIATE_TRACE"
+cleanup_stub_state
+
+# 11-C: rc=2/3 では fr_terminate_immediate_failure_streak は呼ばれない（既存経路を壊さない）
+reset_stub_state
+RUN_ATTEMPT_RC_QUEUE=(2)
+set +e
+_fr_dispatch_candidate "issue" "910"
+set -e
+assert_eq "#411 NFR 1.1: rc=2 では fr_terminate_immediate_failure_streak が呼ばれない" "0" "$(count_pattern "." "$TERMINATE_IMMEDIATE_TRACE")"
+cleanup_stub_state
+
+reset_stub_state
+RUN_ATTEMPT_RC_QUEUE=(3)
+set +e
+_fr_dispatch_candidate "issue" "911"
+set -e
+assert_eq "#411 NFR 1.1: rc=3 では fr_terminate_immediate_failure_streak が呼ばれない" "0" "$(count_pattern "." "$TERMINATE_IMMEDIATE_TRACE")"
 cleanup_stub_state
 
 # ============================================================

--- a/local-watcher/test/fr_state_test.sh
+++ b/local-watcher/test/fr_state_test.sh
@@ -386,6 +386,53 @@ assert_eq "Req 4.8: 正常値 100 はそのまま" "100" "$(normalize_max_attemp
 assert_eq "Req 4.8: 正常値 1 はそのまま" "1" "$(normalize_max_attempts '1')"
 
 # ============================================================
+# Section: #411 immediate_failure_streak フィールドの後方互換 + 読み書き
+# ============================================================
+echo ""
+echo "--- Section #411: immediate_failure_streak フィールド ---"
+
+FAILED_RECOVERY_STATE_DIR=$(new_state_dir)
+
+# 1) 6 番目引数（streak）を明示指定で保存できる
+assert_rc "#411 Req 1.4: streak を明示指定で save 成功" 0 \
+  fr_save_state 411 1 "in-progress" "sigsig" "" "2"
+loaded=$(fr_load_state 411)
+streak=$(printf '%s' "$loaded" | jq -r '.immediate_failure_streak // "absent"')
+assert_eq "#411 Req 1.4: schema.immediate_failure_streak = 2" "2" "$streak"
+
+# 2) 6 番目引数を省略すると既存 state から streak を継承（NFR 1.1 後方互換）
+assert_rc "#411 NFR 1.1: 6 番目引数省略で save 成功" 0 \
+  fr_save_state 411 2 "in-progress" "sigsig" ""
+loaded=$(fr_load_state 411)
+streak=$(printf '%s' "$loaded" | jq -r '.immediate_failure_streak // "absent"')
+assert_eq "#411 NFR 1.1: streak が前回値 2 から継承される" "2" "$streak"
+
+# 3) 既存 state が streak field を持たない場合（#411 導入前の state）でも load して 0 fallback
+FAILED_RECOVERY_STATE_DIR=$(new_state_dir)
+legacy_path=$(fr_state_path 411)
+mkdir -p "$(dirname "$legacy_path")"
+# 既存 schema（streak フィールド無し）の JSON を直接書き込む
+printf '%s\n' '{"issue":411,"total_attempts":1,"last_status":"in-progress","last_failure_signature":"","last_head_sha":"","last_attempt_at":"2026-06-25T00:00:00Z","history":[]}' > "$legacy_path"
+
+loaded=$(fr_load_state 411)
+streak=$(printf '%s' "$loaded" | jq -r '.immediate_failure_streak // 0')
+assert_eq "#411 NFR 1.1: 既存 state (streak field 不在) を load → 0 fallback" "0" "$streak"
+
+# 4) 既存 state を 6 番目引数省略で save すると streak は 0 で永続化される
+assert_rc "#411 NFR 1.1: 既存 state を save 成功（6 番目引数省略）" 0 \
+  fr_save_state 411 2 "in-progress" "newsig" ""
+loaded=$(fr_load_state 411)
+streak=$(printf '%s' "$loaded" | jq -r '.immediate_failure_streak // "absent"')
+assert_eq "#411 NFR 1.1: 既存 state（streak 不在）→ save で 0 が永続化される" "0" "$streak"
+
+# 5) 不正値（非数値）を渡すと 0 に正規化される
+assert_rc "#411 NFR 3.1: 不正値 streak=abc で save 成功（0 正規化）" 0 \
+  fr_save_state 411 3 "in-progress" "sig3" "" "abc"
+loaded=$(fr_load_state 411)
+streak=$(printf '%s' "$loaded" | jq -r '.immediate_failure_streak')
+assert_eq "#411 NFR 3.1: 不正値 streak=abc → 0 に正規化" "0" "$streak"
+
+# ============================================================
 # Summary
 # ============================================================
 echo ""


### PR DESCRIPTION
## 概要

`FAILED_RECOVERY` Processor で claude セッションが約 2 秒で rc=1 で即時終了するケースが発生し、既定 4 attempts を
短時間で空消費して `claude-failed` を premature に確定させる問題と、stdout/stderr が `/dev/null` に捨てられて
事後診断ができない問題が観測された（altpocket-server #119）。

本 PR は以下 4 系統を追加し、上記問題を解消する:
1. **即時失敗の attempt 除外**: rc=98 sentinel + `immediate_failure_streak` カウンタ + attempt ロールバック
2. **専用ログ保存**: `$LOG_DIR/failed-recovery-<kind>-<number>-<TS>.log` を必ず生成（`LOG` 未設定でも `/dev/null` に逃さない）
3. **対象 repo 作業ツリーでの起動**: `REPO_DIR` 上で claude branch / PR head branch / BASE_BRANCH を checkout して claude を起動
4. **独立エスカレーション**: 連続即時失敗上限到達時に `immediate-failure-streak` 識別子で終端（`max-attempts` と区別可能）

quota 燃焼上界保証（無限リトライ防止）は維持し、既存の env var / ラベル / 終端識別子は無変更。

## 対応 Issue

Closes #411

## 関連 PR

なし

## 実装内容

- (Req 1.1〜1.8 / NFR 1.1〜1.4) `fr_invoke_claude` の 2 段 tee 構成・tool_use 観測・elapsed 計測・rc=98 sentinel + `fr_run_recovery_attempt` の attempt ロールバック・streak カウンタ・事前判定を実装
- (Req 2.1〜2.6 / NFR 2.1〜2.2) `fr_resolve_dedicated_log_path` 新規追加（`$LOG_DIR` fallback 含む）と専用ログへの保存経路を実装
- (Req 3.1〜3.6 / NFR 3.1) `fr_prepare_repo_worktree` 新規追加（PR head branch / issue claude branch / BASE_BRANCH の checkout）
- (Req 4.1〜4.6 / NFR 3.2) `fr_terminate_immediate_failure_streak` 新規追加・`_fr_dispatch_candidate` に rc=4 case 追加
- `issue-watcher.sh` Config ブロックに `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS`（既定 10）と `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK`（既定 3）の env 正規化を追加
- `fr_save_state` に 6 番目引数 `immediate_failure_streak` を追加（省略時は既存 state から継承・後方互換）
- `fr_immediate_fail_test.sh` を新規追加、既存テスト 5 ファイルに #411 拡張 section を追加
- README に終端動作テーブル / env 表 / state JSON フィールド説明 / Migration Note を更新

## 受入基準チェック

- [x] Req 1.1: attempt budget ロールバック ← `fr_immediate_fail_test.sh` Section C
- [x] Req 1.2: 即時失敗判定条件（rc 非ゼロ + tool_use 無 + 短時間） ← `fr_invoke_test.sh` Section 14 A〜G
- [x] Req 1.3: 閾値 env 上書き / 既定 安全側 ← `fr_invoke_test.sh` Section 14-F/G 境界値
- [x] Req 1.4: streak 永続化 ← `fr_state_test.sh` Section #411、`fr_immediate_fail_test.sh` Section C/D
- [x] Req 1.5: streak 上限到達で停止・委譲 ← `fr_immediate_fail_test.sh` Section D/E、`fr_process_test.sh` Section 11
- [x] Req 1.6: streak 上限 env 上書き ← `fr_immediate_fail_test.sh` Section D（max=3）
- [x] Req 1.7: 実質作業着手時 streak リセット ← `fr_immediate_fail_test.sh` Section F/G
- [x] Req 1.8: quota（rc=99）は判定対象外 ← `fr_invoke_test.sh` Section 13, 14-A
- [x] Req 2.1〜2.4: 専用ログ保存・命名・`/dev/null` 行き防止 ← `fr_immediate_fail_test.sh` Section A/I
- [x] Req 2.5: dedicated_log path を一次運用ログに記録 ← `fr_immediate_fail_test.sh` Section J
- [x] Req 2.6: 保存失敗時の fail-continue ← shellcheck + 静的解析（i/o エラー path は unit test 困難）
- [x] Req 3.1〜3.6: 対象 repo 作業ツリーでの起動 ← `fr_immediate_fail_test.sh` Section H/J
- [x] Req 4.1〜4.6: 独立エスカレーション（識別子・ログ・コメント・通知） ← `fr_immediate_fail_test.sh` Section B
- [x] NFR 1.1〜1.4: 後方互換（既存 env / ラベル / 識別子 / 二重 opt-in gate 維持） ← 既存テスト全件 PASS
- [x] NFR 2.1〜2.2: 可観測性（判定根拠 / dedicated log path / worktree ref をログ） ← `fr_invoke_test.sh` Section 10、`fr_immediate_fail_test.sh` Section J
- [x] NFR 3.1〜3.2: セキュリティ（kind/number 検証・`--` オプション打ち切り・機微値除外） ← `fr_immediate_fail_test.sh` Section A/B

## テスト結果

```
すべて FAIL=0:

| Test                       | PASS |
|----------------------------|------|
| fr_attempt_test.sh         |   60 |
| fr_fetch_test.sh           |   42 |
| fr_immediate_fail_test.sh  |   42 |  (new)
| fr_invoke_test.sh          |   56 |
| fr_is_enabled_test.sh      |   40 |
| fr_no_progress_test.sh     |   12 |
| fr_process_test.sh         |   71 |
| fr_state_test.sh           |   60 |
| fr_terminate_test.sh       |   77 |

その他 local-watcher/test/*_test.sh 全件（68 ファイル）も FAIL=0

静的解析:
- shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/modules/*.sh → 警告ゼロ
- shellcheck local-watcher/test/fr_*_test.sh → 警告ゼロ
- diff -r .claude/agents repo-template/.claude/agents → 空（drift なし）
- diff -r .claude/rules repo-template/.claude/rules → 空（drift なし）
```

## 実装上の判断

- `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` 既定 10 秒（altpocket-server #119 の ~2 秒 rc=1 を安全マージン付きで捕捉）
- `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` 既定 3 回（2 分 cron × 3 ≒ 6 分でエスカレーション）
- 両閾値とも env で上書き可能、非整数 / ≤0 は安全側の既定値に正規化
- quota sentinel（rc=99）と即時失敗 sentinel（rc=98）は別経路で処理し衝突なし
- `fr_save_state` の 6 番目引数は省略時に既存 state の streak フィールドを継承（legacy state は 0 fallback）
- worktree checkout は `( cd "$REPO_DIR"; fr_invoke_claude ... )` subshell に隔離し caller の cwd を変更しない
- 詳細は `docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/impl-notes.md` を参照

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後に検証済み）
- Reviewer の approve 判定: `docs/specs/411-fix-failed-recovery-claude-rc-1-2s-attem/review-notes.md` 参照（RESULT: approve）
- `FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS` の既定値 10 秒は運用ログ蓄積後に再評価の余地あり（impl-notes 確認事項参照）
- `FAILED_RECOVERY_IMMEDIATE_FAIL_MAX_STREAK` の既定値 3 は watcher の実行間隔が 30 秒など短い環境では上げる必要がある可能性あり
- stream-json `"type":"tool_use"` 検出パターンは claude CLI の出力形式に依存。形式変更時は更新が必要
- 専用ログのローテーション方針は Out of Scope（impl-notes 確認事項参照）
- Req 2.6 の i/o エラー fail-continue path は unit test 困難につき shellcheck + コードレビューで担保

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #411 のコメントを参照してください。
