### PR TITLE
fix(#416): quota-aware が平文セッション上限メッセージを検出できない Bug を修正

### DIFF
--- a/docs/specs/416--bug-quota-aware-you-ve-hit-your-session/impl-notes.md
+++ b/docs/specs/416--bug-quota-aware-you-ve-hit-your-session/impl-notes.md
@@ -1,0 +1,117 @@
+# Implementation Notes — Issue #416
+
+## 概要
+
+quota-aware モジュールが claude CLI の平文 `You've hit your session limit · resets
+<time>` を検出できず `claude-failed` に誤分類していた Bug を修正した。`qa_detect_rate_limit`
+に第 4 検出経路 `session_limit_plain_v1` を追加し、既存 JSON 経路（rate_limit_event_v2 /
+v1 / synthetic_429_result）と同じ deferral 経路（exit 99 + reset 永続化）に合流させる。
+
+## 設計判断（Open Questions の確定）
+
+requirements.md の 3 つの Open Questions について、以下の方針で確定した。
+
+### 1. マッチ粒度: `You've hit your session limit` substring のみで判定
+
+- **採用**: 「`resets` 部分まで含めて判定」よりも substring 一致を採用
+- **理由**: Claude Code のバージョン差で `resets` の有無や記号（中黒 `·` / TZ 括弧表記）が
+  変わるリスクの方が、誤検出リスクより高い。本文言は claude CLI が session 上限到達時に
+  特定的に出力するエラーメッセージであり、一般のユーザー出力と衝突する確率は低い
+- **副次効果**: reset 部分が抽出できなくても detection_path だけは観測でき、reset 欠落
+  fallback（既存 JSON 経路と同等の安全側）に倒せる（Req 2.5 担保）
+- **実装**: `grep -F` で fixed-string 検索（regex escape 不要、quote 済み入力）
+
+### 2. 直近の該当時刻決定ロジック: 過去なら翌日 +86400 秒
+
+- **採用**: 解決された epoch が現在 epoch より過去なら +86400 して翌日同時刻を採用、
+  未来ならそのまま採用
+- **理由**: GNU `date -d "7:40pm"` は常に「今日の 19:40」を返す。実運用では quota メッセージは
+  reset の **未来時刻**を示しているはずだが、日付境界をまたいだ場合や処理タイミングの揺らぎで
+  「今日の 19:40 が現在より過去」になるケースがあるため、その場合は翌日を採用する
+- **24 時間以内の最近未来時刻**を一意に決定でき、`qa_persist_reset_time` に渡せる numeric
+  epoch が必ず未来になる
+- **trade-off**: 仮に CLI が「数日前の reset 時刻」を出した場合、本ロジックは「今日 or 翌日」に
+  解釈してしまう。ただしそのケースは現実には起き得ない（claude CLI が「過ぎた reset」を出す
+  意味がない）ため許容する
+
+### 3. detection_path 識別子: `session_limit_plain_v1`
+
+- **採用**: 既存 JSON 経路の `rate_limit_event_v2` / `rate_limit_event_v1` /
+  `synthetic_429_result` と同じ snake_case + 検出元の意味 + `_v1` サフィックスの命名規約に
+  従い `session_limit_plain_v1` とした
+- **理由**: 将来 claude CLI が文言を変えた場合に `session_limit_plain_v2` を追加する余地を
+  残せる（既存 `_v2` 命名が JSON スキーマバージョン拡張の前例）
+
+## 変更ファイル
+
+| ファイル | 種別 | 主な変更 |
+|---|---|---|
+| `local-watcher/bin/modules/quota-aware.sh` | 修正 | `qa_parse_session_limit_reset` 純粋関数新設 / `qa_detect_rate_limit` を 2 pass 構造（JSON + 平文）に拡張 |
+| `local-watcher/test/qa_detect_rate_limit_test.sh` | 修正 | `qa_parse_session_limit_reset` を extract source リストに追加 / 平文経路と純粋関数のテスト 13 件追加 |
+| `local-watcher/test/qa_run_claude_stage_test.sh` | 修正 | `qa_parse_session_limit_reset` を extract source リストに追加 / 平文経路の統合テスト 11 件追加 |
+| `local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-*.txt` | 新規 | 平文 / 複数行混在 / TZ 揺れ / reset 欠落 / JSON+平文混在の 7 fixture |
+
+## AC Traceability
+
+| AC ID | カバー方法 |
+|---|---|
+| 1.1 | `qa_detect_rate_limit` の Pass 2 が `grep -F` で平文 substring 検出。`qa_detect_rate_limit_test.sh: session-limit-plain-tokyo-pm path` |
+| 1.2 | `qa_run_claude_stage` の検出 TSV 解釈ロジックは既存のまま動作（epoch を持つ最新検出を採用）。`qa_run_claude_stage_test.sh: session-limit-plain-tokyo-pm rc=99` |
+| 1.3 | `qa_run_claude_stage` が exit 99 を返すことで呼び出し側が `qa_handle_quota_exceeded` 経路（needs-quota-wait 付与 / claude-failed 不付与）へ分岐する既存契約に合流（design.md の Stage Wrapping Pattern 通り）。テスト: `qa_run_claude_stage_test.sh: session-limit-plain-tokyo-pm rc=99` |
+| 1.4 | epoch 持ち検出が 1 件以上あれば 1 つを採用する既存 TSV 解釈で二重 escalation を抑止。`qa_run_claude_stage_test.sh: mixed JSON+plain rc=99` / `qa_detect_rate_limit_test.sh: mixed JSON+plain both paths emitted` |
+| 1.5 | grep `-F` で session limit 平文が含まれない入力では Pass 2 が無出力。`qa_detect_rate_limit_test.sh: normal-success does not trigger session_limit_plain_v1` |
+| 2.1 | `qa_parse_session_limit_reset` が GNU date で「直近の該当時刻」を解決し、過去なら +86400。`qa_detect_rate_limit_test.sh: resolved epoch is >= now` / `qa_run_claude_stage_test.sh: session-limit-plain-tokyo-pm epoch >= now` |
+| 2.2 | `qa_run_claude_stage` 既存ロジックが reset_file に epoch を atomic 書込（変更なし）。`qa_run_claude_stage_test.sh: session-limit-plain-tokyo-pm reset_file numeric` |
+| 2.3 | `qa_parse_session_limit_reset` が `(<tz>)` 部を `BASH_REMATCH[4]` で抽出し `TZ=<tz>` 付き `date -d` で解決。`qa_detect_rate_limit_test.sh: parse Asia/Tokyo == UTC equiv` |
+| 2.4 | `7:40pm` と `19:40` は GNU date が同一として扱う。`qa_detect_rate_limit_test.sh: parse 12h/24h same epoch` / `session-limit-plain 12h/24h equal epoch` |
+| 2.5 | reset 抽出 / epoch 解決失敗時は `qa_parse_session_limit_reset` が return 1、`qa_detect_rate_limit` は detection_path のみ epoch 空で出力。`qa_run_claude_stage` 既存ロジックが reset 欠落 fallback（claude_rc 透過 + warn）に倒す。`qa_run_claude_stage_test.sh: session-limit-plain-no-reset rc passthrough` |
+| 2.6 | `qa_detect_rate_limit` Pass 2 は `grep -F` で行をまたいで判定。`qa_detect_rate_limit_test.sh: session-limit-plain-multiline path` / `qa_run_claude_stage_test.sh: session-limit-plain-multiline rc=99` |
+| 3.1 | 既存 jq fold（Pass 1）は変更していない。既存 10 件のテスト（qa_detect_rate_limit_test.sh）すべて pass、既存 23 件のテスト（qa_run_claude_stage_test.sh）すべて pass |
+| 3.2 | `qa_run_claude_stage` 冒頭の `QUOTA_AWARE_ENABLED != "true"` 早期 return は変更なし。`qa_run_claude_stage_test.sh: opt-out session-limit-plain rc=1` / `opt-out session-limit-plain reset_file untouched` |
+| 3.3 | `qa_run_claude_stage` の戻り値（0 / 99 / N≠0,99）契約は変更なし。既存 23 件のテストで担保 |
+| 3.4 | 既存 env var（`QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC` / `QUOTA_RESET_STATE_FILE` / `LOG_DIR`）の Config 節は変更していない。新規 env var を追加していない |
+| 3.5 | `qa_handle_quota_exceeded` のラベル付け替えロジック（`claude-claimed` → `needs-quota-wait`）は変更なし。`qa_run_claude_stage` が exit 99 で抜けた後の挙動は detection_path に依存しないため、既存ラベル契約は不変 |
+| 4.1 | `qa_run_claude_stage` の `qa_log "stage detected exceeded label=$stage_label path=${_path} reset_epoch=$_epoch"` 既存ログが `path=session_limit_plain_v1` を含めて出力される |
+| 4.2 | `qa_run_claude_stage` の `qa_warn "stage detected without reset label=$stage_label path=${_path}"` 既存ログが平文経路でも同形式で出力される |
+| 4.3 | `qa_handle_quota_exceeded` の escalation コメントテンプレート（`qa_build_escalation_comment`）は変更していない。検出経路の差異は呼び出し側ロジックに吸収される |
+| NFR 1.1 | 平文 pass は `grep -F` 1 段 + bash function 呼び出しのみで sleep / 追加同期は無し。既存 stream-json throughput（数 KB/s）に対するオーバーヘッドは無視可能 |
+| NFR 1.2 | sleep / wait などのブロッキング待機を新規導入していない |
+| NFR 2.1 | `qa_run_claude_stage` 冒頭の opt-out 早期 return パスは未変更。テスト `opt-out session-limit-plain rc=1` で確認 |
+| NFR 2.2 | `repo-template/` 側にモジュールは配布されないため re-install は不要。`install.sh` 再実行で `~/bin/modules/quota-aware.sh` が更新される（既存配布ロジック流用） |
+| NFR 3.1 | `qa_detect_rate_limit_test.sh` に平文単独ケースを追加 |
+| NFR 3.2 | `qa_detect_rate_limit_test.sh: mixed JSON+plain both paths emitted` / `qa_run_claude_stage_test.sh: mixed JSON+plain rc=99` |
+| NFR 3.3 | `qa_detect_rate_limit_test.sh: session-limit-plain-multiline path` / `qa_run_claude_stage_test.sh: session-limit-plain-multiline rc=99` |
+| NFR 3.4 | TZ 揺れ: `qa_detect_rate_limit_test.sh: parse Asia/Tokyo == UTC equiv` / 12h・24h: `parse 12h/24h same epoch` |
+| NFR 3.5 | 既存テスト `qa_detect_rate_limit_test.sh` 10 件・`qa_run_claude_stage_test.sh` 23 件すべて pass を確認 |
+
+## 静的解析・テスト結果
+
+- `shellcheck local-watcher/bin/modules/quota-aware.sh local-watcher/test/qa_detect_rate_limit_test.sh local-watcher/test/qa_run_claude_stage_test.sh`: clean
+- `bash -n` syntax check: clean
+- `bash local-watcher/test/qa_detect_rate_limit_test.sh`: PASS 23 / FAIL 0（既存 10 + 新規 13）
+- `bash local-watcher/test/qa_run_claude_stage_test.sh`: PASS 34 / FAIL 0（既存 23 + 新規 11）
+
+## 二重管理同期確認
+
+- `diff -r .claude/agents repo-template/.claude/agents`: 空（変更なし）
+- `diff -r .claude/rules repo-template/.claude/rules`: 空（変更なし）
+- `local-watcher/bin/modules/quota-aware.sh` は `install.sh` 経由でユーザーホームに配布される
+  ファイルであり、`repo-template/` 側にミラー対象は無い（既存配布構造に従う）
+
+## 確認事項（人間判断を仰ぎたい点）
+
+- **GNU date 依存**: `qa_parse_session_limit_reset` は GNU `date -d` の `7:40pm` 形式と
+  `TZ=...` env による解決に依存している。watcher 全体は CLAUDE.md「技術スタック」で
+  Linux / macOS / WSL 動作と謳っているが、macOS BSD date は本パスを満たさない。失敗時は
+  return 1 で reset 欠落 fallback に倒れるため macOS 実行環境でも regression にはならないが、
+  macOS 環境で quota 自動 resume が機能しないことになる。必要なら BSD date の `-jf` 形式
+  fallback を別 Issue で追加検討（既存の `qa_format_iso8601` には GNU / BSD 両対応があるため
+  同等の対応は可能）
+- **平文 substring の文言依存**: `You've hit your session limit` を fixed string match
+  しているため、claude CLI が文言を `You have reached your session limit` 等に変えた場合
+  検出できなくなる。バージョンアップ時の観測責務として、運用側で `$LOG_DIR/issue-*.log` に
+  `session_limit_plain_v1` 検出ログが残るかをモニタリングすることを推奨
+- **「直近の該当時刻」採用ロジック**: 解決 epoch が過去なら +86400（翌日）採用としたが、
+  仮に CLI が「数時間後の reset」ではなく「数日後の reset」を出すケースが将来現れた場合
+  本ロジックでは正しく解釈できない。現状の claude CLI 観測サンプルは「今日 or 翌日の中の
+  時刻」を返すため許容したが、要件側で前提が変わった場合は別 Issue で再設計が必要

--- a/docs/specs/416--bug-quota-aware-you-ve-hit-your-session/requirements.md
+++ b/docs/specs/416--bug-quota-aware-you-ve-hit-your-session/requirements.md
@@ -1,0 +1,104 @@
+# Requirements Document
+
+## Introduction
+
+quota-aware モジュール（#66 / #104 / #169）は Claude Max の 5 時間ローリング quota 枯渇を
+検出し、当該 Issue を `needs-quota-wait` 状態にして reset 時刻経過後に自動 resume するための
+機構である。しかし現状の検出経路は claude CLI が出力する stream-json の 3 スキーマ
+（`rate_limit_event_v2` / `rate_limit_event_v1` / `synthetic_429_result`）のみであり、
+**セッション上限到達時に claude CLI が stream-json を一切出さず平文 1 行で early-exit する**
+ケース（観測例: `You've hit your session limit · resets 7:40pm (Asia/Tokyo)`）を取りこぼす。
+この結果、本来 quota 起因として deferral すべき一過性失敗が `claude-failed`（手動復旧 +
+Failed Recovery 起動）に誤分類される。本要件は quota-aware が平文セッション上限メッセージを
+quota 枯渇として検出し、既存 JSON 経路と同じ deferral 経路（`needs-quota-wait` 付与 + reset
+時刻永続化 + 自動 resume）に合流させることを目的とする。既存の JSON 検出経路・opt-out 挙動・
+ラベル契約・cron 登録は本修正で変更しない。
+
+## Requirements
+
+### Requirement 1: 平文セッション上限メッセージの quota 検出
+
+**Objective:** As a 運用者, I want claude CLI が出力する平文「You've hit your session limit · resets <time>」メッセージを quota 枯渇として検出したい, so that セッション上限到達時に Issue が `claude-failed` ではなく `needs-quota-wait` に遷移し、自動 resume の対象になる
+
+#### Acceptance Criteria
+
+1. While `QUOTA_AWARE_ENABLED=true` が有効である間, the Quota-Aware Watcher shall claude CLI が Stage 実行中に出力した平文セッション上限メッセージ（`You've hit your session limit` を含む行）を quota 枯渇として検出する
+2. When 平文セッション上限メッセージが Stage 実行中に検出されたとき, the Quota-Aware Watcher shall 既存 JSON 経路（`rate_limit_event_v2` / `rate_limit_event_v1` / `synthetic_429_result`）と同じ deferral 経路に合流させ、Stage Wrapper の exit 99 sentinel 経路で呼び出し側へ通知する
+3. When 平文セッション上限メッセージが Stage 実行中に検出されたとき, the Quota-Aware Watcher shall 当該 Issue を `claude-failed` ではなく `needs-quota-wait` に遷移させる
+4. When 同一 Stage 実行中に平文セッション上限メッセージと JSON 形式の quota 検出（`rate_limit_event_*` / `synthetic_429_result`）が同時に観測されたとき, the Quota-Aware Watcher shall いずれか 1 つを採用して 1 回の quota 検出として扱い、二重 escalation を発生させない
+5. While 平文セッション上限メッセージが Stage 実行中に観測されない間, the Quota-Aware Watcher shall 当該 Stage を本要件の検出経路では quota 枯渇として分類しない
+
+### Requirement 2: reset 時刻のパースと永続化
+
+**Objective:** As a 運用者, I want 平文メッセージから抽出された reset 時刻を可能な限り epoch に解決して永続化したい, so that 既存 Quota Resume Processor が reset+grace 経過後に自動 resume できる
+
+#### Acceptance Criteria
+
+1. When 平文セッション上限メッセージから `resets <time>` 部分の時刻表記が抽出できたとき, the Quota-Aware Watcher shall 当該時刻を「現在時刻から見た直近の該当時刻」の UNIX epoch 秒に解決する
+2. When reset 時刻の解決に成功したとき, the Quota-Aware Watcher shall 解決された epoch を当該 Issue 番号 keyed の永続化先（`QUOTA_RESET_STATE_FILE`）にアトミックに書き込み、Issue 単位の最新値 1 件のみが保持される状態を維持する
+3. Where 平文の時刻表記にタイムゾーン指定（例: `(Asia/Tokyo)`）が含まれる, the Quota-Aware Watcher shall 当該タイムゾーンを尊重して epoch に解決する
+4. Where 平文の時刻表記が 12 時間表記（`am` / `pm` サフィックス）または 24 時間表記である, the Quota-Aware Watcher shall いずれの表記揺れに対しても同一の epoch 解決結果を得る
+5. If 平文セッション上限メッセージは検出されたが reset 時刻の抽出または epoch 解決に失敗したとき, the Quota-Aware Watcher shall 当該 Issue を `claude-failed` に落とさず、既存の「reset 欠落 fallback」と同等の安全側挙動（quota として認識し、warn ログを出力した上で claude 本体の rc を透過）に倒す
+6. If 平文セッション上限メッセージが複数行に分割されて出力されたとき, the Quota-Aware Watcher shall 行をまたいで判定し、少なくとも `You've hit your session limit` を含む単一行を検出した時点で本要件を満たす
+
+### Requirement 3: 既存 JSON 検出経路との後方互換
+
+**Objective:** As a 既存運用者, I want 平文検出の追加によって既存 JSON 経路の挙動が変わらないこと, so that 本 Bug 修正の deploy が既存 quota-aware の動作を退行させない
+
+#### Acceptance Criteria
+
+1. While 本要件群の修正後の quota-aware が稼働している間, the Quota-Aware Watcher shall 既存 JSON 検出経路（`rate_limit_event_v2` / `rate_limit_event_v1` / `synthetic_429_result`）の検出ロジック・優先順位・出力契約を変更しない
+2. While `QUOTA_AWARE_ENABLED` が未設定または `false` である間, the Quota-Aware Watcher shall 平文セッション上限メッセージの検出・解析・ラベル付与・永続化のいずれも実行しない
+3. The Quota-Aware Watcher shall 既存の Stage Wrapper exit code 契約（`0` = 正常、`99` = quota 検出、それ以外 = claude 本体の非ゼロ exit）を本要件追加によって変更しない
+4. The Quota-Aware Watcher shall 既存環境変数（`QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC` / `QUOTA_RESET_STATE_FILE` / `LOG_DIR` 等）の名前・受理形式・既定値を本要件追加によって変更しない
+5. The Quota-Aware Watcher shall 既存ラベル（`needs-quota-wait` / `claude-failed` / `claude-claimed` / `claude-picked-up`）の名前・付与契約・遷移条件を本要件追加によって変更しない
+
+### Requirement 4: 検出結果の観測性
+
+**Objective:** As a 運用者, I want 平文検出経路で quota が検出されたことをログから事後検索したい, so that 既存 JSON 経路と平文経路のどちらで検出されたかを切り分けて運用判断できる
+
+#### Acceptance Criteria
+
+1. When 平文セッション上限メッセージが quota 枯渇として検出されたとき, the Quota-Aware Watcher shall 検出経路を識別できる文字列（既存 `detection_path` 表記体系と整合する識別子）と検出 Stage ラベルと reset epoch（解決できた場合）を `$LOG_DIR` 配下のログに 1 行で記録する
+2. If 平文セッション上限メッセージは検出されたが reset 時刻の epoch 解決に失敗したとき, the Quota-Aware Watcher shall reset 欠落である旨と Stage ラベルを warn レベルでログに記録する
+3. The Quota-Aware Watcher shall 平文検出経路で投稿される escalation コメントの構造（h2 タイトル / 検知情報 / 自動復帰の条件 / 手動介入したい場合）を既存 JSON 経路と同一テンプレートに揃え、検出経路の差異が運用者に追加学習コストを強いない形にする
+
+## Non-Functional Requirements
+
+### NFR 1: 性能・処理コスト
+
+1. The Quota-Aware Watcher shall 平文検出経路の追加によって、既存 JSON 経路のみで処理した場合と比較して単一 Stage 実行の wall-clock レイテンシが体感できる水準（数秒以上）で増加しない状態を維持する
+2. The Quota-Aware Watcher shall 平文検出経路の追加にあたって、Stage 実行の正常終了を遅延させるためのブロッキング待機（sleep / 追加同期処理）を新規に導入しない
+
+### NFR 2: 後方互換性
+
+1. The Quota-Aware Watcher shall `QUOTA_AWARE_ENABLED=false`（明示 opt-out）または未設定環境において、本要件追加前と 100% 同一の挙動（素通し実行・検出なし・永続化なし）を維持する
+2. The Quota-Aware Watcher shall 既 install 済み consumer リポジトリの再 install を必須としない形で本修正を提供する（`install.sh` 再実行のみで反映され、追加の手作業を要求しない）
+
+### NFR 3: 回帰防止テスト
+
+1. The Quota-Aware Watcher shall 平文セッション上限メッセージ単独入力ケースの単体テストを `local-watcher/test/qa_detect_rate_limit_test.sh` または同等のテストファイルに追加する
+2. The Quota-Aware Watcher shall stream-json と平文が同一 Stage 実行内で混在するケースの単体テストを追加する
+3. The Quota-Aware Watcher shall 平文メッセージが複数行に分割されて出力されるケースの単体テストを追加する
+4. The Quota-Aware Watcher shall reset 時刻のタイムゾーン表記揺れ（少なくとも `(Asia/Tokyo)` を含むケース）と 12 時間表記（`am` / `pm`）のケースを単体テストでカバーする
+5. The Quota-Aware Watcher shall 既存 JSON 検出経路の単体テスト（既存 `qa_detect_rate_limit_test.sh` / `qa_run_claude_stage_test.sh`）を本修正後も合格させる
+
+## Out of Scope
+
+- 外部 Feature Flag SaaS との連携
+- Failed Recovery Processor の terminal コメント spam（別 Issue で扱う。本 Issue は「quota を `claude-failed` に落とさない」検出修正に限定）
+- claude CLI 側の出力フォーマット指定変更（stream-json 強制化）による上流根治。本要件は watcher 側の検出網拡張のみを扱う（Issue 本文「仮案 B」は対象外）
+- セッション上限以外の平文エラーメッセージ全般の quota 分類（例: API 接続失敗 / モデル切替時の通知等）。本要件は「セッション上限」文言に限定する
+- 既存 `rate_limit_event_v2` / `rate_limit_event_v1` / `synthetic_429_result` JSON 検出ロジック自体の修正・拡張
+- `needs-quota-wait` の新規ラベル定義変更や `idd-claude-labels.sh` の変更（#66 で導入済みのラベルをそのまま流用する）
+
+## Open Questions
+
+- 平文メッセージ文言の厳密マッチ範囲: Claude Code のバージョンによって `You've hit your session limit · resets <time>` の正確な文言・記号（中黒 `·` / TZ 括弧表記 等）が変わり得る。**緩いと誤検出、厳しいとバージョン差で取りこぼし**となるトレードオフがあるため、最終的なマッチパターンの粒度（substring `You've hit your session limit` のみで判定するか、`resets` 部分まで含めて判定するか）は design.md で確定する
+- reset 時刻に日付が含まれない場合（例: `7:40pm (Asia/Tokyo)` のみ）の「直近の該当時刻」決定ロジック: 現在時刻が `7:40pm` を過ぎていれば翌日同時刻を採用するか、24 時間以内の最近未来時刻を採用するか。design.md で確定する
+- 平文検出経路の `detection_path` 識別子の命名（例: `session_limit_plain_v1` 等）。既存 JSON 経路の命名体系と整合させる形で design.md で確定する
+
+## 関連
+
+- Depends on: #66
+- Related: #104 #169 #118

--- a/docs/specs/416--bug-quota-aware-you-ve-hit-your-session/review-notes.md
+++ b/docs/specs/416--bug-quota-aware-you-ve-hit-your-session/review-notes.md
@@ -1,0 +1,50 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-7 timestamp=2026-06-27T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-416-impl--bug-quota-aware-you-ve-hit-your-session
+- HEAD commit: 36a12b9047c020bfa92dd63e92f11b7631394a6c
+- Compared to: main..HEAD
+
+## Verified Requirements
+
+- 1.1 — `qa_detect_rate_limit` Pass 2（`grep -F -- "You've hit your session limit"`）で平文行を substring 検出。test: `qa_detect_rate_limit_test.sh: session-limit-plain-tokyo-pm path`
+- 1.2 — 検出時 `qa_run_claude_stage` が exit 99 を返却。test: `qa_run_claude_stage_test.sh: session-limit-plain-tokyo-pm rc=99`
+- 1.3 — exit 99 経路が既存の `qa_handle_quota_exceeded`（`needs-quota-wait` 付与）に合流（既存契約温存）。test: 同上 rc=99 通過で担保
+- 1.4 — Pass 1 (JSON) と Pass 2 (平文) が両方出力されても epoch を持つ最新検出が採用され二重 escalation なし。test: `qa_detect_rate_limit_test.sh: mixed JSON+plain both paths emitted` / `qa_run_claude_stage_test.sh: mixed JSON+plain rc=99 + reset_file numeric`
+- 1.5 — 平文文言が含まれない場合 Pass 2 は無出力。test: `qa_detect_rate_limit_test.sh: normal-success does not trigger session_limit_plain_v1`
+- 2.1 — `qa_parse_session_limit_reset` が GNU `date -d` で epoch 解決し、過去なら +86400 で「直近未来時刻」を保証。test: `resolved epoch is >= now` / `session-limit-plain-tokyo-pm epoch >= now`
+- 2.2 — 既存 `qa_run_claude_stage` の reset_file atomic 書込ロジックを変更せず透過。test: `session-limit-plain-tokyo-pm reset_file numeric`
+- 2.3 — 正規表現で `(<tz>)` を `BASH_REMATCH[4]` 抽出し `TZ=<tz>` 付き `date -d` で解決。test: `parse Asia/Tokyo == UTC equiv` / `session-limit-plain Asia/Tokyo == UTC equiv epoch`
+- 2.4 — `7:40pm` と `19:40` が同一 epoch を返す。test: `parse 12h/24h same epoch` / `session-limit-plain 12h/24h equal epoch`
+- 2.5 — reset 抽出 / epoch 解決失敗時は `qa_parse_session_limit_reset` return 1 → epoch 空で path のみ出力 → 呼び出し側で claude_rc 透過。test: `session-limit-plain-no-reset` / `session-limit-plain-no-reset rc passthrough` / `parse without 'resets' returns rc != 0`
+- 2.6 — Pass 2 は `grep` で行を走査するため複数行入力でも単一行検出で成立。test: `session-limit-plain-multiline path` / `session-limit-plain-multiline rc=99`
+- 3.1 — Pass 1 の jq フィルタ本文（v2 / v1 / synthetic_429 検出）は byte 等価で温存。既存 10 件のテスト（`v2-rate-limit-event-rejected` 等）が全件 PASS
+- 3.2 — `qa_run_claude_stage` 冒頭 `QUOTA_AWARE_ENABLED != "true"` 早期 return は未変更。test: `opt-out session-limit-plain rc=1` / `opt-out session-limit-plain reset_file untouched`
+- 3.3 — exit code 契約（0 / 99 / その他透過）を変更せず。既存 23 件のテストが全件 PASS で担保
+- 3.4 — 新規 env var なし。`QUOTA_AWARE_ENABLED` / `QUOTA_RESUME_GRACE_SEC` / `QUOTA_RESET_STATE_FILE` / `LOG_DIR` の名前・既定値とも未変更
+- 3.5 — 既存ラベル契約（`needs-quota-wait` / `claude-failed` / `claude-claimed` / `claude-picked-up`）は呼び出し側 `qa_handle_quota_exceeded` で温存
+- 4.1 — `qa_run_claude_stage` 内の `qa_log "stage detected exceeded label=$stage_label path=${_path} reset_epoch=$_epoch"` が `path=session_limit_plain_v1` を含めて出力（既存ログフォーマット流用）
+- 4.2 — reset 欠落時 `qa_warn "stage detected without reset label=$stage_label path=${_path}"` が同形式で warn 出力（既存パス流用）
+- 4.3 — `qa_build_escalation_comment` テンプレートは未変更。検出経路差は呼び出し側に吸収
+- NFR 1.1 — Pass 2 は `grep -F` 1 段 + bash function のみ。sleep / ブロッキング新規導入なし
+- NFR 1.2 — sleep / wait の新規導入なし（diff で確認）
+- NFR 2.1 — opt-out 早期 return パス未変更。test `opt-out session-limit-plain` 2 件で確認
+- NFR 2.2 — `quota-aware.sh` 単体修正で完結、`repo-template/` ミラー対象外（既存配布構造）
+- NFR 3.1 — `qa_detect_rate_limit_test.sh` に平文単独ケース追加（`session-limit-plain-tokyo-pm` 等）
+- NFR 3.2 — JSON + 平文混在ケース追加（`mixed JSON+plain` 2 件）
+- NFR 3.3 — 複数行分割ケース追加（`session-limit-plain-multiline` 2 件）
+- NFR 3.4 — TZ 揺れ（Asia/Tokyo / UTC）と 12h/24h を test 4 件でカバー
+- NFR 3.5 — 既存 10 + 23 件のテストは reviewer 環境でも全件 PASS（23 + 34 各テストファイル合計）
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #416 で要求された全 numeric ID（Req 1.1〜1.5 / 2.1〜2.6 / 3.1〜3.5 / 4.1〜4.3 / NFR 1.1〜1.2 / 2.1〜2.2 / 3.1〜3.5）が実装と新規テストで観測可能にカバーされている。既存 JSON 検出経路は Pass 構造分離により byte 等価で温存され、両テストファイル合計 57 件（23 + 34）が PASS。変更範囲は quota-aware モジュールとその近接テストおよび fixture / spec docs に限定され、boundary 逸脱なし。
+
+RESULT: approve

--- a/local-watcher/bin/modules/quota-aware.sh
+++ b/local-watcher/bin/modules/quota-aware.sh
@@ -49,9 +49,82 @@
 #   設計参照: docs/specs/66-feat-watcher-claude-max-quota-rate-limit/design.md
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-# stdin の stream-json（1 行 1 JSON）を fold し、quota 枯渇イベントを検出して
+# 平文セッション上限メッセージから `resets <time>` を抽出し、TZ を尊重した「直近の
+# 該当時刻」UNIX epoch を stdout に返す純粋関数（Req 2.1, 2.3, 2.4 / Issue #416）。
+#
+# 入力:
+#   $1 = 1 行の平文メッセージ（例: "You've hit your session limit · resets 7:40pm (Asia/Tokyo)"）
+#
+# 出力:
+#   stdout: UNIX epoch (integer) on success / 空文字列 on failure
+#   return: 0 = epoch 取得成功 / 1 = 失敗（reset 欠落 fallback / Req 2.5）
+#
+# 解決ロジック:
+#   1. 入力から `resets <HH:MM[am|pm]?>` 部の時刻表記と任意の `(<TZ>)` を抽出する
+#   2. TZ が含まれる場合は `TZ=<tz>` 付き GNU `date -d` で「当日同時刻」の epoch を解決
+#   3. TZ が含まれない場合は呼び出し時の TZ で「当日同時刻」の epoch を解決
+#   4. 解決された epoch が「現在時刻より過去」なら +86400 して翌日同時刻を採用
+#      （Open Question 確定: 解決時刻が過去なら翌日扱い、未来ならそのまま）
+#   5. 失敗 / 抽出不能時は return 1（呼び出し側で reset 欠落 fallback / Req 2.5）
+#
+# 後方互換: GNU date 専用（macOS BSD date は本パス未対応 / 失敗で fallback）。
+# 既存 watcher は GNU coreutils 前提のため本制約は新規 regression を引き起こさない。
+qa_parse_session_limit_reset() {
+  local line="$1"
+  local time_str=""
+  local tz=""
+  local now_epoch reset_epoch out
+
+  # `resets <time> (<tz>)` または `resets <time>` を抽出。
+  # 時刻表記は 12h `7:40pm` / `7:40 PM` / 24h `19:40` / `7pm` 等の揺れを許容。
+  # bash の `[[ =~ ]]` 内では `\(` がパースエラーになるため正規表現を変数で渡す
+  # （rationale: shellcheck SC1072 / bash 3.2+ ベストプラクティス）。
+  local re_with_tz='resets[[:space:]]+([0-9]{1,2}(:[0-9]{2})?[[:space:]]*([aApP][mM])?)[[:space:]]*\(([^)]+)\)'
+  local re_no_tz='resets[[:space:]]+([0-9]{1,2}(:[0-9]{2})?[[:space:]]*([aApP][mM])?)'
+  if [[ "$line" =~ $re_with_tz ]]; then
+    time_str="${BASH_REMATCH[1]}"
+    tz="${BASH_REMATCH[4]}"
+  elif [[ "$line" =~ $re_no_tz ]]; then
+    time_str="${BASH_REMATCH[1]}"
+    tz=""
+  else
+    return 1
+  fi
+
+  # 余計な空白を圧縮（`7:40 PM` → `7:40PM`。GNU date は両方受理する）。
+  time_str=$(printf '%s' "$time_str" | tr -d '[:space:]')
+  if [ -z "$time_str" ]; then
+    return 1
+  fi
+
+  # 解決の TZ context を決める（TZ 不明時は呼び出し時 TZ で解決）。
+  if [ -n "$tz" ]; then
+    out=$(TZ="$tz" date -d "$time_str" +%s 2>/dev/null)
+    now_epoch=$(TZ="$tz" date +%s 2>/dev/null)
+  else
+    out=$(date -d "$time_str" +%s 2>/dev/null)
+    now_epoch=$(date +%s 2>/dev/null)
+  fi
+
+  # epoch 取得失敗（GNU date 不在 / 解析失敗）→ reset 欠落 fallback へ
+  if ! [[ "$out" =~ ^[0-9]+$ ]] || ! [[ "$now_epoch" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+  reset_epoch="$out"
+
+  # 直近の該当時刻決定（Open Question 確定）:
+  # 解決 epoch が現在より過去なら翌日 +86400、未来ならそのまま採用。
+  if [ "$reset_epoch" -lt "$now_epoch" ]; then
+    reset_epoch=$((reset_epoch + 86400))
+  fi
+  printf '%s' "$reset_epoch"
+  return 0
+}
+
+# stdin の claude CLI 出力 stream を fold し、quota 枯渇イベントを検出して
 # `<detection_path>\t<reset_epoch>` 形式の TSV を 1 検出 1 行で stdout に出力する
-# （Req 1.1〜1.4, 2.1〜2.2, 3.1〜3.4, 5.1〜5.4 / Issue #66 Req 2.x との後方互換）。
+# （Req 1.1〜1.4, 2.1〜2.2, 3.1〜3.4, 5.1〜5.4 / Issue #66 Req 2.x との後方互換 /
+# Issue #416 で平文セッション上限経路を追加）。
 #
 # 検出経路（detection_path フィールド値）:
 #   - `rate_limit_event_v2`  : 現行 Claude CLI スキーマ
@@ -65,6 +138,14 @@
 #                              `type==result` かつ `is_error == true` かつ
 #                              `api_error_status == 429`
 #                              （Issue #104 Bug 2 / Req 3.1）
+#   - `session_limit_plain_v1` : セッション上限到達時に claude CLI が stream-json を
+#                              出さず平文 1 行で early-exit するケース。
+#                              `You've hit your session limit` を含む行に
+#                              substring match する（Issue #416 Req 1.1 / 1.5）。
+#                              マッチ粒度は `You've hit your session limit` のみで
+#                              判定（バージョン差を吸収するための緩いマッチを採用 /
+#                              Open Question 確定）。reset 時刻は
+#                              `qa_parse_session_limit_reset` で解決する。
 #
 # Reset 時刻フィールド探索順（現行 / 旧スキーマ揺れと synthetic 429 同居を許容）:
 #   1) .rate_limit_info.resetsAt / .resets_at / .reset_at  （現行スキーマ ネスト位置 / Req 1.3）
@@ -73,17 +154,27 @@
 #   いずれも取得できなければ空（呼び出し側で reset 欠落 fallback / Req 1.4, 3.2）。
 #
 # 出力契約:
-#   - 1 検出 1 行: `<detection_path>\t<epoch_or_empty>`
+#   - 1 検出 1 行: `<detection_path>\t<epoch_or_empty>`（出力形式は #416 で不変）
 #   - 解析失敗（非 JSON / schema 違い）の行は無視して継続（Req 2.5 / Issue #66）
 #   - allowed のみ / 通常 result（is_error:false）は無視（Req 3.4）
 #   - 同一 stream に複数検出があっても全件出力（呼び出し側で `tail -1` 等を選択）
+#   - 同一 stream 内に JSON 検出と平文検出が混在しても両方出力し、呼び出し側で
+#     epoch を持つ最終検出を優先する（Issue #416 Req 1.4: 二重 escalation 抑止）
 #
 # 実装メモ: jq は default だと stdin を "concatenated JSON" として一括 parse する
 # ため、無効な 1 行があると stream 全体が fatal で止まる。stream を停止させない
 # 要件（Req 2.5）を満たすため、`-R`（raw input）で 1 行ずつ受け取り、各行を
-# `try fromjson catch null` で個別 parse する。
+# `try fromjson catch null` で個別 parse する。平文経路は jq 内では bash 関数を
+# 呼べないため、stdin を一時バッファに保持して 2 pass（JSON pass + 平文 pass）で
+# 走査する（Issue #416）。
 qa_detect_rate_limit() {
-  jq -R -r '
+  # stdin を 1 度だけ全行読み出して buffer に保持する。jq pass と平文 pass の
+  # 2 系統に同じ入力を流すため。buffer は in-memory（小規模 stream-json 前提）。
+  local buf
+  buf=$(cat)
+
+  # ── Pass 1: 既存 JSON 検出経路（rate_limit_event_v2 / v1 / synthetic_429_result）──
+  printf '%s' "$buf" | jq -R -r '
     # 入力 1 行を JSON object に折りたたむ。fromjson 失敗 / 非 object は捨てる。
     . as $line
     | (try ($line | fromjson) catch null)
@@ -132,6 +223,24 @@ qa_detect_rate_limit() {
     # 出力: <detection_path>\t<epoch_or_empty>
     | "\($path)\t\($epoch_str)"
   ' 2>/dev/null
+
+  # ── Pass 2: 平文セッション上限メッセージ検出（Issue #416 / Req 1.1, 1.5, 2.1, 2.6）──
+  # 行をまたいで判定し、`You've hit your session limit` を含む行を 1 行ずつ走査する
+  # （Req 2.6: 複数行分割でも単一行を検出した時点で AC を満たす）。
+  # `--` で grep のオプション解釈を打ち切り、quote / fixed-string で fragile な
+  # メタ文字解釈を回避する（未信頼入力の取り扱い / CLAUDE.md §5）。
+  local plain_line
+  while IFS= read -r plain_line; do
+    [ -z "$plain_line" ] && continue
+    local epoch=""
+    if epoch=$(qa_parse_session_limit_reset "$plain_line"); then
+      printf 'session_limit_plain_v1\t%s\n' "$epoch"
+    else
+      # reset 抽出失敗時は epoch 空で出力（Req 2.5: 平文検出は維持し、reset 欠落
+      # fallback を呼び出し側に委ねる）。
+      printf 'session_limit_plain_v1\t\n'
+    fi
+  done < <(printf '%s' "$buf" | grep -F -- "You've hit your session limit" 2>/dev/null || true)
 }
 
 # 既存 6 stage の claude 呼び出しを横断ラップする Stage Wrapper（Req 1.1, 1.2,

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-mixed-with-json.txt
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-mixed-with-json.txt
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","tools":["Read"],"model":"claude-opus-4-7"}
+{"type":"rate_limit_event","timestamp":"2026-05-15T01:00:00Z","rate_limit_info":{"status":"rejected","resetsAt":"2026-05-15T05:00:00Z","tier":"5h"}}
+You've hit your session limit · resets 7:40pm (Asia/Tokyo)

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-multiline.txt
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-multiline.txt
@@ -1,0 +1,4 @@
+Starting Claude session...
+loading project context
+You've hit your session limit · resets 7:40pm (Asia/Tokyo)
+session terminated

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-no-reset.txt
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-no-reset.txt
@@ -1,0 +1,1 @@
+You've hit your session limit · please try again later

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-no-tz.txt
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-no-tz.txt
@@ -1,0 +1,1 @@
+You've hit your session limit · resets 7:40pm

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-tokyo-24h.txt
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-tokyo-24h.txt
@@ -1,0 +1,1 @@
+You've hit your session limit · resets 19:40 (Asia/Tokyo)

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-tokyo-pm.txt
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-tokyo-pm.txt
@@ -1,0 +1,1 @@
+You've hit your session limit · resets 7:40pm (Asia/Tokyo)

--- a/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-utc.txt
+++ b/local-watcher/test/fixtures/qa_detect_rate_limit/session-limit-plain-utc.txt
@@ -1,0 +1,1 @@
+You've hit your session limit · resets 10:40am (UTC)

--- a/local-watcher/test/qa_detect_rate_limit_test.sh
+++ b/local-watcher/test/qa_detect_rate_limit_test.sh
@@ -54,11 +54,20 @@ extract_function() {
   ' "$script" "$QUOTA_AWARE_SH"
 }
 
+# Issue #416: qa_detect_rate_limit は内部で qa_parse_session_limit_reset を呼ぶため、
+# 当該ヘルパーも extract して同 shell に読み込む（extract_function イディオムの依存関数
+# 追従 / CLAUDE.md「7. テストの近接配置」）。
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "qa_parse_session_limit_reset")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit")"
 
 if ! declare -F qa_detect_rate_limit >/dev/null; then
   echo "ERROR: qa_detect_rate_limit not loaded" >&2
+  exit 2
+fi
+if ! declare -F qa_parse_session_limit_reset >/dev/null; then
+  echo "ERROR: qa_parse_session_limit_reset not loaded" >&2
   exit 2
 fi
 
@@ -157,6 +166,141 @@ out=$(detect_last_line "v2-rate-limit-malformed-line.jsonl")
 assert_eq "v2-rate-limit-malformed-line (Req 5.4 / NFR resilience)" \
   "$(printf 'rate_limit_event_v2\t1778821200')" \
   "$out"
+
+# ─── Issue #416: 平文セッション上限メッセージ検出経路 ───
+echo ""
+echo "--- session_limit_plain_v1 cases (Issue #416) ---"
+
+# 検出経路文字列を取り出す補助（path 部分のみ assert したいとき用）。
+detect_path() {
+  local fx="$1"
+  local out
+  out=$(detect_last_line "$fx")
+  printf '%s' "${out%%$'\t'*}"
+}
+
+# 検出 epoch 部分のみを取り出す補助。
+detect_epoch() {
+  local fx="$1"
+  local out
+  out=$(detect_last_line "$fx")
+  printf '%s' "${out#*$'\t'}"
+}
+
+# Req 1.1 (#416), 2.3: 平文単独 + TZ Asia/Tokyo 12h pm 表記
+# → path=session_limit_plain_v1 / epoch は numeric integer
+out=$(detect_path "session-limit-plain-tokyo-pm.txt")
+assert_eq "session-limit-plain-tokyo-pm path (#416 Req 1.1, 2.3)" \
+  "session_limit_plain_v1" "$out"
+epoch=$(detect_epoch "session-limit-plain-tokyo-pm.txt")
+if [[ "$epoch" =~ ^[0-9]+$ ]]; then
+  echo "PASS: session-limit-plain-tokyo-pm epoch is numeric (#416 Req 2.1)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: session-limit-plain-tokyo-pm epoch must be numeric (got '$epoch')"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# Req 2.4 (#416): 24h 表記 (`19:40`) は 12h `7:40pm` と同一 epoch を解決する
+epoch_pm=$(detect_epoch "session-limit-plain-tokyo-pm.txt")
+epoch_24=$(detect_epoch "session-limit-plain-tokyo-24h.txt")
+assert_eq "session-limit-plain 12h/24h equal epoch (#416 Req 2.4)" \
+  "$epoch_pm" "$epoch_24"
+
+# Req 2.3 (#416): TZ=UTC で `10:40am` を指定すると Asia/Tokyo `7:40pm` と同一 epoch
+# （19:40 JST = 10:40 UTC）
+epoch_utc=$(detect_epoch "session-limit-plain-utc.txt")
+assert_eq "session-limit-plain Asia/Tokyo == UTC equiv epoch (#416 Req 2.3)" \
+  "$epoch_pm" "$epoch_utc"
+
+# Req 2.6 (#416): 複数行のうち 1 行に session limit があれば検出する
+out=$(detect_path "session-limit-plain-multiline.txt")
+assert_eq "session-limit-plain-multiline path (#416 Req 2.6)" \
+  "session_limit_plain_v1" "$out"
+
+# Req 1.4 (#416): JSON 検出と平文検出が混在 → 両方検出されるが detect_all で両 path が出る
+all=$(detect_all_lines "session-limit-plain-mixed-with-json.txt" | tr '\n' ';')
+# 期待: 1 行目は rate_limit_event_v2 (JSON / epoch あり), 2 行目は session_limit_plain_v1
+# （epoch は現在時刻依存のため numeric 部分は別途検証）
+case "$all" in
+  *"rate_limit_event_v2"*"session_limit_plain_v1"*)
+    echo "PASS: mixed JSON+plain both paths emitted (#416 Req 1.4)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: mixed JSON+plain should emit both rate_limit_event_v2 and session_limit_plain_v1"
+    echo "  actual: $all"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+
+# Req 2.5 (#416): 平文検出はされたが reset 時刻表記が無い → path のみ、epoch 空
+out=$(detect_last_line "session-limit-plain-no-reset.txt")
+assert_eq "session-limit-plain-no-reset (#416 Req 2.5)" \
+  "$(printf 'session_limit_plain_v1\t')" \
+  "$out"
+
+# Req 3.5 (#416): 平文セッション上限メッセージが無い既存 normal-success では本経路は発火しない
+all=$(detect_all_lines "normal-success.jsonl")
+case "$all" in
+  *session_limit_plain_v1*)
+    echo "FAIL: normal-success should not trigger session_limit_plain_v1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+  *)
+    echo "PASS: normal-success does not trigger session_limit_plain_v1 (#416 Req 3.5, NFR 2.1)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+esac
+
+# ─── Issue #416: qa_parse_session_limit_reset 純粋関数の単体テスト ───
+echo ""
+echo "--- qa_parse_session_limit_reset unit cases (Issue #416) ---"
+
+# TZ 指定あり: Asia/Tokyo / pm 12h → 数値 epoch を返し return 0
+if epoch=$(qa_parse_session_limit_reset "You've hit your session limit · resets 7:40pm (Asia/Tokyo)"); then
+  if [[ "$epoch" =~ ^[0-9]+$ ]]; then
+    echo "PASS: parse Asia/Tokyo 7:40pm → numeric epoch (#416 Req 2.1, 2.3)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: parse Asia/Tokyo 7:40pm returned non-numeric epoch: '$epoch'"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+else
+  echo "FAIL: parse Asia/Tokyo 7:40pm should succeed but returned rc != 0"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# 直近の該当時刻ロジック: 解決 epoch >= 現在 epoch であること（過去なら +86400 されている）
+now=$(date +%s)
+if epoch=$(qa_parse_session_limit_reset "You've hit your session limit · resets 7:40pm (Asia/Tokyo)"); then
+  if [ "$epoch" -ge "$now" ]; then
+    echo "PASS: resolved epoch is >= now (直近の該当時刻 / #416 Req 2.1)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: resolved epoch should be >= now (got epoch=$epoch now=$now)"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+fi
+
+# 12h と 24h 表記揺れが同一 epoch を返すこと
+e_pm=$(qa_parse_session_limit_reset "You've hit your session limit · resets 7:40pm (Asia/Tokyo)")
+e_24=$(qa_parse_session_limit_reset "You've hit your session limit · resets 19:40 (Asia/Tokyo)")
+assert_eq "parse 12h/24h same epoch (#416 Req 2.4)" "$e_pm" "$e_24"
+
+# TZ 等価性: Asia/Tokyo 7:40pm == UTC 10:40am
+e_tokyo=$(qa_parse_session_limit_reset "You've hit your session limit · resets 7:40pm (Asia/Tokyo)")
+e_utc=$(qa_parse_session_limit_reset "You've hit your session limit · resets 10:40am (UTC)")
+assert_eq "parse Asia/Tokyo == UTC equiv (#416 Req 2.3)" "$e_tokyo" "$e_utc"
+
+# reset 表記が無い → return 1
+if qa_parse_session_limit_reset "You've hit your session limit · please try again later" >/dev/null 2>&1; then
+  echo "FAIL: parse without 'resets' should return rc != 0"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+else
+  echo "PASS: parse without 'resets' returns rc != 0 (#416 Req 2.5)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+fi
 
 echo ""
 echo "==========================================="

--- a/local-watcher/test/qa_run_claude_stage_test.sh
+++ b/local-watcher/test/qa_run_claude_stage_test.sh
@@ -73,12 +73,17 @@ eval "$(extract_function "$WATCHER_SH" "qa_log")"
 eval "$(extract_function "$WATCHER_SH" "qa_warn")"
 # shellcheck disable=SC1090
 eval "$(extract_function "$WATCHER_SH" "qa_error")"
+# Issue #416: qa_detect_rate_limit は内部で qa_parse_session_limit_reset を呼ぶため、
+# 当該ヘルパーも extract して同 shell に読み込む（extract_function イディオムの依存関数
+# 追従 / CLAUDE.md「7. テストの近接配置」）。
+# shellcheck disable=SC1090
+eval "$(extract_function "$WATCHER_SH" "qa_parse_session_limit_reset")"
 # shellcheck disable=SC1090
 eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit")"
 # shellcheck disable=SC1090
 eval "$(extract_function "$WATCHER_SH" "qa_run_claude_stage")"
 
-for fn in qa_log qa_warn qa_error qa_detect_rate_limit qa_run_claude_stage; do
+for fn in qa_log qa_warn qa_error qa_parse_session_limit_reset qa_detect_rate_limit qa_run_claude_stage; do
   if ! declare -F "$fn" >/dev/null; then
     echo "ERROR: $fn not loaded" >&2
     exit 2
@@ -183,6 +188,100 @@ run_case "normal-success with claude rc=2 (NFR 1.2 既存 rc 透過)" \
 # Req 5.4: malformed line 混入でも検出を継続
 run_case "v2-rate-limit-malformed-line (Req 5.4)" \
   99 "1778821200" "v2-rate-limit-malformed-line.jsonl" 0
+
+# ─── Issue #416: 平文セッション上限経路の統合テスト ───
+# epoch は実行時刻依存のため固定値 assert ではなく以下を検証する:
+#   - rc=99（既存 JSON 経路と同じ deferral 経路に合流 / Req 1.2）
+#   - reset_file に numeric epoch が書かれる（Req 2.2）
+#   - その epoch が現在時刻以上である（直近の該当時刻 / Req 2.1）
+
+# 平文単独 + TZ 付き → exit 99 + epoch 永続化（#416 Req 1.1, 1.2, 1.3, 2.1〜2.3）
+reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+rc=0
+qa_run_claude_stage "TestStage" "$reset_file" -- \
+  fake_claude "$FIXTURE_DIR/session-limit-plain-tokyo-pm.txt" 1 >/dev/null 2>&1 || rc=$?
+actual_reset=$(cat "$reset_file" 2>/dev/null || true)
+rm -f "$reset_file" "${reset_file}.detect"
+
+assert_eq "session-limit-plain-tokyo-pm rc=99 (#416 Req 1.2)" "99" "$rc"
+if [[ "$actual_reset" =~ ^[0-9]+$ ]]; then
+  echo "PASS: session-limit-plain-tokyo-pm reset_file numeric (#416 Req 2.2)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+  now=$(date +%s)
+  if [ "$actual_reset" -ge "$now" ]; then
+    echo "PASS: session-limit-plain-tokyo-pm epoch >= now (#416 Req 2.1)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: epoch should be >= now (got '$actual_reset' now='$now')"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+else
+  echo "FAIL: session-limit-plain-tokyo-pm reset_file should be numeric epoch (got '$actual_reset')"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# 平文 + 複数行混在でも検出する（#416 Req 2.6）
+reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+rc=0
+qa_run_claude_stage "TestStage" "$reset_file" -- \
+  fake_claude "$FIXTURE_DIR/session-limit-plain-multiline.txt" 1 >/dev/null 2>&1 || rc=$?
+actual_reset=$(cat "$reset_file" 2>/dev/null || true)
+rm -f "$reset_file" "${reset_file}.detect"
+assert_eq "session-limit-plain-multiline rc=99 (#416 Req 2.6)" "99" "$rc"
+if [[ "$actual_reset" =~ ^[0-9]+$ ]]; then
+  echo "PASS: session-limit-plain-multiline reset_file numeric (#416 Req 2.6)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: session-limit-plain-multiline reset_file should be numeric epoch (got '$actual_reset')"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# 平文だが reset 表記欠落 → reset 欠落 fallback（既存 JSON 経路の reset 欠落と同じ挙動 / #416 Req 2.5）
+# 期待: claude_rc 透過（ここでは 1）、reset_file は空
+reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+rc=0
+qa_run_claude_stage "TestStage" "$reset_file" -- \
+  fake_claude "$FIXTURE_DIR/session-limit-plain-no-reset.txt" 1 >/dev/null 2>&1 || rc=$?
+actual_reset=$(cat "$reset_file" 2>/dev/null || true)
+rm -f "$reset_file" "${reset_file}.detect"
+assert_eq "session-limit-plain-no-reset rc passthrough (#416 Req 2.5)" "1" "$rc"
+assert_eq "session-limit-plain-no-reset reset_file empty (#416 Req 2.5)" "" "$actual_reset"
+
+# JSON 検出 + 平文検出の混在: epoch を持つ最新検出が優先される（#416 Req 1.4 二重 escalation 抑止）
+# 期待: rc=99、reset_file は numeric epoch（JSON 1778821200 または平文の現在以降 epoch）
+reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+rc=0
+qa_run_claude_stage "TestStage" "$reset_file" -- \
+  fake_claude "$FIXTURE_DIR/session-limit-plain-mixed-with-json.txt" 1 >/dev/null 2>&1 || rc=$?
+actual_reset=$(cat "$reset_file" 2>/dev/null || true)
+rm -f "$reset_file" "${reset_file}.detect"
+assert_eq "mixed JSON+plain rc=99 (#416 Req 1.4)" "99" "$rc"
+if [[ "$actual_reset" =~ ^[0-9]+$ ]]; then
+  echo "PASS: mixed JSON+plain reset_file numeric (#416 Req 1.4 / 二重 escalation 抑止)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  echo "FAIL: mixed JSON+plain reset_file should be numeric epoch (got '$actual_reset')"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+# opt-out で平文セッション上限が来ても素通し（#416 Req 3.2, NFR 2.1）
+export QUOTA_AWARE_ENABLED="false"
+reset_file=$(mktemp -p "$TMPDIR_TEST" "reset.XXXXXX")
+rm -f "$reset_file"
+rc=0
+qa_run_claude_stage "TestStage" "$reset_file" -- \
+  fake_claude "$FIXTURE_DIR/session-limit-plain-tokyo-pm.txt" 1 >/dev/null 2>&1 || rc=$?
+assert_eq "opt-out session-limit-plain rc=1 (#416 Req 3.2, NFR 2.1)" "1" "$rc"
+if [ ! -e "$reset_file" ]; then
+  echo "PASS: opt-out session-limit-plain reset_file untouched (#416 Req 3.2, NFR 2.1)"
+  PASS_COUNT=$((PASS_COUNT + 1))
+else
+  rm -f "$reset_file"
+  echo "FAIL: opt-out session-limit-plain reset_file unexpectedly created"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+# opt-in 状態を元に戻す
+export QUOTA_AWARE_ENABLED="true"
 
 echo ""
 echo "--- qa_run_claude_stage cases (opt-out) ---"


### PR DESCRIPTION
## 概要

quota-aware モジュールが claude CLI の平文セッション上限メッセージ（`You've hit your session limit · resets <time>`）を検出できず `claude-failed` に誤分類していた Bug を修正した。

`qa_detect_rate_limit` に第 4 検出経路 `session_limit_plain_v1`（`grep -F` による fixed-string 検索）を Pass 2 として追加し、既存 JSON 検出経路（`rate_limit_event_v2` / `v1` / `synthetic_429_result`）と同じ deferral 経路（exit 99 + reset 永続化 → `needs-quota-wait` 付与）に合流させる。あわせて `qa_parse_session_limit_reset` 純粋関数を新設し、TZ 指定・12h/24h 表記揺れ・reset 欠落を安全側 fallback で吸収する。

## 対応 Issue

Closes #416

## 関連 PR

なし（Architect による設計 PR は走っていない）

## 実装内容

- (Req 1.1 / 1.5) `qa_detect_rate_limit` に Pass 2（平文 `grep -F` 検索）を追加し、`session_limit_plain_v1` 経路を実装
- (Req 1.2 / 1.3) 検出時に既存の exit 99 sentinel 経路へ合流し `needs-quota-wait` 付与を保証
- (Req 1.4) epoch 持ち最新検出を採用する既存 TSV 解釈で JSON + 平文混在時の二重 escalation を抑止
- (Req 2.1〜2.6) `qa_parse_session_limit_reset` 新設：GNU `date -d`＋`TZ=` による epoch 解決、過去 epoch の +86400 補正、reset 欠落時の return 1 fallback
- (Req 3.1〜3.5) 既存 JSON 検出 jq フィルタ・opt-out 早期 return・exit code 契約・env var・ラベル契約を無変更で温存
- (Req 4.1〜4.3) 既存 `qa_log` / `qa_warn` / `qa_build_escalation_comment` をそのまま流用し観測性を維持
- (NFR 3.1〜3.5) 平文単独・JSON+平文混在・複数行分割・TZ 揺れ・12h/24h 表記の計 24 件テスト追加

## 受入基準チェック

- [x] Req 1.1: 平文セッション上限メッセージ（`You've hit your session limit` を含む行）を quota 枯渇として検出 ← `qa_detect_rate_limit_test.sh: session-limit-plain-tokyo-pm path`
- [x] Req 1.2: 検出時に exit 99 で呼び出し側へ通知 ← `qa_run_claude_stage_test.sh: session-limit-plain-tokyo-pm rc=99`
- [x] Req 1.3: `needs-quota-wait` 付与経路に合流（`claude-failed` 不付与）← exit 99 経路が `qa_handle_quota_exceeded` に吸収される既存契約で担保
- [x] Req 1.4: JSON + 平文混在時も 1 回の quota 検出として処理 ← `qa_run_claude_stage_test.sh: mixed JSON+plain rc=99`
- [x] Req 1.5: 平文文言が含まれない入力では Pass 2 が無出力 ← `qa_detect_rate_limit_test.sh: normal-success does not trigger session_limit_plain_v1`
- [x] Req 2.1: reset 時刻を「直近の該当時刻」の epoch に解決（過去なら +86400）← `qa_detect_rate_limit_test.sh: resolved epoch is >= now`
- [x] Req 2.2: reset epoch を `QUOTA_RESET_STATE_FILE` にアトミック書込 ← `qa_run_claude_stage_test.sh: session-limit-plain-tokyo-pm reset_file numeric`
- [x] Req 2.3: TZ 指定（`Asia/Tokyo`）を尊重した epoch 解決 ← `qa_detect_rate_limit_test.sh: parse Asia/Tokyo == UTC equiv`
- [x] Req 2.4: 12h（`7:40pm`）と 24h（`19:40`）が同一 epoch を返す ← `qa_detect_rate_limit_test.sh: parse 12h/24h same epoch`
- [x] Req 2.5: reset 抽出・epoch 解決失敗時は安全側 fallback（warn + claude rc 透過）← `qa_run_claude_stage_test.sh: session-limit-plain-no-reset rc passthrough`
- [x] Req 2.6: 複数行入力でも単一行検出で成立 ← `qa_run_claude_stage_test.sh: session-limit-plain-multiline rc=99`
- [x] Req 3.1〜3.5: 既存 JSON 経路・opt-out・exit code・env var・ラベル契約を温存 ← 既存テスト全件 PASS（qa_detect_rate_limit_test.sh 10 件 + qa_run_claude_stage_test.sh 23 件）
- [x] NFR 1.1〜1.2: `grep -F` 1 段 + bash function のみ。sleep / ブロッキング待機の新規導入なし

## テスト結果

```
bash local-watcher/test/qa_detect_rate_limit_test.sh
PASS 23 / FAIL 0（既存 10 + 新規 13）

bash local-watcher/test/qa_run_claude_stage_test.sh
PASS 34 / FAIL 0（既存 23 + 新規 11）

shellcheck local-watcher/bin/modules/quota-aware.sh
  local-watcher/test/qa_detect_rate_limit_test.sh
  local-watcher/test/qa_run_claude_stage_test.sh
→ clean（warning なし）

bash -n quota-aware.sh → clean
diff -r .claude/agents repo-template/.claude/agents → 空
diff -r .claude/rules  repo-template/.claude/rules  → 空
```

## 実装上の判断

- **マッチ粒度**: `You've hit your session limit` substring のみで判定（`resets` 部分まで含めない）。バージョン差で記号・表記が変わるリスクを誤検出リスクより重視
- **直近の該当時刻決定**: 解決 epoch が現在より過去なら +86400 して翌日採用（GNU `date -d` は「今日の HH:MM」を返すため）
- **detection_path 識別子**: `session_limit_plain_v1`（既存 `_v1` / `_v2` 命名規約に準拠、将来の文言変更に備えて拡張余地を残す）
- **GNU date 依存**: macOS BSD date は `date -d` / `TZ=` 非対応のため reset 欠落 fallback に倒れる。regression にはならないが macOS 環境では quota 自動 resume が機能しない（別 Issue で BSD date fallback を追加検討）

## 確認事項 / レビュワーへの依頼

- Reviewer の独立レビュー結果: `docs/specs/416--bug-quota-aware-you-ve-hit-your-session/review-notes.md` 参照（RESULT: approve、Findings: なし）
- **GNU date 依存（macOS）**: macOS / BSD date 環境では `qa_parse_session_limit_reset` の epoch 解決が失敗し reset 欠落 fallback に倒れる。必要なら別 Issue での BSD date 対応追加を検討（impl-notes.md「確認事項」参照）
- **平文文言の変更リスク**: claude CLI が `You've hit your session limit` の文言を変えた場合、本経路は機能しなくなる。`$LOG_DIR/issue-*.log` で `session_limit_plain_v1` 検出ログのモニタリングを推奨
- **base 検証**: --base 指定値=main / baseRefName=main / OK
- design-less impl: 単一 PR で完了のため Closes を採用

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #416 のコメントを参照してください。
