### PR TITLE
fix(#417): Failed Recovery Processor の terminate cross-cycle べき等化（spam コメント防止）

### DIFF
--- a/docs/specs/417--bug-failed-recovery-processor-attempt-c/impl-notes.md
+++ b/docs/specs/417--bug-failed-recovery-processor-attempt-c/impl-notes.md
@@ -1,0 +1,119 @@
+# Implementation Notes — #417 Failed Recovery Processor terminate cross-cycle べき等化
+
+## 設計判断
+
+**採用方針: 仮案 C（state JSON 永続化 + ガード両刀）**
+
+人間コメントの選択肢（A=state 管理 / B=列挙除外 / C=両刀）に対し、Developer が**両刀**を採用した。
+理由は以下のとおり:
+
+- **terminate 関数のべき等ガード単独（仮案 A）では不十分**: `fr_run_recovery_attempt` 内で
+  着手コメント → 試行開始時 attempt++ → claude session 起動が走ってから `return 2` で
+  terminate に到達する経路がある。AC は 2 サイクル目以降に「着手コメントも attempt 加算も
+  claude session 起動もしない」(Req 2.1〜2.6) と明示しているため、**fetch 段階で物理的に
+  除外する必要がある**。
+- **列挙除外単独（仮案 B）では不十分**: 状態を読まない実装では候補列挙時の race condition
+  （別 worker が同時に state を読み書き）で取りこぼしが発生しうる。terminate 関数側でも
+  ガードしておく方が二重防御として安全であり、コード量も小さい。
+- **両刀の追加コスト**: `fr_is_terminated` という純粋関数を 1 つ追加し、両方から呼ぶだけ
+  なので技術的負債にならない。
+
+### 既存 schema を変更しない（NFR 1.1）
+
+state JSON の `last_status` enum はすでに `"max-attempts"` / `"no-progress"` を許容して
+おり、`fr_save_state` 第 3 引数で書き込み済みである（既存 design.md Data Model 節）。
+新フィールド追加は不要で、**既存 enum 値を terminate 時に永続化する経路を追加するだけ** で
+要件を満たせる。
+
+### state 不在 / 破損で fail-open（Req 5.1〜5.3）
+
+`fr_load_state` は元から「不在 / parse 失敗で `{}` を返す」契約。本実装の `fr_is_terminated`
+も `{}` を受け取ったら未終端として rc=1 を返すため、自然と fail-open になる。これにより
+**state 破損が原因で動作不能になるリスクはない**（最悪、本変更導入前と同等の「毎サイクル
+コメント再投稿」に退行するだけ / Req 5.3 fail-continue 維持）。
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---|---|
+| `local-watcher/bin/modules/failed-recovery.sh` | `fr_is_terminated` 純粋関数追加 / `fr_filter_terminated_candidates` 追加 / `fr_fetch_failed_issues` / `fr_fetch_failed_prs` の最終出力にフィルタ適用 / `fr_terminate_max_attempts` / `fr_terminate_no_progress` 冒頭にべき等ガード + 末尾に state 永続化を追加 |
+| `local-watcher/test/fr_fetch_test.sh` | 新 helper `fr_filter_terminated_candidates` が未抽出で壊れたため、Issue #410「新規公開 IF 追加で壊れた既存テストの fixture 追従責務」に基づき pass-through stub を追加（テスト意図維持） |
+| `local-watcher/test/fr_terminate_idempotent_test.sh` | 新規 regression test（64 ケース） |
+
+`failed-recovery.sh` は `repo-template/` 配下にないため root 単独管理。同期作業なし
+（grep / find で確認済み）。
+
+## AC Traceability
+
+| Req | カバー方法 |
+|---|---|
+| Req 1.1（2 サイクル目 max-attempts コメント非投稿） | `fr_terminate_max_attempts` 冒頭の `fr_is_terminated` ガード / `fr_terminate_idempotent_test.sh` Section 3 |
+| Req 1.2（2 サイクル目 no-progress コメント非投稿） | `fr_terminate_no_progress` 冒頭の `fr_is_terminated` ガード / 同 Section 4 |
+| Req 1.3（max-attempts 生涯 1 件） | cross-status ガードで担保 / 同 Section 5 |
+| Req 1.4（no-progress 生涯 1 件） | 同上 / 同 Section 5 |
+| Req 1.5（max-attempts 終端永続化） | `fr_terminate_max_attempts` 末尾の `fr_save_state` / 同 Section 2 |
+| Req 1.6（no-progress 終端永続化） | `fr_terminate_no_progress` 末尾の `fr_save_state` / 同 Section 9 |
+| Req 2.1（claude session 起動しない max-attempts） | `fr_filter_terminated_candidates` で fetch 段階除外 / 同 Section 7 |
+| Req 2.2（claude session 起動しない no-progress） | 同上 / 同 Section 7 |
+| Req 2.3（着手 / 結果コメント不投稿） | fetch 除外で `fr_run_recovery_attempt` 自体が呼ばれない / 同 Section 3-4 + 7 |
+| Req 2.4（Slack 通知 emitter 再発火なし） | terminate ガード + fetch 除外 / 同 Section 3-4 |
+| Req 2.5（attempt カウンタ加算なし） | fetch 除外で `fr_save_state` 呼び出し自体なし / 同 Section 7 |
+| Req 2.6（run-summary 確定なし） | terminate ガード + fetch 除外 / 同 Section 3-4 + 7 |
+| Req 3.1（max/no-progress/未終端の 3 状態判定） | `fr_is_terminated` 純粋関数 / 同 Section 1 |
+| Req 3.2（プロセス再起動・再ログイン跨ぎで保持） | `fr_save_state` が `$HOME/.issue-watcher/` 配下 JSON ファイルに永続化（既存実装 / NFR 2.2 / NFR 2.3）。fr_state_test.sh で間接検証 |
+| Req 3.3（terminate と同一サイクル内永続化） | terminate 関数末尾で `fr_save_state` を呼ぶ実装 / 同 Section 2, 9 |
+| Req 4.1〜4.3（claude-failed ラベル据え置き） | `--remove-label` を呼ぶコードを追加していない / 既存 fr_terminate_test.sh + 新 Section 8 |
+| Req 4.4（人間が手動でラベル除去した場合の挙動） | 人間がラベルを除去すれば既存 `fr_fetch_failed_*` の server-side filter `label:"claude-failed"` から外れる（既存挙動）。本変更は影響しない |
+| Req 5.1（state 破損で fail-open） | `fr_load_state` が `{}` を返し `fr_is_terminated` が rc=1（未終端扱い）/ 同 Section 6-B + 7-F |
+| Req 5.2（state 欠落で fail-open） | 同上 / 同 Section 6-A |
+| Req 5.3（fail-continue 維持） | terminate 関数の return は元から 0 / `fr_save_state` 失敗時は `fr_warn` で記録のみ |
+| Req 6.1（gate OFF で state 書き込みなし） | gate チェックは `process_failed_recovery` 冒頭で行われ early return する。本変更で gate 外の経路は追加していない / 既存 fr_process_test.sh Section 1（gate off） / fr_is_enabled_test.sh で間接担保 |
+| Req 6.2（FULL_AUTO_ENABLED gate） | 同上 |
+| Req 6.3（gate OFF で全副作用ゼロ） | 同上 |
+| NFR 1.1（既存 schema フィールド維持） | `fr_save_state` の既存呼び出し規約に従い、新フィールド追加なし。既存 immediate_failure_streak / last_failure_signature / last_head_sha は前回値継承 / 同 Section 10 |
+| NFR 1.2（既存識別子文字列維持） | terminate コメント本文・log message 共に `max-attempts` / `no-progress` 識別子を据え置く / 既存 fr_terminate_test.sh |
+| NFR 1.3（旧 schema state を未終端として扱う） | last_status 不在の旧 state JSON で `fr_is_terminated` が rc=1 を返す / 同 Section 6-C |
+| NFR 1.4（既存 env var 名・既定値維持） | 新 env var を追加していない。本変更は既存 `FAILED_RECOVERY_ENABLED` / `FAILED_RECOVERY_STATE_DIR` のみ参照 |
+| NFR 1.5（終端コメント本文の既存文言維持） | コメント本文を変更していない（既存 fr_terminate_test.sh が継続 green） |
+| NFR 2.1（抑止ログ 1 行記録） | `fr_log "${kind}=#${number} terminated reason=<status> suppressed=<...>"` / 同 Section 3-4, 7 |
+| NFR 2.2（grep 可能粒度） | 抑止ログに `failed-recovery:` prefix + Issue/PR 番号 + reason 識別子 / 同 Section 3-4, 7 |
+| NFR 3.1（`$HOME/.issue-watcher/` 配下配置） | 既存 `$FAILED_RECOVERY_STATE_DIR` を使う（追加配置先なし） |
+| NFR 3.2（secrets を含めない） | terminate ログ / コメント / Slack detail に secrets / signature 全文を含めない（既存実装維持） |
+| NFR 3.3（未信頼入力 `^[0-9]+$` 検証） | 既存 terminate 関数の number 検証を継続。`fr_filter_terminated_candidates` も number 検証を実装（同 Section 7-E） |
+
+## 確認事項（人間に判断を委ねたい点）
+
+特になし。要件・運用者コメントの両方とも明確で、Open Questions も「なし」と PM が宣言済み。
+1 点のみ補足:
+
+- **Req 3.2 の「watcher プロセス再起動・cron 実行ユーザー再ログインを跨いでも保持」**: 既存
+  `fr_save_state` の atomic write 実装（mktemp → mv -f）と `$FAILED_RECOVERY_STATE_DIR`
+  既定値 `$HOME/.issue-watcher/failed-recovery/<repo-slug>` の永続性で担保されている。本
+  変更で追加の永続性確保は行っていない。直接の単体テストは `fr_state_test.sh` Section 4
+  「save → load の往復」で間接担保されているが、Req 3.2 をより厳密に検証したい場合は
+  「state ファイル書き込み後にプロセス kill → 再起動 → 同一値を read」する e2e test を
+  追加することも考えうる（本 PR スコープ外）。
+
+## テスト結果サマリ
+
+```
+=== fr_attempt_test.sh ===           PASS=60 FAIL=0
+=== fr_fetch_test.sh ===              PASS=42 FAIL=0
+=== fr_immediate_fail_test.sh ===     PASS=42 FAIL=0
+=== fr_invoke_test.sh ===             PASS=56 FAIL=0
+=== fr_is_enabled_test.sh ===         PASS=40 FAIL=0
+=== fr_no_progress_test.sh ===        PASS=12 FAIL=0
+=== fr_process_test.sh ===            PASS=71 FAIL=0
+=== fr_state_test.sh ===              PASS=60 FAIL=0
+=== fr_terminate_idempotent_test.sh ===  PASS=64 FAIL=0  (新規)
+=== fr_terminate_test.sh ===          PASS=77 FAIL=0
+```
+
+合計: 524 tests PASS / 0 FAIL。
+
+- `bash -n local-watcher/bin/modules/failed-recovery.sh` → 構文 OK
+- `shellcheck local-watcher/bin/modules/failed-recovery.sh
+   local-watcher/test/fr_terminate_idempotent_test.sh
+   local-watcher/test/fr_fetch_test.sh` → 警告ゼロ
+
+STATUS: complete

--- a/docs/specs/417--bug-failed-recovery-processor-attempt-c/requirements.md
+++ b/docs/specs/417--bug-failed-recovery-processor-attempt-c/requirements.md
@@ -1,0 +1,118 @@
+# Requirements Document
+
+## Introduction
+
+Failed Recovery Processor（#359）は `claude-failed` Issue / auto-merge 待ち PR を fresh Claude session で
+復旧する仕組みで、通算 attempt 上限到達時（`max-attempts`）と同原因再発による無進捗時（`no-progress`）に
+**終端理由コメントを 1 件だけ投稿して `claude-failed` ラベルを据え置く**契約になっている。しかし現状の実装は
+終端状態を cross-cycle で永続化しておらず、終端到達後も毎 cron tick（既定 2 分間隔）で候補列挙に再ヒットし、
+同一の「修正試行を停止します（終端理由: max-attempts）」「同（no-progress）」コメントを無制限に再投稿し続ける。
+人間運用者のコメントで `max-attempts` 経路だけでなく `no-progress` 経路でも同じ spam を観測済みである旨が
+補足されているため、**両経路に共通する cross-cycle のべき等性**を回復することが本要件の目的である。
+
+関連: 同原因の上流に位置する quota 由来の誤 `claude-failed` 確定は #416 で扱う。本要件は terminate 経路の
+べき等化に限定し、`FAILED_RECOVERY_MAX_ATTEMPTS` 既定値の見直し・既存重複コメントの遡及削除は扱わない。
+
+## Requirements
+
+### Requirement 1: 終端コメントの cross-cycle べき等性
+
+**Objective:** As an idd-claude 運用者, I want 終端理由コメントが 1 Issue / PR の生涯で最大 1 回だけ投稿される, so that cron tick ごとに同一終端コメントが繰り返し再投稿される spam を受け取らずに済む
+
+#### Acceptance Criteria
+
+1. When 通算 attempt 上限到達による終端処理が同一 Issue / PR に対して 2 回目以降のサイクルで起動された場合, the Failed Recovery Processor shall 終端理由コメントを新たに投稿しない
+2. When 同原因再発・無進捗（no-progress）による終端処理が同一 Issue / PR に対して 2 回目以降のサイクルで起動された場合, the Failed Recovery Processor shall 終端理由コメントを新たに投稿しない
+3. The Failed Recovery Processor shall 同一 Issue / PR の `max-attempts` 終端理由コメントを生涯で最大 1 件しか投稿しない
+4. The Failed Recovery Processor shall 同一 Issue / PR の `no-progress` 終端理由コメントを生涯で最大 1 件しか投稿しない
+5. When `max-attempts` 終端処理が起動された場合, the Failed Recovery Processor shall 当該 Issue / PR が以後のサイクルでも終端済みと判定できる情報を永続化する
+6. When `no-progress` 終端処理が起動された場合, the Failed Recovery Processor shall 当該 Issue / PR が以後のサイクルでも終端済みと判定できる情報を永続化する
+
+### Requirement 2: 終端後サイクルの副作用ゼロ
+
+**Objective:** As an idd-claude 運用者, I want 終端到達後のサイクルでは Failed Recovery Processor が一切の副作用を起こさない, so that 終端済み Issue / PR に対する claude session 起動・コメント・ラベル変更・通知の全種別が二重発火しない
+
+#### Acceptance Criteria
+
+1. While 同一 Issue / PR が `max-attempts` 終端済みである, the Failed Recovery Processor shall 当該 Issue / PR に対して recovery claude session を起動しない
+2. While 同一 Issue / PR が `no-progress` 終端済みである, the Failed Recovery Processor shall 当該 Issue / PR に対して recovery claude session を起動しない
+3. While 同一 Issue / PR が `max-attempts` または `no-progress` で終端済みである, the Failed Recovery Processor shall 着手コメント・結果コメントを新たに投稿しない
+4. While 同一 Issue / PR が `max-attempts` または `no-progress` で終端済みである, the Failed Recovery Processor shall Slack 通知 emitter を新たに発火しない
+5. While 同一 Issue / PR が `max-attempts` または `no-progress` で終端済みである, the Failed Recovery Processor shall 通算 attempt カウンタを加算しない
+6. While 同一 Issue / PR が `max-attempts` または `no-progress` で終端済みである, the Failed Recovery Processor shall run-summary の最終結果確定を新たに行わない
+
+### Requirement 3: 終端済み Issue / PR の識別
+
+**Objective:** As an idd-claude 運用者, I want 終端済みの Issue / PR をサイクル間で確実に識別できる, so that 終端済み判定の取りこぼしや誤判定が起きずに Req 1・Req 2 が成立する
+
+#### Acceptance Criteria
+
+1. The Failed Recovery Processor shall 各 Issue / PR について「`max-attempts` 終端済み」「`no-progress` 終端済み」「未終端」のいずれかを cron tick 間で判定可能な情報源を 1 つ以上維持する
+2. The Failed Recovery Processor shall 終端済み判定の情報源を、watcher プロセスの再起動・cron 実行ユーザーの再ログインを跨いでも保持する
+3. When 終端済み判定の情報源が新たに `max-attempts` または `no-progress` の状態を記録する場合, the Failed Recovery Processor shall その記録を、対応する終端理由コメントの投稿と同一サイクル内で確定させる
+
+### Requirement 4: ラベル運用と既存契約の維持
+
+**Objective:** As an idd-claude 運用者, I want 終端済みでも `claude-failed` ラベルが据え置かれる既存運用を維持したい, so that 手動レビュー対象の検出フロー（`claude-failed` ラベルでの列挙）が壊れずに済む
+
+#### Acceptance Criteria
+
+1. When `max-attempts` 終端処理が完了した場合, the Failed Recovery Processor shall 当該 Issue / PR の `claude-failed` ラベルを除去しない
+2. When `no-progress` 終端処理が完了した場合, the Failed Recovery Processor shall 当該 Issue / PR の `claude-failed` ラベルを除去しない
+3. While 同一 Issue / PR が `max-attempts` または `no-progress` で終端済みである, the Failed Recovery Processor shall 当該 Issue / PR の `claude-failed` ラベルを変更しない
+4. When 終端済みの Issue / PR に対して人間運用者が `claude-failed` ラベルを手動で除去した場合, the Failed Recovery Processor shall 通常の候補列挙経路から外れた結果として副作用を起こさない
+
+### Requirement 5: 異常系（state 不整合）の fail-open
+
+**Objective:** As an idd-claude 運用者, I want 終端済み判定の情報源が破損・欠落していた場合に従来挙動に fail-open する, so that 本変更が新たな停止リスクを生まずに既存の fail-continue 方針と整合する
+
+#### Acceptance Criteria
+
+1. If 終端済み判定の情報源（state ファイル等）が parse 失敗・読み出し不能となった場合, the Failed Recovery Processor shall 警告ログを残した上で当該 Issue / PR を「未終端」として扱い、本変更導入前と同等の候補選定フローに退行する
+2. If 終端済み判定の情報源がサイクル開始時点で欠落していた場合, the Failed Recovery Processor shall 警告ログを残した上で当該 Issue / PR を「未終端」として扱い、本変更導入前と同等の候補選定フローに退行する
+3. The Failed Recovery Processor shall fail-open 退行時も watcher 本体の後続 Issue 処理を停止させない（fail-continue を維持する）
+
+### Requirement 6: gate OFF 時の副作用ゼロ
+
+**Objective:** As an idd-claude 運用者, I want `FAILED_RECOVERY_ENABLED=false` または `FULL_AUTO_ENABLED=false` の環境では本変更による副作用がゼロである, so that 機能 opt-out 中の repo に対して本修正が新たな状態書き込みやコメント投稿を発生させない
+
+#### Acceptance Criteria
+
+1. While `FAILED_RECOVERY_ENABLED` が `true` 以外（未設定・空・`false`・typo を含む）である, the Failed Recovery Processor shall 終端済み判定の情報源への書き込みを行わない
+2. While `FULL_AUTO_ENABLED` が `true` 以外である, the Failed Recovery Processor shall 終端済み判定の情報源への書き込みを行わない
+3. While 二重 opt-in gate のいずれかが OFF である, the Failed Recovery Processor shall 終端理由コメントの投稿・ラベル変更・Slack 通知 emitter の発火を行わない
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Failed Recovery Processor shall 既存の state JSON スキーマの必須フィールド（`issue` / `total_attempts` / `last_status` / `last_failure_signature` / `last_head_sha` / `last_attempt_at` / `immediate_failure_streak` / `history`）の名称と型を変更しない
+2. The Failed Recovery Processor shall 既存の終端理由識別子文字列（`max-attempts` / `no-progress` / `immediate-failure-streak`）を変更しない
+3. The Failed Recovery Processor shall 本変更導入以前に書かれた state ファイル（終端状態が永続化されていない既存ファイル）を読み込んだ際、当該 Issue / PR を「未終端」として扱い、現行サイクルから新仕様に従って終端済みを永続化する経路に進ませる
+4. The Failed Recovery Processor shall 既存の環境変数名（`FAILED_RECOVERY_ENABLED` / `FULL_AUTO_ENABLED` / `FAILED_RECOVERY_MAX_ATTEMPTS` / `FAILED_RECOVERY_STATE_DIR` 等）の意味と既定値を変更しない
+5. The Failed Recovery Processor shall 既存の終端コメント本文に含まれる「通算回数」「上限値」「終端理由識別子」「`claude-failed` ラベルは据え置く」旨の文言を引き続き含める
+
+### NFR 2: 可観測性
+
+1. When 同一 Issue / PR が終端済みと判定されて副作用が抑止された場合, the Failed Recovery Processor shall 当該抑止の事実を一次運用ログ（`failed-recovery:` prefix 付きの行）に Issue / PR 番号と終端理由識別子と共に 1 行記録する
+2. The Failed Recovery Processor shall 終端済み判定の抑止ログを、運用者が `grep` で重複コメント spam の収束を確認可能な粒度（理由識別子の文字列を含む）で出力する
+
+### NFR 3: セキュリティ
+
+1. The Failed Recovery Processor shall 終端済み判定の情報源を、既存 state ファイルと同じディレクトリ（`$FAILED_RECOVERY_STATE_DIR` 配下、既定で `$HOME/.issue-watcher/` 配下）に配置し、予測可能名の `/tmp` 配下を採用しない
+2. The Failed Recovery Processor shall 終端済み判定に関わるログ・コメント・通知 detail に GH_TOKEN 等の secrets・failure signature の全文を含めない
+3. The Failed Recovery Processor shall 終端済み判定の情報源を読み書きする際、未信頼入力（Issue / PR 番号等）の使用前検証（`^[0-9]+$`）を維持する
+
+## Out of Scope
+
+- 既に投稿済みの重複終端コメントの遡及削除・clean-up（GitHub 上の履歴は据え置く）
+- quota 由来の誤 `claude-failed` 確定の修正（#416 の上流原因対応で扱う）
+- `FAILED_RECOVERY_MAX_ATTEMPTS` 既定値（4）の見直し
+- 既存の `no-progress` 判定ロジック自体の変更（signature 比較・head SHA 比較の閾値・アルゴリズム）
+- `claude-failed` ラベル運用の方針変更（自動除去・別ラベルへの差し替え等）
+- `immediate-failure-streak` 終端経路（#411）への同様のべき等性適用（本要件は max-attempts と no-progress に限定）
+- 候補列挙段階での server-side filter（GitHub Search API）による終端済み除外（実装手段は design.md の領分）
+
+## Open Questions
+
+- なし

--- a/docs/specs/417--bug-failed-recovery-processor-attempt-c/review-notes.md
+++ b/docs/specs/417--bug-failed-recovery-processor-attempt-c/review-notes.md
@@ -1,0 +1,85 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-27T11:35:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-417-impl--bug-failed-recovery-processor-attempt-c
+- HEAD commit: cca9b7025a3cff24b0928f3dfab37e8b6054656b
+- Compared to: main..HEAD
+
+変更ファイル（4 件）:
+
+- `local-watcher/bin/modules/failed-recovery.sh`（+186/−2）
+- `local-watcher/test/fr_terminate_idempotent_test.sh`（新規 +625 行 / 64 ケース）
+- `local-watcher/test/fr_fetch_test.sh`（+24 行 / pass-through stub 追加）
+- `docs/specs/417--.../impl-notes.md`（新規）
+
+設計判断（仮案 C 両刀）:
+
+1. `fr_is_terminated` 純粋関数を追加し state JSON の既存 `last_status` enum
+   (`max-attempts` / `no-progress`) を判定
+2. `fr_filter_terminated_candidates` を `fr_fetch_failed_issues` / `fr_fetch_failed_prs`
+   末尾で適用（fetch 段階で物理除外 / Req 2.1〜2.6）
+3. `fr_terminate_max_attempts` / `fr_terminate_no_progress` 冒頭にべき等ガード + 末尾に
+   `fr_save_state` 永続化（Req 1.5 / 1.6 / 3.1〜3.3）
+
+検証実行（reviewer 自身が確認）:
+
+- `bash local-watcher/test/fr_terminate_idempotent_test.sh` → PASS=64 / FAIL=0
+- `bash local-watcher/test/fr_fetch_test.sh` → PASS=42 / FAIL=0
+- `bash local-watcher/test/fr_terminate_test.sh` → PASS=77 / FAIL=0
+- `shellcheck` 警告ゼロ（failed-recovery.sh + 新規 / 改修 test 2 本）
+
+## Verified Requirements
+
+- 1.1 — `fr_terminate_max_attempts` 冒頭 `fr_is_terminated` ガード（failed-recovery.sh:1685〜1696）/ Section 3 (count=0 for gh issue comment / rs_set_result / sn_notify)
+- 1.2 — `fr_terminate_no_progress` 冒頭 `fr_is_terminated` ガード（failed-recovery.sh:1781〜1791）/ Section 4
+- 1.3 — cross-status ガード（last_status が max-attempts/no-progress いずれでも no-op）/ Section 5-A + 3 で生涯 1 件契約担保
+- 1.4 — 同上 / Section 5-B + 4
+- 1.5 — `fr_terminate_max_attempts` 末尾 `fr_save_state ... "max-attempts" ...`（failed-recovery.sh:1733〜1736）/ Section 2 で state JSON last_status 検証
+- 1.6 — `fr_terminate_no_progress` 末尾 `fr_save_state ... "no-progress" ...`（failed-recovery.sh:1824〜1827）/ Section 9
+- 2.1 — `fr_filter_terminated_candidates` で fetch 段階除外 → `fr_run_recovery_attempt` 自体不発火 / Section 7-B/7-G
+- 2.2 — 同上（PR 経路 / Section 7-G）
+- 2.3 — fetch 除外 + terminate ガード両方で抑止 / Section 3, 4, 7
+- 2.4 — Section 3, 4 で `sn_notify` count=0 を assertion
+- 2.5 — fetch 除外で `fr_run_recovery_attempt` → `fr_save_state` の attempt 加算経路自体起動しない / Section 7-B で除外確認
+- 2.6 — Section 3, 4 で `rs_set_result` count=0 を assertion
+- 3.1 — `fr_is_terminated` 純粋関数の 3 状態判定（max-attempts / no-progress / それ以外）/ Section 1-A〜1-H
+- 3.2 — `fr_save_state` の atomic write が `$FAILED_RECOVERY_STATE_DIR`（`$HOME` 配下既定）で動作 / 既存 fr_state_test.sh + Section 2/9 で間接担保
+- 3.3 — terminate 関数末尾で `fr_save_state` 呼び出し（同一サイクル内確定）/ Section 2/9 で state file 即時存在を検証
+- 4.1 — `--remove-label claude-failed` 呼び出しを追加していない / Section 8-A で assert_not_grep
+- 4.2 — 同上（既存 fr_terminate_test.sh + 本変更で remove-label 追加なし）
+- 4.3 — Section 8-B（2 サイクル目でも remove-label 呼ばれず）
+- 4.4 — 本変更は server-side filter `label:"claude-failed"` に手を入れず、人間がラベル除去すれば既存挙動で除外される
+- 5.1 — `fr_is_terminated` が jq parse 失敗で rc=1 / Section 1-H + 6-B + 7-F
+- 5.2 — `fr_load_state` が不在で `{}` を返す既存挙動を継承 / Section 6-A
+- 5.3 — terminate 関数の return は 0 / `fr_save_state` 失敗時は `fr_warn` で記録のみ（failed-recovery.sh:1737, 1828）
+- 6.1 — gate チェックは `process_failed_recovery` 冒頭で行われ early return（本変更で gate 外の経路追加なし。既存 fr_process_test.sh / fr_is_enabled_test.sh で間接担保）
+- 6.2 — 同上（`FULL_AUTO_ENABLED` gate）
+- 6.3 — 同上
+- NFR 1.1 — Section 10 で `immediate_failure_streak` / `last_failure_signature` / `last_head_sha` / `total_attempts` の前回値継承検証
+- NFR 1.2 — terminate コメント本文の `max-attempts` / `no-progress` 識別子据え置き（既存 fr_terminate_test.sh 継続 PASS）
+- NFR 1.3 — Section 6-C で旧 schema（last_status 不在）を未終端扱いで fail-open
+- NFR 1.4 — 新 env var 追加なし（diff 確認済）
+- NFR 1.5 — terminate コメント本文未変更（既存 fr_terminate_test.sh PASS）
+- NFR 2.1 — `fr_log` で `failed-recovery: <kind>=#<n> terminated reason=<status> suppressed=<...>` 1 行ログ / Section 3 (3 件), 4 (3 件), 7-B/7-G で assertion
+- NFR 2.2 — 同上（reason 識別子文字列を含む）
+- NFR 3.1 — `$FAILED_RECOVERY_STATE_DIR` 既存配置を継承（新規 path 追加なし）
+- NFR 3.2 — terminate ログ / コメント / Slack detail に secrets / signature 全文を含めない（既存実装維持）
+- NFR 3.3 — `fr_filter_terminated_candidates` 内で `[[ "$number" =~ ^[0-9]+$ ]]` 数値検証実装（failed-recovery.sh:347）
+
+## Findings
+
+なし。
+
+## Summary
+
+採用方針（仮案 C: terminate ガード + fetch 段階除外の二重防御）は AC の Req 2.x
+（claude session 起動・着手コメント・attempt 加算・Slack 通知・run-summary 確定の全副作用
+抑止）を満たすために必要であり、設計判断が妥当。既存 schema を変更せず last_status enum
+を流用して NFR 1.1 後方互換を保ち、state 破損 / 欠落時は `fr_load_state` の `{}` 返却で
+自然に fail-open する fail-continue 設計も Req 5.1〜5.3 と整合。524 tests 全 PASS、shellcheck
+警告ゼロ。境界は failed-recovery.sh + その近接テスト + impl-notes に限定されており逸脱なし。
+
+RESULT: approve

--- a/local-watcher/bin/modules/failed-recovery.sh
+++ b/local-watcher/bin/modules/failed-recovery.sh
@@ -252,6 +252,123 @@ fr_save_state() {
   return 0
 }
 
+# fr_is_terminated: state JSON の last_status から「max-attempts / no-progress 終端済み」
+# を判定する純粋関数（#417）。
+#
+# Args:
+#   $1 = state_json (string、`{}` または schema 準拠 JSON、空可)
+#
+# Stdout: 終端理由（"max-attempts" / "no-progress"）。未終端なら空文字。
+# Returns:
+#   0 = 終端済み（max-attempts または no-progress）
+#   1 = 未終端（state 不在 / 破損 / それ以外の status / status 不在 → fail-open）
+#
+# 設計判断（#417 仮案 C）:
+#   - state JSON の `last_status` 既存 enum をそのまま使う（新規フィールド追加せず NFR 1.1
+#     後方互換を維持する）
+#   - state 不在・破損は呼出元の `fr_load_state` で `{}` に正規化されるため、本関数は
+#     status を読み出せれば判定し、読み出せなければ未終端として扱う（fail-open / Req 5.1〜5.3）
+#   - jq parse 失敗時も同様に未終端扱いで rc=1 を返す
+#
+# 副作用なし（純粋関数）。
+fr_is_terminated() {
+  local state_json="${1-}"
+  if [ -z "$state_json" ]; then
+    return 1
+  fi
+  local status
+  if ! status=$(printf '%s' "$state_json" | jq -r '.last_status // ""' 2>/dev/null); then
+    return 1
+  fi
+  case "$status" in
+    max-attempts|no-progress)
+      printf '%s' "$status"
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# fr_filter_terminated_candidates: 候補列挙の JSON 配列から terminal 状態（max-attempts /
+# no-progress）に永続化済みの番号を client-side filter で除外する（#417）。
+#
+# Args:
+#   $1 = kind ("issue" | "pr"、ログ識別用)
+#   $2 = candidates_json (JSON 配列文字列)
+#
+# Stdout: フィルタ後の JSON 配列（terminal 除外済み）
+# Returns: 0（常に。fail-continue）
+#
+# 設計判断（#417 Req 2.1〜2.6）:
+#   - state 不在 / 破損は fr_load_state が `{}` を返すため fr_is_terminated が rc=1
+#     （未終端）で fail-open（Req 5.1〜5.3）
+#   - 抑止時は NFR 2.1 の観点で 1 行ログを `failed-recovery: <kind>=#<n> terminated
+#     reason=<status> suppressed=enumeration` 形式で残し、運用者が `grep` で重複コメント
+#     spam の収束を確認可能にする（NFR 2.2）
+#   - number が非数値なら fail-open で残す（candidate_json の他のフィルタが処理する）
+#   - 入力が空 / JSON 配列でない場合は `[]` を返す
+fr_filter_terminated_candidates() {
+  local kind="$1"
+  local candidates_json="${2-}"
+
+  case "$kind" in
+    issue|pr) : ;;
+    *)
+      fr_warn "fr_filter_terminated_candidates: 不正な kind=$(printf '%s' "$kind" | tr -cd '[:alnum:]_-' | head -c 16)"
+      printf '%s' "[]"
+      return 0
+      ;;
+  esac
+
+  if [ -z "$candidates_json" ]; then
+    printf '%s' "[]"
+    return 0
+  fi
+  if ! printf '%s' "$candidates_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
+    printf '%s' "[]"
+    return 0
+  fi
+
+  local count
+  count=$(printf '%s' "$candidates_json" | jq -r 'length' 2>/dev/null || echo "0")
+  if ! [[ "$count" =~ ^[0-9]+$ ]] || [ "$count" = "0" ]; then
+    printf '%s' "[]"
+    return 0
+  fi
+
+  local result="[]"
+  local idx=0
+  while [ "$idx" -lt "$count" ]; do
+    local item number state_json terminal_reason
+    item=$(printf '%s' "$candidates_json" | jq -c --argjson i "$idx" '.[$i]' 2>/dev/null || echo "")
+    if [ -z "$item" ]; then
+      idx=$((idx + 1))
+      continue
+    fi
+    number=$(printf '%s' "$item" | jq -r '.number // ""' 2>/dev/null || echo "")
+    if ! [[ "$number" =~ ^[0-9]+$ ]]; then
+      # 数値検証失敗は fail-open で残す（候補列挙側で再度 sanitize される）
+      result=$(printf '%s' "$result" | jq -c --argjson it "$item" '. + [$it]' 2>/dev/null || printf '%s' "$result")
+      idx=$((idx + 1))
+      continue
+    fi
+    state_json=$(fr_load_state "$number")
+    terminal_reason=""
+    if terminal_reason=$(fr_is_terminated "$state_json"); then
+      # 終端済み → 除外 + 抑止ログ（NFR 2.1 / 2.2）
+      fr_log "${kind}=#${number} terminated reason=${terminal_reason} suppressed=enumeration"
+    else
+      result=$(printf '%s' "$result" | jq -c --argjson it "$item" '. + [$it]' 2>/dev/null || printf '%s' "$result")
+    fi
+    idx=$((idx + 1))
+  done
+
+  printf '%s' "$result"
+  return 0
+}
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Candidate Selection Layer
 #
@@ -315,7 +432,11 @@ fr_fetch_failed_issues() {
     echo "[]"
     return 0
   fi
-  printf '%s' "$issues_json"
+  # #417: terminal 状態（max-attempts / no-progress）に永続化済みの番号を除外する。
+  # state 不在 / 破損は fr_load_state が `{}` を返すので fr_is_terminated が 1（未終端）
+  # で fail-open する（Req 5.1〜5.3）。各 issue ごとに状態を確認し、抑止時は NFR 2.1 の
+  # 観点で 1 行ログを残す。
+  printf '%s' "$(fr_filter_terminated_candidates "issue" "$issues_json")"
   return 0
 }
 
@@ -444,7 +565,9 @@ fr_fetch_failed_prs() {
     idx=$((idx + 1))
   done
 
-  printf '%s' "$result"
+  # #417: terminal 状態（max-attempts / no-progress）に永続化済みの PR 番号を除外する
+  # （Req 2.1〜2.6 / fail-open は fr_filter_terminated_candidates 内で担保 / Req 5.1〜5.3）
+  printf '%s' "$(fr_filter_terminated_candidates "pr" "$result")"
   return 0
 }
 
@@ -1559,6 +1682,19 @@ fr_terminate_max_attempts() {
     return 1
   fi
 
+  # #417 Req 1.1 / 1.3 / 2.3 / 2.6: cross-cycle のべき等ガード。state JSON の last_status
+  # が既に max-attempts / no-progress なら、終端コメント・rs_set_result・sn_notify の
+  # いずれも再発火させずに即 return 0（NFR 4.2 多重発火しない契約と整合）。
+  # state 不在 / 破損は fr_load_state が `{}` を返すため fr_is_terminated が 1（未終端）
+  # で fail-open（Req 5.1〜5.3）。
+  local _prev_state _prev_status
+  _prev_state=$(fr_load_state "$number")
+  if _prev_status=$(fr_is_terminated "$_prev_state"); then
+    # 抑止ログ（NFR 2.1 / 2.2 / Req 6.1：grep でコメント spam 収束を確認可能）
+    fr_log "${kind}=#${number} terminated reason=${_prev_status} suppressed=terminate-max-attempts"
+    return 0
+  fi
+
   # 終端理由コメント 1 件を投稿（Req 4.6）。本文に通算回数 + 上限値を含めて
   # 運用者が手動レビュー時に試行履歴を把握できるようにする。secrets は含めない
   # （NFR 3.2 / printf '%s' で値埋め込み）。
@@ -1576,6 +1712,27 @@ fr_terminate_max_attempts() {
   # fr_log は core_utils.sh で `[YYYY-MM-DD HH:MM:SS] [$REPO] failed-recovery: $*`
   # の 3 段 prefix を付与する。
   fr_log "${kind}=#${number} terminated reason=max-attempts total=${total_attempts} max=${FAILED_RECOVERY_MAX_ATTEMPTS}"
+
+  # #417 Req 1.5 / 3.1〜3.3: cross-cycle の終端済み判定情報源として state JSON に
+  # last_status="max-attempts" を永続化する。既存 schema の last_failure_signature /
+  # last_head_sha / immediate_failure_streak は前回値を継承する（NFR 1.1）。fr_save_state
+  # 失敗時は fr_warn で記録するが、コメント・rs_set_result は既に確定済みなので
+  # caller は落とさない（fail-continue）。
+  local _prev_sig _prev_head_sha _prev_streak
+  if ! _prev_sig=$(printf '%s' "$_prev_state" | jq -r '.last_failure_signature // ""' 2>/dev/null); then
+    _prev_sig=""
+  fi
+  if ! _prev_head_sha=$(printf '%s' "$_prev_state" | jq -r '.last_head_sha // ""' 2>/dev/null); then
+    _prev_head_sha=""
+  fi
+  if ! _prev_streak=$(printf '%s' "$_prev_state" | jq -r '.immediate_failure_streak // 0' 2>/dev/null); then
+    _prev_streak=0
+  fi
+  if ! [[ "$_prev_streak" =~ ^[0-9]+$ ]]; then
+    _prev_streak=0
+  fi
+  fr_save_state "$number" "$total_attempts" "max-attempts" "$_prev_sig" "$_prev_head_sha" "$_prev_streak" \
+    || fr_warn "fr_terminate_max_attempts: fr_save_state 失敗 ${kind}=#${number}（cross-cycle べき等性が失われる可能性）"
 
   # Issue #370 task 5: Slack 通知 emitter（fail-open / gate OFF 時は no-op）
   sn_notify failed-recovery "$number" "https://github.com/$REPO/${kind}s/$number" max-attempts "kind=${kind} attempts=${total_attempts} max=${FAILED_RECOVERY_MAX_ATTEMPTS}" || true
@@ -1621,6 +1778,17 @@ fr_terminate_no_progress() {
     return 1
   fi
 
+  # #417 Req 1.2 / 1.4 / 2.3 / 2.6: cross-cycle のべき等ガード。state JSON の last_status
+  # が既に max-attempts / no-progress なら、終端コメント・rs_set_result・sn_notify の
+  # いずれも再発火させずに即 return 0（NFR 4.2 多重発火しない契約と整合）。
+  # state 不在 / 破損は fail-open（Req 5.1〜5.3）。
+  local _prev_state _prev_status
+  _prev_state=$(fr_load_state "$number")
+  if _prev_status=$(fr_is_terminated "$_prev_state"); then
+    fr_log "${kind}=#${number} terminated reason=${_prev_status} suppressed=terminate-no-progress"
+    return 0
+  fi
+
   # 終端理由コメント 1 件を投稿（Req 5.3）。本文には「no-progress」「同原因再発」
   # 「無進捗」のキーワードを含めて運用者が手動レビュー時に検索可能にする。
   # signature の hex 値は運用者向け本文の可読性を優先して**含めない**（log には残す）。
@@ -1642,6 +1810,22 @@ fr_terminate_no_progress() {
     sig_prefix=" signature=$(printf '%s' "$signature" | cut -c1-8)"
   fi
   fr_log "${kind}=#${number} terminated reason=no-progress total=${total_attempts}${sig_prefix}"
+
+  # #417 Req 1.6 / 3.1〜3.3: cross-cycle の終端済み判定情報源として state JSON に
+  # last_status="no-progress" を永続化する。signature は引数のものを保持（既存 schema
+  # の last_failure_signature を上書き）、head_sha / streak は前回値を継承（NFR 1.1）。
+  local _prev_head_sha _prev_streak
+  if ! _prev_head_sha=$(printf '%s' "$_prev_state" | jq -r '.last_head_sha // ""' 2>/dev/null); then
+    _prev_head_sha=""
+  fi
+  if ! _prev_streak=$(printf '%s' "$_prev_state" | jq -r '.immediate_failure_streak // 0' 2>/dev/null); then
+    _prev_streak=0
+  fi
+  if ! [[ "$_prev_streak" =~ ^[0-9]+$ ]]; then
+    _prev_streak=0
+  fi
+  fr_save_state "$number" "$total_attempts" "no-progress" "$signature" "$_prev_head_sha" "$_prev_streak" \
+    || fr_warn "fr_terminate_no_progress: fr_save_state 失敗 ${kind}=#${number}（cross-cycle べき等性が失われる可能性）"
 
   # Issue #370 task 5: Slack 通知 emitter（fail-open / gate OFF 時は no-op）。
   # signature 値は detail に含めない（NFR 3.3 / fr_log 側で先頭 8 桁を維持）。

--- a/local-watcher/test/fr_fetch_test.sh
+++ b/local-watcher/test/fr_fetch_test.sh
@@ -57,6 +57,30 @@ for fn in fr_fetch_failed_issues fr_fetch_failed_prs; do
   fi
 done
 
+# #417: fr_fetch_failed_issues / fr_fetch_failed_prs の末尾で
+# fr_filter_terminated_candidates を呼ぶようになった。本テストは fetch のみの
+# 動作を検証する性質なので、フィルタは pass-through stub（state を読まずに入力をそのまま
+# 返す）として隔離する。terminal 除外の挙動は fr_fetch_terminated_filter_test.sh で
+# 別途検証する。
+# shellcheck disable=SC2317
+fr_filter_terminated_candidates() {
+  # $1 = kind, $2 = candidates_json。入力 JSON 配列をそのまま stdout に返す。
+  printf '%s' "${2-[]}"
+}
+# shellcheck disable=SC2317
+fr_load_state() {
+  # 念のため stub（候補列挙では未終端扱いで pass-through する想定）。
+  printf '%s' "{}"
+}
+# shellcheck disable=SC2317
+fr_is_terminated() {
+  return 1
+}
+# shellcheck disable=SC2317
+fr_log() {
+  :
+}
+
 # ── グローバル env（遅延束縛で抽出関数本体から参照される） ──
 # shellcheck disable=SC2034
 REPO="owner/test-repo"

--- a/local-watcher/test/fr_terminate_idempotent_test.sh
+++ b/local-watcher/test/fr_terminate_idempotent_test.sh
@@ -1,0 +1,625 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #417 で導入した Failed Recovery Processor の terminate cross-cycle
+#       べき等化を検証する回帰テスト。
+#
+#       対象関数:
+#         - fr_is_terminated                     (#417 純粋関数)
+#         - fr_terminate_max_attempts            (#417 Req 1.1 / 1.3 / 1.5 / 2.3 / 2.6 / 3.1〜3.3)
+#         - fr_terminate_no_progress             (#417 Req 1.2 / 1.4 / 1.6 / 2.3 / 2.6 / 3.1〜3.3)
+#         - fr_filter_terminated_candidates      (#417 Req 2.1〜2.6 列挙除外)
+#
+#       検証する AC（docs/specs/417--bug-failed-recovery-processor-attempt-c/requirements.md）:
+#         Req 1.1 / 1.2: 2 回目以降のサイクルで終端コメントを新たに投稿しない
+#         Req 1.3 / 1.4: 生涯で最大 1 件しか投稿しない
+#         Req 1.5 / 1.6: 終端済みを永続化（state JSON last_status）
+#         Req 2.3:      terminate 後サイクルで着手 / 結果コメントを新たに投稿しない（fetch 段階で除外）
+#         Req 2.4:      Slack 通知 emitter を新たに発火しない
+#         Req 2.5:      attempt カウンタを加算しない（claude session 自体起動しない）
+#         Req 2.6:      run-summary 確定を新たに行わない（rs_set_result 多重発火なし）
+#         Req 3.1〜3.3: 永続化情報源（state JSON）
+#         Req 4.1〜4.3: claude-failed ラベルを除去しない（既存 fr_terminate_test.sh と並行検証）
+#         Req 5.1〜5.3: state 破損 / 欠落で fail-open
+#         Req 6.1〜6.3: NFR 2.1 観測ログ + gate OFF 副作用ゼロは別 test で検証
+#         NFR 2.1:      抑止時に `failed-recovery:` prefix 付き 1 行ログ
+#         NFR 4.2:      rs_set_result 多重発火なし
+#         NFR 1.1:      既存 schema 維持
+#
+# 配置先: local-watcher/test/fr_terminate_idempotent_test.sh
+# 依存:   bash 4+, awk, jq, mktemp
+# 実行:   bash local-watcher/test/fr_terminate_idempotent_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery.sh"
+
+if [ ! -f "$MODULE_SH" ]; then
+  echo "ERROR: cannot find failed-recovery.sh at $MODULE_SH" >&2
+  exit 2
+fi
+
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# 対象: terminate 関数 + 依存ヘルパー + 状態管理関数
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_state_path")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_load_state")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_save_state")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_is_terminated")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_filter_terminated_candidates")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_post_attempt_comment")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_terminate_max_attempts")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "fr_terminate_no_progress")"
+
+for fn in fr_state_path fr_load_state fr_save_state fr_is_terminated \
+          fr_filter_terminated_candidates fr_post_attempt_comment \
+          fr_terminate_max_attempts fr_terminate_no_progress; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# ── グローバル env（遅延束縛で抽出関数本体から参照される） ──
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# shellcheck disable=SC2034
+LABEL_FAILED="claude-failed"
+# shellcheck disable=SC2034
+FAILED_RECOVERY_GIT_TIMEOUT=60
+# shellcheck disable=SC2034
+FAILED_RECOVERY_MAX_ATTEMPTS=4
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_rc() {
+  local label="$1"
+  local expected_rc="$2"
+  local actual_rc="$3"
+  if [ "$expected_rc" = "$actual_rc" ]; then
+    echo "PASS: $label (rc=$actual_rc)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected rc: $expected_rc"
+    echo "  actual rc  : $actual_rc"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_grep() {
+  local label="$1"
+  local pattern="$2"
+  local file="$3"
+  if grep -qE -- "$pattern" "$file" 2>/dev/null; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  pattern: $pattern"
+    echo "  --- contents ---"
+    cat "$file"
+    echo "  --- /contents ---"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_not_grep() {
+  local label="$1"
+  local pattern="$2"
+  local file="$3"
+  if grep -qE -- "$pattern" "$file" 2>/dev/null; then
+    echo "FAIL: $label"
+    echo "  unexpected match for pattern: $pattern"
+    echo "  --- contents ---"
+    cat "$file"
+    echo "  --- /contents ---"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+count_pattern() {
+  local pattern="$1"
+  local file="$2"
+  local n
+  n=$(grep -cE -- "$pattern" "$file" 2>/dev/null || true)
+  n="${n//[[:space:]]/}"
+  if [ -z "$n" ]; then
+    n="0"
+  fi
+  printf '%s' "$n"
+}
+
+assert_count() {
+  local label="$1"
+  local pattern="$2"
+  local file="$3"
+  local expected="$4"
+  local actual
+  actual=$(count_pattern "$pattern" "$file")
+  if [ "$actual" = "$expected" ]; then
+    echo "PASS: $label (count=$actual)"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  pattern : $pattern"
+    echo "  expected: $expected"
+    echo "  actual  : $actual"
+    echo "  --- contents ---"
+    cat "$file"
+    echo "  --- /contents ---"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ── stub state ──
+GH_CALL_LOG=""
+FR_WARN_TRACE=""
+FR_LOG_TRACE=""
+RS_TRACE=""
+SN_NOTIFY_TRACE=""
+
+# state directory（fr_save_state / fr_load_state は実体を扱う）
+FAILED_RECOVERY_STATE_DIR=""
+
+reset_stub_state() {
+  GH_CALL_LOG="$(mktemp)"
+  FR_WARN_TRACE="$(mktemp)"
+  FR_LOG_TRACE="$(mktemp)"
+  RS_TRACE="$(mktemp)"
+  SN_NOTIFY_TRACE="$(mktemp)"
+  FAILED_RECOVERY_STATE_DIR=$(mktemp -d)
+}
+
+cleanup_stub_state() {
+  rm -f "$GH_CALL_LOG" "$FR_WARN_TRACE" "$FR_LOG_TRACE" "$RS_TRACE" "$SN_NOTIFY_TRACE" 2>/dev/null || true
+  if [ -n "$FAILED_RECOVERY_STATE_DIR" ] && [ -d "$FAILED_RECOVERY_STATE_DIR" ]; then
+    rm -rf "$FAILED_RECOVERY_STATE_DIR" 2>/dev/null || true
+  fi
+}
+
+# fr_warn / fr_log stub
+# shellcheck disable=SC2317
+fr_warn() {
+  echo "fr_warn: $*" >> "$FR_WARN_TRACE"
+}
+# shellcheck disable=SC2317
+fr_log() {
+  echo "[YYYY-MM-DD HH:MM:SS] [$REPO] failed-recovery: $*" >> "$FR_LOG_TRACE"
+}
+# shellcheck disable=SC2317
+rs_set_result() {
+  echo "rs_set_result $*" >> "$RS_TRACE"
+  return 0
+}
+# shellcheck disable=SC2317
+sn_notify() {
+  echo "sn_notify $*" >> "$SN_NOTIFY_TRACE"
+  return 0
+}
+# shellcheck disable=SC2317
+timeout() {
+  shift
+  "$@"
+}
+# shellcheck disable=SC2317
+gh() {
+  echo "gh $*" >> "$GH_CALL_LOG"
+  return 0
+}
+
+# ============================================================
+# Section 1: fr_is_terminated 純粋関数の振る舞い
+# ============================================================
+echo "--- Section 1: fr_is_terminated 純粋関数 ---"
+
+# 1-A: 空 / 不在 → 未終端
+set +e
+reason=$(fr_is_terminated "")
+rc=$?
+set -e
+assert_rc "fr_is_terminated 空文字 → rc=1（未終端 / fail-open）" "1" "$rc"
+assert_eq "fr_is_terminated 空文字 → stdout 空" "" "$reason"
+
+# 1-B: `{}` → 未終端
+set +e
+reason=$(fr_is_terminated "{}")
+rc=$?
+set -e
+assert_rc "fr_is_terminated {} → rc=1（未終端）" "1" "$rc"
+
+# 1-C: last_status="in-progress" → 未終端
+set +e
+reason=$(fr_is_terminated '{"last_status":"in-progress"}')
+rc=$?
+set -e
+assert_rc "fr_is_terminated in-progress → rc=1（未終端）" "1" "$rc"
+
+# 1-D: last_status="succeeded" → 未終端
+set +e
+reason=$(fr_is_terminated '{"last_status":"succeeded"}')
+rc=$?
+set -e
+assert_rc "fr_is_terminated succeeded → rc=1（未終端）" "1" "$rc"
+
+# 1-E: last_status="max-attempts" → 終端
+set +e
+reason=$(fr_is_terminated '{"last_status":"max-attempts"}')
+rc=$?
+set -e
+assert_rc "fr_is_terminated max-attempts → rc=0（終端）" "0" "$rc"
+assert_eq "fr_is_terminated max-attempts → stdout=\"max-attempts\"" "max-attempts" "$reason"
+
+# 1-F: last_status="no-progress" → 終端
+set +e
+reason=$(fr_is_terminated '{"last_status":"no-progress"}')
+rc=$?
+set -e
+assert_rc "fr_is_terminated no-progress → rc=0（終端）" "0" "$rc"
+assert_eq "fr_is_terminated no-progress → stdout=\"no-progress\"" "no-progress" "$reason"
+
+# 1-G: last_status="immediate-failure-streak" → 未終端（#411 の終端は本 #417 のスコープ外）
+set +e
+reason=$(fr_is_terminated '{"last_status":"immediate-failure-streak"}')
+rc=$?
+set -e
+assert_rc "fr_is_terminated immediate-failure-streak → rc=1（本 Issue #417 のスコープ外）" "1" "$rc"
+
+# 1-H: JSON parse 失敗（不正 JSON）→ 未終端（fail-open / Req 5.1）
+set +e
+reason=$(fr_is_terminated '{not json')
+rc=$?
+set -e
+assert_rc "fr_is_terminated 不正 JSON → rc=1（fail-open / Req 5.1）" "1" "$rc"
+
+# ============================================================
+# Section 2: 初回 terminate（state 不在）→ コメント投稿 + state 永続化
+# ============================================================
+echo ""
+echo "--- Section 2: 初回 terminate（state 不在 / Req 1.5 / 3.1〜3.3） ---"
+
+reset_stub_state
+trap 'cleanup_stub_state' EXIT
+
+# state 不在の状態で fr_terminate_max_attempts を呼ぶ → 初回終端
+set +e
+fr_terminate_max_attempts "issue" "417" "4"
+rc=$?
+set -e
+
+assert_rc "Req 4.6: 初回 max-attempts → rc=0" "0" "$rc"
+assert_count "Req 1.3 (初回): gh issue comment が 1 件発火" "gh issue comment 417" "$GH_CALL_LOG" "1"
+assert_count "Req 1.3 (初回): rs_set_result が 1 件発火" "^rs_set_result " "$RS_TRACE" "1"
+assert_count "Req 2.4 (初回): sn_notify が 1 件発火" "^sn_notify " "$SN_NOTIFY_TRACE" "1"
+
+# Req 1.5: state JSON に last_status="max-attempts" が永続化されている
+state_file="$FAILED_RECOVERY_STATE_DIR/417.json"
+if [ -f "$state_file" ]; then
+  status=$(jq -r '.last_status // ""' "$state_file" 2>/dev/null || echo "<parse-err>")
+  assert_eq "Req 1.5 / 3.1: state JSON の last_status=\"max-attempts\" が永続化" "max-attempts" "$status"
+  total=$(jq -r '.total_attempts // ""' "$state_file" 2>/dev/null || echo "")
+  assert_eq "Req 3.1: state JSON の total_attempts=4 が記録" "4" "$total"
+else
+  echo "FAIL: Req 1.5: state file が存在しない: $state_file"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+
+cleanup_stub_state
+
+# ============================================================
+# Section 3: 2 サイクル目（既終端 state あり）→ 完全に no-op
+# ============================================================
+echo ""
+echo "--- Section 3: 2 サイクル目（既 max-attempts）→ Req 1.1 / 2.3 / 2.4 / 2.6 ---"
+
+reset_stub_state
+
+# 事前条件: state JSON に last_status="max-attempts" を既に永続化済み
+fr_save_state "417" "4" "max-attempts" "abc" "" "0" >/dev/null
+
+# 2 サイクル目で再度 fr_terminate_max_attempts を呼ぶ
+set +e
+fr_terminate_max_attempts "issue" "417" "4"
+rc=$?
+set -e
+
+assert_rc "Req 1.1: 2 サイクル目 max-attempts → rc=0（no-op）" "0" "$rc"
+
+# Req 1.1 / 2.3: コメントが再投稿されない
+assert_count "Req 1.1 / 2.3: 2 サイクル目で gh comment が呼ばれない" "gh issue comment" "$GH_CALL_LOG" "0"
+# Req 2.6: rs_set_result が再発火しない（NFR 4.2 多重発火なし）
+assert_count "Req 2.6: 2 サイクル目で rs_set_result が呼ばれない" "^rs_set_result " "$RS_TRACE" "0"
+# Req 2.4: sn_notify が再発火しない
+assert_count "Req 2.4: 2 サイクル目で sn_notify が呼ばれない" "^sn_notify " "$SN_NOTIFY_TRACE" "0"
+# Req 6.1 / NFR 2.1 / 2.2: 抑止ログが残る（運用者が grep で確認可能）
+assert_grep "NFR 2.1: 抑止ログに 'failed-recovery:' prefix" "failed-recovery:" "$FR_LOG_TRACE"
+assert_grep "NFR 2.2: 抑止ログに 'reason=max-attempts'" "reason=max-attempts" "$FR_LOG_TRACE"
+assert_grep "NFR 2.2: 抑止ログに 'suppressed='" "suppressed=" "$FR_LOG_TRACE"
+assert_grep "NFR 2.1: 抑止ログに 'issue=#417'" "issue=#417" "$FR_LOG_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Section 4: fr_terminate_no_progress も同様の no-op（Req 1.2 / 2.3 / 2.4 / 2.6）
+# ============================================================
+echo ""
+echo "--- Section 4: 2 サイクル目（既 no-progress）→ Req 1.2 / 2.3 / 2.4 / 2.6 ---"
+
+reset_stub_state
+fr_save_state "555" "3" "no-progress" "sig_aaa" "" "0" >/dev/null
+
+set +e
+fr_terminate_no_progress "pr" "555" "3" "sig_aaa"
+rc=$?
+set -e
+
+assert_rc "Req 1.2: 2 サイクル目 no-progress → rc=0（no-op）" "0" "$rc"
+assert_count "Req 1.2 / 2.3: 2 サイクル目で gh comment が呼ばれない" "gh pr comment" "$GH_CALL_LOG" "0"
+assert_count "Req 2.6: 2 サイクル目で rs_set_result が呼ばれない" "^rs_set_result " "$RS_TRACE" "0"
+assert_count "Req 2.4: 2 サイクル目で sn_notify が呼ばれない" "^sn_notify " "$SN_NOTIFY_TRACE" "0"
+assert_grep "NFR 2.1: 抑止ログに 'failed-recovery:' prefix" "failed-recovery:" "$FR_LOG_TRACE"
+assert_grep "NFR 2.2: 抑止ログに 'reason=no-progress'" "reason=no-progress" "$FR_LOG_TRACE"
+assert_grep "NFR 2.1: 抑止ログに 'pr=#555'" "pr=#555" "$FR_LOG_TRACE"
+
+cleanup_stub_state
+
+# ============================================================
+# Section 5: cross-status no-op
+#   既に max-attempts で終端済みなら no_progress 関数も no-op
+#   既に no-progress で終端済みなら max_attempts 関数も no-op
+# ============================================================
+echo ""
+echo "--- Section 5: cross-status no-op (Req 1.3 / 1.4 生涯 1 件契約) ---"
+
+# 5-A: max-attempts 永続化済 → no_progress も no-op
+reset_stub_state
+fr_save_state "700" "4" "max-attempts" "sig" "" "0" >/dev/null
+set +e
+fr_terminate_no_progress "issue" "700" "4" "sig"
+set -e
+assert_count "Req 1.3: cross-status max→no_progress でも comment 抑止" "gh issue comment" "$GH_CALL_LOG" "0"
+assert_count "Req 1.3: cross-status max→no_progress でも rs_set_result 抑止" "^rs_set_result " "$RS_TRACE" "0"
+cleanup_stub_state
+
+# 5-B: no-progress 永続化済 → max_attempts も no-op
+reset_stub_state
+fr_save_state "701" "3" "no-progress" "sig" "" "0" >/dev/null
+set +e
+fr_terminate_max_attempts "issue" "701" "3"
+set -e
+assert_count "Req 1.4: cross-status no_progress→max でも comment 抑止" "gh issue comment" "$GH_CALL_LOG" "0"
+assert_count "Req 1.4: cross-status no_progress→max でも rs_set_result 抑止" "^rs_set_result " "$RS_TRACE" "0"
+cleanup_stub_state
+
+# ============================================================
+# Section 6: fail-open（Req 5.1〜5.3）
+#   state ファイル破損時 / 欠落時に従来通り終端コメントが投稿される
+# ============================================================
+echo ""
+echo "--- Section 6: state 破損 / 欠落で fail-open (Req 5.1〜5.3) ---"
+
+# 6-A: state ファイル欠落（初回） → 従来通り投稿（Section 2 で検証済みなのでここでは subset）
+reset_stub_state
+set +e
+fr_terminate_max_attempts "issue" "800" "4"
+set -e
+assert_count "Req 5.2: state 欠落 → 従来通り gh comment が 1 件発火" "gh issue comment 800" "$GH_CALL_LOG" "1"
+assert_count "Req 5.2: state 欠落 → 従来通り rs_set_result が 1 件発火" "^rs_set_result " "$RS_TRACE" "1"
+cleanup_stub_state
+
+# 6-B: state ファイル破損（不正 JSON）→ fr_load_state が `{}` を返し fail-open
+reset_stub_state
+mkdir -p "$FAILED_RECOVERY_STATE_DIR"
+printf 'NOT VALID JSON {{{' > "$FAILED_RECOVERY_STATE_DIR/801.json"
+set +e
+fr_terminate_max_attempts "issue" "801" "4"
+set -e
+assert_count "Req 5.1: state 破損 → 従来通り gh comment が 1 件発火（fail-open）" "gh issue comment 801" "$GH_CALL_LOG" "1"
+assert_count "Req 5.1: state 破損 → 従来通り rs_set_result が 1 件発火（fail-open）" "^rs_set_result " "$RS_TRACE" "1"
+cleanup_stub_state
+
+# 6-C: 既存 schema（last_status field 不在 / 旧 schema）→ 未終端扱いで投稿
+reset_stub_state
+mkdir -p "$FAILED_RECOVERY_STATE_DIR"
+printf '%s' '{"issue":802,"total_attempts":2}' > "$FAILED_RECOVERY_STATE_DIR/802.json"
+set +e
+fr_terminate_max_attempts "issue" "802" "4"
+set -e
+assert_count "NFR 1.1: last_status 不在の旧 schema → 未終端扱いで投稿" "gh issue comment 802" "$GH_CALL_LOG" "1"
+cleanup_stub_state
+
+# ============================================================
+# Section 7: fr_filter_terminated_candidates 候補列挙除外
+# ============================================================
+echo ""
+echo "--- Section 7: fr_filter_terminated_candidates (Req 2.1〜2.6 物理担保) ---"
+
+# 7-A: 終端済みなし → 入力をそのまま返す
+reset_stub_state
+input='[{"number":900,"labels":[]},{"number":901,"labels":[]}]'
+filtered=$(fr_filter_terminated_candidates "issue" "$input")
+len=$(printf '%s' "$filtered" | jq -r 'length' 2>/dev/null || echo "0")
+assert_eq "Req 2.6: 終端済みなし → 2 件残る" "2" "$len"
+cleanup_stub_state
+
+# 7-B: 1 件が終端済み → 除外されて 1 件残る + 抑止ログ
+reset_stub_state
+fr_save_state "910" "4" "max-attempts" "sig" "" "0" >/dev/null
+input='[{"number":910,"labels":[]},{"number":911,"labels":[]}]'
+filtered=$(fr_filter_terminated_candidates "issue" "$input")
+len=$(printf '%s' "$filtered" | jq -r 'length' 2>/dev/null || echo "0")
+assert_eq "Req 2.1〜2.6: 終端済み 1 件除外 → 1 件残る" "1" "$len"
+remaining=$(printf '%s' "$filtered" | jq -r '.[0].number' 2>/dev/null || echo "")
+assert_eq "Req 2.1〜2.6: 残ったのは未終端の 911" "911" "$remaining"
+assert_grep "NFR 2.1: 列挙除外時の抑止ログ（issue=#910）" "issue=#910" "$FR_LOG_TRACE"
+assert_grep "NFR 2.2: 抑止ログに reason=max-attempts + suppressed=enumeration" "suppressed=enumeration" "$FR_LOG_TRACE"
+cleanup_stub_state
+
+# 7-C: 全件終端済み → `[]` を返す
+reset_stub_state
+fr_save_state "920" "4" "max-attempts" "" "" "0" >/dev/null
+fr_save_state "921" "3" "no-progress" "" "" "0" >/dev/null
+input='[{"number":920,"labels":[]},{"number":921,"labels":[]}]'
+filtered=$(fr_filter_terminated_candidates "issue" "$input")
+len=$(printf '%s' "$filtered" | jq -r 'length' 2>/dev/null || echo "0")
+assert_eq "Req 2.6: 全件終端済み → 0 件残る" "0" "$len"
+cleanup_stub_state
+
+# 7-D: 入力が空配列 / 空文字 / 非配列 → `[]` を返す
+reset_stub_state
+filtered=$(fr_filter_terminated_candidates "issue" "[]")
+assert_eq "境界値: 空配列 → []" "[]" "$filtered"
+filtered=$(fr_filter_terminated_candidates "issue" "")
+assert_eq "境界値: 空文字 → []" "[]" "$filtered"
+filtered=$(fr_filter_terminated_candidates "issue" "not json")
+assert_eq "境界値: 非 JSON → []" "[]" "$filtered"
+cleanup_stub_state
+
+# 7-E: kind 不正値ガード
+reset_stub_state
+filtered=$(fr_filter_terminated_candidates "foo" '[{"number":930}]')
+assert_eq "NFR 3.1: 不正 kind → []" "[]" "$filtered"
+assert_grep "NFR 3.1: 不正 kind で fr_warn 1 件" "fr_warn:" "$FR_WARN_TRACE"
+cleanup_stub_state
+
+# 7-F: state 破損時 → fail-open（未終端扱いで残す / Req 5.1）
+reset_stub_state
+mkdir -p "$FAILED_RECOVERY_STATE_DIR"
+printf 'NOT VALID' > "$FAILED_RECOVERY_STATE_DIR/940.json"
+input='[{"number":940,"labels":[]}]'
+filtered=$(fr_filter_terminated_candidates "issue" "$input")
+len=$(printf '%s' "$filtered" | jq -r 'length' 2>/dev/null || echo "0")
+assert_eq "Req 5.1: state 破損時 fail-open → 未終端扱いで残る" "1" "$len"
+cleanup_stub_state
+
+# 7-G: PR 経路でも同様に動く
+reset_stub_state
+fr_save_state "950" "4" "max-attempts" "" "" "0" >/dev/null
+input='[{"number":950,"headRefName":"claude/issue-x"},{"number":951,"headRefName":"claude/issue-y"}]'
+filtered=$(fr_filter_terminated_candidates "pr" "$input")
+len=$(printf '%s' "$filtered" | jq -r 'length' 2>/dev/null || echo "0")
+assert_eq "Req 2.1〜2.6: PR 経路でも除外が機能" "1" "$len"
+assert_grep "NFR 2.1: PR 経路の抑止ログ（pr=#950）" "pr=#950" "$FR_LOG_TRACE"
+cleanup_stub_state
+
+# ============================================================
+# Section 8: claude-failed ラベルを除去しない（Req 4.1〜4.3）
+# ============================================================
+echo ""
+echo "--- Section 8: claude-failed ラベル据え置き（Req 4.1〜4.3） ---"
+
+# 8-A: 初回 max-attempts → label 除去しない
+reset_stub_state
+set +e
+fr_terminate_max_attempts "issue" "960" "4"
+set -e
+assert_not_grep "Req 4.1: 初回 max-attempts → --remove-label claude-failed が呼ばれない" "--remove-label claude-failed" "$GH_CALL_LOG"
+cleanup_stub_state
+
+# 8-B: 2 サイクル目 max-attempts → label 除去しない（no-op で何も呼ばれない）
+reset_stub_state
+fr_save_state "961" "4" "max-attempts" "" "" "0" >/dev/null
+set +e
+fr_terminate_max_attempts "issue" "961" "4"
+set -e
+assert_not_grep "Req 4.3: 2 サイクル目でも --remove-label claude-failed が呼ばれない" "--remove-label claude-failed" "$GH_CALL_LOG"
+cleanup_stub_state
+
+# ============================================================
+# Section 9: 初回 no-progress の state 永続化（Req 1.6）
+# ============================================================
+echo ""
+echo "--- Section 9: 初回 no-progress の state 永続化（Req 1.6 / 3.1〜3.3） ---"
+
+reset_stub_state
+set +e
+fr_terminate_no_progress "issue" "970" "2" "deadbeef0000000000000000000000000000beef"
+set -e
+
+state_file="$FAILED_RECOVERY_STATE_DIR/970.json"
+if [ -f "$state_file" ]; then
+  status=$(jq -r '.last_status // ""' "$state_file" 2>/dev/null || echo "<parse-err>")
+  assert_eq "Req 1.6 / 3.1: state JSON の last_status=\"no-progress\" が永続化" "no-progress" "$status"
+  sig=$(jq -r '.last_failure_signature // ""' "$state_file" 2>/dev/null || echo "")
+  assert_eq "NFR 1.1: signature が引数値で上書きされる" "deadbeef0000000000000000000000000000beef" "$sig"
+else
+  echo "FAIL: Req 1.6: state file が存在しない"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+fi
+cleanup_stub_state
+
+# ============================================================
+# Section 10: 既存 streak / immediate_failure_streak 継承（NFR 1.1）
+# ============================================================
+echo ""
+echo "--- Section 10: terminate 前後で streak 等の既存フィールドが破壊されない（NFR 1.1） ---"
+
+reset_stub_state
+# 事前条件: in-progress + streak=2 の state
+fr_save_state "980" "3" "in-progress" "old_sig" "abc123" "2" >/dev/null
+
+set +e
+fr_terminate_max_attempts "issue" "980" "4"
+set -e
+
+state_file="$FAILED_RECOVERY_STATE_DIR/980.json"
+status=$(jq -r '.last_status // ""' "$state_file")
+streak=$(jq -r '.immediate_failure_streak // ""' "$state_file")
+sig=$(jq -r '.last_failure_signature // ""' "$state_file")
+head_sha=$(jq -r '.last_head_sha // ""' "$state_file")
+total=$(jq -r '.total_attempts // ""' "$state_file")
+
+assert_eq "NFR 1.1: last_status が max-attempts に更新される" "max-attempts" "$status"
+assert_eq "NFR 1.1: immediate_failure_streak が前回値 2 を保持" "2" "$streak"
+assert_eq "NFR 1.1: last_failure_signature が前回値を保持" "old_sig" "$sig"
+assert_eq "NFR 1.1: last_head_sha が前回値を保持" "abc123" "$head_sha"
+assert_eq "NFR 1.1: total_attempts が引数値で記録される" "4" "$total"
+cleanup_stub_state
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=================================================="
+echo "RESULT: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "=================================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Failed Recovery Processor が `max-attempts` / `no-progress` のいずれの終端経路でも、終端状態を cross-cycle で永続化していなかったため、cron tick ごとに同一の終端理由コメントを無制限に再投稿し続けるバグを修正する。

- 終端時に既存 state JSON の `last_status` enum (`max-attempts` / `no-progress`) を永続化し、次サイクル以降の fetch 段階でフィルタ除外する二重防御（仮案 C: terminate ガード + fetch 段階除外）を実装
- 新規純粋関数 `fr_is_terminated` を追加し、`fr_terminate_max_attempts` / `fr_terminate_no_progress` 冒頭のべき等ガードと `fr_fetch_failed_issues` / `fr_fetch_failed_prs` 末尾の候補フィルタ両方から呼び出す
- state 破損 / 欠落時は fail-open し、従来の挙動（`fr_load_state` が `{}` を返す → 未終端扱い）に退行する

## 対応 Issue

Closes #417

## 関連 PR

なし（設計 PR なし / design-less impl）

## 実装内容

- (Req 1.1 / Req 1.2) `fr_terminate_max_attempts` / `fr_terminate_no_progress` 冒頭に `fr_is_terminated` ガードを追加し、2 サイクル目以降の終端コメント投稿を抑止
- (Req 1.5 / Req 1.6) 各 terminate 関数末尾で `fr_save_state` を呼び `last_status` を永続化
- (Req 2.1〜2.6) `fr_filter_terminated_candidates` 追加、`fr_fetch_failed_issues` / `fr_fetch_failed_prs` の最終出力にフィルタ適用し、fetch 段階で終端済み Issue / PR を物理除外（着手コメント・attempt 加算・claude session 起動・Slack 通知・run-summary 確定を全副作用抑止）
- (Req 3.1) `fr_is_terminated` 純粋関数により「`max-attempts` 終端済み / `no-progress` 終端済み / 未終端」の 3 状態を判定
- (Req 4.1〜4.3) `--remove-label claude-failed` を追加せず、ラベル据え置き契約を維持
- (Req 5.1〜5.3) state 破損 / 欠落で `fr_is_terminated` が rc=1（未終端扱い）→ fail-open し fail-continue を維持
- (NFR 1.1〜1.5) 既存 state JSON スキーマ・終端理由識別子・env var・コメント本文に変更なし
- (NFR 2.1〜2.2) 抑止時に `failed-recovery: <kind>=#<n> terminated reason=<status> suppressed=<...>` 1 行ログを記録
- (NFR 3.3) `fr_filter_terminated_candidates` 内で Issue / PR 番号の `^[0-9]+$` 検証を実装

## 受入基準チェック

- [x] Req 1.1: When 2 回目以降の max-attempts 終端処理が起動された場合 shall コメントを投稿しない ← `fr_terminate_idempotent_test.sh` Section 3
- [x] Req 1.2: When 2 回目以降の no-progress 終端処理が起動された場合 shall コメントを投稿しない ← Section 4
- [x] Req 1.3: max-attempts 終端コメントを生涯で最大 1 件しか投稿しない ← Section 5
- [x] Req 1.4: no-progress 終端コメントを生涯で最大 1 件しか投稿しない ← Section 5
- [x] Req 1.5: max-attempts 終端処理後に終端済み情報を永続化する ← Section 2（state JSON last_status 検証）
- [x] Req 1.6: no-progress 終端処理後に終端済み情報を永続化する ← Section 9
- [x] Req 2.1〜2.6: 終端後サイクルの副作用ゼロ ← Section 7-B/7-G（fetch 段階除外）+ Section 3/4（ガード）
- [x] Req 3.1: 3 状態判定 ← `fr_is_terminated` Section 1-A〜1-H
- [x] Req 4.1〜4.3: claude-failed ラベル据え置き ← Section 8-A（assert_not_grep）
- [x] Req 5.1〜5.3: fail-open / fail-continue ← Section 6-A/6-B/6-C
- [x] NFR 1.1: 既存 schema フィールド継承 ← Section 10
- [x] NFR 2.1〜2.2: 抑止ログ 1 行記録（grep 可能粒度）← Section 3/4/7

## テスト結果

```
=== fr_attempt_test.sh ===              PASS=60 FAIL=0
=== fr_fetch_test.sh ===                PASS=42 FAIL=0
=== fr_immediate_fail_test.sh ===       PASS=42 FAIL=0
=== fr_invoke_test.sh ===               PASS=56 FAIL=0
=== fr_is_enabled_test.sh ===           PASS=40 FAIL=0
=== fr_no_progress_test.sh ===          PASS=12 FAIL=0
=== fr_process_test.sh ===              PASS=71 FAIL=0
=== fr_state_test.sh ===                PASS=60 FAIL=0
=== fr_terminate_idempotent_test.sh === PASS=64 FAIL=0  (新規)
=== fr_terminate_test.sh ===            PASS=77 FAIL=0

合計: 524 tests PASS / 0 FAIL

shellcheck local-watcher/bin/modules/failed-recovery.sh
         local-watcher/test/fr_terminate_idempotent_test.sh
         local-watcher/test/fr_fetch_test.sh → 警告ゼロ
bash -n local-watcher/bin/modules/failed-recovery.sh → 構文 OK
```

## 実装上の判断

- **仮案 C（terminate ガード + fetch 段階除外の二重防御）を採用**: terminate ガード単独（仮案 A）では `fr_run_recovery_attempt` 内で着手コメント → attempt++ → claude session 起動が走ってから terminate に到達する経路があり、Req 2.1〜2.6（全副作用抑止）を満たせない。fetch 段階で物理除外することで副作用ゼロを保証する。
- **既存 schema を変更しない（NFR 1.1）**: `last_status` enum はすでに `"max-attempts"` / `"no-progress"` を許容しており、`fr_save_state` 第 3 引数で永続化する経路を追加するだけで要件を満たせる。新フィールド追加は不要。
- 詳細は `docs/specs/417--bug-failed-recovery-processor-attempt-c/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer（独立 context）による全 AC 検証済み: `docs/specs/417--bug-failed-recovery-processor-attempt-c/review-notes.md` 参照（RESULT: approve / 524 tests PASS / shellcheck 警告ゼロ）
- base: main / baseRefName: main / OK（作成後に検証）
- `failed-recovery.sh` は `repo-template/` 配下にないため root 単独管理。root ↔ repo-template の同期作業は不要（impl-notes.md にも記載）。

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #417 のコメントを参照してください。
