### PR TITLE
fix(#420): pr_already_processed をページネートして marker 重複判定を全コメントで実施

### DIFF
--- a/docs/specs/420--bug-pr-reviewer-pr-already-processed-co/impl-notes.md
+++ b/docs/specs/420--bug-pr-reviewer-pr-already-processed-co/impl-notes.md
@@ -1,0 +1,87 @@
+# 実装メモ (#420)
+
+## 採用方針
+
+仮案 A（`gh api --paginate --slurp` + `per_page=100`）を採用。`pr_already_processed`
+の単一関数を全ページ走査へ書き換えることで、3 つの呼び出し経路
+（`pr_post_exec_fail_escalation_comment` / `pr_post_error_comment` /
+`pr_run_review_for_pr` の review marker 判定）に同時にフィックスが行き渡る。
+
+### 不採用案の弊害
+
+- **仮案 B（Search API）**: 全文検索 API は eventual consistency があり、投稿直後の
+  marker 検出が確実でない。レート制限も別系統で運用が読みづらい。
+- **仮案 C（PR body marker への移行）**: marker 形式変更は NFR 1.2（既存 marker 文字列
+  形式不変）と衝突する。既存投稿済み marker との互換性のため二重判定が必要になり、
+  最小変更原則からも逸脱する。
+
+### 仮案 A の優位性
+
+- 既存の (sha, kind) 単位判定セマンティクス（NFR 1.3）と marker 形式（NFR 1.2）を完全
+  維持。引数順 / 戻り値契約も不変（NFR 1.1）
+- `pr_already_processed` という単一の集約点の修正で 3 経路すべてに同時適用される
+  （Req 2.1, 2.2, 2.3, 2.4）
+- `per_page=100`（GitHub REST 最大値）により、コメント 100 件以下の PR では 1 ページのみで
+  完結 → 30 件以下では呼び出し回数を増やさない（NFR 2.1 既存挙動と等価）
+- `--paginate` は途中ページ失敗で非ゼロ終了するため、既存の `if !` フォールバック分岐に
+  自然に合流（Req 3.1, 3.2, 3.3, 3.4）
+
+## 変更ファイル一覧
+
+| File | 種別 | 概要 |
+|------|-----|------|
+| `local-watcher/bin/modules/pr-reviewer.sh` | 修正 | `pr_already_processed` を `gh api --paginate --slurp` + `per_page=100` + jq `(add // []) \| any(...)` 経路へ書き換え。ヘッダコメントに Issue #420 の経緯を追記 |
+| `local-watcher/test/pr_already_processed_pagination_test.sh` | 新規 | ページネーション挙動 / 取得失敗 fallback / gh 呼び出し引数検証の 15 件アサーション。`extract_function` イディオム |
+
+`pr-reviewer.sh` の関数 signature・marker 形式・env var 名・gh API path は不変。
+GitHub Actions workflow / labels / `repo-template/` への変更は不要（root ↔
+`repo-template/.claude/{agents,rules}` parity も保持。`diff -r` で空を確認済）。
+
+## AC Traceability
+
+| AC | 担保するコード / テスト |
+|----|----------------------|
+| Req 1.1 全コメント走査 | `pr-reviewer.sh:268-273`（`gh api --paginate --slurp ... per_page=100`） / test Section 4 |
+| Req 1.2 30 件以下の従来挙動 | `pr-reviewer.sh:274-278`（jq `add // []` の平坦化が単ページでも同じ結果） / test Section 1 (A, B) |
+| Req 1.3 31 件以上 / marker が page2 以降 | test Section 2 (A, C) — 105 件 / 205 件で page2・page3 末尾の marker 検出 |
+| Req 1.4 31 件以上 / marker 不在 | test Section 1 (C 0 件) / Section 2 (B 105 件 marker 無) |
+| Req 1.5 (sha, kind) 単位判定 | jq filter は `sha=` / `kind=` の両方を `[^>]*` 連結で test() / test Section 2 (D) sha 一致 kind 不一致 → rc=1 |
+| Req 1.6 marker 形式不変 | `pr_build_marker` 未変更（line 223-228）。判定 regex も `idd-claude:pr-reviewer sha=...kind=...` の従来形式 |
+| Req 2.1 exec-fail-escalated 経路 | `pr-reviewer.sh:607` の `pr_already_processed` 呼び出し（経路共有） |
+| Req 2.2 pr_post_error_comment 経路 | `pr-reviewer.sh:945` の `pr_already_processed` 呼び出し（経路共有） |
+| Req 2.3 review 経路 | `pr-reviewer.sh:1418` の `pr_already_processed` 呼び出し（経路共有） |
+| Req 2.4 全経路で誤判定回避 | 単一関数の修正により 3 経路すべてに同時適用（実装の自然な帰結） |
+| Req 3.1 取得失敗で安全側 rc=0 | `pr-reviewer.sh:269-272` の `if !` フォールバック / test Section 3 (A) |
+| Req 3.2 途中ページ失敗で安全側 rc=0 | `gh api --paginate` は途中ページ rc≠0 で abort → 同一 fallback / test Section 3 (B) |
+| Req 3.3 失敗時の WARN ログ | `pr-reviewer.sh:271` `pr_warn "コメント取得に失敗（marker 重複判定をスキップ＝安全側で既存扱い）"` / test Section 3 (A, B) |
+| Req 3.4 全経路で fallback 一貫 | 単一関数で fallback 経路を実装、各経路は当該関数の rc=0 を「skip すべき」として扱う既存契約のまま |
+| NFR 1.1 入出力契約不変 | 関数 signature `pr_already_processed(pr_number, sha, kind)` / 戻り値意味 0=既存 1=未存在 不変 |
+| NFR 1.2 marker 形式不変 | `pr_build_marker` 不変 |
+| NFR 1.3 (sha, kind) 単位 | jq filter の `test("idd-claude:pr-reviewer sha=" + $sha + "[^>]*kind=" + $kind)` 不変（tool= 属性は照合外） |
+| NFR 1.4 env var 名・既定値不変 | `PR_REVIEWER_GIT_TIMEOUT` のみ参照、新規 env var 追加なし |
+| NFR 1.5 投稿済み marker 不変 | 既存コメント本文への書き換えなし |
+| NFR 2.1 ≤30 件で呼び出し増えない | `per_page=100` により 100 件以下は 1 ページで完結 / test Section 1 (gh 呼び出し回数=1) |
+| NFR 2.2 timeout 範囲内 | 既存 `timeout "$PR_REVIEWER_GIT_TIMEOUT" gh api ...` の wrapper 不変 |
+| NFR 3.1 観測ログ粒度維持 | `pr_warn` の既存メッセージ「コメント取得に失敗」を流用、ログ出力契約不変 |
+| NFR 3.2 取得失敗を pr_warn 記録 | 同上 |
+
+## 静的解析・テスト実行結果
+
+- `bash -n local-watcher/bin/modules/pr-reviewer.sh` → OK
+- `shellcheck local-watcher/bin/*.sh local-watcher/bin/modules/*.sh install.sh setup.sh .github/scripts/*.sh` → OK（警告ゼロ）
+- `shellcheck local-watcher/test/pr_already_processed_pagination_test.sh` → OK
+- `bash local-watcher/test/pr_already_processed_pagination_test.sh` → **PASS=15 FAIL=0**
+- 既存 PR 関連テスト 13 本（`pr_*.sh` / `pdr_*.sh`）を subshell 実行 → 全 PASS（回帰なし）
+- 退行検出テスト: 実装を一時 revert して同テスト実行 → 6 件 FAIL（pagination 不足を確実に検出）
+
+## 確認事項
+
+- `gh` の `--slurp` フラグは gh 2.x で導入済み（手元: 2.92.0 で動作確認）。サポート最小
+  バージョンが明文化されていないが、`install.sh` / `setup.sh` で gh インストール手順が
+  公式リポジトリ最新版を案内しているため運用上の制約はない見込み。古い gh 利用者がいる
+  場合は別 issue でドキュメント補足を検討。
+- 仮案 A は marker 数 100 件超のページネーション境界をテストで網羅したが、実環境では
+  `auto-merge` 等で 200 件超のコメントを抱える PR も想定される（Section 2 Case C で
+  3 ページ走査までは検証済み）。
+
+STATUS: complete

--- a/docs/specs/420--bug-pr-reviewer-pr-already-processed-co/requirements.md
+++ b/docs/specs/420--bug-pr-reviewer-pr-already-processed-co/requirements.md
@@ -1,0 +1,89 @@
+# Requirements Document
+
+## Introduction
+
+pr-reviewer モジュールの `pr_already_processed` は、(sha, kind) ペアの marker が既存コメントに
+存在するかを判定して重複投稿を防ぐ関数だが、現在 PR コメントを GitHub REST API のデフォルト件数
+（per_page=30 / 1 ページのみ）で取得しているため、コメント総数が 30 件を超え該当 marker が 1
+ページ目の外（page 2 以降）に存在する PR では「未投稿」と誤判定する。結果として、`exec-fail-escalated`
+advisory が cron tick 毎（約 2 分間隔）に同一 head sha のまま重複投稿されてしまい、運用者の
+ノイズと PR コメントスレッドの汚染を招く。本要件は、(sha, kind) 単位の重複判定セマンティクスと
+marker 形式を変えずに、PR のコメント総数に依らない正確な重複判定を実現し、同一の盲点を共有する
+他の呼び出し経路（`pr_post_error_comment` / レビュー結果コメント）にも漏れなく適用することを
+目的とする。
+
+## Requirements
+
+### Requirement 1: コメント総数に依らない marker 重複判定
+
+**Objective:** As an idd-claude 運用者, I want `pr_already_processed` が PR のコメント総数に依らず全コメントを走査して marker の有無を判定できる, so that コメント 30 件を超える PR でも `exec-fail-escalated` などの advisory が二重投稿されない
+
+#### Acceptance Criteria
+
+1. When `pr_already_processed` が呼び出された場合, the PR Reviewer Module shall 当該 PR の全 issue コメントを対象に (sha, kind) marker の有無を判定する
+2. While 当該 PR の issue コメント総数が 30 件以下である間, the PR Reviewer Module shall 従来と同一の判定結果（既存=rc 0 / 未存在=rc 1）を返す
+3. When 当該 PR の issue コメント総数が 30 件を超え該当 marker が 31 件目以降のコメントに存在する場合, the PR Reviewer Module shall 当該 marker を「既存」と判定して rc 0 を返す
+4. When 当該 PR の issue コメント総数が 31 件以上で該当 marker が 1 件も存在しない場合, the PR Reviewer Module shall 当該 marker を「未存在」と判定して rc 1 を返す
+5. The PR Reviewer Module shall (sha, kind) ペア単位の判定セマンティクスを維持し、tool 属性の値を判定条件に含めない
+6. The PR Reviewer Module shall 既存の marker 文字列形式（`<!-- idd-claude:pr-reviewer sha=<sha> kind=<kind> tool=<tool> -->`）を変更しない
+
+### Requirement 2: 同一盲点を共有する呼び出し経路への適用
+
+**Objective:** As an idd-claude 運用者, I want `pr_already_processed` を共有する全ての投稿経路で同じ重複判定を効かせたい, so that exec-fail-escalated advisory と同様の重複投稿が他の kind（exec-failed / no-tool / review 等）でも発生しない
+
+#### Acceptance Criteria
+
+1. When `pr_post_exec_fail_escalation_comment` が同一 (sha, kind=exec-fail-escalated) marker の既存判定を行う場合, the PR Reviewer Module shall Requirement 1 と同一の判定経路を経由する
+2. When `pr_post_error_comment` が同一 (sha, kind) marker の既存判定を行う場合, the PR Reviewer Module shall Requirement 1 と同一の判定経路を経由する
+3. When レビュー結果コメント投稿経路が同一 (sha, kind=review) marker の既存判定を行う場合, the PR Reviewer Module shall Requirement 1 と同一の判定経路を経由する
+4. The PR Reviewer Module shall 上記いずれの経路でも、コメント 30 件超 PR で marker が 1 ページ目外にあるケースを「未存在」と誤判定しない
+
+### Requirement 3: コメント取得失敗時の安全側フォールバック
+
+**Objective:** As an idd-claude 運用者, I want コメント取得が失敗した場合でも重複投稿を発生させない安全側フォールバックを維持したい, so that 一時的な GitHub API エラーが advisory の連続再投稿を引き起こさない
+
+#### Acceptance Criteria
+
+1. If 当該 PR のコメント取得が失敗（API エラー / timeout / 認証失敗 / レート制限など）した場合, the PR Reviewer Module shall 該当 marker を「既存扱い」として rc 0 を返し、呼び出し元の再投稿を抑止する
+2. If 全コメント走査の途中ページ取得が失敗した場合, the PR Reviewer Module shall それまでに取得済みのページに marker が含まれていない場合でも「既存扱い」として rc 0 を返す
+3. If コメント取得が失敗した場合, the PR Reviewer Module shall 警告ログ（`pr_warn` prefix）を一次運用ログに出力し、運用者が事後に状況を追跡できるようにする
+4. The PR Reviewer Module shall コメント取得失敗時のフォールバック挙動を Requirement 1 / Requirement 2 のいずれの呼び出し経路でも一貫して適用する
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The PR Reviewer Module shall `pr_already_processed` の入出力契約（引数順 = pr_number / sha / kind、戻り値 0=既存 / 1=未存在）を変更しない
+2. The PR Reviewer Module shall 既存の marker 文字列形式・hidden HTML コメントとしての可視性・GitHub UI 上での非表示性を変更しない
+3. The PR Reviewer Module shall 既存の (sha, kind) 単位重複判定セマンティクス（tool 属性を判定に含めない方針）を変更しない
+4. The PR Reviewer Module shall 既存の環境変数名と既定値（`PR_REVIEWER_GIT_TIMEOUT` を含む timeout 設定）の意味を変更しない
+5. The PR Reviewer Module shall 既存に投稿済みの marker 付きコメントを遡及的に削除・修正しない
+
+### NFR 2: 性能
+
+1. The PR Reviewer Module shall コメント 30 件以下の PR では Requirement 1 適用前と比較して GitHub API 呼び出し回数を増やさない
+2. The PR Reviewer Module shall コメント走査のページ取得を `PR_REVIEWER_GIT_TIMEOUT` の範囲内で完了させ、超過時はコメント取得失敗として Requirement 3 のフォールバックに合流する
+
+### NFR 3: 可観測性
+
+1. The PR Reviewer Module shall marker 重複判定の結果（既存 / 未存在 / 取得失敗）を識別できる粒度のログ出力を維持する
+2. The PR Reviewer Module shall コメント取得失敗を `pr_warn` レベルで一次運用ログに記録する
+
+## Out of Scope
+
+- 外部レビューツール（codex / antigravity）側の rate-limit / quota 制御や HTTP 429 ハンドリングそのものは本要件の対象外
+- `pr_post_exec_fail_escalation_comment` の advisory 本文・連続失敗回数閾値（`PR_REVIEWER_EXEC_FAIL_LIMIT`）・ラベル付与方針の見直しは本要件の対象外
+- failed-recovery processor の no-progress 終端 spam（#417）は別 Issue で追跡し本要件では扱わない
+- 既に投稿済みの重複 `exec-fail-escalated` advisory コメントの遡及削除 / 整理は本要件の対象外（運用者の手動対応に委ねる）
+- pr-iteration / pr-design-reviewer / adjudicator / security-review 等の他モジュール側の独立した重複判定パスのページネーション点検は本要件の対象外（`pr_already_processed` を直接呼び出す経路のみを対象とする）
+- marker 形式そのものを変える設計（PR body marker への移行 / idempotency flag 追加等）は本要件の対象外（後方互換性 NFR 1.2 と整合）
+
+## Open Questions
+
+- なし（具体的な実装方式は仮案 A/B/C の選択を含めて Architect / Developer の責務）
+
+## 関連
+
+- Depends on: なし
+- Parent: なし
+- Related: #417

--- a/docs/specs/420--bug-pr-reviewer-pr-already-processed-co/review-notes.md
+++ b/docs/specs/420--bug-pr-reviewer-pr-already-processed-co/review-notes.md
@@ -1,0 +1,57 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-27T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-420-impl--bug-pr-reviewer-pr-already-processed-co
+- HEAD commit: c2abcac385a9fde29bd683c5c407d6daac11ac69
+- Compared to: main..HEAD
+- Changed files:
+  - `local-watcher/bin/modules/pr-reviewer.sh`（`pr_already_processed` 修正）
+  - `local-watcher/test/pr_already_processed_pagination_test.sh`（新規 / 15 assertions）
+  - `docs/specs/420--bug-pr-reviewer-pr-already-processed-co/requirements.md`
+  - `docs/specs/420--bug-pr-reviewer-pr-already-processed-co/impl-notes.md`
+
+## Verified Requirements
+
+- 1.1 — `pr-reviewer.sh:262-264` の `gh api --paginate --slurp .../comments?per_page=100` で全コメントを取得 / test Section 4 で `--paginate`・`--slurp`・comments エンドポイントの呼び出し検証
+- 1.2 — `(add // [])` フラット化 + `any(.[]; ...)` で単ページ・複数ページが同一フィルタ / test Section 1 (Case A, B) 30 件で marker 有/無の双方 PASS、NFR 2.1 込みで gh 呼び出し回数=1 を確認
+- 1.3 — test Section 2 Case A (105 件 / marker 最終ページ末尾) と Case C (205 件 / 3 ページ走査 / page2 中段) で page2 以降の marker 検出を確認
+- 1.4 — test Section 1 Case C (0 件) / Section 2 Case B (105 件 marker 無) で rc=1 を確認
+- 1.5 — jq filter は `sha=` と `kind=` の双方を `[^>]*` 連結で `test()`。tool 属性を判定に含めない既存セマンティクス維持。test Section 2 Case D で sha 一致・kind 不一致が rc=1
+- 1.6 — `pr_build_marker`（line 223-228）と marker 検出 regex の文字列形式（`idd-claude:pr-reviewer sha=...kind=...`）を不変
+- 2.1 — `pr-reviewer.sh:623` の `pr_post_exec_fail_escalation_comment` 内の `pr_already_processed "$pr_number" "$sha" "exec-fail-escalated"` 呼び出しで同一関数を経由
+- 2.2 — `pr-reviewer.sh:961` の `pr_post_error_comment` 内の `pr_already_processed "$pr_number" "$sha" "$kind"` 呼び出しで同一関数を経由
+- 2.3 — `pr-reviewer.sh:1434` の review 経路の `pr_already_processed "$pr_number" "$sha" "review"` 呼び出しで同一関数を経由
+- 2.4 — 単一関数 `pr_already_processed` の修正により 3 経路すべてに同時適用（実装の自然な帰結）
+- 3.1 — `pr-reviewer.sh:262-267` の `if ! comments_json=$(...)` で取得失敗時 rc=0 / test Section 3 Case A
+- 3.2 — `gh api --paginate` は途中ページ失敗で非ゼロ終了 → 同一の `if !` 分岐で rc=0 既存扱い / test Section 3 Case B
+- 3.3 — `pr_warn "PR #${pr_number}: コメント取得に失敗（marker 重複判定をスキップ＝安全側で既存扱い）"` / test Section 3 (A, B) で WARN ログ 1 行記録を確認
+- 3.4 — 単一 fallback 経路を 3 呼び出し経路すべてが共有
+- NFR 1.1 — 関数 signature `pr_already_processed(pr_number, sha, kind)` / 戻り値 0=既存・1=未存在 不変
+- NFR 1.2 — `pr_build_marker` 未変更、marker 文字列形式・hidden HTML としての可視性不変
+- NFR 1.3 — jq filter の `test("idd-claude:pr-reviewer sha=" + $sha + "[^>]*kind=" + $kind)` で (sha, kind) 単位を維持、tool 属性は照合外
+- NFR 1.4 — 既存 `PR_REVIEWER_GIT_TIMEOUT` のみ参照、新規 env var 追加なし
+- NFR 1.5 — 既存コメント本文への書き換えなし（投稿済み marker 不変）
+- NFR 2.1 — `per_page=100` により 100 件以下は 1 ページで完結 / test Section 1 で gh 呼び出し回数=1 を assertion
+- NFR 2.2 — 既存 `timeout "$PR_REVIEWER_GIT_TIMEOUT" gh api ...` wrapper を保持
+- NFR 3.1 — `pr_warn` プレフィックスを維持、既存メッセージ流用
+- NFR 3.2 — Req 3.3 と同上
+
+## Findings
+
+なし
+
+## Summary
+
+`pr_already_processed` を `gh api --paginate --slurp ... per_page=100` 経路に書き換える
+最小変更で、(sha, kind) marker 重複判定のページネーション盲点を解消。jq filter `(add // [])`
+平坦化により 0 ページ / 単ページ / 複数ページが同一経路で扱われ、既存の `if !` フォールバック
+分岐が `--paginate` の途中失敗にもそのまま合流する。3 呼び出し経路（exec-fail-escalated /
+pr_post_error_comment / review）はすべて単一関数を経由しており、修正が自然に伝播する。
+新規テスト 15 件すべて PASS、impl-notes.md 記載の既存 PR テスト 13 本も回帰なし。marker 形式・
+関数 signature・env var・(sha, kind) セマンティクスはすべて不変で NFR 1.1〜1.5 / 2.1〜2.2 /
+3.1〜3.2 を満たす。
+
+RESULT: approve

--- a/local-watcher/bin/modules/pr-reviewer.sh
+++ b/local-watcher/bin/modules/pr-reviewer.sh
@@ -232,14 +232,26 @@ pr_build_marker() {
 #   入力: $1 = pr_number, $2 = sha, $3 = kind
 #   出力: なし
 #   戻り値: 0 = 既存（skip すべき）/ 1 = 未存在（処理を続行してよい）
-#   AC: 3.3, 6.2, 6.3, NFR 4.1
+#   AC: 3.3, 6.2, 6.3, NFR 4.1, Issue #420 Req 1.1〜1.6 / 3.1〜3.4
 #
-#   - `gh api /repos/$REPO/issues/<n>/comments` で全コメントを取得し、jq で
-#     marker（sha と kind の双方一致）の存在を test する（tool 属性は照合に使わない
-#     = Decision 6 の (sha, kind) 単位重複判定）。
+#   - `gh api --paginate --slurp /repos/$REPO/issues/<n>/comments?per_page=100`
+#     で全ページを 1 配列にまとめて取得し、jq で marker（sha と kind の双方一致）の
+#     存在を test する（tool 属性は照合に使わない = Decision 6 の (sha, kind) 単位
+#     重複判定）。
+#   - `--paginate --slurp` は各ページ JSON 配列を outer JSON 配列 `[[page1...],
+#     [page2...]]` にラップして返すため、jq 側で `add // []` により単一の配列に
+#     平坦化して `any(...)` で走査する（0 ページ / 単ページ / 複数ページいずれも同じ
+#     fold で扱える / Req 1.3, 1.4）。
+#   - `per_page=100` は GitHub REST API の最大値（既定 30 件）。これによりコメント
+#     100 件以下の PR は 1 ページのみで完結し、API 呼び出し回数は導入前と同一に保たれる
+#     （NFR 2.1）。101 件以上のときのみ追加ページが発火する。
 #   - sha は hex、kind は固定語彙のため正規表現メタ文字を含まず test() に安全。
-#   - gh API 失敗時は **安全側（重複投稿回避）** に倒し「既存扱い (rc=0)」で skip。
-#     SHA が不変なら次サイクルで再評価されるため self-heal する（NFR 3.1 で WARN 記録）。
+#   - gh API 失敗（authentication / rate-limit / timeout / 途中ページ失敗）時は
+#     **安全側（重複投稿回避）** に倒し「既存扱い (rc=0)」で skip。`gh api --paginate`
+#     は途中ページ取得失敗時に非ゼロ終了するため、それまでに取得済みのページに
+#     marker が無くても全体としてフォールバック経路に合流する（Req 3.1, 3.2）。
+#     SHA が不変なら次サイクルで再評価されるため self-heal する（Req 3.3 / NFR 3.1 で
+#     WARN 記録）。
 # ─────────────────────────────────────────────────────────────────────────────
 pr_already_processed() {
   local pr_number="${1:-}"
@@ -248,15 +260,19 @@ pr_already_processed() {
 
   local comments_json
   if ! comments_json=$(timeout "$PR_REVIEWER_GIT_TIMEOUT" \
-      gh api "/repos/${REPO}/issues/${pr_number}/comments" 2>/dev/null); then
+      gh api --paginate --slurp \
+      "/repos/${REPO}/issues/${pr_number}/comments?per_page=100" 2>/dev/null); then
     pr_warn "PR #${pr_number}: コメント取得に失敗（marker 重複判定をスキップ＝安全側で既存扱い）"
     return 0
   fi
 
+  # --paginate --slurp の戻りは [[page1...], [page2...], ...] 形式。`add // []` で
+  # 平坦化して any(...) で走査する。空配列・単ページ・複数ページの全パターンで同一
+  # フィルタが機能する（Req 1.2, 1.3, 1.4）。
   if echo "$comments_json" | jq -e \
       --arg sha "$sha" \
       --arg kind "$kind" \
-      'any(.[]; (.body // "") | test("idd-claude:pr-reviewer sha=" + $sha + "[^>]*kind=" + $kind))' \
+      '(add // []) | any(.[]; (.body // "") | test("idd-claude:pr-reviewer sha=" + $sha + "[^>]*kind=" + $kind))' \
       >/dev/null 2>&1; then
     return 0
   fi

--- a/local-watcher/test/pr_already_processed_pagination_test.sh
+++ b/local-watcher/test/pr_already_processed_pagination_test.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/pr-reviewer.sh の `pr_already_processed`
+#       関数が PR コメントを全ページ走査し、marker 総数に依らない (sha, kind)
+#       単位の重複判定を返すことを検証する単体スモークテスト（Issue #420）。
+#
+# 対象関数:
+#   - pr_already_processed: hidden marker `<!-- idd-claude:pr-reviewer sha=<sha>
+#     kind=<kind> tool=<tool> -->` の存在を全コメントから検出する重複判定
+#
+# 検証する AC（docs/specs/420--bug-pr-reviewer-pr-already-processed-co/requirements.md）:
+#   Req 1.1 / 1.2 / 1.3 / 1.4 / 1.5 / 1.6 / 2.1〜2.4 / 3.1〜3.4
+#   NFR 1.1 / 1.3 / 2.1 / 3.1
+#
+# 既存テストと同じイディオム（pr_reviewer_exec_fail_streak_test.sh 参照）:
+#   extract_function で対象関数を awk 抽出して eval。依存（gh / timeout / pr_warn）
+#   は stub 化し、gh stub に「ページ数」と「marker を埋め込むコメント」を仕込んで
+#   `--paginate --slurp` 経路の挙動を再現する。
+#
+# 配置先: local-watcher/test/pr_already_processed_pagination_test.sh
+# 依存:   bash 4+, awk, grep, jq, mktemp
+# 実行:   bash local-watcher/test/pr_already_processed_pagination_test.sh
+
+set -euo pipefail
+
+# 抽出関数で参照されるグローバル env / stub が shellcheck から未使用に見えるため抑止。
+# shellcheck disable=SC2034
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
+
+if [ ! -f "$PR_MOD" ]; then
+  echo "ERROR: cannot find pr-reviewer.sh at $PR_MOD" >&2
+  exit 2
+fi
+
+# extract_function イディオム（pr_reviewer_exec_fail_streak_test.sh と同一）
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+for fn in pr_already_processed pr_build_marker; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$PR_MOD" "$fn")"
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# グローバル env（遅延束縛で抽出関数本体から参照される）
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# shellcheck disable=SC2034
+PR_REVIEWER_GIT_TIMEOUT="120"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_rc() {
+  local label="$1"; local expected_rc="$2"; shift 2
+  local actual_rc=0
+  "$@" >/dev/null 2>&1 || actual_rc=$?
+  if [ "$expected_rc" = "$actual_rc" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected rc: $expected_rc"
+    echo "  actual rc  : $actual_rc"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_eq() {
+  local label="$1"; local expected="$2"; local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ── 共通 stub ─────────────────────────────────────────────────────────────────
+# timeout: 第 1 引数（秒数）を捨てて残りを実行する素通し stub
+# shellcheck disable=SC2317
+timeout() {
+  shift
+  "$@"
+}
+
+# 観測ログ用 stub（pr_warn は WARN_LOG に行追加）
+WARN_LOG=""
+reset_stub_state() {
+  WARN_LOG="$(mktemp)"
+  GH_CALL_LOG="$(mktemp)"
+}
+cleanup_stub_state() {
+  rm -f "$WARN_LOG" "$GH_CALL_LOG" 2>/dev/null || true
+}
+# shellcheck disable=SC2317
+pr_warn() { echo "$*" >>"$WARN_LOG"; }
+# shellcheck disable=SC2317
+pr_log()  { :; }
+
+# ── gh stub のページネーション再現 ───────────────────────────────────────────
+# GH_PAGE_FILES: 各ページの JSON 配列ファイルパス（space 区切り、page1〜N の順）
+# GH_FAIL_ON_PAGE: そのページの取得を失敗扱いにする 1-based index（0 = 失敗なし）
+# GH_PAGINATE_RC: 全体としての終了コード（route 用、既定 0）
+# 本実装は `gh api --paginate --slurp <path>` 呼び出しを前提として、ページ群を
+# `[[page1...], [page2...], ...]` 形式の outer 配列として stdout へ出力する。
+# 途中ページ失敗の場合は GH_FAIL_ON_PAGE 以降を切り捨て、rc=1 を返す（実 gh の
+# --paginate が途中失敗で rc≠0 を返す挙動を模倣）。
+GH_PAGE_FILES=""
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+
+# shellcheck disable=SC2317
+gh() {
+  echo "gh $*" >>"$GH_CALL_LOG"
+  # 引数列に --paginate / --slurp が含まれているかを検証
+  local has_paginate="false"
+  local has_slurp="false"
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --paginate) has_paginate="true" ;;
+      --slurp)    has_slurp="true" ;;
+    esac
+  done
+  if [ "$has_paginate" != "true" ] || [ "$has_slurp" != "true" ]; then
+    # 期待していない呼び出し（--paginate --slurp なし）。テスト失敗を顕在化させる
+    # ため exit 2 を返す（gh 本体の failure と同等の安全側 fallback で吸収される）。
+    echo "gh stub: missing --paginate or --slurp" >&2
+    return 2
+  fi
+
+  # outer 配列を組み立て: 各 page file を読み込んで `[` `,` `]` でラップする
+  local pages_count=0
+  local p
+  for p in $GH_PAGE_FILES; do
+    pages_count=$((pages_count + 1))
+  done
+
+  if [ "$pages_count" -eq 0 ]; then
+    # 0 ページ（GH_PAGE_FILES 未設定）= 空のコメント配列 1 ページ
+    printf '[[]]'
+    return "$GH_PAGINATE_RC"
+  fi
+
+  printf '['
+  local idx=0
+  for p in $GH_PAGE_FILES; do
+    idx=$((idx + 1))
+    if [ "$GH_FAIL_ON_PAGE" -gt 0 ] && [ "$idx" -ge "$GH_FAIL_ON_PAGE" ]; then
+      # このページから失敗 → outer 配列を閉じずに rc=1 で abort（gh --paginate 模倣）。
+      # それまでに取得済みのページは stdout に残るが、呼び出し元の `if !` 分岐で
+      # fallback 経路（rc=0 既存扱い）に倒れることを検証する。
+      printf '\n'
+      return 1
+    fi
+    if [ "$idx" -gt 1 ]; then
+      printf ','
+    fi
+    cat "$p"
+  done
+  printf ']'
+  return "$GH_PAGINATE_RC"
+}
+
+# ── ヘルパ: marker 付き / 無し のコメント JSON 配列ファイルを作る ─────────────
+# make_page <out_file> <count> <marker_sha?> <marker_kind?>
+#   out_file: 書き出し先 path
+#   count:    そのページに含める comment 個数（>= 1）
+#   marker_sha / marker_kind: 任意。指定するとそのページの末尾コメント本文に
+#     `<!-- idd-claude:pr-reviewer sha=<sha> kind=<kind> tool=codex -->` を埋め込む。
+make_page() {
+  local out_file="$1"
+  local count="$2"
+  local marker_sha="${3:-}"
+  local marker_kind="${4:-}"
+  local i
+  printf '[' >"$out_file"
+  for i in $(seq 1 "$count"); do
+    if [ "$i" -gt 1 ]; then printf ',' >>"$out_file"; fi
+    if [ "$i" -eq "$count" ] && [ -n "$marker_sha" ] && [ -n "$marker_kind" ]; then
+      # 末尾に marker 付きコメント
+      printf '{"body":"<!-- idd-claude:pr-reviewer sha=%s kind=%s tool=codex -->"}' \
+        "$marker_sha" "$marker_kind" >>"$out_file"
+    else
+      # marker 無しのダミー
+      printf '{"body":"comment-%d"}' "$i" >>"$out_file"
+    fi
+  done
+  printf ']' >>"$out_file"
+}
+
+VALID_SHA="abcdef0123456789abcdef0123456789abcdef01"
+VALID_PR="123"
+
+# ============================================================
+# Section 1: 単ページ（コメント 30 件以下 / 後方互換 / Req 1.2）
+# ============================================================
+echo "--- Section 1: 単ページ 30 件以下 ---"
+
+# Case 1.A: 30 件で marker が末尾に存在 → rc=0（既存）
+reset_stub_state
+PAGE1=$(mktemp)
+make_page "$PAGE1" 30 "$VALID_SHA" "exec-fail-escalated"
+GH_PAGE_FILES="$PAGE1"
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+assert_rc "Req 1.2: 30 件 / marker 末尾 → rc=0（既存）" 0 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+# NFR 2.1: gh 呼び出しは 1 回のみ
+gh_count=$(grep -cE "^gh api " "$GH_CALL_LOG" || true)
+assert_eq "NFR 2.1: 30 件以下では gh api 呼び出しは 1 回のみ" "1" "$gh_count"
+rm -f "$PAGE1"
+cleanup_stub_state
+
+# Case 1.B: 30 件で marker 無し → rc=1（未存在）
+reset_stub_state
+PAGE1=$(mktemp)
+make_page "$PAGE1" 30
+GH_PAGE_FILES="$PAGE1"
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+assert_rc "Req 1.2: 30 件 / marker 無し → rc=1（未存在）" 1 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+rm -f "$PAGE1"
+cleanup_stub_state
+
+# Case 1.C: 0 件のコメント → rc=1（未存在 / Req 1.4 境界値）
+reset_stub_state
+GH_PAGE_FILES=""
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+assert_rc "Req 1.4: コメント 0 件 → rc=1（未存在）" 1 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+cleanup_stub_state
+
+# ============================================================
+# Section 2: 複数ページ（31 件以上 / 本 Issue のリグレッション境界 / Req 1.3, 1.4）
+# ============================================================
+echo ""
+echo "--- Section 2: 複数ページ 31 件以上 ---"
+
+# Case 2.A: 2 ページ（100+5=105 件）で marker が最終ページにある → rc=0
+# `per_page=100` を前提に、page1=100 件すべて marker 無し / page2=5 件で末尾に marker。
+# これは「30 件超 / marker が page2 以降」の核心ケース（Req 1.3）。
+reset_stub_state
+PAGE1=$(mktemp); PAGE2=$(mktemp)
+make_page "$PAGE1" 100
+make_page "$PAGE2" 5 "$VALID_SHA" "exec-fail-escalated"
+GH_PAGE_FILES="$PAGE1 $PAGE2"
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+assert_rc "Req 1.3: 31 件以上 (105) / marker が最終ページ末尾 → rc=0（既存）" 0 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+rm -f "$PAGE1" "$PAGE2"
+cleanup_stub_state
+
+# Case 2.B: 2 ページ（合計 105 件）で marker が **どこにも無い** → rc=1（未存在 / Req 1.4）
+reset_stub_state
+PAGE1=$(mktemp); PAGE2=$(mktemp)
+make_page "$PAGE1" 100
+make_page "$PAGE2" 5
+GH_PAGE_FILES="$PAGE1 $PAGE2"
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+assert_rc "Req 1.4: 31 件以上 (105) / marker が全ページに無い → rc=1（未存在）" 1 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+rm -f "$PAGE1" "$PAGE2"
+cleanup_stub_state
+
+# Case 2.C: 3 ページ（合計 205 件）で marker が page2 中段 → rc=0（複数ページ走査の確認）
+reset_stub_state
+PAGE1=$(mktemp); PAGE2=$(mktemp); PAGE3=$(mktemp)
+make_page "$PAGE1" 100
+make_page "$PAGE2" 100 "$VALID_SHA" "review"
+make_page "$PAGE3" 5
+GH_PAGE_FILES="$PAGE1 $PAGE2 $PAGE3"
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+assert_rc "Req 1.3: 3 ページ走査で page2 の marker (kind=review) を検出 → rc=0" 0 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "review"
+rm -f "$PAGE1" "$PAGE2" "$PAGE3"
+cleanup_stub_state
+
+# Case 2.D: (sha, kind) 単位判定 — sha 一致 / kind 不一致は「未存在」(rc=1) / Req 1.5
+reset_stub_state
+PAGE1=$(mktemp); PAGE2=$(mktemp)
+make_page "$PAGE1" 100
+make_page "$PAGE2" 1 "$VALID_SHA" "review"
+GH_PAGE_FILES="$PAGE1 $PAGE2"
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+# 同一 sha で kind=exec-fail-escalated を探す → review marker は対象外 → rc=1
+assert_rc "Req 1.5: sha 一致 / kind 不一致 → rc=1（(sha,kind) 単位判定）" 1 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+rm -f "$PAGE1" "$PAGE2"
+cleanup_stub_state
+
+# ============================================================
+# Section 3: gh API 失敗時の安全側フォールバック（Req 3.1〜3.4）
+# ============================================================
+echo ""
+echo "--- Section 3: 取得失敗時のフォールバック ---"
+
+# Case 3.A: 初回ページから完全失敗 → rc=0（既存扱い）+ pr_warn 記録（Req 3.1, 3.3）
+reset_stub_state
+GH_PAGE_FILES=""
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="1"   # gh stub は 0 ページでも RC=1 で完全失敗を再現
+assert_rc "Req 3.1: 初回 gh API 失敗 → rc=0（安全側で既存扱い）" 0 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+warn_count=$(grep -cE "コメント取得に失敗" "$WARN_LOG" || true)
+assert_eq "Req 3.3: 失敗時 pr_warn が 1 行記録される" "1" "$warn_count"
+cleanup_stub_state
+
+# Case 3.B: 途中ページ失敗（page1 成功 / page2 失敗） → marker は page1 に無い場合でも
+#           rc=0 既存扱い（Req 3.2 / 安全側フォールバックの合流）
+# stub 上は「2 ページ目を fetch しようとする」状態を作るため、GH_PAGE_FILES に
+# ダミーの page2 entry を含め、GH_FAIL_ON_PAGE=2 で page2 のループ反復時に rc=1 で abort させる。
+reset_stub_state
+PAGE1=$(mktemp); PAGE2_FAIL=$(mktemp)
+make_page "$PAGE1" 100             # marker 無し / 100 件
+make_page "$PAGE2_FAIL" 1          # page2 entry（実際には reach されず破棄される）
+GH_PAGE_FILES="$PAGE1 $PAGE2_FAIL"
+GH_FAIL_ON_PAGE="2"                # page2 取得時に rc=1 で abort（gh --paginate 模倣）
+GH_PAGINATE_RC="0"
+assert_rc "Req 3.2: 途中ページ失敗 → rc=0（既存扱い、再投稿抑止）" 0 \
+  pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated"
+warn_count=$(grep -cE "コメント取得に失敗" "$WARN_LOG" || true)
+assert_eq "Req 3.3: 途中ページ失敗でも pr_warn を 1 行記録" "1" "$warn_count"
+rm -f "$PAGE1" "$PAGE2_FAIL"
+cleanup_stub_state
+
+# ============================================================
+# Section 4: per_page=100 / --paginate / --slurp が呼び出されている（Req 1.1 / NFR 1.3）
+# ============================================================
+echo ""
+echo "--- Section 4: gh 呼び出し引数の検証 ---"
+
+reset_stub_state
+PAGE1=$(mktemp)
+make_page "$PAGE1" 1
+GH_PAGE_FILES="$PAGE1"
+GH_FAIL_ON_PAGE="0"
+GH_PAGINATE_RC="0"
+pr_already_processed "$VALID_PR" "$VALID_SHA" "exec-fail-escalated" >/dev/null 2>&1 || true
+call_line=$(cat "$GH_CALL_LOG")
+case "$call_line" in
+  *"--paginate"*"--slurp"*|*"--slurp"*"--paginate"*)
+    echo "PASS: Req 1.1: gh api 呼び出しに --paginate / --slurp 両方が含まれる"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: Req 1.1: gh api 呼び出しに --paginate / --slurp が含まれない"
+    echo "  call_line: $call_line"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+case "$call_line" in
+  *"per_page=100"*)
+    echo "PASS: NFR 2.1: gh api 呼び出しに per_page=100 が含まれる（30 件以下 PR の呼び出し回数を増やさない）"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: NFR 2.1: gh api 呼び出しに per_page=100 が含まれない"
+    echo "  call_line: $call_line"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+case "$call_line" in
+  *"/repos/owner/test-repo/issues/${VALID_PR}/comments"*)
+    echo "PASS: Req 1.1: issue comments エンドポイントを使用"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    ;;
+  *)
+    echo "FAIL: Req 1.1: issue comments エンドポイントが含まれない"
+    echo "  call_line: $call_line"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    ;;
+esac
+rm -f "$PAGE1"
+cleanup_stub_state
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=================================================="
+echo "RESULT: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "=================================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

pr-reviewer モジュールの `pr_already_processed` は、(sha, kind) marker の重複判定時に
PR コメントを GitHub REST API デフォルトの 1 ページ（per_page=30）しか取得しておらず、
コメント 30 件超の PR では marker が「未存在」と誤判定されていた。その結果、
`exec-fail-escalated` advisory が cron tick ごとに重複投稿されるバグが発生していた。

本 PR では `pr_already_processed` を `gh api --paginate --slurp per_page=100` 経路へ
書き換え、全コメントを対象に marker 走査できるよう修正する。単一関数の修正により、
`pr_post_exec_fail_escalation_comment` / `pr_post_error_comment` / review 結果投稿の
3 呼び出し経路すべてに同時にフィックスが行き渡る。

## 対応 Issue

Closes #420

## 関連 PR

なし（design-less impl: Architect フェーズなし）

## 実装内容

- (Req 1.1 / NFR 2.1) `pr_already_processed` を `gh api --paginate --slurp per_page=100` 経路へ書き換え、全コメントを対象に (sha, kind) marker を走査
- (Req 1.2) `(add // [])` jq フラット化により 0 件・単ページ・複数ページを同一フィルタで処理、30 件以下では呼び出し回数増加なし
- (Req 1.3, 1.4) 31 件超 PR での marker 有無を正確に判定（page2 以降も走査）
- (Req 1.5, 1.6) (sha, kind) 単位判定セマンティクスと marker 文字列形式を不変維持
- (Req 2.1–2.4) 単一関数修正により exec-fail-escalated / pr_post_error_comment / review の 3 経路全てへ同時適用
- (Req 3.1–3.4 / NFR 2.2) コメント取得失敗・途中ページ失敗時は既存の `if !` フォールバックへ合流し rc=0（安全側）を返す
- (NFR 1.1–1.5) 入出力契約・marker 形式・env var 名・(sha, kind) セマンティクスはすべて不変
- 新規テスト `local-watcher/test/pr_already_processed_pagination_test.sh` を追加（15 assertions）

## 受入基準チェック

- [x] Req 1.1: When `pr_already_processed` が呼び出された場合、全 issue コメントを対象に marker を判定 ← `test/pr_already_processed_pagination_test.sh` Section 4 (gh 引数検証)
- [x] Req 1.2: While コメント 30 件以下、従来と同一の判定結果を返す ← Section 1 Case A/B (30 件 marker 有/無)
- [x] Req 1.3: When コメント 31 件超・marker が page2 以降に存在、「既存」と判定して rc=0 ← Section 2 Case A (105 件) / Case C (205 件)
- [x] Req 1.4: When コメント 31 件超・marker 不在、「未存在」と判定して rc=1 ← Section 1 Case C (0 件) / Section 2 Case B (105 件 marker 無)
- [x] Req 1.5: (sha, kind) 単位判定、tool 属性を判定に含めない ← Section 2 Case D (sha 一致 kind 不一致 → rc=1)
- [x] Req 1.6: marker 形式不変 ← `pr_build_marker` 未変更
- [x] Req 2.1–2.4: 3 呼び出し経路全てに修正が適用 ← 単一関数修正による自然な伝播
- [x] Req 3.1–3.4: 取得失敗時に rc=0（安全側）+ pr_warn ログ ← Section 3 Case A/B
- [x] NFR 1.1–1.5: 後方互換性（入出力契約・marker 形式・env var・semanatics）を確認
- [x] NFR 2.1: ≤100 件 PR では gh 呼び出し回数増加なし ← Section 1 の呼び出し回数 assertion
- [x] NFR 2.2: 既存 `PR_REVIEWER_GIT_TIMEOUT` timeout wrapper 不変

## テスト結果

```
bash local-watcher/test/pr_already_processed_pagination_test.sh
PASS=15 FAIL=0

shellcheck local-watcher/bin/modules/pr-reviewer.sh ... → OK（警告ゼロ）
既存 PR 関連テスト 13 本（pr_*.sh / pdr_*.sh）→ 全 PASS（回帰なし）
退行検出テスト（実装を一時 revert して実行）→ 6 件 FAIL（pagination 不足を確実に検出）
```

## 実装上の判断

- `gh api --paginate --slurp per_page=100` を採用（仮案 A）。Search API（仮案 B）は eventual consistency があり marker 投稿直後の検出が不確実。PR body marker 移行（仮案 C）は NFR 1.2 の marker 形式不変と衝突するため不採用
- `per_page=100`（GitHub REST 最大値）により 100 件以下は 1 ページで完結し、30 件以下の従来挙動と等価
- `--paginate` は途中ページ失敗で非ゼロ終了するため、既存の `if !` フォールバック分岐がそのまま流用できる

詳細は `docs/specs/420--bug-pr-reviewer-pr-already-processed-co/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer の独立レビュー（approve）済み: `docs/specs/420--bug-pr-reviewer-pr-already-processed-co/review-notes.md` 参照
- `gh --slurp` フラグは gh 2.x 以降で有効。`install.sh` / `setup.sh` で最新版インストールを案内しているため運用上の制約はない見込み。古い gh 利用者向けの補足は別 issue で検討
- base: main / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #420 のコメントを参照してください。