### PR TITLE
fix(#421): per-task diff range 解決で trailing issue-ref suffix 付き marker を許容

### DIFF
--- a/docs/specs/421--bug-per-task-reviewer-diff-range-marker/impl-notes.md
+++ b/docs/specs/421--bug-per-task-reviewer-diff-range-marker/impl-notes.md
@@ -1,0 +1,91 @@
+<!-- Issue: #421 -->
+<!-- URL: https://github.com/hitoshiichikawa/idd-claude/issues/421 -->
+
+# Implementation Notes
+
+## 設計判断（matcher 緩和 vs 正規化の選択理由）
+
+**採用方針: matcher 緩和（regex / glob ベース）**
+
+理由:
+
+1. **2 経路ある照合点の整合性**: `pt_resolve_diff_range` は (a) 単記パスで bash 文字列等価
+   `[ "$subject" = "..." ]` と (b) 連記パスで `sed -nE` の正規表現抽出を併用している。
+   subject 正規化（suffix を事前 strip して比較する案）は両経路に「正規化ステップ」を挟む
+   必要があり、結果として 2 段階処理になる。一方 matcher 緩和は (a) を「正規 + canonical
+   suffix 付き」2 候補のいずれかにマッチで OK、(b) を `( \(#[0-9]+\))?` optional group を
+   追加する 1 行修正で済み、変更箇所が局所化される。
+2. **拒否境界の表現力**: Req 4 で「空白なし / 括弧なし / 追加文字列 / 非数字」を拒否する
+   必要があるが、これは canonical suffix の構造（` (#<digits>)` 行終端）を厳密に正規表現
+   側で表現するのが直接的。subject 正規化は「strip すべき接尾辞か否か」を別途判定する
+   ステップが必要になり、結果的に同じ判定ロジックを書く羽目になる。
+3. **既存ログ列の温存**: NFR 1.1 で「既存 `via=multi-id-marker` の文字列形式と発火条件を
+   変更しない」要件があるため、suffix 経路を新タグ（`-with-suffix`）として分離する必要が
+   ある。matcher 緩和では via 変数の代入を 4 ケース（`single-id-marker` / `single-id-marker-with-suffix`
+   / `multi-id-marker` / `multi-id-marker-with-suffix`）に分けるだけで実現できる。
+4. **bash glob の特性活用**: 単記パスでは `[[ "$subject" == "${canonical} (#"*")" ]]` で
+   prefix + 任意 + 閉じ括弧という構造を 1 行で粗判定し、続けて `${var#prefix}` /
+   `${var%)}` のパラメータ展開で `<number>` 部を抽出してから `=~ ^[0-9]+$` で厳密検証
+   する 2 段階構成を取った。これにより task_id の `.` などのメタ文字を意識せずに済む
+   （glob `*` の前後は quote 済みのリテラル文字列）。
+
+## 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `local-watcher/bin/issue-watcher.sh` | `pt_resolve_diff_range` 関数の単記 / 連記いずれの照合パスでも canonical suffix `(#<digits>)` を optional として許容。新 via タグ `single-id-marker-with-suffix` / `multi-id-marker-with-suffix` を追加し、stderr ログに出力。関数ヘッダ doc を Issue #421 Req 1〜5 反映で更新 |
+| `local-watcher/test/pt_resolve_diff_range_test.sh` | 新規追加（既存 `pt_post_marker_classify_test.sh` の awk 抽出 + eval パターン踏襲）。Req 1〜5 / NFR 1.1 をカバーする 50 アサーション |
+
+## AC Traceability
+
+| Requirement | テスト（test_file:section） | 備考 |
+|-------------|---------------------------|------|
+| Req 1.1 | `pt_resolve_diff_range_test.sh:Section A` (suffix 付き 単記 marker / 初回 task) | 解決成功と range pair を確認 |
+| Req 1.2 | `pt_resolve_diff_range_test.sh:Section A` (混在 順方向 / 逆方向) | 時系列最終一致が一意に採用される |
+| Req 1.3 | `pt_resolve_diff_range_test.sh:Section D Req 4.5` (非数字 / 数字混在) | `<number>` を `^[0-9]+$` で厳密検証 |
+| Req 1.4 | `pt_resolve_diff_range_test.sh:Section D Req 4.1〜4.4` | canonical 表記の境界を網羅 |
+| Req 1.5 | `pt_resolve_diff_range_test.sh:Section A` (`via=single-id-marker-with-suffix` 観測) | 観測タグの出力を確認 |
+| Req 2.1 | `pt_resolve_diff_range_test.sh:Section B` (slash / comma 連記 suffix 付き) | 連記 suffix 付き marker の解決 |
+| Req 2.2 | `pt_resolve_diff_range_test.sh:Section B Req 2.2` (誤マッチ防止) | token 化規則を suffix 有無で同一適用 |
+| Req 2.3 | `pt_resolve_diff_range_test.sh:Section B` (`via=multi-id-marker-with-suffix`) | 単記タグとの区別を確認 |
+| Req 3.1 | `pt_resolve_diff_range_test.sh:Section C Req 3.1` | suffix 無し 単記の SHA pair 一致 |
+| Req 3.2 | `pt_resolve_diff_range_test.sh:Section C Req 3.2` | 既存 `via=multi-id-marker` の維持 |
+| Req 3.3 | `pt_resolve_diff_range_test.sh:Section A/C` (`-with-suffix` 不出力) | 既存ログタグの文字列形式と発火条件を温存 |
+| Req 4.1 | `pt_resolve_diff_range_test.sh:Section D Req 4.1` | 解決する |
+| Req 4.2 | `pt_resolve_diff_range_test.sh:Section D Req 4.2` | 空白なし → 解決しない |
+| Req 4.3 | `pt_resolve_diff_range_test.sh:Section D Req 4.3` | 括弧なし → 解決しない |
+| Req 4.4 | `pt_resolve_diff_range_test.sh:Section D Req 4.4` | 追加文字列 → 解決しない |
+| Req 4.5 | `pt_resolve_diff_range_test.sh:Section D Req 4.5 / 4.5 (mixed)` | 非数字 / 数字混在 → 解決しない |
+| Req 4.6 | `pt_resolve_diff_range_test.sh:Section D Req 4.6 x2` | 連記パスにも同一規則を適用 |
+| Req 5.1 | `pt_resolve_diff_range_test.sh:Section E Req 5.1 x2` | marker 不在 / 該当 task_id 不在で rc=1 |
+| Req 5.2 | （observation） | 失敗時挙動は本変更で touch しないため、`mark_issue_failed` 経由の既存契約を維持 |
+| NFR 1.1 | `pt_resolve_diff_range_test.sh:Section C` | 既存タグの文字列・発火条件を変更しないことを観測 |
+| NFR 1.2 | （observation） | `PER_TASK_LOOP_ENABLED` gate は本関数の呼び出し元（既存）で制御されており、本関数自体は gate 外で評価しない |
+| NFR 2.1 | `pt_resolve_diff_range_test.sh:Section A/B` | `via=*-with-suffix` タグの grep 可能性を確認 |
+| NFR 2.2 | （observation） | 解決失敗は `pt_resolve_diff_range` の rc=1 を呼び出し元が `pt_mark_diff_range_resolve_failed` で診断する既存経路。本関数自体は失敗時に新規ログ追加しない |
+| NFR 3.1 | `pt_resolve_diff_range_test.sh:Section D Req 4.5` | `<number>` を `^[0-9]+$` で検証してから採用 |
+| NFR 3.2 | コードレビュー観点 | 量指定子は `[0-9]+`（線形時間）に限定。`(.+) as done( \(#[0-9]+\))?$` は末尾アンカで境界を固定しているため ReDoS リスクなし |
+| NFR 4.1 | `pt_resolve_diff_range_test.sh:Section D` | 5 パターン（許容 1 / 拒否 4）を fixture で網羅 |
+| NFR 4.2 | 既存 `pt_*_test.sh` 全 4 ファイル | 既存テスト全 101 件 (18+24+20+39) パス維持 |
+
+## 静的解析
+
+- `shellcheck local-watcher/bin/issue-watcher.sh` → クリーン（出力 0 行）
+- `shellcheck local-watcher/test/pt_resolve_diff_range_test.sh` → クリーン
+- `bash -n local-watcher/bin/issue-watcher.sh` → syntax OK
+- `diff -r .claude/agents repo-template/.claude/agents` → 空（変更なし）
+- `diff -r .claude/rules repo-template/.claude/rules` → 空（変更なし）
+
+## テスト結果
+
+- `bash local-watcher/test/pt_resolve_diff_range_test.sh` → **PASS: 50, FAIL: 0**
+- 既存 pt_*_test.sh 4 ファイル → 全 PASS（合計 PASS: 101, FAIL: 0）
+
+## 確認事項
+
+なし。requirements.md の Out of Scope に「Developer 側 prompt の suffix 付与禁止化」「`(#<number>)`
+以外の trailing suffix 形式」「retrofit」が明示されており、本実装はそれに準拠して watcher 側の
+許容拡大のみを行った。design.md / tasks.md は本 Issue では生成されていないが、Triage が
+`needs_architect: false` と判定したと推測される（regex / glob の局所変更で完結する scope）。
+
+STATUS: complete

--- a/docs/specs/421--bug-per-task-reviewer-diff-range-marker/requirements.md
+++ b/docs/specs/421--bug-per-task-reviewer-diff-range-marker/requirements.md
@@ -1,0 +1,126 @@
+<!-- Issue: #421 -->
+<!-- URL: https://github.com/hitoshiichikawa/idd-claude/issues/421 -->
+
+# Requirements Document
+
+## Introduction
+
+`PER_TASK_LOOP_ENABLED=true` の per-task ループにおいて、per-task Reviewer の diff range 解決
+（`local-watcher/bin/issue-watcher.sh` の `pt_resolve_diff_range`、L3695-3775 付近）は
+`docs(tasks): mark <id> as done` の **subject 完全一致**（単記 marker パス）と **末尾アンカ
+付き正規表現** `^docs\(tasks\): mark (.+) as done$`（連記 marker fallback パス）で marker
+commit を識別している。このため Developer が Conventional Commits / GitHub 慣習に従って
+trailing issue-ref suffix（例: `docs(tasks): mark 6 as done (#118)`）を付けた marker を
+作成すると、subject が完全一致せず、かつ末尾アンカも満たさないため当該 task の marker
+commit が解決できず `diff-range-resolve-failed (no-marker-commit-found)` で `claude-failed`
+に落ちる事象が altpocket-server #118 で観測された。
+
+本 spec は (1) 単記 / 連記いずれのパスでも trailing issue-ref suffix `(#<number>)` 付き
+marker を解決可能にする許容範囲拡大、(2) canonical（suffix 無し）marker の挙動温存、
+(3) 連記 marker fallback の既存挙動温存、(4) `as done` 後ろの suffix 文字列パターンの
+許容 / 拒否境界の明確化、を要件として定義する。実装手段（regex 拡張 / subject 正規化等）は
+`design.md` に委ねる。
+
+関連: 本 spec は #164（連記 marker fallback 導入）の許容範囲をさらに広げる継続改善であり、
+#164 で確立された「1 commit = 1 task ID」の canonical 規約自体は本 spec で変更しない。
+
+## Requirements
+
+### Requirement 1: trailing issue-ref suffix 付き単記 marker の解決
+
+**Objective:** As the Per-Task Diff Range Resolver, I want subject 末尾に issue-ref suffix `(#<number>)` を伴う単記 marker commit からも当該 task ID を解決できる, so that Developer が Conventional Commits 慣習に従って付与した issue-ref suffix を理由に diff range 解決が失敗しないようにする
+
+#### Acceptance Criteria
+
+1. When `${BASE_BRANCH}..HEAD` 範囲に subject が `docs(tasks): mark <id> as done (#<number>)` 形式の単記 marker commit のみ存在する場合, the Per-Task Diff Range Resolver shall 当該 task ID の marker commit SHA を解決する
+2. When 同一 task ID に対して suffix 無し marker と suffix 付き marker の双方が時系列上に存在する場合, the Per-Task Diff Range Resolver shall いずれか 1 つを一意に決定し、選択基準を観測ログで識別可能にする
+3. The Per-Task Diff Range Resolver shall trailing issue-ref suffix の `<number>` 部を `^[0-9]+$` を満たす整数とみなして照合する
+4. The Per-Task Diff Range Resolver shall suffix 形式として canonical に許容する表記を `docs(tasks): mark <id> as done (#<number>)`（`as done` と `(` の間に半角空白 1 つ、`#` の直後に数字、閉じ括弧 `)` で終端）と定義する
+5. Where suffix 付き marker から解決した場合, the Per-Task Diff Range Resolver shall 観測可能な識別子（例: `via=single-id-marker-with-suffix` 相当のタグ）を stdout または stderr のログ行に残し、運用者が grep で件数を把握できるようにする
+
+### Requirement 2: trailing issue-ref suffix 付き連記 marker の解決
+
+**Objective:** As the Per-Task Diff Range Resolver, I want subject 末尾に issue-ref suffix を伴う連記 marker commit からも当該 task ID を解決できる, so that #164 で導入した連記 fallback と suffix 許容が両立し、連記かつ suffix 付きという複合パターンでも解決失敗を回避する
+
+#### Acceptance Criteria
+
+1. When subject が `docs(tasks): mark <ids> as done (#<number>)` 形式の連記 marker commit のみ存在し、`<ids>` に当該 task ID と完全一致するトークンが含まれる場合, the Per-Task Diff Range Resolver shall 当該 commit を当該 task ID の marker commit として解決する
+2. The Per-Task Diff Range Resolver shall 連記 ID の token 化（`/` / `,` / 空白を区切りとする word 単位完全一致）を、suffix 有無に関わらず同一の規則で適用する
+3. The Per-Task Diff Range Resolver shall 連記 suffix 付き marker から解決した場合の観測ログを、Requirement 1.5 と区別可能な形（例: `via=multi-id-marker-with-suffix` 相当のタグ）で出力する
+
+### Requirement 3: canonical（suffix 無し）marker の挙動温存
+
+**Objective:** As the Per-Task Diff Range Resolver, I want 既存の suffix 無し marker のみで構成される履歴で解決結果を本変更前と完全一致させる, so that 既存リポジトリ・既存 PR・既存ログ列が本変更の影響を受けないことを保証する（CLAUDE.md「後方互換性」規約）
+
+#### Acceptance Criteria
+
+1. When `${BASE_BRANCH}..HEAD` 範囲が既存形式の suffix 無し単記 marker（`docs(tasks): mark <id> as done`）のみで構成されている場合, the Per-Task Diff Range Resolver shall 本変更前と同一の解決結果（同一 range_start / range_end SHA pair）を返す
+2. When `${BASE_BRANCH}..HEAD` 範囲が #164 で導入された suffix 無し連記 marker（`mark 1 / 1.1 as done` / `mark 1, 1.1 as done`）を含む場合, the Per-Task Diff Range Resolver shall 本変更前と同一の解決結果を返す
+3. The Per-Task Diff Range Resolver shall suffix 許容に伴って単記経由 / 連記経由いずれの既存観測ログ（`via=multi-id-marker` 等の既存タグ）の文字列形式と発火条件を変更しない
+
+### Requirement 4: suffix の許容 / 拒否境界の明確化
+
+**Objective:** As the Per-Task Diff Range Resolver, I want `as done` 後に続く文字列の許容パターンを明示的に定義する, so that 「どこまでが marker として認識され、どこからが marker として無視されるか」が運用者にとって曖昧にならない
+
+#### Acceptance Criteria
+
+1. When subject が `docs(tasks): mark <id> as done (#<number>)`（`as done` と `(` の間に半角空白 1 つ、閉じ括弧で終端）である場合, the Per-Task Diff Range Resolver shall 当該 commit を marker として **解決する**
+2. If subject が `docs(tasks): mark <id> as done(#<number>)`（空白なし）である場合, the Per-Task Diff Range Resolver shall 当該 commit を marker として **解決しない**
+3. If subject が `docs(tasks): mark <id> as done #<number>`（括弧なし）である場合, the Per-Task Diff Range Resolver shall 当該 commit を marker として **解決しない**
+4. If subject が `docs(tasks): mark <id> as done (#<number>) <任意の追加文字列>`（閉じ括弧の後に追加文字列）である場合, the Per-Task Diff Range Resolver shall 当該 commit を marker として **解決しない**
+5. If subject が `docs(tasks): mark <id> as done (#<非数字>)` のように `<number>` 部が `^[0-9]+$` を満たさない場合, the Per-Task Diff Range Resolver shall 当該 commit を marker として **解決しない**
+6. The Per-Task Diff Range Resolver shall 上記許容 / 拒否境界を単記パスと連記パス双方に同一規則で適用する
+
+### Requirement 5: 解決失敗時の挙動温存（既存契約）
+
+**Objective:** As the Per-Task Diff Range Resolver, I want suffix 許容の範囲外と判定された marker しか存在しない場合でも、`diff-range-resolve-failed` で停止する既存契約を維持する, so that 誤検出による silent な range 解決を回避しつつ、運用者向けの既存復旧導線（#164 Requirement 4）を温存する
+
+#### Acceptance Criteria
+
+1. If 当該 task ID に対する単記 / 連記いずれの marker（suffix 有無を問わず）も Requirement 1〜4 のもとで解決できなかった場合, the Per-Task Diff Range Resolver shall `diff-range-resolve-failed (no-marker-commit-found)` 相当の既存失敗終端を発火させる
+2. The Per-Task Diff Range Resolver shall 失敗終端時の失敗カテゴリ識別子・Issue コメント書式・`claude-failed` ラベル遷移を本変更前と同一に保つ
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The Per-Task Diff Range Resolver shall 既存 env var 名・既存ラベル名・既存失敗カテゴリ識別子（`diff-range-resolve-failed`）・既存観測ログタグ（`via=single-id-marker` / `via=multi-id-marker`）の文字列を変更せず、本変更後も完全一致で grep / 一致検査ができる
+2. The Per-Task Diff Range Resolver shall `PER_TASK_LOOP_ENABLED` が未設定または `=true` 以外の起動経路では本変更経路に到達しないことで、本機能導入前と完全に同一の外形挙動を維持する
+
+### NFR 2: 可観測性
+
+1. When suffix 付き marker（単記 / 連記いずれか）経由で解決した場合, the Per-Task Diff Range Resolver shall 解決経路を識別可能なタグをログ行に残し、運用者が `via=*-with-suffix` 相当の grep で件数把握できるようにする
+2. When 解決失敗時, the Per-Task Diff Range Resolver shall ログに当該 task ID と「単記 / 連記 / suffix 有 / suffix 無 のいずれの候補も見つからなかった」旨を明示する
+
+### NFR 3: セキュリティ
+
+1. The Per-Task Diff Range Resolver shall subject から抽出する `<number>` 部を使用直前に `^[0-9]+$` で検証し、未検証の文字列を path / git revision / 外部コマンド引数に渡さない（CLAUDE.md「未信頼 GitHub 入力の取り扱い」規約準拠）
+2. The Per-Task Diff Range Resolver shall subject 抽出に用いる正規表現が `<id>` / `<number>` 部のメタ文字によって ReDoS 級の処理時間爆発を起こさないよう、量指定子を有界化する
+
+### NFR 4: テスト追随性
+
+1. The Per-Task Loop Implementation shall 本要件追加に対応する近接テスト（`local-watcher/test/` 配下、既存 `extract_function` イディオム）を追加し、Requirement 4 で定義する許容 / 拒否境界 5 パターンを fixture として網羅する
+2. The Per-Task Loop Implementation shall 既存テスト（#164 / #270 / #304 配下の per-task Reviewer 関連テスト）を改変せずパスさせる
+
+## Out of Scope
+
+- #417 / #420 で扱われる別系統の per-task Reviewer 不具合（本 spec の責務外）
+- marker commit 自体が存在しないケースの挙動変更（既存の `diff-range-resolve-failed` 終端を温存し、本 spec では拡張しない）
+- Developer 側 prompt の suffix 付与禁止化 / 強制 canonical 化（Option C 系の規約変更は本 spec の対象外。canonical 規約は #164 で既定済みで、本 spec は watcher 側の許容拡大のみを扱う）
+- `(#<number>)` 以外の trailing suffix 形式（例: 末尾 `[#<number>]` / `Closes #<n>` / 任意 free-form 文字列）の許容拡大
+- 既に main にマージ済みの過去 commit / 過去 PR 履歴の遡及書き換え（retrofit）
+- per-task ループ以外の Reviewer Gate（Stage B 既存経路 / Failed Recovery / PR Reviewer 等）への波及変更
+- 連記 marker を canonical 表記として推奨する方向への規約変更（canonical は引き続き「1 commit = 1 task ID」、連記 / suffix 付きは「許容するが推奨しない」位置付け）
+
+## Open Questions
+
+なし（Issue 本文「受入基準」節に許容 / 拒否の境界 4 パターンが明示されており、本 spec は
+Requirement 4 で 5 パターン（Issue 本文の 4 パターン + `<number>` 部の非数字ケース）として
+網羅した。Issue にコメントは投稿されておらず、Developer 側の suffix 付与可否や代替仕様の
+人間決定事項は未提示）
+
+## 関連
+
+- Depends on: なし
+- Parent: なし
+- Related: #164 #304 #305 #417 #420

--- a/docs/specs/421--bug-per-task-reviewer-diff-range-marker/review-notes.md
+++ b/docs/specs/421--bug-per-task-reviewer-diff-range-marker/review-notes.md
@@ -1,0 +1,85 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.7 timestamp=2026-06-27T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-421-impl--bug-per-task-reviewer-diff-range-marker
+- HEAD commit: f23d689810e0eda17f335608ad45b791e22e21f3
+- Compared to: main..HEAD
+- 変更ファイル:
+  - `local-watcher/bin/issue-watcher.sh`（`pt_resolve_diff_range` 関数のみ改修、+96/-33）
+  - `local-watcher/test/pt_resolve_diff_range_test.sh`（新規 394 行）
+  - `docs/specs/421--bug-per-task-reviewer-diff-range-marker/impl-notes.md`（新規）
+- 注: tasks.md は本 spec では未生成（Triage が `needs_architect: false` 判定で
+  Architect 経由しない単純改修と推定。Boundary は requirements.md と Issue 本文の
+  明示範囲＝`pt_resolve_diff_range` 関数および近接テストに限定されているため、
+  実装はその範囲内で完結している）
+
+## Verified Requirements
+
+- 1.1 — `pt_resolve_diff_range_test.sh` Section A "Req 1.1: suffix 付き 単記 marker のみ → 解決"（sha0006 解決 / range pair sha0005\tsha0006）および初回 task fixture で確認
+- 1.2 — Section A "Req 1.2 順方向 / 逆方向" 双方向 fixture で時系列最終一致が一意に採用されることを確認
+- 1.3 — Section D "Req 4.5" 非数字 / 数字混在（`(#abc)` / `(#12a)`）が拒否され `^[0-9]+$` 検証が機能している
+- 1.4 — Section D "Req 4.1〜4.4" で canonical 表記（半角空白 1 + `(#<digits>)` + 行終端）が境界として実装側コード（`[[ "$subject" == "${single_canonical} (#"*")" ]]` + `${var#prefix}` / `${var%)}` + `^[0-9]+$`）で表現
+- 1.5 — Section A の `assert_contains "via=single-id-marker-with-suffix"` で stderr 観測タグを確認。実装側は `case "$via"` 分岐で stderr 出力
+- 2.1 — Section B "Req 2.1 suffix 付き 連記" の slash / comma 連記 fixture が解決成功
+- 2.2 — Section B "Req 2.2 token 化規則同一"（`task_id=1` が `1.1 / 1.2` に誤マッチしないこと）で確認
+- 2.3 — Section B `via=multi-id-marker-with-suffix` 観測タグ確認、かつ `single-id-marker-with-suffix` が出ないことの否定アサーションあり
+- 3.1 — Section C "Req 3.1" で suffix 無し 単記のみ fixture が本変更前と同一 SHA pair（sha_a\tsha_b）を返す
+- 3.2 — Section C "Req 3.2" で suffix 無し 連記 fixture が既存挙動を保持
+- 3.3 — Section A の逆順 fixture / Section C で `-with-suffix` タグが既存ログタグ条件下では出ないことを否定アサーションで確認、既存 `via=multi-id-marker ` の文字列は維持
+- 4.1 — Section D "Req 4.1" `mark 10 as done (#1)` 解決
+- 4.2 — Section D "Req 4.2" 空白なし `done(#118)` rc=1
+- 4.3 — Section D "Req 4.3" 括弧なし `done #118` rc=1
+- 4.4 — Section D "Req 4.4" 閉じ括弧後追加文字列 `done (#118) extra` rc=1
+- 4.5 — Section D "Req 4.5 / 4.5 (mixed)" 非数字・数字混在 rc=1
+- 4.6 — Section D "Req 4.6 (multi) x2" 連記パスにも同一規則（空白なし / 閉じ括弧後追加文字列）が rc=1 で適用
+- 5.1 — Section E "Req 5.1 x2" marker 0 件 / 該当 task_id 不在で rc=1
+- 5.2 — 実装は `mark_issue_failed` 経由の既存失敗終端（呼び出し元）に影響を与えない（本関数は rc=1 のみ返却、失敗カテゴリ識別子・ラベル遷移を新規追加せず）
+- NFR 1.1 — Section C で既存 `via=multi-id-marker` の文字列形式（trailing space を含む）と発火条件（suffix 無し連記）を維持。`diff-range-resolve-failed` 等の既存識別子は本 PR で touch していない（grep 確認）
+- NFR 1.2 — `pt_resolve_diff_range` は呼び出し元（`PER_TASK_LOOP_ENABLED=true` で gate された経路）からのみ到達する。本関数自体は gate を持たないため、未設定経路では到達しない既存設計を温存
+- NFR 2.1 — Section A / B で `via=*-with-suffix` の grep 可能性を `assert_contains` で確認
+- NFR 2.2 — 解決失敗時のログは本関数で新規追加していない（呼び出し元 `pt_mark_diff_range_resolve_failed` の既存契約に委譲、impl-notes.md で明示）
+- NFR 3.1 — Section D "Req 4.5" / 実装で `[[ "$suffix_num" =~ ^[0-9]+$ ]]` の事前検証を経てから採用
+- NFR 3.2 — 実装の正規表現は `[0-9]+`（線形時間量指定子）・glob は末尾 `)` アンカー固定で ReDoS リスクなし（design 観点で確認）
+- NFR 4.1 — Section D が許容 1 + 拒否 4 = 5 パターンを fixture として網羅
+- NFR 4.2 — 既存 `pt_*_test.sh` 4 ファイル（`pt_check_fail_fast_test.sh:18` / `pt_extract_debugger_section_test.sh:24` / `pt_extract_findings_block_test.sh:20` / `pt_post_marker_classify_test.sh:39`）全て PASS（合計 101）を Reviewer 側でも再実行確認
+
+## 追加検証
+
+- 新規 `pt_resolve_diff_range_test.sh` を再実行: `PASS: 50, FAIL: 0`
+- 既存 pt_* 系 4 テストを再実行: 全 PASS（合計 PASS: 101, FAIL: 0、回帰なし）
+- `shellcheck local-watcher/bin/issue-watcher.sh` クリーン（出力 0 行）
+- `shellcheck local-watcher/test/pt_resolve_diff_range_test.sh` クリーン（出力 0 行）
+- Issue 本文の root example（`mark 6 as done (#118)`）が Section F で回帰固定されており、altpocket-server #118 の再発防止が観測可能
+
+## Feature Flag Protocol 採否確認
+
+CLAUDE.md に `## Feature Flag Protocol` 節は存在しない（参照テーブル行のみ）。
+opt-out 扱いとし、flag 観点の細目（旧パス削除 / `if (flag)` 分岐 / flag-off path mutation /
+flag 命名規約）は本判定に **適用しない**。通常の 3 カテゴリ判定のみ。
+
+## Boundary 確認
+
+- 変更スコープは `pt_resolve_diff_range` 関数本体 + 関数ヘッダ doc + 近接テスト新規追加のみ
+- 既存 env var 名 / ラベル名 / 既存失敗カテゴリ識別子 (`diff-range-resolve-failed`) /
+  既存ログタグ (`via=single-id-marker` 不出力 / `via=multi-id-marker`) の文字列・発火条件は
+  変更なし（CLAUDE.md「後方互換性」規約を逸脱せず）
+- `repo-template/` への二重管理対象（agents / rules）は本 PR では `diff -r` 空で同期維持
+  （impl-notes 申告どおり）
+- 関数の主出力は stdout の `<range_start>\t<range_end>`、観測タグは stderr に分離されており
+  呼び出し元の SHA pair 受け取りに副作用を起こさない
+
+## Findings
+
+なし
+
+## Summary
+
+Issue #421 で要求された 5 要件群（trailing issue-ref suffix 許容拡大 / 既存挙動温存 /
+許容拒否境界 / 失敗時挙動温存）と全 NFR が、`pt_resolve_diff_range` の局所改修 + 新規
+近接テスト 50 アサーションで実装・検証されている。既存 pt_* 4 テスト計 101 件も回帰なく
+通過しており、boundary 逸脱もない。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -3776,31 +3776,47 @@ EOF
 # per-task Reviewer に渡す diff range の開始 SHA / 終了 SHA を解決して
 # `<range_start_sha>\t<range_end_sha>` を stdout に出力。
 #
-# アルゴリズム（design.md「diff range 解決アルゴリズム」節 + Issue #164 拡張）:
+# アルゴリズム（design.md「diff range 解決アルゴリズム」節 + Issue #164 / #421 拡張）:
 #   1. `$BASE_BRANCH..HEAD` 範囲の `docs(tasks): mark ... as done` commit を SHA+subject の
 #      タブ区切り pair で時系列昇順に全列挙
 #   2. 当該 task_id の marker commit を以下の優先順で特定（range_end）:
-#      a. 単記 marker（subject が `docs(tasks): mark <task_id> as done` に完全一致）
-#         複数マッチ時は最後（最新）のマッチを採用（既存挙動を維持 / Req 3.1）
-#      b. 単記 marker が無ければ連記 marker（subject が `docs(tasks): mark <ids> as done` で
-#         <ids> を `/` / `,` / 空白で token 化したときに task_id と完全一致する token を含む）
-#         複数マッチ時は最後のマッチを採用（NFR 2.1: 連記経由解決時は stdout ログに
-#         `via=multi-id-marker` を残す）
+#      a. 単記 marker（subject が `docs(tasks): mark <task_id> as done` に完全一致、
+#         または canonical suffix 付き `docs(tasks): mark <task_id> as done (#<number>)`
+#         に一致 / Issue #421 Req 1）。複数マッチ時は最後（最新）のマッチを採用
+#         （既存挙動を維持 / Req 3.1）
+#      b. 単記 marker が無ければ連記 marker（subject が
+#         `docs(tasks): mark <ids> as done` または
+#         `docs(tasks): mark <ids> as done (#<number>)` で、<ids> を `/` / `,` /
+#         空白で token 化したときに task_id と完全一致する token を含む）。
+#         複数マッチ時は最後のマッチを採用（NFR 2.1: 連記経由解決時は stderr ログに
+#         `via=multi-id-marker` または `via=multi-id-marker-with-suffix` を残す）
 #   3. 全 mark commit 列の中で range_end の直前要素を range_start とする
 #   4. 直前要素が存在しない（初回 task）場合は range_start = `$BASE_BRANCH` の SHA
 #   5. 当該 task の marker commit が単記でも連記でも見つからない場合は return 1
 #
-# 後方互換性（Req 3.1 / NFR 1.1）:
-#   - 単記 marker のみで構成されるリポジトリ履歴では、単記 marker が常に優先採用されるため
-#     本変更前と完全に同一の SHA pair を返す
-#   - 連記 marker は単記 marker が無い場合の fallback として動作するため、既存ログ列の
-#     観測可能な副作用は発生しない
+# 後方互換性（Req 3.1, 3.2, 3.3 / NFR 1.1）:
+#   - suffix 無し単記 marker のみで構成されるリポジトリ履歴では、単記 marker が常に
+#     優先採用されるため本変更前と完全に同一の SHA pair を返す
+#   - suffix 無し連記 marker は単記 marker が無い場合の fallback として動作するため、
+#     既存ログタグ（`via=multi-id-marker`）の文字列形式と発火条件は変更しない
+#   - suffix 付き経由で解決した場合のみ、新タグ（`*-with-suffix`）を追加で出力する
 #
-# False positive 防止（Req 2.5）:
-#   - <ids> 部を `/` / `,` / 空白で正規化した後 word 単位で完全一致照合するため、task_id `1`
-#     が `1.1` や `11` に誤マッチしない
+# Suffix 許容境界（Issue #421 Req 4 / NFR 3.2）:
+#   - 許容: `docs(tasks): mark <id...> as done (#<digits>)`
+#     （`as done` と `(` の間に半角空白 1 つ、`#` 直後に 1 文字以上の連続 digit、
+#     閉じ括弧 `)` で行終端）
+#   - 拒否: 空白なし / 括弧なし / 閉じ括弧後の追加文字列 / `<number>` 部に非数字
+#   - 上記境界は単記パス / 連記パス双方に同一規則で適用する（Req 4.6）
 #
-# Requirements: 3.2, 4.5, 5.4, Issue #164 Req 2.1, 2.2, 2.3, 2.4, 2.5, 3.1, 3.2, NFR 2.1
+# False positive 防止（Issue #164 Req 2.5 / Issue #421 NFR 3.1）:
+#   - <ids> 部を `/` / `,` / 空白で正規化した後 word 単位で完全一致照合するため、
+#     task_id `1` が `1.1` や `11` に誤マッチしない
+#   - suffix 抽出に用いる正規表現の `<number>` 部は `[0-9]+` で有界化（NFR 3.2）。
+#     ReDoS リスクの無い線形時間照合
+#
+# Requirements (Issue #421): 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 3.1, 3.2, 3.3,
+#   4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 5.1, 5.2, NFR 1.1, NFR 2.1, NFR 2.2, NFR 3.1, NFR 3.2
+# 旧 Requirements (Issue #164 / #270 / #305): 3.2, 4.5, 5.4, #164 Req 2.1-2.5, 3.1, 3.2, NFR 2.1
 pt_resolve_diff_range() {
   local task_id="$1"
   local base="${BASE_BRANCH:-main}"
@@ -3812,24 +3828,59 @@ pt_resolve_diff_range() {
     return 1
   fi
 
-  # ─── (a) 単記 marker を優先検索（subject 完全一致 / Req 3.1 後方互換） ───
-  local current_mark="" via="" sha subject id_list tok found
+  # canonical suffix 付き 単記 subject の組み立て（task_id をリテラル文字列として扱い、
+  # 正規表現メタ文字回避のため bash =~ ではなく文字列等価比較で照合する）。
+  local single_canonical="docs(tasks): mark ${task_id} as done"
+
+  # ─── (a) 単記 marker を優先検索（suffix 無し → suffix 付きの順 / Req 1, 3.1） ───
+  # 同 task_id に対して suffix 無し / suffix 付き双方が混在する場合は「all_pairs を
+  # 時系列順に 1 回走査し、最後にマッチした方を採用」する。これにより：
+  # - 履歴上の最新 marker が採用される（Req 1.2 の「いずれか 1 つを一意に決定」）
+  # - 採用された marker の via タグが選択基準（suffix 有無）の観測手段になる（Req 1.5）
+  local current_mark="" via="" sha subject id_list tok found suffix_num
   while IFS=$'\t' read -r sha subject; do
     [ -n "$sha" ] || continue
-    if [ "$subject" = "docs(tasks): mark ${task_id} as done" ]; then
+    if [ "$subject" = "$single_canonical" ]; then
       current_mark="$sha"
       via="single-id-marker"
+    elif [[ "$subject" == "${single_canonical} (#"*")" ]]; then
+      # `<canonical> (#<n>)` の形に粗くマッチしたうえで、`<n>` 部が `^[0-9]+$` を
+      # 満たすかを厳密検証する（Req 1.3 / Req 4.5 / NFR 3.1）。閉じ括弧後の追加
+      # 文字列は上の glob `*)` 終端で既に排除されている（Req 4.4）。
+      # `${single_canonical} (#` の長さ分だけ prefix を剥がし、末尾 `)` を 1 文字
+      # 落として `<n>` 部を抽出する。
+      suffix_num="${subject#"${single_canonical}" (#}"
+      suffix_num="${suffix_num%)}"
+      if [[ "$suffix_num" =~ ^[0-9]+$ ]]; then
+        current_mark="$sha"
+        via="single-id-marker-with-suffix"
+      fi
     fi
   done <<<"$all_pairs"
 
-  # ─── (b) 単記 marker が無ければ連記 marker を fallback 検索（Req 2.2 / 2.5） ───
+  # ─── (b) 単記 marker が無ければ連記 marker を fallback 検索（Req 2 / #164 Req 2.2） ───
   if [ -z "$current_mark" ]; then
     while IFS=$'\t' read -r sha subject; do
       [ -n "$sha" ] || continue
-      # subject から <ids> 部を抽出（`docs(tasks): mark <ids> as done`）。
-      # 末尾アンカで「as done」以降にコメント等が付いた変則 subject は対象外とする。
-      id_list=$(printf '%s' "$subject" | sed -nE 's/^docs\(tasks\): mark (.+) as done$/\1/p')
+      # subject から <ids> 部を抽出（`docs(tasks): mark <ids> as done` または
+      # `docs(tasks): mark <ids> as done (#<n>)`）。
+      # - 末尾 ` (#<n>)` は optional（capture group 2 / Req 2.1）。<n> は `[0-9]+` で
+      #   有界化（NFR 3.2）。閉じ括弧後の追加文字列は末尾アンカ `$` で排除（Req 4.4）。
+      # - capture group 1（<ids> 部）が空白なし / 括弧なし / 非数字 suffix を含む
+      #   変則 subject にマッチしないことは末尾アンカ + 厳密な suffix 構造で担保される。
+      # - sed BRE には `?` 量指定子が無いため `-E` (ERE) を維持しつつ optional group
+      #   `(...)?` を使う。
+      id_list=$(printf '%s' "$subject" | sed -nE 's/^docs\(tasks\): mark (.+) as done( \(#[0-9]+\))?$/\1/p')
       [ -n "$id_list" ] || continue
+      # suffix 有無の判定（observability tag の選択用 / Req 2.3）。
+      # subject 末尾が ` (#<n>)` の形ならば suffix 付き、そうでなければ無し。
+      local _matched_with_suffix=0
+      if [[ "$subject" == *" (#"*")" ]]; then
+        # 抽出した id_list の後ろに ` (#<n>)` が続いて行終端していることを再確認する。
+        # （上の sed が match している時点で構造は保証されているが、observability
+        # タグ選択の判定として明示的に確認する）
+        _matched_with_suffix=1
+      fi
       # `/` / `,` を空白に正規化し、word 単位で task_id と完全一致する token を探す。
       # word splitting は IFS のデフォルト（空白）で行われ、任意連続空白に対応する。
       found=false
@@ -3841,7 +3892,11 @@ pt_resolve_diff_range() {
       done
       if [ "$found" = "true" ]; then
         current_mark="$sha"
-        via="multi-id-marker"
+        if [ "$_matched_with_suffix" -eq 1 ]; then
+          via="multi-id-marker-with-suffix"
+        else
+          via="multi-id-marker"
+        fi
       fi
     done <<<"$all_pairs"
   fi
@@ -3871,13 +3926,21 @@ pt_resolve_diff_range() {
     fi
   fi
 
-  # NFR 2.1: 連記経由で解決した場合は stdout ログに識別可能な印を残す（運用者が
-  # `grep via=multi-id-marker` で件数把握できる）。単記経由は出力しない（既存ログ量を
-  # 増やさない後方互換）。stdout に出すことで呼び出し側 `pt_log` 経由のログ書式と
-  # 揃える代わりに、関数の主出力（SHA pair）と区別するため独立行 + tag prefix で出す。
-  if [ "$via" = "multi-id-marker" ]; then
-    echo "[$(date '+%F %T')] per-task: diff-range resolved via=multi-id-marker task_id=${task_id} sha=${current_mark}" >&2
-  fi
+  # NFR 2.1 / Req 1.5 / Req 2.3: 解決経路を識別可能なタグを stderr に残す（運用者が
+  # `grep via=...` で件数把握できる）。suffix 無し単記経由は出力しない（既存ログ量を
+  # 増やさない後方互換 / Req 3.3）。stderr に出すことで関数の主出力（stdout の
+  # SHA pair）と分離する。
+  case "$via" in
+    multi-id-marker)
+      echo "[$(date '+%F %T')] per-task: diff-range resolved via=multi-id-marker task_id=${task_id} sha=${current_mark}" >&2
+      ;;
+    single-id-marker-with-suffix)
+      echo "[$(date '+%F %T')] per-task: diff-range resolved via=single-id-marker-with-suffix task_id=${task_id} sha=${current_mark}" >&2
+      ;;
+    multi-id-marker-with-suffix)
+      echo "[$(date '+%F %T')] per-task: diff-range resolved via=multi-id-marker-with-suffix task_id=${task_id} sha=${current_mark}" >&2
+      ;;
+  esac
 
   printf '%s\t%s\n' "$range_start" "$current_mark"
   return 0

--- a/local-watcher/test/pt_resolve_diff_range_test.sh
+++ b/local-watcher/test/pt_resolve_diff_range_test.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+#
+# 本テストの fake 依存（git）は eval で読み込んだ pt_resolve_diff_range から
+# 間接的にのみ呼ばれるため unreachable 扱いになる false positive を抑止する
+# （既存 pt_post_marker_classify_test.sh と同じ扱い）。
+# shellcheck disable=SC2317
+#
+# SC2034 も同様に、`BASE_BRANCH` は eval で読み込んだ pt_resolve_diff_range 内の
+# `${BASE_BRANCH:-main}` から参照されるが shellcheck からは unused に見える。
+# false positive のため抑止する。
+# shellcheck disable=SC2034
+#
+# 用途: local-watcher/bin/issue-watcher.sh の Issue #421（per-task Reviewer の
+#       diff-range 解決で trailing issue-ref suffix `(#<number>)` を許容する
+#       拡張）における `pt_resolve_diff_range` 関数の挙動を fixture で
+#       検証するスモークテスト。
+#
+#       対象 Requirements (Issue #421):
+#         - Req 1.1 / 1.3 / 1.4 / 1.5: suffix 付き 単記 marker の解決と
+#           `via=single-id-marker-with-suffix` 観測タグ
+#         - Req 1.2: suffix 無し / suffix 付き 混在時の一意決定（時系列最終一致）
+#         - Req 2.1 / 2.2 / 2.3: suffix 付き 連記 marker の解決と
+#           `via=multi-id-marker-with-suffix` 観測タグ
+#         - Req 3.1 / 3.2 / 3.3: 既存 suffix 無し marker の後方互換
+#         - Req 4.1〜4.6: suffix 許容 / 拒否境界（空白なし / 括弧なし /
+#           追加文字列 / 非数字 number / 単記＆連記の同一規則適用）
+#         - Req 5.1: 該当 marker 不在で return 1
+#         - NFR 1.1: 既存ログタグ `via=single-id-marker` / `via=multi-id-marker`
+#           の文字列形式と発火条件を変更しないこと
+#
+#       既存 `pt_post_marker_classify_test.sh` の「awk による関数抽出 +
+#       eval 読み込み」パターンを踏襲し、`git log` / `git rev-parse` を
+#       本テスト内で stub する。トップレベル副作用は回避する。
+#
+# 配置先: local-watcher/test/pt_resolve_diff_range_test.sh
+# 依存:   bash 4+, awk, grep, sed
+# 実行:   bash local-watcher/test/pt_resolve_diff_range_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+
+# issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "pt_resolve_diff_range")"
+
+if ! declare -F pt_resolve_diff_range >/dev/null; then
+  echo "ERROR: pt_resolve_diff_range not loaded" >&2
+  exit 2
+fi
+
+# ── fake git: 以下のサブコマンドを fixture から差し替え可能にする。
+#    - git log --grep=^docs(tasks): mark  --format=%H<TAB>%s --reverse <range>
+#        → $GIT_LOG_OUTPUT の echo
+#    - git rev-parse <base>  → $GIT_REVPARSE_OUTPUT の echo
+#    上記以外の git 呼び出しは想定外として exit 127。
+GIT_LOG_OUTPUT=""
+GIT_LOG_RC=0
+GIT_REVPARSE_OUTPUT=""
+GIT_REVPARSE_RC=0
+
+git() {
+  case "${1:-}" in
+    log)
+      if [ "$GIT_LOG_RC" != "0" ]; then
+        return "$GIT_LOG_RC"
+      fi
+      printf '%s' "$GIT_LOG_OUTPUT"
+      return 0
+      ;;
+    rev-parse)
+      if [ "$GIT_REVPARSE_RC" != "0" ]; then
+        return "$GIT_REVPARSE_RC"
+      fi
+      printf '%s' "$GIT_REVPARSE_OUTPUT"
+      return 0
+      ;;
+  esac
+  echo "[fake-git] unexpected git call: $*" >&2
+  return 127
+}
+
+BASE_BRANCH="main"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  needle  : $(printf '%q' "$needle")"
+    echo "  haystack: $(printf '%q' "$haystack")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1"
+  local needle="$2"
+  local haystack="$3"
+  if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+    echo "FAIL: $label"
+    echo "  needle (should NOT contain): $(printf '%q' "$needle")"
+    echo "  haystack                  : $(printf '%q' "$haystack")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  else
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  fi
+}
+
+# 一時 stderr ファイル管理
+STDERR_TMP="$(mktemp -t pt_resolve_diff_range_stderr.XXXXXX)"
+STDOUT_TMP="$(mktemp -t pt_resolve_diff_range_stdout.XXXXXX)"
+trap 'rm -f "$STDERR_TMP" "$STDOUT_TMP"' EXIT
+
+# run_resolve <task_id>
+#
+# stdout / stderr / rc を一時ファイルに残し、呼び出し側は以下の変数で参照する:
+#   - $RESOLVE_STDOUT : stdout 全文（trailing newline は printf '%s' で除去済）
+#   - $RESOLVE_STDERR : stderr 全文
+#   - $RESOLVE_RC     : 終了コード
+#
+# 注: pt_resolve_diff_range は while ループ内で stdin リダイレクト (<<<) を使うため、
+# `command || rc=$?` イディオムを使うと subshell が走るリスクがある（実際には bash の
+# `||` は subshell を作らないが、関数の安全な実行のため明示的に rc を保存する）。
+run_resolve() {
+  local _task_id="$1"
+  RESOLVE_RC=0
+  pt_resolve_diff_range "$_task_id" >"$STDOUT_TMP" 2>"$STDERR_TMP" || RESOLVE_RC=$?
+  RESOLVE_STDOUT="$(cat "$STDOUT_TMP")"
+  RESOLVE_STDERR="$(cat "$STDERR_TMP")"
+}
+
+echo "================================================================"
+echo "pt_resolve_diff_range 単体テスト (Issue #421 / 既存 #164 回帰)"
+echo "================================================================"
+
+# ───────────────────────────────────────────────────────────────────
+# Section A: Req 1 — suffix 付き 単記 marker の解決
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Req 1.1: suffix 付き 単記 marker のみ → 解決 ---"
+# task 5 の suffix 無し marker（range_start 算出用の先行 marker）
+# task 6 の suffix 付き marker（解決対象）
+GIT_LOG_OUTPUT="sha0005	docs(tasks): mark 5 as done
+sha0006	docs(tasks): mark 6 as done (#118)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "6"
+assert_eq "Req 1.1: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Req 1.1: range_start=sha0005 / range_end=sha0006" "sha0005	sha0006" "$RESOLVE_STDOUT"
+assert_contains "Req 1.5: stderr に via=single-id-marker-with-suffix" \
+  "via=single-id-marker-with-suffix" "$RESOLVE_STDERR"
+assert_contains "Req 1.5: stderr に task_id=6" "task_id=6" "$RESOLVE_STDERR"
+assert_contains "Req 1.5: stderr に sha=sha0006" "sha=sha0006" "$RESOLVE_STDERR"
+
+echo ""
+echo "--- Req 1.1 (初回 task): suffix 付き 単記 marker のみ・先行 marker なし ---"
+GIT_LOG_OUTPUT="sha0001	docs(tasks): mark 1 as done (#42)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "1"
+assert_eq "Req 1.1: rc=0 (initial task)" "0" "$RESOLVE_RC"
+assert_eq "Req 1.1: range_start=base / range_end=sha0001" "sha_base_main	sha0001" "$RESOLVE_STDOUT"
+assert_contains "Req 1.5: stderr に via=single-id-marker-with-suffix" \
+  "via=single-id-marker-with-suffix" "$RESOLVE_STDERR"
+
+echo ""
+echo "--- Req 1.2: suffix 無し と suffix 付き が同 task_id で混在 → 時系列最終を採用 ---"
+# 時系列順: suffix 無し (oldest) → suffix 付き (newer)
+GIT_LOG_OUTPUT="sha_old	docs(tasks): mark 7 as done
+sha_new	docs(tasks): mark 7 as done (#99)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "7"
+assert_eq "Req 1.2: rc=0" "0" "$RESOLVE_RC"
+# 時系列最終一致が採用される → range_end=sha_new、range_start=sha_old
+assert_eq "Req 1.2: range_end は最新 (sha_new)" "sha_old	sha_new" "$RESOLVE_STDOUT"
+assert_contains "Req 1.2: 最新が suffix 付きなので via=single-id-marker-with-suffix" \
+  "via=single-id-marker-with-suffix" "$RESOLVE_STDERR"
+
+echo ""
+echo "--- Req 1.2 (逆順): suffix 付き → suffix 無し 順の混在 → 時系列最終 (suffix 無し) を採用 ---"
+GIT_LOG_OUTPUT="sha_old	docs(tasks): mark 8 as done (#101)
+sha_new	docs(tasks): mark 8 as done"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "8"
+assert_eq "Req 1.2: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Req 1.2: 最新 suffix 無し を採用" "sha_old	sha_new" "$RESOLVE_STDOUT"
+# 最新が suffix 無し → 既存ログタグ無し（NFR 1.1 後方互換）
+assert_not_contains "Req 3.3: 最新 suffix 無し なら -with-suffix タグは出力しない" \
+  "-with-suffix" "$RESOLVE_STDERR"
+
+# ───────────────────────────────────────────────────────────────────
+# Section B: Req 2 — suffix 付き 連記 marker の解決
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Req 2.1: suffix 付き 連記 marker のみ → 解決 ---"
+GIT_LOG_OUTPUT="sha0010	docs(tasks): mark 1 / 1.1 as done (#205)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "1.1"
+assert_eq "Req 2.1: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Req 2.1: range_end は連記 suffix 付き marker" "sha_base_main	sha0010" "$RESOLVE_STDOUT"
+assert_contains "Req 2.3: stderr に via=multi-id-marker-with-suffix" \
+  "via=multi-id-marker-with-suffix" "$RESOLVE_STDERR"
+# 単記タグが誤って出ていないこと
+assert_not_contains "Req 2.3: via=single-id-marker-with-suffix が出ていないこと" \
+  "via=single-id-marker-with-suffix" "$RESOLVE_STDERR"
+
+echo ""
+echo "--- Req 2.1 (comma): suffix 付き カンマ連記 → 解決 ---"
+GIT_LOG_OUTPUT="sha0011	docs(tasks): mark 2, 2.1, 2.2 as done (#206)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "2.1"
+assert_eq "Req 2.1: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Req 2.1: range_end は連記 suffix 付き marker" "sha_base_main	sha0011" "$RESOLVE_STDOUT"
+assert_contains "Req 2.3: stderr に via=multi-id-marker-with-suffix" \
+  "via=multi-id-marker-with-suffix" "$RESOLVE_STDERR"
+
+echo ""
+echo "--- Req 2.2: token 化規則は suffix 有無で同一（task_id 1 が 1.1 と誤マッチしない） ---"
+GIT_LOG_OUTPUT="sha0012	docs(tasks): mark 1.1 / 1.2 as done (#207)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "1"
+assert_eq "Req 2.2: task_id=1 は 1.1 / 1.2 トークンに誤マッチしないため rc=1" \
+  "1" "$RESOLVE_RC"
+assert_eq "Req 2.2: stdout 空" "" "$RESOLVE_STDOUT"
+
+# ───────────────────────────────────────────────────────────────────
+# Section C: Req 3 — canonical (suffix 無し) marker 後方互換
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Req 3.1: suffix 無し 単記 marker のみ → 既存挙動 (タグ無し) ---"
+GIT_LOG_OUTPUT="sha_a	docs(tasks): mark 3 as done
+sha_b	docs(tasks): mark 4 as done"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "4"
+assert_eq "Req 3.1: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Req 3.1: 既存と同一 SHA pair" "sha_a	sha_b" "$RESOLVE_STDOUT"
+assert_eq "Req 3.3: 既存挙動 — stderr に -with-suffix タグを出さない" "" "$RESOLVE_STDERR"
+
+echo ""
+echo "--- Req 3.2: suffix 無し 連記 marker → 既存タグ via=multi-id-marker 維持 ---"
+GIT_LOG_OUTPUT="sha_c	docs(tasks): mark 9 / 9.1 as done"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "9.1"
+assert_eq "Req 3.2: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Req 3.2: range pair" "sha_base_main	sha_c" "$RESOLVE_STDOUT"
+assert_contains "Req 3.2 / NFR 1.1: 既存タグ via=multi-id-marker (suffix 無し) を維持" \
+  "via=multi-id-marker " "$RESOLVE_STDERR"
+assert_not_contains "Req 3.2: -with-suffix サフィックスが付かないこと" \
+  "-with-suffix" "$RESOLVE_STDERR"
+
+# ───────────────────────────────────────────────────────────────────
+# Section D: Req 4 — suffix 許容 / 拒否境界
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Req 4.1: 空白あり + 括弧 + 数字 → 解決 (canonical suffix) ---"
+GIT_LOG_OUTPUT="sha_d	docs(tasks): mark 10 as done (#1)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "10"
+assert_eq "Req 4.1: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Req 4.1: range pair" "sha_base_main	sha_d" "$RESOLVE_STDOUT"
+
+echo ""
+echo "--- Req 4.2: 空白なし → 解決しない (rc=1) ---"
+GIT_LOG_OUTPUT="sha_e	docs(tasks): mark 11 as done(#118)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "11"
+assert_eq "Req 4.2: rc=1 (空白なし)" "1" "$RESOLVE_RC"
+assert_eq "Req 4.2: stdout 空" "" "$RESOLVE_STDOUT"
+
+echo ""
+echo "--- Req 4.3: 括弧なし → 解決しない (rc=1) ---"
+GIT_LOG_OUTPUT="sha_f	docs(tasks): mark 12 as done #118"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "12"
+assert_eq "Req 4.3: rc=1 (括弧なし)" "1" "$RESOLVE_RC"
+assert_eq "Req 4.3: stdout 空" "" "$RESOLVE_STDOUT"
+
+echo ""
+echo "--- Req 4.4: 閉じ括弧後に追加文字列 → 解決しない (rc=1) ---"
+GIT_LOG_OUTPUT="sha_g	docs(tasks): mark 13 as done (#118) extra"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "13"
+assert_eq "Req 4.4: rc=1 (閉じ括弧後の追加文字列)" "1" "$RESOLVE_RC"
+assert_eq "Req 4.4: stdout 空" "" "$RESOLVE_STDOUT"
+
+echo ""
+echo "--- Req 4.5: <number> 部が非数字 → 解決しない (rc=1) ---"
+GIT_LOG_OUTPUT="sha_h	docs(tasks): mark 14 as done (#abc)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "14"
+assert_eq "Req 4.5: rc=1 (非数字 number)" "1" "$RESOLVE_RC"
+assert_eq "Req 4.5: stdout 空" "" "$RESOLVE_STDOUT"
+
+echo ""
+echo "--- Req 4.5 (mixed): <number> 部が数字混在 → 解決しない (rc=1) ---"
+GIT_LOG_OUTPUT="sha_i	docs(tasks): mark 15 as done (#12a)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "15"
+assert_eq "Req 4.5: rc=1 (数字混在 number)" "1" "$RESOLVE_RC"
+
+echo ""
+echo "--- Req 4.6: 連記パスにも同一規則 — 空白なし suffix → 解決しない (rc=1) ---"
+GIT_LOG_OUTPUT="sha_j	docs(tasks): mark 16 / 16.1 as done(#118)"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "16.1"
+assert_eq "Req 4.6 (multi): rc=1 (空白なし suffix)" "1" "$RESOLVE_RC"
+
+echo ""
+echo "--- Req 4.6: 連記パスにも同一規則 — 閉じ括弧後の追加文字列 → 解決しない (rc=1) ---"
+GIT_LOG_OUTPUT="sha_k	docs(tasks): mark 17 / 17.1 as done (#118) extra"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "17.1"
+assert_eq "Req 4.6 (multi): rc=1 (閉じ括弧後の追加文字列)" "1" "$RESOLVE_RC"
+
+# ───────────────────────────────────────────────────────────────────
+# Section E: Req 5 — 解決失敗時の既存契約
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Req 5.1: marker commit 0 件 → rc=1 ---"
+GIT_LOG_OUTPUT=""
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "1"
+assert_eq "Req 5.1: rc=1 (marker 不在)" "1" "$RESOLVE_RC"
+assert_eq "Req 5.1: stdout 空" "" "$RESOLVE_STDOUT"
+
+echo ""
+echo "--- Req 5.1: 当該 task_id に対する単記 / 連記いずれも該当無し → rc=1 ---"
+GIT_LOG_OUTPUT="sha_l	docs(tasks): mark 99 as done (#1)
+sha_m	docs(tasks): mark 100 / 100.1 as done"
+GIT_REVPARSE_OUTPUT="sha_base_main"
+run_resolve "200"
+assert_eq "Req 5.1: rc=1 (該当 task_id 不在)" "1" "$RESOLVE_RC"
+assert_eq "Req 5.1: stdout 空" "" "$RESOLVE_STDOUT"
+
+# ───────────────────────────────────────────────────────────────────
+# Section F: Issue 本文 example の回帰固定（altpocket-server #118 由来）
+# ───────────────────────────────────────────────────────────────────
+echo ""
+echo "--- Issue #421 root example: 'mark 6 as done (#118)' は解決される ---"
+GIT_LOG_OUTPUT="sha_root	docs(tasks): mark 6 as done (#118)"
+GIT_REVPARSE_OUTPUT="sha_base_root"
+run_resolve "6"
+assert_eq "Issue 本文 example: rc=0" "0" "$RESOLVE_RC"
+assert_eq "Issue 本文 example: range pair" "sha_base_root	sha_root" "$RESOLVE_STDOUT"
+assert_contains "Issue 本文 example: stderr に via=single-id-marker-with-suffix" \
+  "via=single-id-marker-with-suffix" "$RESOLVE_STDERR"
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

`PER_TASK_LOOP_ENABLED=true` の per-task ループにおいて、`pt_resolve_diff_range` 関数の marker 識別正規表現が
trailing issue-ref suffix（例: `docs(tasks): mark 6 as done (#118)`）を許容していなかったため、
Developer が Conventional Commits 慣習に従って suffix を付与した marker commit の diff range 解決が
`diff-range-resolve-failed (no-marker-commit-found)` で失敗し `claude-failed` に落ちる事象を修正した。
単記 / 連記いずれの照合パスでも canonical suffix `(#<digits>)` を optional として許容し、
既存の suffix 無し marker の挙動は完全に温存する。

## 対応 Issue

Closes #421

## 関連 PR

- 設計 PR: なし（Architect 経由なし。`needs_architect: false` と判定された局所的 regex 修正）

## 実装内容

- (Req 1 / Req 4) `pt_resolve_diff_range` 単記パスに `docs(tasks): mark <id> as done (#<number>)` 形式の
  suffix 付き marker を許容する glob + パラメータ展開 + `^[0-9]+$` 検証を追加
- (Req 2) 連記パスの `sed -nE` 正規表現に `( \(#[0-9]+\))?$` optional group を追加し、suffix 付き連記も解決可能に
- (Req 3) suffix 無し既存パス（単記 / 連記）の解決結果・観測ログタグを無変更で温存
- (NFR 1 / NFR 2) 新解決経路の識別タグ `via=single-id-marker-with-suffix` / `via=multi-id-marker-with-suffix` を
  stderr に出力し、grep 可能な観測性を確保
- (NFR 3) `<number>` 部を `^[0-9]+$` 検証後に採用し、未検証文字列の流入を防止（セキュリティ規約準拠）
- (NFR 4) 新規近接テスト `local-watcher/test/pt_resolve_diff_range_test.sh` を追加（50 アサーション）

## 受入基準チェック

- [x] Req 1.1: suffix 付き単記 marker のみ存在 → SHA 解決成功 ← `Section A: Req 1.1 suffix 付き 単記 marker のみ → 解決`
- [x] Req 1.2: suffix 有無が混在 → 時系列最終一致を一意選択 ← `Section A: Req 1.2 順方向 / 逆方向`
- [x] Req 1.3: `<number>` 部を `^[0-9]+$` で厳密検証 ← `Section D: Req 4.5 非数字 / 数字混在`
- [x] Req 1.4: canonical suffix 境界の定義（空白 1 + `(#<digits>)` + 行終端） ← `Section D: Req 4.1〜4.4`
- [x] Req 1.5: `via=single-id-marker-with-suffix` を stderr に出力 ← `Section A: assert_contains`
- [x] Req 2.1: 連記 suffix 付き（slash / comma 区切り）を解決 ← `Section B: Req 2.1`
- [x] Req 2.2: token 化規則は suffix 有無で変化しない ← `Section B: Req 2.2`
- [x] Req 2.3: `via=multi-id-marker-with-suffix` を区別可能に出力 ← `Section B: 否定アサーション付き`
- [x] Req 3.1: suffix 無し単記 → 本変更前と同一 SHA pair ← `Section C: Req 3.1`
- [x] Req 3.2: suffix 無し連記 → 既存挙動保持 ← `Section C: Req 3.2`
- [x] Req 3.3: 既存 `via=multi-id-marker` タグの文字列・発火条件を変更しない ← `Section A / C`
- [x] Req 4.1〜4.6: 許容 / 拒否 境界 5 パターン（空白 1 + `(#<digits>)` 行終端のみ許容） ← `Section D`
- [x] Req 5.1: marker 0 件 / 該当 task_id 不在 → rc=1 ← `Section E: Req 5.1 x2`
- [x] Req 5.2: 失敗終端の失敗カテゴリ識別子 / ラベル遷移を変更しない ← `observation`

## テスト結果

```
# 新規テスト
bash local-watcher/test/pt_resolve_diff_range_test.sh
PASS: 50, FAIL: 0

# 既存 pt_* 系テスト（回帰確認）
bash local-watcher/test/pt_check_fail_fast_test.sh          # PASS: 18
bash local-watcher/test/pt_extract_debugger_section_test.sh # PASS: 24
bash local-watcher/test/pt_extract_findings_block_test.sh   # PASS: 20
bash local-watcher/test/pt_post_marker_classify_test.sh     # PASS: 39
合計: PASS: 101, FAIL: 0（回帰なし）

# 静的解析
shellcheck local-watcher/bin/issue-watcher.sh              → クリーン（出力 0 行）
shellcheck local-watcher/test/pt_resolve_diff_range_test.sh → クリーン
bash -n local-watcher/bin/issue-watcher.sh                 → syntax OK
diff -r .claude/agents repo-template/.claude/agents        → 空（同期維持）
diff -r .claude/rules repo-template/.claude/rules          → 空（同期維持）
```

## 実装上の判断

`impl-notes.md` より:
- **matcher 緩和（regex / glob ベース）を採用**（subject 正規化案は却下）。理由: 単記 / 連記 2 経路を
  一貫して修正でき、拒否境界（空白なし / 括弧なし / 追加文字列 / 非数字）の表現力を正規表現側で直接担保できる
- bash glob の特性（`[[ "$subject" == "${canonical} (#"*")" ]]`）でメタ文字の影響を受けずに
  粗判定し、続けてパラメータ展開 + `^[0-9]+$` 厳密検証する 2 段階構成
- 既存観測ログタグ（`via=multi-id-marker`）の文字列・発火条件を温存するために `-with-suffix` variant を分岐追加

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer の独立レビューで全 Requirement / NFR が approve 済み（詳細: `docs/specs/421--bug-per-task-reviewer-diff-range-marker/review-notes.md`）
- Issue 本文の root example（`mark 6 as done (#118)`）は `Section F` のリグレッション fixture で固定されており再発を防止
- base: main / baseRefName: main / OK（作成後検証）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #421 のコメントを参照してください。
