### PR TITLE
fix(repo): 誤コミットされた .antigravitycli セッション symlink を除去

### DIFF
--- a/.antigravitycli/c456a48c-60bd-4069-b56c-95d107dfc131.json
+++ b/.antigravitycli/c456a48c-60bd-4069-b56c-95d107dfc131.json
@@ -1,1 +1,0 @@
-/home/hitoshi/.gemini/config/projects/c456a48c-60bd-4069-b56c-95d107dfc131.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .claude/settings.local.json
+
+# antigravity CLI のセッション固有ファイル（symlink）はコミットしない
+.antigravitycli/


### PR DESCRIPTION
## 概要

#430 の作業中、`git add -A` が antigravity CLI のセッション固有 symlink
（`.antigravitycli/c456a48c-...json` / mode `120000`）を意図せず stage し、main に混入した。

## 変更

- 当該 symlink を `git rm` で除去
- `.gitignore` に `.antigravitycli/` を追加して再発防止

## 影響

- symlink の target はセッション一時ディレクトリで、他クローン（self-hosting watcher の
  `idd-claude-watcher` 等）では broken symlink になる。除去により解消。
- `repo-template/**` 配布物・watcher 挙動には影響なし（`.antigravitycli` は配布対象外）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)