### PR TITLE
fix(#434): claude-failed 遷移後も arm 済み native auto-merge が disarm されない不具合を修正（disarm processor + Reviewer fail-closed）

### DIFF
--- a/README.md
+++ b/README.md
@@ -2599,8 +2599,11 @@ suppression ログに委ねて重複させません（Req 7.3）。
   本機能導入前と完全に等価です（gh API 呼び出しゼロ / Req 1.5, 6.1, NFR 1.1）
 - 不具合発生時は `AUTO_MERGE_ENABLED=false` を明示するか `FULL_AUTO_ENABLED=false`
   を倒すことで全 full-auto 系挙動を即時 no-op にできます（#348 AND ゲート）
-- 既に auto-merge が enable された PR を後から取り消す機能は本 processor のスコープ外です
-  （Out of Scope）。必要なら GitHub UI / `gh pr merge --disable-auto` で個別に解除してください
+- 既に auto-merge が enable（arm）された PR が `claude-failed` / `needs-decisions` といった
+  terminal ラベルへ遷移した場合、[Auto-Merge Disarm Processor (#434)](#auto-merge-disarm-processor-434)
+  が毎サイクル自動で `gh pr merge --disable-auto` を実行して arm を取り消します（#434 で実装）。
+  arm 時点判定（#352 本 processor）は arm 後の遷移を追えないため、disarm は専用 processor が
+  GitHub 直接クエリで補います
 
 ---
 
@@ -2740,12 +2743,72 @@ suppression ログに委ねて重複させません（[#352](#auto-merge-process
   を倒すことで全 full-auto 系挙動を即時 no-op にできます（[#348 AND ゲート](#full-auto-kill-switch)）
 - 実装 PR 用 [`AUTO_MERGE_ENABLED`](#auto-merge-processor-352) と独立に制御できるため、設計
   PR 経路だけ一時停止することも可能です
-- 既に auto-merge が enable された PR を後から取り消す機能は本 processor のスコープ外です
-  （Out of Scope）。必要なら GitHub UI / `gh pr merge --disable-auto` で個別に解除してください
+- 設計 PR でも、arm 済みの PR が `claude-failed` / `needs-decisions` といった terminal ラベルへ
+  遷移した場合は [Auto-Merge Disarm Processor (#434)](#auto-merge-disarm-processor-434) が毎サイクル
+  自動で `gh pr merge --disable-auto` を実行して arm を取り消します（#434 で実装。impl / design
+  双方の arm 源を共通の disarm processor が補います）
 
 ### ⚠️ merge 後の再配置が必要
 
 本機能は新規モジュール `modules/auto-merge-design.sh` を追加します。既存 watcher を使っている
+場合は merge 後に以下を再実行して `$HOME/bin/modules/` を更新してください（未配置だと
+`REQUIRED_MODULES` のローダが起動時にエラーで停止します）:
+
+```bash
+cd ~/.idd-claude && git pull && ./install.sh --local
+```
+
+---
+
+## Auto-Merge Disarm Processor (#434)
+
+local watcher は [Auto-Merge Processor (#352)](#auto-merge-processor-352) /
+[Design Auto-Merge Processor (#354)](#design-auto-merge-processor-354) の **直後**で、
+**`FULL_AUTO_ENABLED=true` AND (`AUTO_MERGE_ENABLED=true` OR `AUTO_MERGE_DESIGN_ENABLED=true`)**
+が成立するときのみ起動する Auto-Merge Disarm Processor を実行します。これは、**arm 済み**
+（GitHub ネイティブ auto-merge が有効化済み = `autoMergeRequest != null`）の open PR が、その後
+`claude-failed` / `needs-decisions` といった **terminal ラベル**へ遷移した場合に、`gh pr merge
+--disable-auto` で **arm を取り消す（disarm）** processor です。
+
+### 解決する不具合（#434）
+
+arm 時点判定（[#352](#auto-merge-processor-352) の `am_should_enable_for_pr`）は `claude-failed` /
+`needs-decisions` を除外しますが、これは **arm 時点のワンショット**です。arm 後に PR が terminal
+ラベルへ遷移しても arm はそのまま残るため、必須 status checks が全 green に到達した瞬間に
+「失敗確定済み PR」が GitHub の auto-merge state machine によって誤って merge されてしまいます。
+本 processor は毎サイクル GitHub を **直接クエリ**し、「arm 済み かつ terminal ラベル付き かつ
+open」な PR を列挙して disarm することでこの不具合を解消します。
+
+加えて、in-flight だった Reviewer が terminal ラベル確定後に `claude-review=success` を publish
+して merge gate を緑へ戻すのを防ぐため、claude-review status publisher
+（`pr_publish_claude_status`）に **fail-closed ガード**を追加しています。success（approve）の
+publish 直前に対象 PR の現在ラベルを再取得し、terminal ラベルがあれば success を publish せず
+skip します（required check が pending のまま残り auto-merge は発火しません）。reject（failure）
+は gate を閉じる方向のため terminal でもそのまま publish します。ラベル再取得に失敗した場合は
+従来どおり publish を継続（fail-open / 可用性優先）し WARN を 1 行残します。
+
+### 設定 env
+
+| env | 既定 | 説明 |
+|---|---|---|
+| （gate 専用 env なし） | — | opt-in gate は arm 源に相乗りです。`FULL_AUTO_ENABLED=true` AND (`AUTO_MERGE_ENABLED=true` OR `AUTO_MERGE_DESIGN_ENABLED=true`) のときのみ動作します。新規 gate env は追加しません |
+| `AUTO_MERGE_DISARM_MAX_PRS` | `10` | 1 サイクルで disarm する PR 数の上限（残りは次回サイクルに持ち越し）。`=数値` 以外は既定 `10` に正規化 |
+
+timeout は既存 `AUTO_MERGE_GIT_TIMEOUT`（既定 `60`）を流用します（新規 timeout env は追加しません）。
+
+### 後方互換 / 不具合時の停止
+
+- gate を arm 源（`AUTO_MERGE_ENABLED` / `AUTO_MERGE_DESIGN_ENABLED`）に相乗りさせているため、
+  arm が起きない環境（両 arm 源 OFF / `FULL_AUTO_ENABLED=false`）では disarm も **完全 no-op**
+  （gh API 呼び出しゼロ）で本不具合修正導入前と等価です
+- claude-review status の fail-closed ガードは既存の claude-review publish opt-in gate
+  （`PR_REVIEWER_STATUS_CHECK_ENABLED` 系）の内側で動作し、新たな外部サービス呼び出し用 gate を
+  追加しません
+- disarm 対象が 0 件のサイクルはサマリ 1 行のみに留め、過剰なログを出しません
+
+### ⚠️ merge 後の再配置が必要
+
+本機能は新規モジュール `modules/auto-merge-disarm.sh` を追加します。既存 watcher を使っている
 場合は merge 後に以下を再実行して `$HOME/bin/modules/` を更新してください（未配置だと
 `REQUIRED_MODULES` のローダが起動時にエラーで停止します）:
 

--- a/docs/specs/434-fix-auto-merge-claude-failed-arm-native/requirements.md
+++ b/docs/specs/434-fix-auto-merge-claude-failed-arm-native/requirements.md
@@ -1,0 +1,102 @@
+# Requirements Document
+
+## Introduction
+
+GitHub ネイティブの auto-merge を arm（`gh pr merge --auto`）した実装 PR が、その後 `claude-failed` /
+`needs-decisions` といった terminal ラベルへ遷移しても disarm されず、必須 status checks が全 green に
+到達した瞬間に「失敗確定済み PR」が merge されてしまう不具合を解消する。本不具合は 2 つの欠陥の複合で
+発生する。Defect A（主因）は `claude-failed` / `needs-decisions` の除外判定が arm 時点のワンショットに
+留まり、arm 後の遷移を取り消す経路（disarm）が watcher に存在しないこと。Defect B（誘発因）は terminal
+ラベル確定後でも in-flight だった Reviewer が `claude-review=success` を publish してしまい、merge gate が
+失敗済み PR に対して緑になることである。本要件は「arm 後の terminal 遷移を disarm する振る舞い」と
+「terminal PR に対し claude-review=success を緑にしない fail-closed 修正」を、既存 auto-merge の opt-in
+gate と後方互換性を壊さない形で規定する。
+
+## Requirements
+
+### Requirement 1: arm 後の terminal 遷移に対する disarm
+
+**Objective:** As a watcher 運用者, I want arm 済みの auto-merge を PR が terminal ラベルへ遷移した時点で取り消したい, so that 失敗確定済みの PR が status checks の green 到達で誤って merge されるのを防げる
+
+#### Acceptance Criteria
+
+1. When arm 済み（`autoMergeRequest != null`）の open PR が `claude-failed` ラベルを持つ状態を watcher が観測したとき, the Auto-Merge Disarm Process shall その PR の native auto-merge を取り消す（`autoMergeRequest` を null へ戻す）
+2. When arm 済みの open PR が `needs-decisions` ラベルを持つ状態を watcher が観測したとき, the Auto-Merge Disarm Process shall その PR の native auto-merge を取り消す
+3. When arm 済みの open PR が `claude-failed` と `needs-decisions` の双方を持つ状態を watcher が観測したとき, the Auto-Merge Disarm Process shall その PR の native auto-merge を取り消す
+4. While disarm 対象 PR を判定するとき, the Auto-Merge Disarm Process shall GitHub を直接クエリして対象を列挙し、`SLACK_NOTIFY_MERGED_ENABLED` に依存する pending state dir の有無に振る舞いを左右されない
+5. When PR が `claude-failed` も `needs-decisions` も持たない arm 済みの状態であるとき, the Auto-Merge Disarm Process shall その PR の auto-merge を取り消さない
+
+### Requirement 2: disarm の冪等性と異常系
+
+**Objective:** As a watcher 運用者, I want disarm を毎サイクル安全に再実行できる状態にしたい, so that 既に解除済み・merge 済み・未 arm の PR を壊さず、API 失敗でパイプラインが止まらない
+
+#### Acceptance Criteria
+
+1. When 対象 PR が既に disarm 済み（`autoMergeRequest == null`）であるとき, the Auto-Merge Disarm Process shall 追加の disarm 副作用を行わず no-op とする
+2. When 対象 PR が既に merge 済み（open でない）であるとき, the Auto-Merge Disarm Process shall その PR を disarm 対象から除外する
+3. When disarm 対象に該当する PR が同一サイクル内に存在しないとき, the Auto-Merge Disarm Process shall 外部副作用なしでサイクルを終える
+4. If disarm の取り消し呼び出しが失敗したとき, the Auto-Merge Disarm Process shall WARN ログを 1 行残してパイプラインを継続する（fail-open）
+5. While 複数の disarm 対象を処理するとき, the Auto-Merge Disarm Process shall 1 件の失敗で残りの対象処理を中断しない
+
+### Requirement 3: terminal PR に対する claude-review publish の fail-closed 化
+
+**Objective:** As a watcher 運用者, I want terminal ラベルが付いた PR には claude-review=success を publish しないようにしたい, so that 失敗確定後に in-flight の Reviewer が merge gate を誤って緑へ戻すのを防げる
+
+#### Acceptance Criteria
+
+1. When PR が `claude-failed` ラベルを持つ状態で claude-review=success の publish が試みられたとき, the Claude Review Publisher shall その success を merge gate 上で緑にしない（fail-closed）
+2. When PR が `needs-decisions` ラベルを持つ状態で claude-review=success の publish が試みられたとき, the Claude Review Publisher shall その success を merge gate 上で緑にしない
+3. When 裁定経路（adjudicator の status decision 適用）から terminal ラベル付き PR への claude-review=success publish が導出されたとき, the Adjudicator Status Decision shall その success を merge gate 上で緑にしない
+4. When catch-up 経路（branch 上の review-notes.md から claude-review status を publish する経路）から terminal ラベル付き PR への claude-review=success publish が試みられたとき, the Claude Review Catch-up Publisher shall その success を merge gate 上で緑にしない
+5. When PR が terminal ラベルを持たない通常状態で claude-review status の publish が試みられたとき, the Claude Review Publisher shall 従来どおり approve/reject に応じた status を publish する
+
+### Requirement 4: claude-failed / needs-decisions の terminal ラベル判定取得
+
+**Objective:** As a watcher 運用者, I want publish 直前の terminal 判定がラベル取得失敗時にも安全側で振る舞ってほしい, so that gh 取得失敗で既存挙動が壊れたり可用性が落ちたりしない
+
+#### Acceptance Criteria
+
+1. When claude-review=success の publish 直前に PR の terminal ラベル有無を判定するとき, the Claude Review Publisher shall 当該 PR の現在のラベル集合を再取得して判定する
+2. If terminal ラベルの再取得が失敗したとき, the Claude Review Publisher shall 従来どおり publish を継続する（fail-open / 可用性優先）
+3. If terminal ラベルの再取得が失敗したとき, the Claude Review Publisher shall その旨を WARN ログで 1 行残す
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性と opt-in gate
+
+1. While auto-merge の opt-in gate（`AUTO_MERGE_ENABLED=true` AND `FULL_AUTO_ENABLED=true`）が成立していないとき, the Auto-Merge Disarm Process shall `gh pr merge --disable-auto` を含む一切の外部副作用を発生させない
+2. While auto-merge の opt-in gate が成立していないとき, the watcher shall 本不具合修正の導入前と完全に同一の挙動（no-op）を保つ
+3. The Claude Review Publisher fail-closed 修正 shall 既存の claude-review publish opt-in gate（`PR_REVIEWER_STATUS_CHECK_ENABLED` 系）の内側で動作し、新たな外部サービス呼び出し用 gate を追加しない
+
+### NFR 2: 未信頼入力ハードニング
+
+1. When PR 番号を URL・git revision・gh 引数として使用する直前, the watcher shall その値を `^[0-9]+$` で検証してから使用する
+2. When 未信頼値を `gh` コマンドへ渡すとき, the watcher shall `--` でオプション解釈を打ち切ってフラグ注入を防ぐ
+3. When 未信頼値を `jq` フィルタへ渡すとき, the watcher shall `--arg` / `--argjson` で渡しフィルタ文字列へ inline 展開しない
+
+### NFR 3: 可観測性
+
+1. When disarm を実行したとき, the Auto-Merge Disarm Process shall 対象 PR 番号と動作（disarmed）を含むログ行を 1 件出力する
+2. While disarm 対象が 0 件のとき, the Auto-Merge Disarm Process shall サイクルあたり過剰なログを出さず最大 1 行のサマリに留める
+
+### NFR 4: 配布物同期とドキュメント
+
+1. Where 本不具合修正が consumer 配布物（modules / workflow / labels）に変更を及ぼす場合, the Delivery Process shall root と repo-template の両系統へ byte 一致で反映し `diff -r` が空である状態を保つ
+2. When 本不具合修正で外部から観測可能な挙動が変わったとき, the Delivery Process shall 同一 PR 内で README の該当箇所を更新する
+
+## Out of Scope
+
+- arm 時点判定（`am_should_enable_for_pr`）の強化（iteration サイクル中の arm 抑止など）。本修正は arm 後の disarm と publish 側の fail-closed に限定する
+- `claude-failed` / `needs-decisions` 以外の terminal 状態の追加（既存 terminal ラベル集合を変更しない）
+- disarm の実装手段の確定（専用 processor 配置か既存処理への inline か、専用 env gate の新設か既存 `AUTO_MERGE_ENABLED` 相乗りか）。これらは design / Developer の領分であり、本要件は外部から観測可能な振る舞い（disarm されること / 冪等であること / Slack gate 非依存であること / gate OFF で副作用ゼロであること）のみを規定する
+- Defect B の修正方式（success を skip するか `failure` を明示 publish するか）の確定。本要件は「terminal PR に対し claude-review=success を merge gate 上で緑にしない（fail-closed）」を AC とし、具体的手段は design / Developer に委ねる
+- 既に merge 済み（過去に誤 merge された）PR の事後 revert / 復旧
+- Slack 通知文面の変更（armed/merged 通知の挙動は #388 の現行仕様を維持）
+
+## Open Questions
+
+- なし（Issue 本文の「確認事項」3 点は、本要件で次のとおり決定として落とした: disarm 発火主体は GitHub 直接クエリ方式の振る舞いを AC 化し実装手段は Out of Scope へ退避、Defect B は fail-closed を AC 化し skip/failure の選択は Out of Scope へ退避、`needs-decisions` も disarm 対象に含める。Issue コメントに人間の確定コメントは無いことを確認済み）
+
+## 関連
+
+- Related: #352 #388 #404 #407 #349

--- a/docs/specs/434-fix-auto-merge-claude-failed-arm-native/review-notes.md
+++ b/docs/specs/434-fix-auto-merge-claude-failed-arm-native/review-notes.md
@@ -1,0 +1,78 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.8 timestamp=2026-06-29T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-434-impl-fix-auto-merge-claude-failed-arm-native
+- HEAD commit: b7213f33926e8db06c8a31c2326c3a8ce8730de6
+- Compared to: main..HEAD
+- 注記: HEAD == main（コミット未作成）のため `git diff main..HEAD` は空。Developer の成果物は
+  working tree（変更 3 ファイル + 新規 4 ファイル）に存在するため、これを実体として読み判定した。
+  本 Issue は単一実装パス（Architect 非経由）で tasks.md / design.md / impl-notes.md は非生成。
+  `_Boundary:_` アノテーションが無いため、境界は requirements.md の Out of Scope と CLAUDE.md の
+  module 配置規約に照らして評価した。
+
+## Verified Requirements
+
+- 1.1 — `amx_should_disarm_for_pr`（LABEL_FAILED 検査）+ `process_auto_merge_disarm` / test:
+  auto-merge-disarm_test.sh Section2 Req1.1, Case C（disarm 1 回）
+- 1.2 — `amx_should_disarm_for_pr`（LABEL_NEEDS_DECISIONS 検査）/ test: Section2 Req1.2, Case G（design PR）
+- 1.3 — 両 terminal ラベル → disarm 対象 / test: Section2 Req1.3
+- 1.4 — `process_auto_merge_disarm` が `gh pr list` で GitHub 直接クエリ（pending state dir 参照なし）/
+  test: Case C（gh pr list 呼び出し検証）
+- 1.5 — arm 済みだが terminal ラベル無し → return 1 / test: Section2 Req1.5, Case D
+- 2.1 — `autoMergeRequest == null` → return 1（no-op）/ test: Section2 Req2.1, Case E
+- 2.2 — `state != OPEN`（MERGED/CLOSED）→ 対象外 / test: Section2 Req2.2, Case I
+- 2.3 — 対象 0 件 → 副作用なしサマリ 1 行で終了 / test: Case D
+- 2.4 — `amx_disarm_pr` 失敗時 WARN 1 行 + rc=1（fail-open）/ test: Section3 Req2.4
+- 2.5 — ループは 1 件失敗で中断せず継続（failed_count 加算）/ test: Case H（3 件中 1 件失敗で 3 件試行）
+- 3.1 — `pr_publish_claude_status` の success ガード（claude-failed 検出で skip）/ test:
+  pr_reviewer_claude_status_fail_closed_test.sh Section1 Req3.1
+- 3.2 — needs-decisions 検出で skip / test: Section1 Req3.2
+- 3.3 — adjudicator 経路 `adj_apply_status_decision` → `pr_publish_claude_status`
+  （adjudicator.sh:790）。単一 publisher へのガード集約で自動 fail-closed 化。呼び出しグラフを確認
+- 3.4 — catch-up 経路 `pr_publish_claude_status_from_branch` → `pr_publish_claude_status`
+  （pr-reviewer.sh:1441）。同上、呼び出しグラフを確認
+- 3.5 — terminal 無し → 従来どおり publish、reject(failure) は terminal でも publish / test:
+  Section2 Req3.5
+- 4.1 — `gh pr view --json labels` で現在ラベルを再取得して判定 / test: Section1
+- 4.2 — 再取得失敗時は publish 継続（fail-open）/ test: Section3 Req4.2
+- 4.3 — 再取得失敗時に WARN 1 行 / test: Section3 Req4.3
+- NFR1.1/1.2 — gate OFF（kill switch / 両 arm 源 OFF）で gh ゼロ呼び出し no-op / test: Case A/B
+- NFR1.3 — ガードは既存 publisher 内に集約、新規外部呼び出し gate を追加せず既存 claude-review
+  publish gate の内側で動作
+- NFR2.1 — PR 番号を `^[0-9]+$` で検証 / test: NFR2.1
+- NFR2.2 — `gh pr merge ... -- "$pr_number"` でオプション解釈打ち切り / test: NFR2.2
+- NFR2.3 — 未信頼値（pattern / owner / label）を `jq --arg` で渡す（inline 展開なし）
+- NFR3.1 — disarm 実行時に PR 番号 + disarmed のログ行 / test: NFR3.1, サマリ行
+- NFR3.2 — 対象 0 件はサマリ 1 行のみ / test: Case D
+- NFR4.1 — modules は `local-watcher/` のみに存在し repo-template 側コピー無し（同期対象 vacuous）。
+  `.claude/{agents,rules}` は無変更で drift 無し（`git diff --stat` 空を確認）
+- NFR4.2 — README に Auto-Merge Disarm Processor 節 + オプション機能一覧を同一変更で追加
+
+### 追加検証
+
+- 静的解析: `shellcheck`（新規 module / pr-reviewer.sh / test 2 本）警告ゼロ、`bash -n issue-watcher.sh` OK
+- テスト再実行: auto-merge-disarm_test.sh = PASS 40 / FAIL 0、
+  pr_reviewer_claude_status_fail_closed_test.sh = PASS 11 / FAIL 0
+- Out of Scope 遵守: `am_should_enable_for_pr`（arm 時点判定）を含む auto-merge.sh /
+  auto-merge-design.sh は無変更。新規 terminal ラベル追加なし。Slack 通知文面変更なし
+- module 配置: 新 processor を `modules/auto-merge-disarm.sh` に切り出し、専用 prefix `amx_` を
+  割当、`REQUIRED_MODULES` ローダ + 本体 call site（arm 直後に直列配置）に登録（CLAUDE.md 機能追加
+  ガイドライン準拠）
+
+## Findings
+
+なし
+
+## Summary
+
+全 AC（Req 1.1〜4.3 + NFR 1〜4）の観測可能な実装・テストを working tree 上で確認。disarm processor /
+fail-closed ガードとも対応テストが green（40/0, 11/0）、shellcheck / bash -n クリーン、Out of Scope
+逸脱なし。Req 3.3/3.4 は単一 publisher へのガード集約により adjudicator / catch-up 経路へ自動波及する
+ことを呼び出しグラフで確認した。境界・AC・test の 3 観点で reject 事由なし。なお HEAD == main で
+変更がコミット未確定（working tree）であり、impl-notes.md も非生成だが、いずれも本 reviewer の 3
+カテゴリ外の事項であるため判定には影響させない（PR 作成前に commit が必要な点のみ情報として記す）。
+
+RESULT: approve

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -487,6 +487,22 @@ AUTO_MERGE_DESIGN_GIT_TIMEOUT="${AUTO_MERGE_DESIGN_GIT_TIMEOUT:-60}"
 # idd-claude の設計 PR は `claude/issue-<N>-design-<slug>` 形式。
 AUTO_MERGE_DESIGN_HEAD_PATTERN="${AUTO_MERGE_DESIGN_HEAD_PATTERN:-^claude/issue-.*-design}"
 
+# ─── Auto-Merge Disarm Processor 設定 (#434) ───
+# arm 済み（`autoMergeRequest != null`）の open PR が `claude-failed` / `needs-decisions` といった
+# terminal ラベルへ遷移した時点で、`gh pr merge --disable-auto` で native auto-merge を取り消す
+# 機能。arm 時点判定（am_should_enable_for_pr）は arm 後の遷移を追えないため、毎サイクル GitHub を
+# 直接クエリして「arm 済み かつ terminal ラベル付き かつ open」な PR を disarm する（Req 1.x）。
+#
+# opt-in gate: `FULL_AUTO_ENABLED=true` AND (`AUTO_MERGE_ENABLED=true` OR
+# `AUTO_MERGE_DESIGN_ENABLED=true`)。arm が起きるのは AUTO_MERGE_ENABLED / AUTO_MERGE_DESIGN_ENABLED
+# のいずれかが ON のときだけなので、disarm gate を arm 源に相乗りさせることで、arm が起きない環境
+# では disarm も完全 no-op になり、新規 env gate を増やさずに後方互換を満たす（NFR 1.1, 1.2）。
+# どちらの arm 源も無効なら gh API 呼び出しゼロで本不具合修正導入前と等価。
+#
+# 1 サイクルで disarm する PR 数の上限（残りは次回サイクルに持ち越し / NFR 3.x）。`=数値` 以外は
+# 既定 10 に正規化。timeout は既存 AUTO_MERGE_GIT_TIMEOUT を流用（新規 env を増やさない）。
+AUTO_MERGE_DISARM_MAX_PRS="${AUTO_MERGE_DISARM_MAX_PRS:-10}"
+
 # ─── PR Iteration Processor 設定 (#26) ───
 # `needs-iteration` ラベル付き PR をレビューコメントに基づいて自動で iterate する。
 # 標準機能としてデフォルト有効化（#112）。無効化したい場合は cron / launchd 側で
@@ -1438,7 +1454,7 @@ IDD_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/mo
 # 3 プロセッサ（promote-pipeline / pr-iteration / stage-a-verify）を並べ、末尾に
 # #238 の scaffolding-health.sh と #239 の per-run evidence サマリ（run-summary.sh）、
 # #325 の token usage 計測（token-usage.sh）を置く。
-REQUIRED_MODULES=( "core_utils.sh" "env-loader.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "auto-merge.sh" "auto-merge-design.sh" "promote-pipeline.sh" "pr-iteration.sh" "pr-reviewer.sh" "adjudicator.sh" "pr-design-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "token-usage.sh" "security-review.sh" "guard-hook.sh" "context-map.sh" "failed-recovery.sh" "stale-pickup-reaper.sh" "needs-decisions-auto.sh" "dep-cycle-detect.sh" "slack-notify.sh" "auto-merge-merged.sh" )
+REQUIRED_MODULES=( "core_utils.sh" "env-loader.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "auto-merge.sh" "auto-merge-design.sh" "auto-merge-disarm.sh" "promote-pipeline.sh" "pr-iteration.sh" "pr-reviewer.sh" "adjudicator.sh" "pr-design-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "token-usage.sh" "security-review.sh" "guard-hook.sh" "context-map.sh" "failed-recovery.sh" "stale-pickup-reaper.sh" "needs-decisions-auto.sh" "dep-cycle-detect.sh" "slack-notify.sh" "auto-merge-merged.sh" )
 for _idd_mod in "${REQUIRED_MODULES[@]}"; do
   _idd_mod_path="$IDD_MODULE_DIR/$_idd_mod"
   if [ ! -f "$_idd_mod_path" ]; then
@@ -1659,6 +1675,17 @@ process_auto_merge || am_warn "process_auto_merge が想定外のエラーで終
 #   独立 processor として共存する（Req 5.2, 5.3）。配置順序は #352 直後（impl と対称）/
 #   Promote Pipeline 前（Req 5.4 / 8.4）。
 process_auto_merge_design || amd_warn "process_auto_merge_design が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+
+# Auto-Merge Disarm Processor (#434) — modules/auto-merge-disarm.sh が定義
+#   arm 済み（`autoMergeRequest != null`）の open PR が `claude-failed` / `needs-decisions` といった
+#   terminal ラベルへ遷移した時点で `gh pr merge --disable-auto` で native auto-merge を取り消す。
+#   arm 時点判定（am_should_enable_for_pr）は arm 後の遷移を追えず、失敗確定済み PR が status checks
+#   の green 到達で誤 merge される不具合（Defect A）を解消する。GitHub を直接クエリして対象を列挙し、
+#   pending state dir には依存しない（Req 1.4）。opt-in gate は FULL_AUTO_ENABLED AND
+#   (AUTO_MERGE_ENABLED OR AUTO_MERGE_DESIGN_ENABLED)。いずれの arm 源も OFF（既定）なら gh API
+#   ゼロ呼び出しで本不具合修正導入前と等価（NFR 1.1）。arm 側（#352 / #354）の直後に直列配置し、
+#   同一サイクルで arm された PR でも terminal ラベルが付いていれば即 disarm できるようにする。
+process_auto_merge_disarm || amx_warn "process_auto_merge_disarm が想定外のエラーで終了しました（後続 Issue 処理は継続）"
 
 # Auto-Merge Merged Notify Processor (#388) — modules/auto-merge-merged.sh が定義
 #   `auto-merge` / `auto-merge-design` で armed された PR の実 merge 完了を pending

--- a/local-watcher/bin/modules/auto-merge-disarm.sh
+++ b/local-watcher/bin/modules/auto-merge-disarm.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# auto-merge-disarm.sh — arm 済み auto-merge を terminal ラベル遷移時に取り消す processor（#434）
+#
+# 用途:
+#   `auto-merge` / `auto-merge-design` processor が `gh pr merge --auto` で arm した PR
+#   （`autoMergeRequest != null`）が、その後 `claude-failed` / `needs-decisions` といった
+#   terminal ラベルへ遷移しても disarm されず、必須 status checks が全 green に到達した
+#   瞬間に「失敗確定済み PR」が誤って merge されてしまう不具合（Defect A / #434）を解消する。
+#   本 processor は毎サイクル GitHub を直接クエリして「arm 済み かつ terminal ラベル付き かつ
+#   open」な PR を列挙し、`gh pr merge --disable-auto` で native auto-merge を取り消す。
+#   実 merge を行わず、arm の取り消し（autoMergeRequest を null へ戻す）のみを行う。
+#
+#   関数 prefix は本 module 専用の `amx_`（auto-merge disarm / 既存 am_ / amm_ / amd_ と非衝突）。
+#
+#   - amx_log / amx_warn / amx_error    : auto-merge-disarm 専用ロガー
+#   - amx_resolve_gate_enabled          : opt-in gate 判定（AUTO_MERGE_ENABLED OR
+#                                         AUTO_MERGE_DESIGN_ENABLED の相乗り。詳細は関数コメント）
+#   - amx_should_disarm_for_pr          : 1 PR が disarm 対象か判定（純粋関数）
+#   - amx_disarm_pr                     : 1 PR に対し `gh pr merge --disable-auto` を実行
+#   - process_auto_merge_disarm         : サイクルあたりの entry point
+#
+# 配置先:
+#   $HOME/bin/modules/auto-merge-disarm.sh（install.sh が local-watcher/bin/modules/ から配置する）
+#
+# 依存:
+#   - 本モジュールは issue-watcher.sh 本体から `source` される前提（単体起動しない）。
+#   - `set -euo pipefail` は本体側で宣言済みのため、本モジュールでは宣言せず関数定義のみを持つ。
+#   - グローバル変数（$AUTO_MERGE_ENABLED / $AUTO_MERGE_DESIGN_ENABLED /
+#     $AUTO_MERGE_DISARM_MAX_PRS / $AUTO_MERGE_GIT_TIMEOUT / $AUTO_MERGE_HEAD_PATTERN /
+#     $AUTO_MERGE_DESIGN_HEAD_PATTERN / $LABEL_FAILED / $LABEL_NEEDS_DECISIONS / $REPO）は
+#     本体冒頭の Config ブロックで定義済み。bash の遅延束縛により呼び出し時に解決される。
+#   - `full_auto_enabled` 関数（#348）は本体に定義済み（AND 二重 opt-in の片側）。
+#   - 外部 CLI: gh / jq。
+#
+# 後方互換性 (#434 / NFR 1.1, 1.2):
+#   - opt-in gate（FULL_AUTO_ENABLED AND (AUTO_MERGE_ENABLED OR AUTO_MERGE_DESIGN_ENABLED)）が
+#     成立しない場合、`process_auto_merge_disarm` は gh API ゼロ呼び出しで早期 return し、
+#     本不具合修正導入前と完全に同一の挙動（no-op）を保つ。
+#   - gate を arm 側（auto-merge / auto-merge-design）に相乗りさせることで、arm が起きない
+#     環境では disarm も no-op になり、新規 env gate を増やさずに後方互換を満たす。
+#
+# セットアップ参照先:
+#   README.md（「オプション機能一覧」節 / Auto-Merge Disarm Processor 節） / install.sh（配置ロジック）
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Auto-Merge Disarm Processor (#434)
+#   FULL_AUTO_ENABLED AND (AUTO_MERGE_ENABLED OR AUTO_MERGE_DESIGN_ENABLED) の opt-in 下で、
+#   arm 済み（autoMergeRequest != null）かつ terminal ラベル（claude-failed / needs-decisions）
+#   付きの open PR の native auto-merge を `gh pr merge --disable-auto` で取り消す。
+#   gate OFF / 非対象 PR では完全 no-op で本不具合修正導入前と等価（Req 1.5, 2.3 / NFR 1.1）。
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+# ロガー: 既存 am_log / amm_log と同形式の `[YYYY-MM-DD HH:MM:SS] [$REPO] auto-merge-disarm:` 形式。
+amx_log() {
+  echo "[$(date '+%F %T')] [$REPO] auto-merge-disarm: $*"
+}
+amx_warn() {
+  echo "[$(date '+%F %T')] [$REPO] auto-merge-disarm: WARN: $*" >&2
+}
+amx_error() {
+  echo "[$(date '+%F %T')] [$REPO] auto-merge-disarm: ERROR: $*" >&2
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# amx_resolve_gate_enabled: 本 processor の opt-in gate を判定する（NFR 1.1, 1.2）。
+#
+#   gate = FULL_AUTO_ENABLED AND (AUTO_MERGE_ENABLED OR AUTO_MERGE_DESIGN_ENABLED)
+#
+#   設計判断（gate の OR 拡張 / #434）:
+#     arm は #352 Auto-Merge（impl PR / AUTO_MERGE_ENABLED）と #354 Design Auto-Merge
+#     （design PR / AUTO_MERGE_DESIGN_ENABLED）の双方で起きうる。どちらの arm 源で arm された
+#     PR も disarm 対象に含めるため、gate は両 arm 源の OR を取る。どちらの arm 源も無効なら
+#     arm 自体が起きないため、disarm も完全 no-op で後方互換（NFR 1.1）。
+#     さらに #348 kill switch（FULL_AUTO_ENABLED）との AND を取り、kill switch OFF では一切
+#     発火しない（arm 側と同じ二重 opt-in セマンティクス）。
+#
+#   値正規化: `AUTO_MERGE_ENABLED` / `AUTO_MERGE_DESIGN_ENABLED` は `=true` 厳密一致のみ ON。
+#     未設定 / 空 / `false` / `0` / `True` / `TRUE` / `1` / `on` / `yes` / typo 等はすべて
+#     OFF として扱う（安全側 / NFR 1.1）。FULL_AUTO_ENABLED は full_auto_enabled に委譲。
+#
+#   戻り値: 0 = gate ON / 1 = OFF
+#   副作用: なし（純粋関数）
+# ─────────────────────────────────────────────────────────────────────────────
+amx_resolve_gate_enabled() {
+  # #348 kill switch（AND の片側）
+  if ! full_auto_enabled; then
+    return 1
+  fi
+  # arm 源の OR（どちらかの arm が有効なら disarm 対象になりうる）
+  case "${AUTO_MERGE_ENABLED:-false}" in
+    true) return 0 ;;
+  esac
+  case "${AUTO_MERGE_DESIGN_ENABLED:-false}" in
+    true) return 0 ;;
+  esac
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# amx_should_disarm_for_pr: 1 PR が disarm 対象か判定する（Req 1.1〜1.3, 1.5 / Req 2.1, 2.2）。
+#
+#   入力: $1 = pr_json（gh pr list が返す 1 要素 JSON）
+#   戻り値:
+#     0 : disarm 対象（arm 済み かつ terminal ラベル付き かつ open）
+#     1 : 対象外（未 arm / terminal ラベル無し / open でない）
+#   副作用: なし（純粋関数）
+#
+#   判定条件（すべて満たすとき true）:
+#     - state == OPEN（既に merge / close 済みは対象外 / Req 2.2）
+#     - autoMergeRequest != null（arm 済み。未 arm は対象外 / Req 2.1 no-op の前提）
+#     - claude-failed または needs-decisions ラベルを持つ（terminal / Req 1.1〜1.3）
+#       → terminal ラベルが無い arm 済み PR は disarm しない（Req 1.5）
+# ─────────────────────────────────────────────────────────────────────────────
+amx_should_disarm_for_pr() {
+  local pr_json="$1"
+
+  # Req 2.2: open でない（merged / closed）PR は対象外
+  local pr_state
+  pr_state=$(echo "$pr_json" | jq -r '.state // ""')
+  if [ "$pr_state" != "OPEN" ]; then
+    return 1
+  fi
+
+  # Req 2.1 / 1.x: 未 arm（autoMergeRequest == null）は対象外（no-op の前提条件）
+  local auto_merge_req
+  auto_merge_req=$(echo "$pr_json" | jq -r '.autoMergeRequest // empty')
+  if [ -z "$auto_merge_req" ] || [ "$auto_merge_req" = "null" ]; then
+    return 1
+  fi
+
+  # Req 1.1, 1.2, 1.3: terminal ラベル（claude-failed / needs-decisions）のいずれかを持つ
+  if echo "$pr_json" | jq -e --arg l "$LABEL_FAILED" \
+      '.labels // [] | map(.name) | index($l)' >/dev/null 2>&1; then
+    return 0
+  fi
+  if echo "$pr_json" | jq -e --arg l "$LABEL_NEEDS_DECISIONS" \
+      '.labels // [] | map(.name) | index($l)' >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Req 1.5: arm 済みだが terminal ラベル無し → disarm しない
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# amx_disarm_pr: 1 PR に対し `gh pr merge --disable-auto` を実行して native auto-merge を
+#   取り消す（Req 1.1〜1.3 / Req 2.4 fail-open）。
+#
+#   入力: $1 = pr_number（数値検証する）
+#         $2 = head_ref（観測ログ用 / 任意）
+#         $3 = pr_url（観測ログ用 / 任意）
+#   戻り値:
+#     0 : disarm 呼び出し成功（log に disarmed 行を出力 / NFR 3.1）
+#     1 : disarm 呼び出し失敗 or PR 番号不正（WARN 1 行を残してパイプライン継続 / Req 2.4）
+#   副作用: gh pr merge --disable-auto API 呼び出し
+#
+#   冪等性: 既に未 arm の PR は amx_should_disarm_for_pr が false で除外され本関数は呼ばれない
+#     （Req 2.1）。万一 disable-auto を二重に打っても GitHub 側で no-op 相当（副作用最小）。
+# ─────────────────────────────────────────────────────────────────────────────
+amx_disarm_pr() {
+  local pr_number="$1"
+  local head_ref="${2:-}"
+  local pr_url="${3:-}"
+
+  # NFR 2.1: PR 番号は数値のみ（URL / gh 引数として使う直前に検証）
+  if ! echo "$pr_number" | grep -qE '^[0-9]+$'; then
+    amx_warn "PR number '${pr_number}' は数値ではないため disarm を skip"
+    return 1
+  fi
+
+  # Req 1.x: `gh pr merge --disable-auto <PR>` で arm を取り消す
+  # NFR 2.2: `--` でオプション解釈打ち切り（PR 番号は数値だが安全側で統一）
+  local stderr_file
+  stderr_file=$(mktemp 2>/dev/null || echo "/tmp/amx-disarm-stderr-$$")
+  local rc=0
+  timeout "$AUTO_MERGE_GIT_TIMEOUT" \
+    gh pr merge --repo "$REPO" --disable-auto -- "$pr_number" \
+      >/dev/null 2>"$stderr_file" || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    # NFR 3.1: 成功時の log line（PR 番号 / 動作 disarmed / head branch）
+    amx_log "PR #${pr_number}: auto-merge disarmed (terminal label present) head=${head_ref} url=${pr_url}"
+    rm -f "$stderr_file" 2>/dev/null || true
+    return 0
+  fi
+
+  # Req 2.4: disarm 失敗は WARN 1 行を残して fail-open（パイプライン継続）。silent fail させない。
+  local stderr_tail=""
+  if [ -f "$stderr_file" ]; then
+    stderr_tail="$(tr '\n' ' ' <"$stderr_file" 2>/dev/null | tail -c 500)"
+  fi
+  amx_warn "PR #${pr_number}: auto-merge disarm failed head=${head_ref} url=${pr_url} stderr=${stderr_tail}"
+  rm -f "$stderr_file" 2>/dev/null || true
+  return 1
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# process_auto_merge_disarm: サイクルあたりの entry point。
+#   1. gate を判定（FULL_AUTO AND (AUTO_MERGE OR AUTO_MERGE_DESIGN)）。OFF なら早期 return
+#      （gh API ゼロ呼び出し / NFR 1.1）
+#   2. open PR を gh pr list で取得（GitHub 直接クエリ。pending state dir に依存しない /
+#      Req 1.4）。head pattern は impl / design 双方を含めてクライアント側 jq でフィルタ
+#      （人間が手書きした PR を除外）
+#   3. 各 PR について amx_should_disarm_for_pr → amx_disarm_pr
+#      1 件失敗で全体を止めない（Req 2.5）
+#   4. サマリ 1 行を出力（NFR 3.1）。対象 0 件は過剰ログを出さない（NFR 3.2）
+#
+#   Req 1.x, 2.x / NFR 1.x, 2.x, 3.x
+# ─────────────────────────────────────────────────────────────────────────────
+process_auto_merge_disarm() {
+  # NFR 1.1, 1.2: gate OFF（kill switch / 両 arm 源 OFF）→ 早期 return（gh API ゼロ呼び出し）。
+  # arm 側（process_auto_merge / process_auto_merge_design）が suppression ログを出すため、
+  # 本 processor からは gate OFF 時の追加ログを出さない（NFR 3.2 / 過剰ログ抑止）。
+  if ! amx_resolve_gate_enabled; then
+    return 0
+  fi
+
+  # 走査件数上限（残りは次回サイクルに持ち越し / NFR 3.x）。数値以外は既定 10 に丸める。
+  local max_prs="${AUTO_MERGE_DISARM_MAX_PRS:-10}"
+  if ! [[ "$max_prs" =~ ^[0-9]+$ ]] || [ "$max_prs" -le 0 ]; then
+    max_prs=10
+  fi
+
+  # Req 1.4: GitHub を直接クエリして open PR を取得（pending state dir には依存しない）。
+  #   - state:open のみ取得。terminal ラベル / arm 有無は client 側 jq で判定する
+  #     （server-side の -label フィルタを使うと「arm 済み かつ terminal」の AND が
+  #      表現しづらく、autoMergeRequest は server-side filter 不可のため client 側で扱う）。
+  local repo_owner="${REPO%%/*}"
+  local prs_json
+  if ! prs_json=$(timeout "$AUTO_MERGE_GIT_TIMEOUT" gh pr list \
+      --repo "$REPO" \
+      --state open \
+      --json number,headRefName,labels,autoMergeRequest,url,state,isDraft,headRepositoryOwner \
+      --limit 100 2>/dev/null); then
+    amx_warn "対象 PR 一覧の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
+    return 0
+  fi
+
+  # head pattern によるクライアント側フィルタ（人間が手書きした PR を除外）+ fork 除外。
+  # impl / design 双方の arm 源を disarm 対象に含めるため、両 head pattern の OR でフィルタ。
+  # NFR 2.3: 未信頼値（pattern / owner）は jq --arg で渡す。
+  prs_json=$(echo "$prs_json" | jq \
+    --arg impl_pattern "$AUTO_MERGE_HEAD_PATTERN" \
+    --arg design_pattern "$AUTO_MERGE_DESIGN_HEAD_PATTERN" \
+    --arg owner "$repo_owner" \
+    '[.[]
+      | select((.headRefName | test($impl_pattern)) or (.headRefName | test($design_pattern)))
+      | select((.headRepositoryOwner.login // "") == $owner)
+    ]' 2>/dev/null || echo '[]')
+
+  local total
+  total=$(echo "$prs_json" | jq 'length' 2>/dev/null || echo 0)
+
+  # 対象候補を amx_should_disarm_for_pr で絞り込む（disarm 対象のみ列挙）。
+  local target_iter
+  target_iter=$(echo "$prs_json" | jq -c '.[]' 2>/dev/null || echo "")
+
+  local disarmed_count=0
+  local failed_count=0
+  local checked=0
+
+  if [ -n "$target_iter" ]; then
+    while IFS= read -r pr_json; do
+      [ -n "$pr_json" ] || continue
+      if [ "$checked" -ge "$max_prs" ]; then
+        amx_log "上限 ${max_prs} に到達したため残りを次サイクルへ持ち越し"
+        break
+      fi
+
+      # disarm 対象でなければ skip（gh 呼び出しなし / Req 1.5, 2.1, 2.2）
+      if ! amx_should_disarm_for_pr "$pr_json"; then
+        continue
+      fi
+      checked=$((checked + 1))
+
+      local pr_number head_ref pr_url
+      pr_number=$(echo "$pr_json" | jq -r '.number')
+      head_ref=$(echo "$pr_json"  | jq -r '.headRefName')
+      pr_url=$(echo "$pr_json"    | jq -r '.url')
+
+      # NFR 2.1: PR 番号は数値のみ
+      if ! echo "$pr_number" | grep -qE '^[0-9]+$'; then
+        amx_warn "PR number '${pr_number}' は数値ではないため disarm を skip (url=${pr_url})"
+        failed_count=$((failed_count + 1))
+        continue
+      fi
+
+      # Req 2.5: 1 件失敗で残りを中断しない
+      if amx_disarm_pr "$pr_number" "$head_ref" "$pr_url"; then
+        disarmed_count=$((disarmed_count + 1))
+      else
+        failed_count=$((failed_count + 1))
+      fi
+    done <<< "$target_iter"
+  fi
+
+  # NFR 3.2: 対象 0 件のときは過剰ログを出さず、サマリ 1 行のみに留める。
+  if [ "$disarmed_count" -eq 0 ] && [ "$failed_count" -eq 0 ]; then
+    amx_log "サマリ: disarmed=0, failed=0 (open候補=${total})"
+    return 0
+  fi
+
+  amx_log "サマリ: disarmed=${disarmed_count}, failed=${failed_count} (open候補=${total})"
+  return 0
+}

--- a/local-watcher/bin/modules/pr-reviewer.sh
+++ b/local-watcher/bin/modules/pr-reviewer.sh
@@ -1275,6 +1275,44 @@ pr_publish_claude_status() {
       ;;
   esac
 
+  # Issue #434 Defect B / Req 3, 4: terminal ラベル付き PR への claude-review=success を
+  # fail-closed する。terminal ラベル（claude-failed / needs-decisions）確定後に in-flight
+  # だった Reviewer が success を publish すると merge gate が「失敗確定済み PR」に対して緑に
+  # 戻り、auto-merge が誤発火する。これを防ぐため、success（result=approve）の publish 直前に
+  # 当該 PR の現在ラベルを再取得し、terminal ラベルがあれば success を publish せず skip する
+  # （required check が pending のまま残り auto-merge は発火しない / fail-closed）。
+  #
+  # 本ガードを唯一の publisher である本関数 1 箇所に集約することで、adjudicator 経路
+  # （adj_apply_status_decision → pr_publish_claude_status）と catch-up 経路
+  # （pr_publish_claude_status_from_branch → pr_publish_claude_status）も自動的に
+  # fail-closed 化される（Req 3.1〜3.4）。reject（failure）は gate を閉じる方向なので
+  # terminal でもそのまま publish する（ガードは success 経路のみ / Req 3.5）。
+  if [ "$state" = "success" ]; then
+    # Req 4.1: 現在のラベル集合を再取得して terminal 判定する。
+    local cur_labels_json gh_rc=0
+    cur_labels_json=$(timeout "${PR_REVIEWER_GIT_TIMEOUT:-120}" \
+      gh pr view "$pr_number" --repo "$REPO" --json labels 2>/dev/null) || gh_rc=$?
+    if [ "$gh_rc" -ne 0 ] || [ -z "$cur_labels_json" ]; then
+      # Req 4.2 / 4.3: ラベル再取得失敗時は従来どおり publish を継続（fail-open / 可用性優先）。
+      # silent fail させず WARN を 1 行残す。
+      pr_warn "claude-review status publish: terminal ラベル再取得に失敗（fail-open で publish 継続 / pr=#${pr_number} sha=${sha} rc=${gh_rc}）"
+    else
+      # Req 3.1, 3.2: claude-failed / needs-decisions のいずれかを持つなら success を publish しない。
+      local terminal_label=""
+      if echo "$cur_labels_json" | jq -e --arg l "$LABEL_FAILED" \
+          '.labels // [] | map(.name) | index($l)' >/dev/null 2>&1; then
+        terminal_label="$LABEL_FAILED"
+      elif echo "$cur_labels_json" | jq -e --arg l "$LABEL_NEEDS_DECISIONS" \
+          '.labels // [] | map(.name) | index($l)' >/dev/null 2>&1; then
+        terminal_label="$LABEL_NEEDS_DECISIONS"
+      fi
+      if [ -n "$terminal_label" ]; then
+        pr_warn "claude-review status publish: terminal label '${terminal_label}' present, skip claude-review=success (fail-closed / pr=#${pr_number} sha=${sha})"
+        return 0
+      fi
+    fi
+  fi
+
   pr_publish_commit_status "$pr_number" "$sha" "claude-review" "$state" "$description" "$target_url"
   return $?
 }

--- a/local-watcher/test/auto-merge-disarm_test.sh
+++ b/local-watcher/test/auto-merge-disarm_test.sh
@@ -1,0 +1,481 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #434 Defect A（arm 後の terminal 遷移を disarm する processor）で
+#       新規追加した local-watcher/bin/modules/auto-merge-disarm.sh の関数群を
+#       fixture と gh stub で検証するスモークテスト。
+#
+#       対象関数:
+#         - amx_resolve_gate_enabled    (NFR 1.1, 1.2 / gate OR 拡張 + kill switch AND)
+#         - amx_should_disarm_for_pr    (Req 1.1〜1.3, 1.5 / Req 2.1, 2.2 純粋判定)
+#         - amx_disarm_pr               (Req 1.x / Req 2.4 fail-open / NFR 2.1, 2.2, 3.1)
+#         - process_auto_merge_disarm   (Req 1.4, 2.3, 2.5 / NFR 1.1, 3.x 統合)
+#
+#       検証する AC（docs/specs/434-fix-auto-merge-claude-failed-arm-native/requirements.md）:
+#         - Req 1.1: arm 済み + claude-failed → disarm 対象
+#         - Req 1.2: arm 済み + needs-decisions → disarm 対象
+#         - Req 1.3: arm 済み + 両 terminal ラベル → disarm 対象
+#         - Req 1.4: GitHub 直接クエリで対象列挙（gh pr list 経由 / pending state dir 非依存）
+#         - Req 1.5: arm 済みだが terminal ラベル無し → disarm しない
+#         - Req 2.1: 未 arm（autoMergeRequest == null）→ 対象外（no-op）
+#         - Req 2.2: open でない（merged / closed）→ 対象外
+#         - Req 2.3: disarm 対象 0 件 → 外部副作用なしでサイクル終了
+#         - Req 2.4: disarm 失敗時 WARN 1 行 + fail-open
+#         - Req 2.5: 1 件失敗で残りを中断しない
+#         - NFR 1.1: gate OFF（両 arm 源 OFF / kill switch OFF）→ gh ゼロ呼び出し
+#
+# 配置先: local-watcher/test/auto-merge-disarm_test.sh
+# 依存:   bash 4+, awk, grep, jq, mktemp
+# 実行:   bash local-watcher/test/auto-merge-disarm_test.sh
+
+set -euo pipefail
+
+# 抽出関数および stub から indirect 参照される変数を多用するため、shellcheck からは
+# 未使用に見える。本ファイル全体で SC2034（unused variable）を抑止する。
+# shellcheck disable=SC2034
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AMX_MOD="$SCRIPT_DIR/../bin/modules/auto-merge-disarm.sh"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+if [ ! -f "$AMX_MOD" ]; then
+  echo "ERROR: cannot find auto-merge-disarm.sh at $AMX_MOD" >&2
+  exit 2
+fi
+if [ ! -f "$WATCHER_SH" ]; then
+  echo "ERROR: cannot find issue-watcher.sh at $WATCHER_SH" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not found in PATH" >&2
+  exit 2
+fi
+
+# 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
+# eval で読み込む。トップレベル副作用は回避する。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# 対象関数群を auto-merge-disarm.sh から読み込む
+for fn in amx_log amx_warn amx_error amx_resolve_gate_enabled amx_should_disarm_for_pr amx_disarm_pr process_auto_merge_disarm; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$AMX_MOD" "$fn")"
+done
+
+# full_auto_enabled は issue-watcher.sh 本体に定義されている（#348）
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$WATCHER_SH" "full_auto_enabled")"
+
+for fn in amx_resolve_gate_enabled amx_should_disarm_for_pr amx_disarm_pr process_auto_merge_disarm full_auto_enabled; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+# グローバル env（遅延束縛で抽出関数本体から参照される / SC2034 false-positive）
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# shellcheck disable=SC2034
+LABEL_FAILED="claude-failed"
+# shellcheck disable=SC2034
+LABEL_NEEDS_DECISIONS="needs-decisions"
+# shellcheck disable=SC2034
+AUTO_MERGE_GIT_TIMEOUT=60
+# shellcheck disable=SC2034
+AUTO_MERGE_DISARM_MAX_PRS=10
+# shellcheck disable=SC2034
+AUTO_MERGE_HEAD_PATTERN='^claude/issue-.*-impl'
+# shellcheck disable=SC2034
+AUTO_MERGE_DESIGN_HEAD_PATTERN='^claude/issue-.*-design'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+assert_rc() {
+  local label="$1"
+  local expected_rc="$2"
+  shift 2
+  local actual_rc=0
+  "$@" >/dev/null 2>&1 || actual_rc=$?
+  if [ "$expected_rc" = "$actual_rc" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected rc: $expected_rc"
+    echo "  actual rc  : $actual_rc"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ── stub state ──
+reset_stub_state() {
+  GH_CALL_LOG="$(mktemp)"
+  LOG_OUT="$(mktemp)"
+  WARN_OUT="$(mktemp)"
+  GH_PR_LIST_RESPONSE='[]'
+  GH_PR_MERGE_RC=0
+  GH_PR_MERGE_STDERR=""
+  # 失敗注入を PR 番号で制御する場合に使う（"" なら無効）。
+  GH_PR_MERGE_FAIL_FOR=""
+}
+
+cleanup_stub_state() {
+  rm -f "$GH_CALL_LOG" "$LOG_OUT" "$WARN_OUT" 2>/dev/null || true
+}
+
+count_calls() {
+  local pattern="$1"
+  local n
+  n=$( { grep -E -- "$pattern" "$GH_CALL_LOG" 2>/dev/null || true; } | wc -l)
+  echo "$((n))"
+}
+
+count_logs() {
+  local file="$1"
+  local pattern="$2"
+  local n
+  n=$( { grep -E -- "$pattern" "$file" 2>/dev/null || true; } | wc -l)
+  echo "$((n))"
+}
+
+# amx_log / amx_warn / amx_error を上書きして出力をファイルへリダイレクト
+# shellcheck disable=SC2317
+amx_log()   { echo "$*" >>"$LOG_OUT"; }
+# shellcheck disable=SC2317
+amx_warn()  { echo "$*" >>"$WARN_OUT"; }
+# shellcheck disable=SC2317
+amx_error() { echo "$*" >>"$WARN_OUT"; }
+
+# timeout を no-op に。実 gh ではなく stub を呼ぶ。
+# shellcheck disable=SC2317
+timeout() {
+  shift  # 第 1 引数（秒数）を捨てる
+  "$@"
+}
+
+# gh stub: gh pr list / gh pr merge の呼び出しを観測。
+# shellcheck disable=SC2317
+gh() {
+  echo "gh $*" >>"$GH_CALL_LOG"
+  case "${1:-}" in
+    pr)
+      case "${2:-}" in
+        list)
+          printf '%s' "$GH_PR_LIST_RESPONSE"
+          return 0
+          ;;
+        merge)
+          # `gh pr merge --repo ... --disable-auto -- <PR>` の PR 番号を末尾引数から取る。
+          local last_arg=""
+          for last_arg in "$@"; do :; done
+          # 特定 PR 番号への失敗注入（Req 2.4 / 2.5）。
+          if [ -n "$GH_PR_MERGE_FAIL_FOR" ] && [ "$last_arg" = "$GH_PR_MERGE_FAIL_FOR" ]; then
+            [ -n "$GH_PR_MERGE_STDERR" ] && printf '%s\n' "$GH_PR_MERGE_STDERR" >&2
+            return 1
+          fi
+          if [ -n "$GH_PR_MERGE_STDERR" ]; then
+            printf '%s\n' "$GH_PR_MERGE_STDERR" >&2
+          fi
+          return "$GH_PR_MERGE_RC"
+          ;;
+      esac
+      ;;
+  esac
+  return 0
+}
+
+# Helper: amx_should_disarm_for_pr 用の PR JSON ビルダー
+build_pr_json() {
+  local pr_number="$1"
+  local head_ref="$2"
+  local state="$3"           # OPEN / MERGED / CLOSED
+  local labels_csv="$4"      # "claude-failed,..." (カンマ区切り / 空可)
+  local auto_merge="$5"      # "" or "{...}"（autoMergeRequest）
+  local labels_json
+  labels_json=$(echo "$labels_csv" | awk -F',' '{
+    printf "[";
+    for (i = 1; i <= NF; i++) {
+      if ($i == "") continue;
+      if (printed) printf ",";
+      printf "{\"name\":\"%s\"}", $i;
+      printed = 1;
+    }
+    printf "]";
+  }')
+  local auto_merge_field
+  if [ -z "$auto_merge" ] || [ "$auto_merge" = "null" ]; then
+    auto_merge_field="null"
+  else
+    auto_merge_field="$auto_merge"
+  fi
+  cat <<EOF
+{
+  "number": $pr_number,
+  "headRefName": "$head_ref",
+  "labels": $labels_json,
+  "url": "https://github.com/owner/test-repo/pull/$pr_number",
+  "state": "$state",
+  "isDraft": false,
+  "headRepositoryOwner": {"login": "owner"},
+  "autoMergeRequest": $auto_merge_field
+}
+EOF
+}
+
+ARMED='{"enabledAt":"2026-06-29T00:00:00Z"}'
+
+# ============================================================
+# Section 1: amx_resolve_gate_enabled（NFR 1.1, 1.2 / gate OR 拡張 + kill switch AND）
+# ============================================================
+echo "--- Section 1: amx_resolve_gate_enabled gate 判定 ---"
+
+# kill switch OFF → 常に OFF
+unset FULL_AUTO_ENABLED
+AUTO_MERGE_ENABLED="true"
+AUTO_MERGE_DESIGN_ENABLED="true"
+assert_rc "NFR 1.1: FULL_AUTO_ENABLED OFF → gate OFF（rc=1）" 1 amx_resolve_gate_enabled
+
+# kill switch ON / 両 arm 源 OFF → OFF
+FULL_AUTO_ENABLED="true"
+unset AUTO_MERGE_ENABLED
+unset AUTO_MERGE_DESIGN_ENABLED
+assert_rc "NFR 1.1: 両 arm 源 OFF → gate OFF（rc=1）" 1 amx_resolve_gate_enabled
+
+# kill switch ON / AUTO_MERGE_ENABLED のみ ON → ON
+FULL_AUTO_ENABLED="true"
+AUTO_MERGE_ENABLED="true"
+unset AUTO_MERGE_DESIGN_ENABLED
+assert_rc "gate OR: AUTO_MERGE_ENABLED のみ ON → gate ON（rc=0）" 0 amx_resolve_gate_enabled
+
+# kill switch ON / AUTO_MERGE_DESIGN_ENABLED のみ ON → ON
+FULL_AUTO_ENABLED="true"
+unset AUTO_MERGE_ENABLED
+AUTO_MERGE_DESIGN_ENABLED="true"
+assert_rc "gate OR: AUTO_MERGE_DESIGN_ENABLED のみ ON → gate ON（rc=0）" 0 amx_resolve_gate_enabled
+
+# 不正値（安全側 OFF）
+FULL_AUTO_ENABLED="true"
+for v in "" "false" "0" "True" "TRUE" "1" "on" "yes"; do
+  AUTO_MERGE_ENABLED="$v"
+  AUTO_MERGE_DESIGN_ENABLED="$v"
+  assert_rc "NFR 1.1: arm 源='$v' は安全側 OFF" 1 amx_resolve_gate_enabled
+done
+# テスト後の gate 値を ON に戻しておく（後続 Section 4 用）
+# shellcheck disable=SC2034
+FULL_AUTO_ENABLED="true"
+# shellcheck disable=SC2034
+AUTO_MERGE_ENABLED="true"
+# shellcheck disable=SC2034
+AUTO_MERGE_DESIGN_ENABLED="true"
+
+# ============================================================
+# Section 2: amx_should_disarm_for_pr 純粋判定（Req 1.1〜1.3, 1.5 / Req 2.1, 2.2）
+# ============================================================
+echo ""
+echo "--- Section 2: amx_should_disarm_for_pr 判定 ---"
+
+# Req 1.1: arm 済み + claude-failed → true（rc=0）
+PR_FAILED=$(build_pr_json 100 "claude/issue-434-impl-foo" "OPEN" "claude-failed" "$ARMED")
+assert_rc "Req 1.1: arm 済み + claude-failed → disarm 対象" 0 amx_should_disarm_for_pr "$PR_FAILED"
+
+# Req 1.2: arm 済み + needs-decisions → true
+PR_NEEDS=$(build_pr_json 101 "claude/issue-434-impl-foo" "OPEN" "needs-decisions" "$ARMED")
+assert_rc "Req 1.2: arm 済み + needs-decisions → disarm 対象" 0 amx_should_disarm_for_pr "$PR_NEEDS"
+
+# Req 1.3: arm 済み + 両 terminal ラベル → true
+PR_BOTH=$(build_pr_json 102 "claude/issue-434-impl-foo" "OPEN" "claude-failed,needs-decisions" "$ARMED")
+assert_rc "Req 1.3: arm 済み + 両 terminal ラベル → disarm 対象" 0 amx_should_disarm_for_pr "$PR_BOTH"
+
+# Req 1.5: arm 済みだが terminal ラベル無し → false（rc=1）
+PR_NO_TERMINAL=$(build_pr_json 103 "claude/issue-434-impl-foo" "OPEN" "ready-for-review" "$ARMED")
+assert_rc "Req 1.5: arm 済み + terminal ラベル無し → disarm しない" 1 amx_should_disarm_for_pr "$PR_NO_TERMINAL"
+
+# Req 2.1: 未 arm（autoMergeRequest == null）→ false
+PR_NOT_ARMED=$(build_pr_json 104 "claude/issue-434-impl-foo" "OPEN" "claude-failed" "")
+assert_rc "Req 2.1: 未 arm + claude-failed → disarm 対象外（no-op）" 1 amx_should_disarm_for_pr "$PR_NOT_ARMED"
+
+# Req 2.2: MERGED（open でない）→ false
+PR_MERGED=$(build_pr_json 105 "claude/issue-434-impl-foo" "MERGED" "claude-failed" "$ARMED")
+assert_rc "Req 2.2: MERGED PR → disarm 対象外" 1 amx_should_disarm_for_pr "$PR_MERGED"
+
+# Req 2.2: CLOSED（open でない）→ false
+PR_CLOSED=$(build_pr_json 106 "claude/issue-434-impl-foo" "CLOSED" "needs-decisions" "$ARMED")
+assert_rc "Req 2.2: CLOSED PR → disarm 対象外" 1 amx_should_disarm_for_pr "$PR_CLOSED"
+
+# design PR（arm 済み + terminal）も対象（head pattern は process 側でフィルタ。判定は state/label/arm のみ）
+PR_DESIGN=$(build_pr_json 107 "claude/issue-434-design-foo" "OPEN" "claude-failed" "$ARMED")
+assert_rc "design PR でも arm + terminal なら disarm 対象" 0 amx_should_disarm_for_pr "$PR_DESIGN"
+
+# ============================================================
+# Section 3: amx_disarm_pr 呼び出し検証（Req 1.x / Req 2.4 / NFR 2.1, 2.2, 3.1）
+# ============================================================
+echo ""
+echo "--- Section 3: amx_disarm_pr 呼び出し検証 ---"
+
+# Req 1.x: gh pr merge --disable-auto が呼ばれる + 成功 log
+reset_stub_state
+GH_PR_MERGE_RC=0
+amx_disarm_pr 100 "claude/issue-434-impl-foo" "https://github.com/owner/test-repo/pull/100"
+merge_call_count=$(count_calls "^gh pr merge")
+assert_eq "Req 1.x: amx_disarm_pr → gh pr merge 1 回発火" "1" "$merge_call_count"
+disable_flag=$(count_calls "gh pr merge.*--disable-auto")
+assert_eq "Req 1.x: --disable-auto フラグあり" "1" "$disable_flag"
+opt_term=$(count_calls "gh pr merge.*-- 100")
+assert_eq "NFR 2.2: -- でオプション解釈打ち切り + PR 番号" "1" "$opt_term"
+disarmed_log=$(count_logs "$LOG_OUT" "PR #100.*disarmed")
+assert_eq "NFR 3.1: 成功時 disarmed log line に PR 番号" "1" "$disarmed_log"
+cleanup_stub_state
+
+# Req 2.4: disarm 失敗時 WARN 1 行 + fail-open（rc=1）
+reset_stub_state
+GH_PR_MERGE_RC=1
+GH_PR_MERGE_STDERR="HTTP 422: something failed"
+amx_disarm_pr 200 "claude/issue-434-impl-bar" "https://github.com/owner/test-repo/pull/200" || true
+warn_log=$(count_logs "$WARN_OUT" "PR #200.*disarm failed")
+assert_eq "Req 2.4: disarm 失敗時 WARN を 1 行残す（silent fail 禁止）" "1" "$warn_log"
+assert_rc "Req 2.4: disarm 失敗で rc=1（fail-open 呼出側で吸収）" 1 amx_disarm_pr 200 "head" "url"
+cleanup_stub_state
+
+# NFR 2.1: 数値でない PR 番号は gh を呼ばずに skip
+reset_stub_state
+amx_disarm_pr "abc" "claude/issue-434-impl" "url" || true
+merge_call_count=$(count_calls "^gh pr merge")
+assert_eq "NFR 2.1: 数値以外の PR 番号で gh pr merge を呼ばない" "0" "$merge_call_count"
+cleanup_stub_state
+
+# ============================================================
+# Section 4: process_auto_merge_disarm 統合（Req 1.4, 2.3, 2.5 / NFR 1.1）
+# ============================================================
+echo ""
+echo "--- Section 4: process_auto_merge_disarm 統合 ---"
+
+# Case A: gate OFF（kill switch OFF）→ gh ゼロ呼び出し（NFR 1.1）
+reset_stub_state
+unset FULL_AUTO_ENABLED
+AUTO_MERGE_ENABLED="true"
+AUTO_MERGE_DESIGN_ENABLED="true"
+process_auto_merge_disarm
+gh_count=$(count_calls "^gh ")
+assert_eq "NFR 1.1: kill switch OFF で gh ゼロ呼び出し" "0" "$gh_count"
+cleanup_stub_state
+
+# Case B: gate OFF（両 arm 源 OFF）→ gh ゼロ呼び出し（NFR 1.1）
+reset_stub_state
+FULL_AUTO_ENABLED="true"
+unset AUTO_MERGE_ENABLED
+unset AUTO_MERGE_DESIGN_ENABLED
+process_auto_merge_disarm
+gh_count=$(count_calls "^gh ")
+assert_eq "NFR 1.1: 両 arm 源 OFF で gh ゼロ呼び出し" "0" "$gh_count"
+cleanup_stub_state
+
+# 以降 gate ON
+# shellcheck disable=SC2034
+FULL_AUTO_ENABLED="true"
+# shellcheck disable=SC2034
+AUTO_MERGE_ENABLED="true"
+# shellcheck disable=SC2034
+AUTO_MERGE_DESIGN_ENABLED="true"
+
+# Case C: gate ON / arm 済み + claude-failed の impl PR 1 件 → disarm 1 回（Req 1.1, 1.4）
+reset_stub_state
+GH_PR_LIST_RESPONSE="[$(build_pr_json 300 "claude/issue-434-impl-foo" "OPEN" "claude-failed" "$ARMED")]"
+process_auto_merge_disarm
+# gh pr list が GitHub 直接クエリで呼ばれる（Req 1.4）
+list_count=$(count_calls "^gh pr list")
+assert_eq "Req 1.4: GitHub 直接クエリ（gh pr list）で対象列挙" "1" "$list_count"
+merge_call_count=$(count_calls "^gh pr merge.*--disable-auto")
+assert_eq "Req 1.1: arm + claude-failed → disarm 1 回" "1" "$merge_call_count"
+summary_log=$(count_logs "$LOG_OUT" "サマリ: disarmed=1")
+assert_eq "NFR 3.1: サマリ行に disarmed=1" "1" "$summary_log"
+cleanup_stub_state
+
+# Case D: gate ON / 対象 0 件（arm 済みだが terminal ラベル無し）→ disarm 呼び出しゼロ（Req 1.5, 2.3）
+reset_stub_state
+GH_PR_LIST_RESPONSE="[$(build_pr_json 301 "claude/issue-434-impl-foo" "OPEN" "ready-for-review" "$ARMED")]"
+process_auto_merge_disarm
+merge_call_count=$(count_calls "^gh pr merge")
+assert_eq "Req 1.5 / 2.3: terminal ラベル無し → disarm 呼び出しゼロ" "0" "$merge_call_count"
+summary_log=$(count_logs "$LOG_OUT" "サマリ: disarmed=0, failed=0")
+assert_eq "NFR 3.2: 対象 0 件はサマリ 1 行のみ" "1" "$summary_log"
+cleanup_stub_state
+
+# Case E: gate ON / 未 arm + terminal → disarm 呼び出しゼロ（Req 2.1）
+reset_stub_state
+GH_PR_LIST_RESPONSE="[$(build_pr_json 302 "claude/issue-434-impl-foo" "OPEN" "claude-failed" "")]"
+process_auto_merge_disarm
+merge_call_count=$(count_calls "^gh pr merge")
+assert_eq "Req 2.1: 未 arm PR → disarm 呼び出しゼロ" "0" "$merge_call_count"
+cleanup_stub_state
+
+# Case F: gate ON / 人間が手書きの PR（head pattern mismatch）→ disarm 呼び出しゼロ
+reset_stub_state
+GH_PR_LIST_RESPONSE="[$(build_pr_json 303 "feature/manual-pr" "OPEN" "claude-failed" "$ARMED")]"
+process_auto_merge_disarm
+merge_call_count=$(count_calls "^gh pr merge")
+assert_eq "head pattern mismatch（手書き PR）→ disarm 呼び出しゼロ" "0" "$merge_call_count"
+cleanup_stub_state
+
+# Case G: gate ON / design PR + arm + needs-decisions → disarm 1 回（Req 1.2 / OR head pattern）
+reset_stub_state
+GH_PR_LIST_RESPONSE="[$(build_pr_json 304 "claude/issue-434-design-foo" "OPEN" "needs-decisions" "$ARMED")]"
+process_auto_merge_disarm
+merge_call_count=$(count_calls "^gh pr merge.*--disable-auto")
+assert_eq "Req 1.2: design PR + arm + needs-decisions → disarm 1 回" "1" "$merge_call_count"
+cleanup_stub_state
+
+# Case H: gate ON / 3 件中 1 件失敗 → 残りを中断しない（Req 2.5）
+reset_stub_state
+GH_PR_LIST_RESPONSE="[$(build_pr_json 305 "claude/issue-434-impl-a" "OPEN" "claude-failed" "$ARMED"),$(build_pr_json 306 "claude/issue-434-impl-b" "OPEN" "claude-failed" "$ARMED"),$(build_pr_json 307 "claude/issue-434-impl-c" "OPEN" "claude-failed" "$ARMED")]"
+GH_PR_MERGE_FAIL_FOR="306"   # 中間の PR を失敗させる
+GH_PR_MERGE_STDERR="HTTP 500: boom"
+process_auto_merge_disarm
+merge_call_count=$(count_calls "^gh pr merge.*--disable-auto")
+assert_eq "Req 2.5: 1 件失敗でも 3 件すべて disarm を試行する" "3" "$merge_call_count"
+summary_disarmed=$(count_logs "$LOG_OUT" "サマリ: disarmed=2, failed=1")
+assert_eq "Req 2.5: サマリに disarmed=2, failed=1" "1" "$summary_disarmed"
+cleanup_stub_state
+
+# Case I: gate ON / merged PR + arm + terminal → disarm 呼び出しゼロ（Req 2.2）
+reset_stub_state
+GH_PR_LIST_RESPONSE="[$(build_pr_json 308 "claude/issue-434-impl-foo" "MERGED" "claude-failed" "$ARMED")]"
+process_auto_merge_disarm
+merge_call_count=$(count_calls "^gh pr merge")
+assert_eq "Req 2.2: MERGED PR → disarm 呼び出しゼロ" "0" "$merge_call_count"
+cleanup_stub_state
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=================================================="
+echo "RESULT: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "=================================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
+++ b/local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #434 Defect B（terminal ラベル付き PR への claude-review=success の fail-closed 化）で
+#       local-watcher/bin/modules/pr-reviewer.sh の pr_publish_claude_status に追加した
+#       success 公開直前ガードを fixture と gh stub で検証するスモークテスト。
+#
+#       対象関数:
+#         - pr_publish_claude_status  (Req 3.1, 3.2, 3.5 / Req 4.1, 4.2, 4.3)
+#
+#       検証する AC（docs/specs/434-fix-auto-merge-claude-failed-arm-native/requirements.md）:
+#         - Req 3.1: claude-failed 付き PR への success → publish しない（fail-closed）
+#         - Req 3.2: needs-decisions 付き PR への success → publish しない
+#         - Req 3.5: terminal ラベル無し → 従来どおり approve/reject に応じた publish
+#         - Req 4.1: success publish 直前に現在のラベル集合を再取得して判定
+#         - Req 4.2: ラベル再取得失敗時は従来どおり publish 継続（fail-open）
+#         - Req 4.3: ラベル再取得失敗時に WARN ログを 1 行残す
+#       （Req 3.3 adjudicator 経路 / Req 3.4 catch-up 経路 は本関数 1 箇所への集約で
+#         自動的に fail-closed 化されるため、本関数の検証で間接的にカバーされる）
+#
+# 配置先: local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
+# 依存:   bash 4+, awk, grep, jq, mktemp
+# 実行:   bash local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
+
+set -euo pipefail
+
+# 抽出関数および stub から indirect 参照される変数を多用するため、shellcheck からは
+# 未使用に見える。本ファイル全体で SC2034（unused variable）を抑止する。
+# shellcheck disable=SC2034
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
+
+if [ ! -f "$PR_MOD" ]; then
+  echo "ERROR: cannot find pr-reviewer.sh at $PR_MOD" >&2
+  exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not found in PATH" >&2
+  exit 2
+fi
+
+# extract_function イディオム
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script"
+}
+
+# 対象関数を pr-reviewer.sh から読み込む
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PR_MOD" "pr_publish_claude_status")"
+
+if ! declare -F pr_publish_claude_status >/dev/null; then
+  echo "ERROR: pr_publish_claude_status not loaded" >&2
+  exit 2
+fi
+
+# グローバル env（遅延束縛で参照される / SC2034 false-positive）
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# shellcheck disable=SC2034
+LABEL_FAILED="claude-failed"
+# shellcheck disable=SC2034
+LABEL_NEEDS_DECISIONS="needs-decisions"
+# shellcheck disable=SC2034
+PR_REVIEWER_GIT_TIMEOUT=60
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+count_logs() {
+  local file="$1"
+  local pattern="$2"
+  local n
+  n=$( { grep -E -- "$pattern" "$file" 2>/dev/null || true; } | wc -l)
+  echo "$((n))"
+}
+
+# ── stub state ──
+reset_stub_state() {
+  WARN_OUT="$(mktemp)"
+  PUBLISH_CALL_LOG="$(mktemp)"
+  GH_PR_VIEW_LABELS='{"labels":[]}'    # 既定: terminal ラベル無し
+  GH_PR_VIEW_RC=0                       # ラベル再取得 rc（!=0 で取得失敗注入）
+}
+
+cleanup_stub_state() {
+  rm -f "$WARN_OUT" "$PUBLISH_CALL_LOG" 2>/dev/null || true
+}
+
+# pr_warn を上書きして WARN を観測
+# shellcheck disable=SC2317
+pr_warn() { echo "$*" >>"$WARN_OUT"; }
+# shellcheck disable=SC2317
+pr_log()  { :; }
+
+# timeout を no-op に（第 1 引数の秒数を捨てて後続を実行）
+# shellcheck disable=SC2317
+timeout() {
+  shift
+  "$@"
+}
+
+# gh stub: gh pr view --json labels の応答を制御
+# shellcheck disable=SC2317
+gh() {
+  if [ "${1:-}" = "pr" ] && [ "${2:-}" = "view" ]; then
+    if [ "$GH_PR_VIEW_RC" -ne 0 ]; then
+      return "$GH_PR_VIEW_RC"
+    fi
+    printf '%s' "$GH_PR_VIEW_LABELS"
+    return 0
+  fi
+  return 0
+}
+
+# pr_publish_commit_status stub: 呼び出しと引数を記録（実 publish が走ったかの観測）
+# shellcheck disable=SC2317
+pr_publish_commit_status() {
+  # $1=pr_number $2=sha $3=context $4=state $5=description $6=target_url
+  echo "publish pr=$1 context=$3 state=$4" >>"$PUBLISH_CALL_LOG"
+  return 0
+}
+
+count_publish() {
+  local pattern="$1"
+  local n
+  n=$( { grep -E -- "$pattern" "$PUBLISH_CALL_LOG" 2>/dev/null || true; } | wc -l)
+  echo "$((n))"
+}
+
+VALID_SHA="0123456789abcdef0123456789abcdef01234567"
+
+# ============================================================
+# Section 1: terminal ラベル付き PR への success → fail-closed（Req 3.1, 3.2, 4.1）
+# ============================================================
+echo "--- Section 1: terminal ラベル付き success の fail-closed ---"
+
+# Req 3.1: claude-failed 付き → success を publish しない
+reset_stub_state
+GH_PR_VIEW_LABELS='{"labels":[{"name":"claude-failed"}]}'
+pr_publish_claude_status 100 "$VALID_SHA" approve "https://example.com/notes"
+publish_count=$(count_publish "context=claude-review")
+assert_eq "Req 3.1: claude-failed 付き → success publish ゼロ（fail-closed）" "0" "$publish_count"
+skip_warn=$(count_logs "$WARN_OUT" "terminal label.*skip claude-review=success")
+assert_eq "Req 3.1: skip 時に WARN 1 行を残す" "1" "$skip_warn"
+cleanup_stub_state
+
+# Req 3.2: needs-decisions 付き → success を publish しない
+reset_stub_state
+GH_PR_VIEW_LABELS='{"labels":[{"name":"needs-decisions"}]}'
+pr_publish_claude_status 101 "$VALID_SHA" approve ""
+publish_count=$(count_publish "context=claude-review")
+assert_eq "Req 3.2: needs-decisions 付き → success publish ゼロ" "0" "$publish_count"
+cleanup_stub_state
+
+# Req 3.1: 両 terminal ラベル付き → success を publish しない
+reset_stub_state
+GH_PR_VIEW_LABELS='{"labels":[{"name":"claude-failed"},{"name":"needs-decisions"}]}'
+pr_publish_claude_status 102 "$VALID_SHA" approve ""
+publish_count=$(count_publish "context=claude-review")
+assert_eq "Req 3.1/3.2: 両 terminal ラベル → success publish ゼロ" "0" "$publish_count"
+cleanup_stub_state
+
+# ============================================================
+# Section 2: terminal ラベル無しの通常経路（Req 3.5）
+# ============================================================
+echo ""
+echo "--- Section 2: terminal ラベル無しの通常 publish ---"
+
+# Req 3.5: terminal ラベル無し → approve を success で publish
+reset_stub_state
+GH_PR_VIEW_LABELS='{"labels":[{"name":"ready-for-review"}]}'
+pr_publish_claude_status 103 "$VALID_SHA" approve ""
+publish_count=$(count_publish "context=claude-review state=success")
+assert_eq "Req 3.5: terminal ラベル無し → success を publish" "1" "$publish_count"
+cleanup_stub_state
+
+# Req 3.5: reject は terminal ラベルの有無に依らず failure で publish（ガードは success のみ）
+reset_stub_state
+GH_PR_VIEW_LABELS='{"labels":[{"name":"claude-failed"}]}'
+pr_publish_claude_status 104 "$VALID_SHA" reject ""
+publish_count=$(count_publish "context=claude-review state=failure")
+assert_eq "Req 3.5: reject は terminal でも failure を publish（ガードは success 経路のみ）" "1" "$publish_count"
+# reject 経路では gh pr view ラベル再取得を行わない → skip WARN は出ない
+skip_warn=$(count_logs "$WARN_OUT" "terminal label.*skip")
+assert_eq "Req 3.5: reject 経路では fail-closed skip WARN を出さない" "0" "$skip_warn"
+cleanup_stub_state
+
+# ============================================================
+# Section 3: ラベル再取得失敗時の fail-open（Req 4.2, 4.3）
+# ============================================================
+echo ""
+echo "--- Section 3: ラベル再取得失敗時の fail-open ---"
+
+# Req 4.2: gh pr view 失敗 → 従来どおり publish 継続（fail-open）
+reset_stub_state
+GH_PR_VIEW_RC=1
+pr_publish_claude_status 105 "$VALID_SHA" approve ""
+publish_count=$(count_publish "context=claude-review state=success")
+assert_eq "Req 4.2: ラベル再取得失敗 → success を従来どおり publish（fail-open）" "1" "$publish_count"
+# Req 4.3: 取得失敗時に WARN 1 行を残す
+failopen_warn=$(count_logs "$WARN_OUT" "terminal ラベル再取得に失敗")
+assert_eq "Req 4.3: ラベル再取得失敗時に WARN 1 行を残す" "1" "$failopen_warn"
+cleanup_stub_state
+
+# 不正な result はガードに到達せず従来どおり rc=4
+reset_stub_state
+rc=0
+pr_publish_claude_status 106 "$VALID_SHA" "bogus" "" >/dev/null 2>&1 || rc=$?
+assert_eq "不正 result は rc=4（既存挙動を維持）" "4" "$rc"
+publish_count=$(count_publish "context=claude-review")
+assert_eq "不正 result は publish しない" "0" "$publish_count"
+cleanup_stub_state
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "=================================================="
+echo "RESULT: PASS=$PASS_COUNT FAIL=$FAIL_COUNT"
+echo "=================================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

GitHub ネイティブ auto-merge を arm 済みの実装 PR が `claude-failed` / `needs-decisions` へ遷移しても disarm されず、status checks が全 green に達した時点で失敗確定済み PR が merge されてしまう不具合を修正する。

修正は 2 軸: (A) arm 後の terminal 遷移を検知して `gh pr merge --disable-auto` で disarm する専用 processor（`modules/auto-merge-disarm.sh`）を新設、(B) in-flight の Reviewer が terminal ラベル付き PR へ `claude-review=success` を publish しないよう `pr_publish_claude_status` に fail-closed ガードを追加。既存 opt-in gate（`AUTO_MERGE_ENABLED=true && FULL_AUTO_ENABLED=true`）の外側では一切の副作用なし。

## 対応 Issue

Closes #434

## 関連 PR

なし

## 実装内容

- (Req 1.1〜1.5 / NFR 1.1〜1.2) `modules/auto-merge-disarm.sh` を新設（prefix `amx_`）: terminal ラベル（`claude-failed` / `needs-decisions`）を持つ arm 済み open PR を GitHub 直接クエリで列挙し disarm。arm gate OFF 時は完全 no-op
- (Req 2.1〜2.5) disarm の冪等性: 既 disarm 済み（`autoMergeRequest == null`）・merge 済み PR はスキップ、失敗時 WARN + fail-open、複数対象は 1 件失敗で中断せず継続
- (Req 3.1〜3.5 / Req 4.1〜4.3) `pr-reviewer.sh`（`pr_publish_claude_status`）に terminal ラベル再取得 → fail-closed ガードを追加。adjudicator / catch-up 経路は単一 publisher へのガード集約で自動波及
- (NFR 2.1〜2.3) PR 番号 `^[0-9]+$` 検証、`--` オプション打ち切り、`jq --arg` 経由
- (NFR 3.1〜3.2) disarm 時 PR 番号＋動作ログ 1 行、0 件時サマリ 1 行のみ
- (NFR 4.2) README に Auto-Merge Disarm Processor 節とオプション機能一覧エントリを追加
- `issue-watcher.sh`: `REQUIRED_MODULES` に `auto-merge-disarm` を登録、arm 直後に `process_auto_merge_disarm` 呼び出しを配置

## 受入基準チェック

- [x] Req 1.1: arm 済み open PR に claude-failed → disarm ← auto-merge-disarm_test.sh Section2 Case C
- [x] Req 1.2: arm 済み open PR に needs-decisions → disarm ← Section2 Req1.2 Case G
- [x] Req 1.3: 両 terminal ラベル → disarm ← Section2 Req1.3
- [x] Req 1.4: GitHub 直接クエリ（pending state dir 非依存）← Case C gh pr list 呼び出し検証
- [x] Req 1.5: terminal ラベルなし arm 済み → 取り消さない ← Case D
- [x] Req 2.1: autoMergeRequest == null → no-op ← Case E
- [x] Req 2.2: MERGED/CLOSED → 対象外 ← Case I
- [x] Req 2.3: 0 件 → 副作用なし ← Case D
- [x] Req 2.4: disarm 失敗 → WARN + rc=1 + 継続 ← Section3 Req2.4
- [x] Req 2.5: 複数対象で 1 件失敗 → 残り継続 ← Case H
- [x] Req 3.1: claude-failed 付き PR → success skip ← pr_reviewer_claude_status_fail_closed_test.sh Section1 Req3.1
- [x] Req 3.2: needs-decisions 付き PR → success skip ← Section1 Req3.2
- [x] Req 3.5: terminal なし → 従来どおり publish ← Section2 Req3.5
- [x] Req 4.1: publish 直前にラベル再取得 ← Section1
- [x] Req 4.2: 再取得失敗 → 従来 publish 継続 ← Section3 Req4.2
- [x] Req 4.3: 再取得失敗 → WARN 1 行 ← Section3 Req4.3
- [x] NFR 1.1/1.2: gate OFF → gh ゼロ呼び出し no-op ← Case A/B
- [x] NFR 2.1: PR 番号 ^[0-9]+$ 検証 ← NFR2.1
- [x] NFR 2.2: gh ... -- "$pr_number" ← NFR2.2
- [x] NFR 4.2: README 同一 PR 内更新 ← 実装内容参照

## テスト結果

```
auto-merge-disarm_test.sh:
  全 40 件 PASS / FAIL 0

pr_reviewer_claude_status_fail_closed_test.sh:
  全 11 件 PASS / FAIL 0

shellcheck: 警告ゼロ（新規 module / pr-reviewer.sh / test 2 本）
bash -n local-watcher/bin/issue-watcher.sh: OK
```

## 実装上の判断

- disarm processor は `modules/auto-merge-disarm.sh`（prefix `amx_`）として切り出し、CLAUDE.md 機能追加ガイドライン（新機能は module へ切り出し、prefix namespace 割当）に準拠
- Defect B（Reviewer fail-closed）は `pr_publish_claude_status` に集約することで adjudicator / catch-up 経路への波及を単一変更点で実現（呼び出しグラフ上 Req 3.3/3.4 を自動カバー）
- terminal ラベル再取得失敗は fail-open（Req 4.2）として可用性を優先
- NFR 4.1: `.claude/{agents,rules}` は無変更のため `diff -r` 空を確認済み。`modules/auto-merge-disarm.sh` は consumer 配布物だが、`repo-template/` 側への `modules/` コピーは元来存在しないため同期対象 vacuous（review-notes.md Section Verified Requirements NFR4.1 参照）

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後に検証済み）
- Reviewer 独立レビュー結果: `docs/specs/434-fix-auto-merge-claude-failed-arm-native/review-notes.md` 参照（RESULT: approve、Findings: なし）
- `process_auto_merge_disarm` の発火タイミング（arm 直後配置）が適切か目視確認推奨

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #434 のコメントを参照してください。
