### PR TITLE
spec(#437): PR Iteration の out-of-scope 第 3 判定と内容ベース早期打ち切りの設計

### DIFF
--- a/docs/specs/437-pr-iteration-pr-design-spec-max-rounds/design.md
+++ b/docs/specs/437-pr-iteration-pr-design-spec-max-rounds/design.md
@@ -1,0 +1,556 @@
+# Design Document
+
+## Overview
+
+**Purpose**: PR Iteration / Adjudicator が「正当だが当該 PR スコープ外（design.md / spec の変更を
+要求しており impl PR では規約上書き換え不可）」な指摘で収束できず、`max_rounds` 消尽でしか
+終われず `claude-failed` に落ちる構造問題を解消する。実装が scope 完結している PR を堂々巡りで
+失敗扱いにせず、設計変更が必要な正当指摘を `needs-decisions` 経路へ還流させる。
+
+**Users**: idd-claude self-hosting および consumer repo の watcher 運用者。`needs-iteration`
+ラベル付き PR が PR Iteration Processor で反復対応される workflow で利用する。
+
+**Impact**: 現在の adjudicator は finding を `legitimate` / `excessive` の二値で裁定し、
+`legitimate` 件数で `needs-iteration` ラベル付与を確定する。本変更は (1) 第 3 判定
+`out-of-scope` を後方互換に追加し、(2) out-of-scope を `legitimate` にカウントしないことで
+iteration round を消費させず、(3) out-of-scope 指摘を既存 excessive marker と同形の hidden
+marker でルーティングし、(4) Developer の構造化マーカー検出と (5) 指摘内容ベース no-progress
+早期打ち切りを加える。全体を 1 つの opt-in gate（既定 OFF / no-op）で囲う。
+
+> **分量バジェット注記**: 本機能は adjudicator.sh / pr-iteration.sh の 2 module 横断 + プロンプト
+> 2 種 + agents 2 種 + 状態機械（marker フィールド追加）変更のため複雑度「複雑」（目安 ≤600 行）に
+> 該当する。既存コードは `file:line` 参照に留め、契約（関数名・引数・戻り値）までで実装本文は
+> Developer に委ねることで分量を抑える。
+
+### Goals
+
+- Adjudicator が「正当だがスコープ外」を独立カテゴリ `out-of-scope` で分類できる（Req 1）
+- out-of-scope のみが残る PR で iteration round / `needs-iteration` を起動しない（Req 2）
+- out-of-scope 指摘を `needs-decisions` 既定経路へ追跡可能な形でルーティングする（Req 3）
+- Developer の out-of-scope 宣言を構造化マーカーで watcher が機械検出し打ち切る（Req 4）
+- 同一指摘の連続 out-of-scope を `max_rounds` 到達前に早期打ち切りする（Req 5）
+- Reviewer / Adjudicator プロンプトを明文化し design-level 指摘の impl reject 誤用を防ぐ（Req 6）
+- 全挙動を opt-in gate（既定 OFF）で囲い、無効時は導入前と完全に同一の no-op（NFR 1）
+
+### Non-Goals
+
+- adjudicator / Developer の具体モジュール分割の確定以外（codex Reviewer 自体の指摘生成ロジック変更）
+- フォローアップ Issue 自動起票（`spawn-issue` ルート）の本実装（env 値だけ予約し本 spec では未実装）
+- 既存 `PR_ITERATION_NO_PROGRESS_LIMIT`（既定 3 / SHA ベース）の数値・挙動変更
+- 既存 `legitimate` / `excessive` 二値経路の挙動変更（後方互換に保つ）
+- design / spec 還流先 Issue の自動本文生成テンプレート設計
+
+## Architecture
+
+### Existing Architecture Analysis
+
+- **adjudicator.sh（`adj_` prefix, 1216 行）**: codex 由来 finding を 1 PR 単位で裁定する。
+  `adj_classify_findings`（claude 呼び出し）→ `adj_validate_decisions`（schema 検証）→
+  `adj_apply_label_decision`（`legitimate` 件数で `needs-iteration` add/remove）→
+  `adj_apply_status_decision`（`claude-review` publish）→ `adj_post_decision_comment`
+  （summary + `excessive` 個別 marker 投稿）。`adj_run_for_pr` がオーケストレート。
+  出力 JSON schema は `{"decisions":[{verdict:"legitimate"|"excessive"},...],"summary":{total,legitimate,excessive}}`。
+- **pr-iteration.sh（`pi_` prefix, 1776 行）**: `needs-iteration` 付き PR を round 単位で再実装する。
+  finding 単位の追跡は持たず、**PR 単位の round / no-progress-streak（PR body hidden marker
+  `<!-- idd-claude:pr-iteration round=N last-run=... no-progress-streak=K -->` / SHA ベース）**で
+  制御する。adjudicator が投稿した `excessive` marker は `pi_general_filter_excessive`
+  （`local-watcher/bin/modules/pr-iteration.sh:293`）で iteration prompt から除外される。
+- **統合点**: adjudicator は pr-reviewer.sh の `pr_run_review_for_pr`
+  （`local-watcher/bin/modules/pr-reviewer.sh:1633`）から hook される。catch-up 経路は
+  `pr_catchup_should_defer_for_adjudicator`（同 :1909）で adjudicator 管轄を defer する。
+- **尊重すべき制約**: 既存 env var 名 / ラベル名 / commit status context 名 / exit code /
+  ログ書式を不変に保つ（CLAUDE.md 禁止事項）。`legitimate` / `excessive` consumer は壊さない。
+- **解消する technical debt**: 「正当だがスコープ外」が `legitimate` に丸められ round を空回り
+  させる構造（adjudicator の二値裁定 + pr-iteration の SHA-only no-progress 判定の組み合わせ）。
+
+### Architecture Pattern & Boundary Map
+
+**採用パターン**: 既存 marker-based filter pattern の踏襲（excessive marker → 第 2 marker
+out-of-scope）。新コンポーネントは投機的に作らず、責務が最も近い既存 module
+（adjudicator.sh / pr-iteration.sh）に同居させる（CLAUDE.md「機能追加ガイドライン §1」）。
+
+```mermaid
+flowchart TD
+  subgraph adjudicator.sh [adjudicator.sh adj_]
+    A1[adj_classify_findings\nclaude 3値分類] --> A2[adj_validate_decisions\nout-of-scope 許容]
+    A2 --> A3[adj_apply_label_decision\nlegitimate 件数のみで needs-iteration]
+    A2 --> A4[adj_post_decision_comment\nexcessive + out-of-scope marker 投稿]
+    A4 --> A5[adj_route_out_of_scope\nneeds-decisions ルーティング]
+  end
+  subgraph pr-iteration.sh [pr-iteration.sh pi_]
+    P1[pi_general_filter_oos\nout-of-scope marker 除外] --> P2[pi_run_iteration]
+    P2 --> P3[pi_detect_developer_oos_marker\nDeveloper 応答マーカー検出]
+    P3 --> P4[pi_oos_fingerprint / pi_next_oos_no_progress_streak\n内容ベース no-progress]
+    P4 --> P5{streak >= limit?}
+    P5 -->|yes| P6[pi_route_out_of_scope_escalate\nneeds-decisions]
+    P5 -->|no| P2
+  end
+  A4 -. excessive/oos marker .-> P1
+  A3 -. needs-iteration 解消 .-> P2
+```
+
+**Architecture Integration**:
+- 採用パターン: marker-based finding routing（既存 `pr-adjudicator-excessive` marker の隣に
+  `pr-adjudicator-out-of-scope` marker を追加。理由: pr-iteration が finding 単位の状態を
+  持たないため、marker を介した PR コメント = 状態保存先という既存設計を再利用するのが最小変更）。
+- ドメイン／機能境界: 裁定（adjudicator.sh）と反復制御（pr-iteration.sh）の責務分離を維持。
+  ルーティング（`needs-decisions` 付与）は両 module に重複させず、共通ヘルパとして
+  pr-iteration.sh 側に集約し adjudicator.sh から呼ぶ。
+- 既存パターンの維持: opt-in gate / 値正規化 case / marker prefix self-filter / fail-safe
+  （取得失敗は安全側）/ 観測ログ 1 行サマリ。
+- 新規コンポーネントの根拠: 新 module は作らない（投機的抽象化の排除 / 設計レビューゲート）。
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| CLI / Runtime | bash 4+ | watcher 本体・module | `set -euo pipefail` は本体側宣言 |
+| Backend / Services | claude CLI（adjudicator）| 3 値分類 prompt | `--permission-mode plan` 既存踏襲 |
+| Data / Storage | PR body hidden marker / PR コメント marker | round / streak / out-of-scope 状態 | 新規状態ファイルは作らず既存 marker を拡張 |
+| Messaging / Events | gh CLI（PR コメント / ラベル）| ルーティング・観測 | 既存 `needs-decisions` ラベル再利用 |
+| 外部 CLI | jq | finding JSON / fingerprint 算出 | 未信頼値は `--arg` / `--argjson` |
+
+## File Structure Plan
+
+### 変更ファイル（idd-claude 本体 / `local-watcher/` は repo-template にミラーされない）
+
+```
+local-watcher/bin/
+├── modules/
+│   ├── adjudicator.sh          # adj_: 3値分類対応 + out-of-scope marker 投稿 + ルーティング委譲
+│   └── pr-iteration.sh         # pi_: oos filter / Developer marker 検出 / 内容ベース no-progress / ルーティング
+├── adjudicator-prompt.tmpl     # 3値判定指針（out-of-scope 分類基準）を追記
+├── iteration-prompt.tmpl       # Developer 構造化マーカー出力指示を追記（impl 用）
+├── iteration-prompt-design.tmpl # 同上（design 用 / 整合のため）
+└── issue-watcher.sh            # 新 env gate の Config ブロック追加 + 正規化 + 起動ログ
+local-watcher/test/
+├── adjudicator_out_of_scope_test.sh        # 3値分類 / schema 検証 / marker 投稿
+├── pr_iteration_oos_routing_test.sh        # oos filter / round 非消費 / ルーティング / gate no-op
+└── pr_iteration_oos_no_progress_test.sh    # Developer marker 検出 / 内容ベース no-progress / fingerprint
+```
+
+### 変更ファイル（root ↔ repo-template byte 一致同期対象 / `.claude/{agents,rules}` のみ）
+
+```
+.claude/agents/reviewer.md       ↔ repo-template/.claude/agents/reviewer.md   # design-level 指摘を impl reject 理由にしない明文化
+.claude/agents/developer.md      ↔ repo-template/.claude/agents/developer.md  # out-of-scope 構造化マーカー宣言規約
+```
+
+### 同期対象外（明示）
+
+- `adjudicator-prompt.tmpl` / `iteration-prompt.tmpl` / `iteration-prompt-design.tmpl` は
+  `install.sh` 経由で `$HOME/bin/` へ配布される系統であり、**`repo-template/local-watcher/` という
+  パスは存在しない**（tasks-generation.md「idd-claude 特有の注意」）。byte 一致 diff 対象外。
+- `issue-watcher.sh` / `modules/*.sh` も同様に repo-template にミラーされない。
+- ラベル script（`idd-claude-labels.sh`）は `needs-decisions` を既に定義済み（行 66）のため変更不要。
+  新ラベルは新設しない（既存ラベル再利用）。
+- README.md は consumer 固有で byte 一致対象外だが、挙動変更の反映先として同一 PR で更新する。
+
+### Modified Files（要点）
+
+- `adjudicator.sh` — `verdict` enum に `out-of-scope` 追加。`adj_validate_decisions` / `summary`
+  集計 / `adj_apply_label_decision`（legitimate のみカウント）/ `adj_post_decision_comment`
+  （out-of-scope marker 投稿）/ `adj_run_for_pr`（gate 連動）を改修。新規 `adj_route_out_of_scope`。
+- `pr-iteration.sh` — 新規 `pi_general_filter_oos` / `pi_detect_developer_oos_marker` /
+  `pi_oos_fingerprint` / `pi_read_oos_no_progress_streak` / `pi_next_oos_no_progress_streak` /
+  `pi_route_out_of_scope_escalate`。`pi_write_marker` に `oos-no-progress-streak` フィールド追加。
+  `pi_collect_general_comments` の filter chain に oos 段を追加。`pi_run_iteration` に
+  Developer marker 検出 → 内容ベース no-progress 判定 → 早期打ち切りを配線。
+- `issue-watcher.sh` — `PR_ITERATION_OOS_ENABLED` / `PR_ITERATION_OOS_ROUTE` /
+  `PR_ITERATION_OOS_NO_PROGRESS_LIMIT` の Config + 正規化。起動ログへの追記。
+
+## Requirements Traceability
+
+| Requirement | Summary | Components | Tasks |
+|-------------|---------|------------|-------|
+| 1.1 | 3 値分類 | adjudicator-prompt.tmpl / adj_validate_decisions | 2, 3 |
+| 1.2 | spec 矛盾 → out-of-scope | adjudicator-prompt.tmpl | 2 |
+| 1.3 | 迷ったら legitimate | adjudicator-prompt.tmpl | 2 |
+| 1.4 | 分類根拠 reason | adjudicator-prompt.tmpl / adj_validate_decisions | 2, 3 |
+| 1.5 | out-of-scope 件数集計 | adj_validate_decisions / summary | 3 |
+| 2.1 | out-of-scope のみで round 起動しない | adj_apply_label_decision / pi_general_filter_oos | 3, 4 |
+| 2.2 | legitimate 残存で従来通り起動 | adj_apply_label_decision | 3 |
+| 2.3 | legitimate 件数に oos を含めない | adj_apply_label_decision / summary | 3 |
+| 2.4 | oos のみで needs-iteration 付与しない | adj_apply_label_decision | 3 |
+| 3.1 | 既定経路へルーティング | adj_route_out_of_scope / pi_route_out_of_scope_escalate | 5 |
+| 3.2 | needs-decisions エスカレート | pi_route_out_of_scope_escalate | 5 |
+| 3.3 | 内容・根拠を追跡可能に記録 | adj_post_decision_comment / pi_route_out_of_scope_escalate | 3, 5 |
+| 3.4 | ルーティング失敗で WARN（silent fail なし）| pi_route_out_of_scope_escalate | 5 |
+| 3.5 | 同一 PR・同一 SHA 重複ルーティングしない | pi_route_out_of_scope_escalate（marker 冪等）| 5 |
+| 4.1 | Developer 構造化マーカー出力 | iteration-prompt.tmpl / developer.md | 6, 7 |
+| 4.2 | watcher がマーカー検出 | pi_detect_developer_oos_marker | 7 |
+| 4.3 | マーカー検出で iteration 打ち切り + ルーティング | pi_run_iteration / pi_route_out_of_scope_escalate | 7 |
+| 4.4 | マーカーに矛盾根拠を併記 | iteration-prompt.tmpl / developer.md | 6 |
+| 4.5 | マーカー不在で従来通り進行 | pi_detect_developer_oos_marker / pi_run_iteration | 7 |
+| 5.1 | 連続 oos 回数を計数 | pi_oos_fingerprint / pi_next_oos_no_progress_streak | 8 |
+| 5.2 | 閾値到達で max_rounds 前に打ち切り | pi_run_iteration / pi_route_out_of_scope_escalate | 8 |
+| 5.3 | SHA 変化のみではリセットしない | pi_next_oos_no_progress_streak（fingerprint ベース）| 8 |
+| 5.4 | 早期打ち切り理由をログ記録 | pi_run_iteration（観測ログ）| 8 |
+| 5.5 | 指摘内容変化でリセット | pi_oos_fingerprint / pi_next_oos_no_progress_streak | 8 |
+| 6.1 | Adjudicator プロンプト明文化 | adjudicator-prompt.tmpl | 2 |
+| 6.2 | impl Reviewer 判定指針明文化 | reviewer.md | 9 |
+| 6.3 | 設計レベル指摘を 3 カテゴリ外として reject しない | reviewer.md | 9 |
+| 6.4 | root ↔ repo-template byte 一致反映 | reviewer.md / developer.md 両系統 | 9, 10 |
+| NFR 1.1 | gate 無効時 no-op | PR_ITERATION_OOS_ENABLED / 全関数 gate 連動 | 1, 全 |
+| NFR 1.2 | gate 不正値を安全側正規化 | issue-watcher.sh 正規化 case | 1 |
+| NFR 1.3 | 既存 env / ラベル / status / exit code / ログ / cron 不変 | 全 module | 1, 3 |
+| NFR 1.4 | legitimate/excessive 既存 schema 後方互換 | adj_validate_decisions | 3 |
+| NFR 2.1 | プロンプト / agents / rules を root↔repo-template byte 一致 | reviewer.md / developer.md | 9, 10 |
+| NFR 2.2 | 新挙動前提（ラベル等）を両系統反映 | 既存 needs-decisions 再利用（新ラベルなし）| 9, 10 |
+| NFR 3.1 | 未信頼値を quote / jq `--arg` | pi_* / adj_* 全関数 | 3, 7, 8 |
+| NFR 3.2 | 未信頼値に grep/git/gh `--` | pi_detect_developer_oos_marker 等 | 7 |
+| NFR 3.3 | PR番号 `^[0-9]+$` / SHA `^[0-9a-f]{7,40}$` 検証 | 全関数（既存踏襲）| 3, 5, 7, 8 |
+| NFR 4.1 | 早期打ち切り / ルーティングを 1 行機械抽出可能ログ | pi_run_iteration / adj_log | 5, 8 |
+
+## Components and Interfaces
+
+### Adjudicator Layer（adjudicator.sh / `adj_`）
+
+#### adj_validate_decisions（改修）
+
+| Field | Detail |
+|-------|--------|
+| Intent | 分類 JSON の schema 検証に `out-of-scope` verdict と summary 集計を後方互換に追加 |
+| Requirements | 1.1, 1.4, 1.5, 2.3, NFR 1.4 |
+
+**Responsibilities & Constraints**
+- gate ON 時のみ `verdict` enum を `{legitimate, excessive, out-of-scope}` の 3 値許容に拡張。
+  gate OFF 時は既存 2 値（`legitimate` / `excessive`）厳密一致を維持（`out-of-scope` を invalid
+  扱い → fallback で legitimate に倒れる / NFR 1.4）。
+- `summary` 検証式を `legitimate + excessive + out_of_scope == total` に拡張。gate OFF 時は
+  既存式 `legitimate + excessive == total` を維持。
+- データ所有権: 入力 JSON の妥当性のみを判定。値の生成は claude prompt 側。
+
+**Contracts**: Service [x]
+
+```text
+adj_validate_decisions(findings_json, decisions_json) -> rc
+  - Preconditions: findings_json は valid JSON 配列
+  - Postconditions: gate ON 時、out-of-scope を含む decisions も valid と判定可能
+  - Invariants: invalid 時は rc=1（呼び出し元が legitimate fallback に倒す / Req 1.3 徹底）
+```
+
+#### adj_apply_label_decision（改修）
+
+| Field | Detail |
+|-------|--------|
+| Intent | `legitimate` 件数のみで `needs-iteration` を add/remove（out-of-scope を数えない）|
+| Requirements | 2.1, 2.2, 2.3, 2.4 |
+
+**Responsibilities & Constraints**
+- 既存シグネチャ `adj_apply_label_decision(pr_number, legitimate_count)` を**変更しない**。
+  呼び出し元 `adj_run_for_pr` が `summary.legitimate`（out-of-scope を除外済みの値）を渡すため、
+  本関数は無改修で Req 2.3 / 2.4 を満たす。
+- out-of-scope のみ（legitimate=0）の PR では `--remove-label needs-iteration`（冪等）→ round
+  非消費（Req 2.1 / 2.4）。
+
+**Contracts**: Service [x]（既存契約維持）
+
+#### adj_post_decision_comment（改修）
+
+| Field | Detail |
+|-------|--------|
+| Intent | summary に out-of-scope 件数を追加し、out-of-scope finding 個別 marker を投稿 |
+| Requirements | 3.3, NFR 3.1 |
+
+**Responsibilities & Constraints**
+- gate ON かつ out-of-scope finding 存在時、`excessive` marker 投稿の隣で out-of-scope 個別
+  marker を投稿: `<!-- idd-claude:pr-adjudicator-out-of-scope id=<N> sha=<sha> -->`。
+- prefix `pr-adjudicator-out-of-scope` は既存 `pr-adjudicator-excessive` / `pr-iteration` の
+  いずれとも前方一致しない（self-filter 非衝突 / NFR 1.3 / 既存設計と整合）。
+- 未信頼値（reason / file / message）は jq `--arg` / `--argjson` でリテラル渡し。
+- summary コメント本文に `out-of-scope: <N>` 行を追加（gate OFF 時は従来通り 3 行 total/legit/excess）。
+
+**Contracts**: Service [x] / Event [x]（PR コメント marker 発行）
+
+#### adj_route_out_of_scope（新規）
+
+| Field | Detail |
+|-------|--------|
+| Intent | adjudicator 確定直後の out-of-scope finding を共通ルーティングヘルパへ委譲 |
+| Requirements | 3.1, 3.3 |
+
+**Dependencies**
+- Outbound: `pi_route_out_of_scope_escalate` — 実ルーティング処理（Criticality: High）
+- External: gh CLI — ラベル / コメント（Criticality: Medium）
+
+**Responsibilities & Constraints**
+- gate OFF / out-of-scope finding ゼロ時は即 return 0（no-op / NFR 1.1）。
+- ルーティングロジック本体は pr-iteration.sh の `pi_route_out_of_scope_escalate` に集約し、
+  adjudicator.sh からはそれを呼ぶ（重複実装回避 / 両 module が source 済み前提）。
+
+**Contracts**: Service [x]
+
+### PR Iteration Layer（pr-iteration.sh / `pi_`）
+
+#### pi_general_filter_oos（新規）
+
+| Field | Detail |
+|-------|--------|
+| Intent | adjudicator が out-of-scope と判定した指摘コメントを iteration prompt から除外 |
+| Requirements | 2.1, NFR 1.1 |
+
+**Responsibilities & Constraints**
+- 既存 `pi_general_filter_excessive`（:293）と同パターン。gate ON
+  （`PR_ITERATION_OOS_ENABLED=true`）時のみ comment.body 中の
+  `idd-claude:pr-adjudicator-out-of-scope` を含むコメントを除外、OFF 時は jq `.` で pass-through。
+- `pi_collect_general_comments` の filter chain を
+  `self → resolved → excessive → out-of-scope → event_style → truncate` の 6 段に拡張。
+  サマリログに `filtered_oos=<N>` を追加（観測可能性 / NFR 4.1）。
+
+**Contracts**: Service [x]
+
+#### pi_detect_developer_oos_marker（新規）
+
+| Field | Detail |
+|-------|--------|
+| Intent | Developer iteration 応答ログ本文から out-of-scope 構造化マーカーを機械検出 |
+| Requirements | 4.2, 4.5, NFR 3.1, NFR 3.2 |
+
+**Responsibilities & Constraints**
+- 入力: Developer 応答ログファイルパス（`$pi_log_file`）。marker 厳密書式（後述 Data Models）に
+  一致する行を `grep -E` で検出。未信頼入力（ログ本文）は変数 quote / `grep --` でオプション
+  打ち切り。検出したマーカーの種別語彙（`design` / `spec-stale`）を stdout に出力（不在なら空）。
+- 検出は読み取り専用・副作用なし。gate OFF 時は呼び出し元で skip（本関数自体も空返しで安全）。
+
+**Contracts**: Service [x]
+
+```text
+pi_detect_developer_oos_marker(log_file) -> stdout: "design"|"spec-stale"|""  (rc=0 固定)
+  - Preconditions: log_file は読み取り可能なテキスト（不在/不能は空返し fail-safe）
+  - Postconditions: 厳密書式に一致した最初のマーカー種別を返す
+  - Invariants: 許容語彙集合外のサフィックスは未検出扱い（空返し / 安全側）
+```
+
+#### pi_oos_fingerprint（新規 / 純粋関数）
+
+| Field | Detail |
+|-------|--------|
+| Intent | 指摘内容の同一性判定キー（fingerprint）を算出する |
+| Requirements | 5.1, 5.3, 5.5, NFR 3.1 |
+
+**Responsibilities & Constraints**
+- 入力: out-of-scope finding 群の JSON（adjudicator marker 由来 / general comments 由来の
+  集約）。各 finding の `severity` / `file` / `message` を正規化連結し sha256（または
+  `cksum` 等 watcher 環境で利用可能なハッシュ）で fingerprint 文字列を生成。
+- 「同じ design-level 矛盾を指している限り同一」を意図（requirements Open Question）。
+  SHA（head commit）には依存しない（Req 5.3）。内容が実質変化すれば fingerprint も変わる（Req 5.5）。
+- 純粋関数（副作用なし / グローバル参照なし）→ `extract_function` テストで隔離検証可能。
+
+**Contracts**: Service [x]
+
+#### pi_read_oos_no_progress_streak / pi_next_oos_no_progress_streak（新規）
+
+| Field | Detail |
+|-------|--------|
+| Intent | 内容ベース no-progress 連続カウンタの読み取り / 次値算出 |
+| Requirements | 5.1, 5.3, 5.5 |
+
+**Responsibilities & Constraints**
+- 既存 `pi_read_no_progress_streak`（:182, SHA ベース）/ `pi_next_no_progress_streak`（:1208）と
+  **独立**。状態は PR body marker の新フィールド `oos-no-progress-streak=K` + `oos-fingerprint=<H>`
+  に保存（後述 Data Models）。
+- `pi_next_oos_no_progress_streak(prev_fingerprint, current_fingerprint, prev_streak)`:
+  fingerprint 同一なら `prev_streak + 1`、異なれば `0`（Req 5.5 リセット / 純粋関数）。
+- 既存 SHA ベース streak は不変（数値・挙動変更しない / Non-Goal）。
+
+**Contracts**: Service [x]
+
+#### pi_route_out_of_scope_escalate（新規 / 共通ルーティングヘルパ）
+
+| Field | Detail |
+|-------|--------|
+| Intent | out-of-scope 指摘を `PR_ITERATION_OOS_ROUTE` 既定経路へルーティングする |
+| Requirements | 3.1, 3.2, 3.3, 3.4, 3.5, 5.2, NFR 3.3, NFR 4.1 |
+
+**Dependencies**
+- Inbound: `adj_route_out_of_scope`（adjudicator 経路）/ `pi_run_iteration`（Developer marker /
+  内容ベース no-progress 経路）— 2 経路から共通呼び出し
+- External: gh CLI — ラベル付与 / コメント投稿（Criticality: High）
+
+**Responsibilities & Constraints**
+- ルート解決: `PR_ITERATION_OOS_ROUTE` が `needs-decisions`（既定）→ `needs-iteration` 除去 +
+  `needs-decisions` 付与 + 追跡コメント投稿。`design-reflow` / `spawn-issue` は**未知値として
+  扱い `needs-decisions` に正規化**（本 spec では needs-decisions のみ実装。env 値は将来予約）。
+- 冪等性（Req 3.5）: 投稿コメントに hidden marker
+  `<!-- idd-claude:pr-iteration-oos-routed sha=<sha> -->` を付与し、同一 PR・同一 SHA で既存
+  marker 検出時は再ルーティングを skip。PR 番号 `^[0-9]+$` / SHA `^[0-9a-f]{7,40}$` を使用直前検証。
+- 失敗時（コメント / ラベル）は WARN を 1 行ログに残し silent fail しない（Req 3.4）。
+- 観測ログ: `PR #<n>: kind=<k> round=<r> reason=out-of-scope route=needs-decisions` を 1 行
+  機械抽出可能形式で出力（NFR 4.1）。
+
+**Contracts**: Service [x] / Event [x] / State [x]（needs-iteration → needs-decisions 遷移）
+
+#### pi_run_iteration（改修配線）
+
+| Field | Detail |
+|-------|--------|
+| Intent | Developer marker 検出 → 内容ベース no-progress 判定 → 早期打ち切りを round に配線 |
+| Requirements | 4.3, 5.2, 5.4 |
+
+**Responsibilities & Constraints**
+- gate OFF 時は本改修分を skip（既存 round フロー完全維持 / NFR 1.1）。
+- claude 実行後、`pi_detect_developer_oos_marker "$pi_log_file"` でマーカー検出 →
+  検出時は当該 round を finalize せず `pi_route_out_of_scope_escalate` へ引き渡し（Req 4.3）。
+- 同一 fingerprint の out-of-scope 回答が連続したら `oos-no-progress-streak` を加算し、
+  `>= PR_ITERATION_OOS_NO_PROGRESS_LIMIT`（既定 2）で `max_rounds` 到達前に早期打ち切り
+  （Req 5.2）。打ち切り理由（指摘内容ベース no-progress / 連続回数 / 閾値）を 1 行ログに記録（Req 5.4）。
+
+**Contracts**: State [x]（round outcome に out-of-scope-routed を追加）
+
+### Configuration（issue-watcher.sh Config ブロック）
+
+| env var | 既定値 | 正規化 | 役割 |
+|---------|--------|--------|------|
+| `PR_ITERATION_OOS_ENABLED` | `false` | `case true) :;; *) false`（厳密 `=true` のみ ON / 安全側 OFF）| 本機能全体の opt-in gate（NFR 1.1, 1.2）|
+| `PR_ITERATION_OOS_ROUTE` | `needs-decisions` | `case needs-decisions\|design-reflow\|spawn-issue) :;; *) needs-decisions`。本 spec では `design-reflow`/`spawn-issue` も実処理は `needs-decisions` に丸める | out-of-scope ルーティング先（Req 3.1, 3.2）|
+| `PR_ITERATION_OOS_NO_PROGRESS_LIMIT` | `2` | `case ''\|*[!0-9]*) 2`、`-lt 1` も `2` に正規化 | 内容ベース no-progress 閾値（Req 5.2）|
+
+**gate 関係（既存 gate との従属/独立）**:
+- `PR_ITERATION_OOS_ENABLED` は `PR_REVIEWER_ADJUDICATOR_ENABLED`（adjudicator 起動）/
+  `PR_ITERATION_ENABLED`（iteration 起動）とは**独立な追加 gate**。3 値分類・marker 投稿・
+  filter・ルーティング・Developer marker 検出・内容ベース no-progress の**全新挙動**を 1 つで囲う。
+- 実効動作には adjudicator 経路（out-of-scope marker 投稿）も iteration 経路（filter / 打ち切り）も
+  必要なため、`PR_ITERATION_OOS_ENABLED=true` でも `PR_REVIEWER_ADJUDICATOR_ENABLED=false`（既定 ON）/
+  `PR_ITERATION_ENABLED=false` の場合は当該経路の新挙動が部分的に no-op になる（既存 gate を
+  尊重し、本 gate が既存 gate を override しない / 後方互換）。design.md「確認事項」参照。
+- 既定 OFF（`false`）は CLAUDE.md「opt-in gate 鉄則」に従う。既存の `PR_REVIEWER_ADJUDICATOR_ENABLED`
+  / `DESIGN_REVIEWER_ENABLED` は既定 ON（opt-out）だが、それらは「既に main で稼働しデフォルト
+  false で配置された機能のデフォルト反転」（#112 / #412 / #432）であり、本機能は**新規導入**の
+  ため CLAUDE.md 禁止事項通り既定 OFF で導入する。
+
+## Data Models
+
+### 裁定 JSON スキーマの後方互換拡張
+
+gate ON 時、adjudicator-prompt.tmpl の出力契約 / `adj_validate_decisions` の検証を以下に拡張:
+
+```json
+{
+  "decisions": [
+    { "id": 1, "severity": "high|medium|low", "file": "...", "line": 42,
+      "verdict": "legitimate | excessive | out-of-scope",
+      "reason": "<日本語 200 字以内 / out-of-scope は矛盾する確定事項・AC・境界を明記>" }
+  ],
+  "summary": { "total": N, "legitimate": L, "excessive": E, "out_of_scope": O }
+}
+```
+
+- **後方互換**: gate OFF 時は `verdict` を 2 値（`legitimate`/`excessive`）厳密一致で検証し、
+  `summary` は既存 3 フィールド（total/legitimate/excessive）+ `legitimate+excessive==total`。
+  `out_of_scope` フィールドは gate OFF では出力させず・無視する（NFR 1.4）。
+- gate ON でも claude が `out-of-scope` を出さなければ既存 2 値経路と同一（safe degrade）。
+- fallback（`adj_synthesize_all_legitimate_decisions`）は全件 legitimate に倒すため
+  out-of-scope を生成しない（Req 1.3「迷ったら legitimate」と整合 / 既存挙動維持）。
+
+### PR body hidden marker（状態永続化先）
+
+CLAUDE.md §6（状態は `$HOME/.issue-watcher/` か既存 marker）に従い、**新規状態ファイルは
+作らず既存 PR body marker を後方互換に拡張**する。既存:
+
+```
+<!-- idd-claude:pr-iteration round=N last-run=ISO8601 no-progress-streak=K -->
+```
+
+拡張後（gate ON 時のみ追記。OFF 時は既存 4 フィールドのまま）:
+
+```
+<!-- idd-claude:pr-iteration round=N last-run=ISO8601 no-progress-streak=K oos-no-progress-streak=J oos-fingerprint=<H> -->
+```
+
+- `pi_write_marker`（:486）の sed 置換正規表現を `[^>]*` で末尾まで貪欲に食う既存方式のまま
+  拡張（旧フォーマット marker も同一 regex で吸収 / 既存 no-progress-streak 追加時と同手法）。
+- `oos-fingerprint=<H>`: 直前 round の out-of-scope 指摘 fingerprint。次 round で同一性を比較。
+- gate OFF の PR では本 2 フィールドを書き込まない（既存 marker と byte 互換 / NFR 1.3）。
+
+### PR コメント hidden marker（ルーティング・filter キー）
+
+| marker | 発行者 | 用途 |
+|--------|--------|------|
+| `<!-- idd-claude:pr-adjudicator-out-of-scope id=<N> sha=<sha> -->` | adj_post_decision_comment | out-of-scope finding 個別 marker（filter / fingerprint キー）|
+| `<!-- idd-claude:pr-iteration-oos-routed sha=<sha> -->` | pi_route_out_of_scope_escalate | ルーティング冪等性（Req 3.5）|
+
+### Developer 構造化マーカー書式
+
+- **厳密書式（正規表現）**: `^OUT-OF-SCOPE:[[:space:]]+(design|spec-stale)[[:space:]]*$`
+  （行頭一致 / 許容語彙集合 `{design, spec-stale}` のみ / 前後空白許容）。
+- 許容語彙集合外（例: `OUT-OF-SCOPE: foo`）は未検出扱い（安全側 = 従来 round 進行 / Req 4.5）。
+- iteration-prompt.tmpl / developer.md で「マーカー出力時はどの確定事項・どの AC と矛盾するかを
+  同じ応答本文に併記」を指示（Req 4.4）。
+- watcher 側パーサ（`pi_detect_developer_oos_marker`）は未信頼入力（Developer 応答ログ）を
+  変数 quote + `grep -E --` で処理（NFR 3.1 / 3.2）。
+
+## Error Handling
+
+### Error Strategy
+
+全新挙動は fail-safe（情報取得不能・処理失敗時は安全側 = 既存挙動 or no-op に倒す）を貫く。
+gate OFF / 不正値は最初に正規化で OFF へ丸める（NFR 1.1 / 1.2）。
+
+### Error Categories and Responses
+
+- **User Errors（運用設定）**: env gate の不正値・typo・空 → 正規化 case で安全側（OFF / 既定
+  ルート / 既定閾値）に丸める（NFR 1.2）。
+- **System Errors（外部 CLI 失敗）**:
+  - adjudicator claude 失敗 → 既存 fallback（`passthrough` / `legitimate`）に倒す。out-of-scope は
+    生成されない（既存挙動維持）。
+  - ルーティング（gh コメント / ラベル）失敗 → WARN 1 行 + silent fail なし（Req 3.4）。
+  - PR body / コメント取得失敗 → out-of-scope 状態を 0 扱い（誤った早期打ち切りを防ぐ安全側）。
+- **Business Logic Errors（schema 不整合）**: `adj_validate_decisions` invalid → 全件 legitimate
+  fallback（Req 1.3 徹底 / 既存経路）。
+
+## Testing Strategy
+
+- **Unit Tests（純粋関数 / `extract_function` 隔離）**:
+  1. `pi_oos_fingerprint`: 同一 severity/file/message で同一 fingerprint、message 変化で別 fingerprint
+  2. `pi_next_oos_no_progress_streak`: fingerprint 同一で +1、変化で 0 リセット（Req 5.3 / 5.5）
+  3. `pi_detect_developer_oos_marker`: `design` / `spec-stale` 検出、語彙外は空、マーカー不在は空（Req 4.2 / 4.5）
+  4. `adj_validate_decisions`: gate ON で out-of-scope verdict + `legit+excess+oos==total` を valid
+  5. gate OFF で `out-of-scope` verdict を invalid 判定（→ legitimate fallback / NFR 1.4）
+- **Integration Tests（gh / git stub + 呼び出しトレース）**:
+  1. out-of-scope のみの PR で `needs-iteration` が付与されない（Req 2.1 / 2.4 / `adj_apply_label_decision`）
+  2. `pi_general_filter_oos`: gate ON で oos marker 除外、OFF で pass-through（Req 2.1 / NFR 1.1）
+  3. `pi_route_out_of_scope_escalate`: 同一 sha 2 回呼び出しで 2 回目 skip（冪等 / Req 3.5）
+  4. ルーティング gh 失敗で WARN ログ出力 + 非 silent（Req 3.4）
+  5. Developer marker 検出 → round finalize せずルーティング（Req 4.3）
+- **後方互換 Tests（gate no-op）**:
+  1. `PR_ITERATION_OOS_ENABLED` 未設定/空/`True`/`1`/typo がすべて `false` に正規化（NFR 1.2）
+  2. gate OFF で marker 拡張なし・filter chain pass-through・既存 marker byte 互換（NFR 1.1 / 1.3）
+  3. `PR_ITERATION_OOS_ROUTE` 未知値が `needs-decisions` に正規化、`PR_ITERATION_OOS_NO_PROGRESS_LIMIT`
+     非数値が `2` に正規化
+
+## Security Considerations
+
+- **未信頼入力（NFR 3）**: Developer 応答ログ・PR コメント本文・finding message は未信頼 GitHub
+  入力。変数は常時 quote、`jq` へは `--arg` / `--argjson` でリテラル渡し（filter inline 展開禁止）、
+  `grep` / `git` / `gh` へは `--` でオプション解釈打ち切り。
+- **ID 検証（NFR 3.3）**: PR 番号 `^[0-9]+$`、SHA `^[0-9a-f]{7,40}$` を path / URL / git revision
+  使用直前に検証（既存 adj_* / pi_* の hardening 踏襲）。
+- **read-only invariant**: adjudicator claude は `--permission-mode plan`（既存）。本変更は
+  read-only 検査経路を変更しない。
+
+## リスクと緩和
+
+| リスク | 緩和 |
+|--------|------|
+| 既存 legitimate/excessive consumer の破壊 | gate OFF で schema・marker・filter を完全 byte 互換に保つ。gate ON でも claude が oos を出さなければ既存経路と同一 |
+| out-of-scope 誤分類で正当指摘を取りこぼし | adjudicator-prompt の「迷ったら legitimate」原則を out-of-scope にも適用（Req 1.3）。out-of-scope は破棄せず needs-decisions へ追跡（Req 3） |
+| 内容ベース no-progress の fingerprint 衝突 | severity/file/message 連結ハッシュで粒度確保。誤って同一視しても max_rounds で最終的に救済（既存 fallback 残存）|
+| 2 経路（adjudicator / Developer marker）の二重ルーティング | 同一 sha marker `pr-iteration-oos-routed` で冪等化（Req 3.5）|
+| adjudicator / iteration gate 不一致での部分 no-op | 「確認事項」に明記。既存 gate を override しない設計（後方互換優先）|
+
+## 確認事項（requirements 確定事項との関係 / 独自解釈を避けるための明示）
+
+1. **gate 構成（独立追加 gate）**: 本設計は `PR_ITERATION_OOS_ENABLED`（既定 OFF）を
+   `PR_REVIEWER_ADJUDICATOR_ENABLED` / `PR_ITERATION_ENABLED` から**独立**な追加 gate とした
+   （NFR 1.1 後方互換最優先）。実効動作には adjudicator（marker 投稿）と iteration（filter /
+   打ち切り）の両経路が必要なため、片方の既存 gate が OFF の環境では新挙動が部分 no-op になる。
+   要件は「1 つ（または最小数）の env gate」を求めており（Issue 論点 2）、本設計は 1 gate で
+   全新挙動を囲う一方、既存 gate の上書きはしない解釈を採った。運用者が両既存 gate を維持
+   （既定 ON / opt-out）している限り問題は生じないが、明示確認を要する。
+2. **ルーティング先の段階導入**: requirements 推奨 `needs-decisions` を既定とし、`spawn-issue`
+   （Issue 自動起票 = 外部副作用）は env 値だけ予約して本 spec では未実装（`needs-decisions` に
+   丸める）とした（Issue 論点 1 / Non-Goal）。`design-reflow`（設計フェーズ還流）も同様に
+   本 spec では `needs-decisions` 扱い。将来別 opt-in で段階導入する想定。
+3. **fingerprint ハッシュ手段**: watcher 環境で確実に利用可能なハッシュ（`sha256sum` /
+   `cksum` 等）を Developer が選定する。一次情報確認不要（idd-claude 内部完結 / 標準 coreutils）。

--- a/docs/specs/437-pr-iteration-pr-design-spec-max-rounds/requirements.md
+++ b/docs/specs/437-pr-iteration-pr-design-spec-max-rounds/requirements.md
@@ -1,0 +1,142 @@
+# Requirements Document
+
+## Introduction
+
+PR Iteration / PR Reviewer + Adjudicator は、codex 由来のレビュー指摘を裁定し、`needs-iteration`
+ラベルと iteration round を駆動する。しかし「正当だが当該 PR タイプのスコープ外（design.md /
+spec の変更が必要で、impl PR では規約上それらを書き換えられない）」な指摘が出ると、裁定が
+legitimate のまま round が空回りし、`max_rounds` 消尽でしか終われず、実装が scope 完結している
+PR でも `claude-failed` に落ちる構造的問題がある（ドッグフーディング実例: ae-mdm PR #51）。
+本要件は、(1) Adjudicator に第 3 判定 out-of-scope を導入し、(2) Developer の out-of-scope 宣言を
+構造化シグナル化し、(3) 指摘内容ベースの no-progress 早期打ち切りを加え、(4) これら全体を既存
+opt-in 鉄則の下で後方互換に導入することを定義する。実装方針・モジュール分割・関数設計は本書では
+扱わず、Architect の design.md に委ねる。
+
+## 関連
+
+- Related: #404
+- Related: #122
+- Related: #397
+
+## Requirements
+
+### Requirement 1: Adjudicator の第 3 判定カテゴリ（out-of-scope）
+
+**Objective:** As a watcher 運用者, I want Adjudicator が「正当だが当該 PR スコープ外」な指摘を独立カテゴリで分類できること, so that 設計変更が必要な正当指摘で impl PR が無限反復せず適切な経路へ還流できる
+
+#### Acceptance Criteria
+
+1. When Adjudicator が 1 件の指摘を裁定するとき, the Adjudicator は当該指摘を `legitimate` / `excessive` / `out-of-scope` の 3 値のいずれか 1 つに分類する
+2. Where 指摘が当該 PR の requirements.md / design.md の確定事項と矛盾し当該 PR タイプでは対処できない設計・spec 変更を要求しているとき, the Adjudicator は当該指摘を `out-of-scope` に分類する
+3. If 指摘が `out-of-scope` か `legitimate` かで判定に確信が持てないとき, the Adjudicator は当該指摘を `legitimate` に分類する
+4. The Adjudicator は各指摘の分類に対し、分類根拠（どの確定事項・どの AC・どの境界に矛盾するか）を含む reason を出力する
+5. When Adjudicator が裁定結果を出力するとき, the Adjudicator は `out-of-scope` 件数を集計値として出力に含める
+
+### Requirement 2: out-of-scope 指摘が iteration round を消費しないこと
+
+**Objective:** As a watcher 運用者, I want out-of-scope と裁定された指摘が impl iteration の round を消費しないこと, so that 無駄な反復 round とトークンコストを発生させずに済む
+
+#### Acceptance Criteria
+
+1. When ある PR の全 legitimate 指摘が解消され残る指摘が `out-of-scope` のみになったとき, the PR Iteration Processor は当該 PR に対する新しい impl iteration round を起動しない
+2. While 1 件以上の `legitimate` 指摘が残っているとき, the PR Iteration Processor は従来どおり iteration round を起動する
+3. When Adjudicator が `needs-iteration` ラベルの付与可否を確定するとき, the Adjudicator は `out-of-scope` 件数を `legitimate` 件数として数えない
+4. If ある PR の指摘が `out-of-scope` のみ（`legitimate` ゼロ）であるとき, the Adjudicator は `needs-iteration` ラベルを付与しない
+
+### Requirement 3: out-of-scope 指摘のルーティング
+
+**Objective:** As a watcher 運用者, I want out-of-scope と裁定された指摘が放置されず明示された経路へルーティングされること, so that 設計変更が必要な正当指摘が失われず適切に追跡される
+
+#### Acceptance Criteria
+
+1. When ある PR で `out-of-scope` 指摘が確定したとき, the PR Iteration Processor は当該指摘を「設計フェーズ還流」「フォローアップ Issue 起票」「人間への needs-decisions エスカレート」のいずれか 1 つの既定経路へルーティングする
+2. Where 既定ルーティング先が `needs-decisions`（推奨デフォルト）に設定されているとき, the PR Iteration Processor は当該 Issue / PR に対し人間判断を促すエスカレーションを行う
+3. When `out-of-scope` 指摘をルーティングするとき, the PR Iteration Processor は当該指摘の内容・分類根拠を人間が追跡できる形（PR コメントまたはログ）で記録する
+4. If `out-of-scope` 指摘のルーティング操作（コメント投稿 / ラベル付与）が失敗したとき, the PR Iteration Processor は WARN をログに残し silent fail しない
+5. The PR Iteration Processor は同一 PR・同一 SHA に対する同一 out-of-scope ルーティングを重複実行しない
+
+### Requirement 4: Developer の out-of-scope 宣言の構造化シグナル
+
+**Objective:** As a watcher 運用者, I want Developer が「当該指摘は当該 PR のスコープ外」と判断したことを構造化マーカーで宣言できること, so that watcher がそれを機械的に検出して反復を打ち切れる
+
+#### Acceptance Criteria
+
+1. When Developer が iteration round で「指摘が design.md / spec 確定事項と矛盾し当該 PR では対処不能」と判断したとき, the Developer は応答本文に構造化マーカー（例: `OUT-OF-SCOPE: design` / `OUT-OF-SCOPE: spec-stale`）を出力する
+2. When PR Iteration Processor が Developer 応答本文を解析するとき, the PR Iteration Processor は当該構造化マーカーの有無を検出する
+3. If PR Iteration Processor が Developer 応答に out-of-scope 構造化マーカーを検出したとき, the PR Iteration Processor は当該指摘に対する iteration を打ち切り、Requirement 3 のルーティング経路へ引き渡す
+4. The Developer は構造化マーカーを出力する際に、どの確定事項・どの AC と矛盾するかの根拠を同じ応答本文に併記する
+5. If Developer 応答に out-of-scope 構造化マーカーが存在しないとき, the PR Iteration Processor は従来どおりの round 進行判定を行う
+
+### Requirement 5: 指摘内容ベースの no-progress 早期打ち切り
+
+**Objective:** As a watcher 運用者, I want 同一の design-level 指摘が連続して堂々巡りする状況を max_rounds 到達前に検出して打ち切れること, so that 同一指摘の反復で max_rounds まで走り切る無駄を削減できる
+
+#### Acceptance Criteria
+
+1. When 同一指摘が連続する round で `legitimate` かつ Developer が out-of-scope 回答を返し続けているとき, the PR Iteration Processor は当該連続回数を round ごとに計数する
+2. If 指摘内容ベースの no-progress 連続回数が閾値（推奨デフォルト 2 round）以上に達したとき, the PR Iteration Processor は `max_rounds` 到達前に当該指摘の iteration を打ち切り、Requirement 3 のルーティング経路へエスカレートする
+3. While head branch に新規 commit が積まれても指摘内容が同一で Developer 回答が out-of-scope のままであるとき, the PR Iteration Processor は SHA 変化のみを理由に no-progress カウンタをリセットしない
+4. When 指摘内容ベースの no-progress により早期打ち切りを行ったとき, the PR Iteration Processor は打ち切り理由（指摘内容ベース no-progress / 連続回数 / 閾値）をログに記録する
+5. If 指摘内容が round 間で実質的に変化したとき, the PR Iteration Processor は指摘内容ベースの no-progress 連続回数をリセットする
+
+### Requirement 6: Reviewer / Adjudicator プロンプトの明文化
+
+**Objective:** As a watcher 運用者, I want 「design.md の確定事項と矛盾する強化要件は impl PR の reject 理由にしない」が明文化されていること, so that impl Reviewer / Adjudicator が design-level 指摘を impl PR の失敗理由に誤用しない
+
+#### Acceptance Criteria
+
+1. The Adjudicator プロンプトは「requirements.md / design.md の確定事項と矛盾し当該 PR タイプでは対処不能な強化要件は `out-of-scope` に分類する」旨の判定指針を含む
+2. The impl Reviewer の判定指針は「design.md の確定事項と矛盾する設計レベル指摘を impl PR の reject 理由にしない（設計 iteration / 別 Issue へ回す）」旨を含む
+3. Where impl Reviewer が設計レベル指摘を検出したとき, the impl Reviewer は当該指摘を AC 未カバー / missing test / boundary 逸脱の 3 カテゴリのいずれにも該当しないものとして reject 理由にしない
+4. The Reviewer / Adjudicator のプロンプト明文化は、idd-claude / consumer repo の双方で参照される文言として root と repo-template の双方に同一内容で反映される
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性・opt-in gate
+
+1. Where 新挙動（out-of-scope 分類 / 構造化マーカー検出 / 内容ベース no-progress）が env gate で opt-in されていないとき, the watcher は本機能導入前と完全に同一の挙動（no-op）を維持する
+2. If 新挙動の opt-in gate に未設定・空・不正値・typo が与えられたとき, the watcher は当該 gate を安全側（無効）に正規化する
+3. The watcher は本機能導入時に既存の env var 名・既存ラベル名・既存 commit status context 名・既存 exit code の意味・既存ログ書式・既存 cron 登録文字列のいずれも変更しない
+4. Where 既存の `legitimate` / `excessive` 二値裁定経路を前提とする既存挙動が opt-in 無効のとき, the watcher は当該経路の出力スキーマ（裁定結果の既存フィールド）を後方互換に保つ
+
+### NFR 2: 二重管理同期
+
+1. The Reviewer / Adjudicator / Developer プロンプトおよび agents / rules への変更は、root と repo-template の対応物に byte 一致で反映される
+2. Where consumer repo に配布される workflow / labels に新挙動の前提（新ラベル等）が追加されるとき, the watcher は当該追加を root と repo-template の双方へ反映する
+
+### NFR 3: セキュリティ（未信頼入力の取り扱い）
+
+1. When PR Iteration Processor が PR コメント本文・Developer 応答本文（未信頼 GitHub 入力）を解析するとき, the PR Iteration Processor は変数展開をクォートし、`jq` へ渡す未信頼値は `--arg` / `--argjson` でリテラル渡しする
+2. When PR Iteration Processor が未信頼値を `grep` / `git` / `gh` に渡すとき, the PR Iteration Processor は `--` でオプション解釈を打ち切る
+3. When PR Iteration Processor が PR 番号・SHA を path / URL / git revision に使うとき, the PR Iteration Processor は PR 番号を `^[0-9]+$`、SHA を `^[0-9a-f]{7,40}$` で使用直前に検証する
+
+### NFR 4: 可観測性
+
+1. When 新挙動により iteration を早期打ち切りまたはルーティングしたとき, the watcher は PR 番号・kind・round・打ち切り理由を 1 行で機械抽出可能なログとして出力する
+
+## Out of Scope
+
+- Adjudicator / Reviewer / Developer の具体的なモジュール分割・関数シグネチャ・env var 名の確定（design.md の領分）
+- out-of-scope 構造化マーカーの厳密な文字列書式・正規表現の確定（design.md の領分。本書は例示に留める）
+- design / spec 還流先 Issue の自動本文生成テンプレートの詳細設計
+- codex Reviewer 自体の指摘生成ロジックの変更（本書は裁定・反復制御のみを対象とする）
+- 既存 alias 表記で書かれた過去 Issue の canonical 記法への retrofit
+- max_rounds / no-progress-streak 既存カウンタの数値デフォルト変更（本書は内容ベース no-progress を**追加**するもので既存カウンタの値は変更しない）
+- 2-branch promote pipeline / merge queue 等、本 Issue と独立した既存 opt-in 機能の挙動変更
+
+## Open Questions
+
+- out-of-scope 裁定指摘の**既定ルーティング先**を「設計フェーズ還流」「フォローアップ Issue 起票」「needs-decisions エスカレート」のどれにするか。本書は推奨デフォルトとして **needs-decisions エスカレート**（人間判断・最も安全側・不可逆操作を伴わない）を採用して AC を記述した（Requirement 3.2）。フォローアップ Issue 自動起票は外部副作用（Issue 量産リスク）を伴うため、opt-in での段階導入が望ましい。最終確定は Architect / 人間レビューに委ねる。
+- 指摘内容ベース no-progress 早期打ち切りの **N round 閾値**。本書は推奨デフォルト **2 round**（PR #51 で 2-3 round 短縮可能との Issue 記述に基づく）を採用して AC を記述した（Requirement 5.2）。既存の `PR_ITERATION_NO_PROGRESS_LIMIT`（既定 3）との関係（独立カウンタか統合か）は design.md で確定する。
+- 「指摘内容が実質的に変化したか」の判定粒度（Requirement 5.5）。完全一致か、severity/file/message の主要フィールド一致かは design.md の領分だが、ビジネス観点では「同じ design-level 矛盾を指している限り同一とみなす」ことを意図している。
+- out-of-scope 構造化マーカーの語彙集合（`design` / `spec-stale` 以外に必要な種別があるか）。本書は Issue 本文の例示 2 種を採用したが、運用上の不足は Open Question として残す。
+
+---
+
+## 自己レビュー結果（要件レビューゲート）
+
+- Mechanical Checks: 全要件見出しが numeric ID（Requirement 1〜6 / NFR 1〜4）。各要件に EARS 形式 AC（When / If / While / Where / The <subject> shall）が 1 件以上存在。実装語彙（DB 名・フレームワーク名・API パターン・関数名・env var 名）は AC 本文に混入させず、例示（マーカー文字列・env 名）は Out of Scope / Open Questions の補足に留めた。
+- EARS・テスト可能性: 全 AC が observable / testable。閾値は数値化（no-progress 2 round / SHA 検証パターン）。曖昧語は具体化済み。
+- スコープ・カバレッジ: Issue 必須論点 8 点を Requirement 1〜6 + NFR 1〜4 に対応付け（1=第3判定 / 2=round 非消費 / 3=ルーティング / 4=構造化シグナル / 5=内容ベース no-progress / 6=プロンプト明文化 / NFR1=opt-in後方互換 / NFR2=二重管理 / NFR3=セキュリティ）。
+- 既存整合: 既存の legitimate/excessive 二値裁定（adjudicator.sh / adjudicator-prompt.tmpl）、no-progress-streak が SHA 変化でリセットされる既存挙動（pr-iteration.sh）、iteration-prompt.tmpl の「設計と矛盾する指摘は取り込まない」運用と矛盾しないことを確認。後方互換は NFR 1 で担保。
+- 残存曖昧性は Open Questions に推奨デフォルト付きで列挙し、AC は推奨デフォルト採用形で記述。レビューは 1 パスで確定。

--- a/docs/specs/437-pr-iteration-pr-design-spec-max-rounds/tasks.md
+++ b/docs/specs/437-pr-iteration-pr-design-spec-max-rounds/tasks.md
@@ -1,0 +1,121 @@
+# Implementation Plan
+
+- [ ] 1. opt-in gate の Config ブロック追加と値正規化
+  - `local-watcher/bin/issue-watcher.sh` の Config ブロックに 3 env を追加する
+  - `PR_ITERATION_OOS_ENABLED`（既定 `false`、`case true) :;; *) false` で厳密 `=true` のみ ON / 安全側 OFF）
+  - `PR_ITERATION_OOS_ROUTE`（既定 `needs-decisions`、`needs-decisions|design-reflow|spawn-issue` 以外は `needs-decisions` に正規化）
+  - `PR_ITERATION_OOS_NO_PROGRESS_LIMIT`（既定 `2`、非数値 / `-lt 1` は `2` に正規化）
+  - 起動ログ行（issue-watcher.sh:1564 付近）に `oos-enabled=${PR_ITERATION_OOS_ENABLED}` を追記
+  - 既存 env var 名 / ラベル名 / commit status context / exit code / cron 文字列を一切変更しない
+  - `local-watcher/test/pr_iteration_oos_routing_test.sh` に正規化マトリクステストを追加（未設定/空/`True`/`1`/typo → `false`、未知 route → `needs-decisions`、非数値 limit → `2`）。`pr_reviewer_adjudicator_default_on_test.sh` の正規化コピーイディオムを踏襲
+  - _Requirements: NFR 1.1, NFR 1.2, NFR 1.3_
+
+- [ ] 2. Adjudicator / Reviewer プロンプトの out-of-scope 判定指針を明文化
+- [ ] 2.1 adjudicator-prompt.tmpl に第 3 判定 out-of-scope を追記
+  - `local-watcher/bin/adjudicator-prompt.tmpl` の分類基準に out-of-scope シグナルを追加
+  - 「requirements.md / design.md の確定事項と矛盾し当該 PR タイプでは対処不能な強化要件は `out-of-scope` に分類」を明記（Req 1.2 / 6.1）
+  - 「確信が持てなければ legitimate」原則を out-of-scope にも適用（Req 1.3）
+  - reason に矛盾する確定事項・AC・境界を明記する指示（Req 1.4）
+  - 出力契約 JSON の `verdict` を 3 値 + `summary.out_of_scope` 追加（Data Models と byte 一致）
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 6.1_
+- [ ] 2.2 iteration-prompt.tmpl / iteration-prompt-design.tmpl に Developer 構造化マーカー出力指示を追記
+  - `local-watcher/bin/iteration-prompt.tmpl` と `iteration-prompt-design.tmpl` の「設計と矛盾するレビュー指摘」節を構造化マーカー出力指示に拡張
+  - マーカー厳密書式 `OUT-OF-SCOPE: design` / `OUT-OF-SCOPE: spec-stale`（許容語彙集合明示）を出力する条件と書式を記述（Req 4.1）
+  - マーカー出力時にどの確定事項・どの AC と矛盾するかを同応答本文に併記する指示（Req 4.4）
+  - _Requirements: 4.1, 4.4_
+
+- [ ] 3. adjudicator.sh の 3 値分類対応（schema 検証 / label / comment）
+  - `local-watcher/bin/modules/adjudicator.sh` の `adj_validate_decisions` を gate ON 時 3 値許容に拡張（gate OFF は既存 2 値厳密一致 / `legit+excess+oos==total` vs 既存 `legit+excess==total`）
+  - `adj_run_for_pr` の summary 抽出に `out_of_scope` を追加し、`adj_apply_label_decision` には `summary.legitimate`（oos 除外値）を渡す（Req 2.1〜2.4。既存 `adj_apply_label_decision` シグネチャは不変）
+  - `adj_post_decision_comment` の summary 本文に `out-of-scope` 件数行を追加し、out-of-scope finding 個別 marker `<!-- idd-claude:pr-adjudicator-out-of-scope id=<N> sha=<sha> -->` を投稿（Req 3.3。未信頼値は jq `--arg`/`--argjson`）
+  - gate OFF 時は schema / summary / marker をすべて既存 byte 互換に保つ（NFR 1.3 / 1.4）
+  - `local-watcher/test/adjudicator_out_of_scope_test.sh` を新規追加: gate ON で out-of-scope verdict + summary 整合を valid 判定、gate OFF で out-of-scope を invalid 判定（→ legitimate fallback / NFR 1.4）、legitimate 件数に oos を含めないこと、out-of-scope marker 投稿の gh 呼び出しトレース
+  - _Requirements: 1.1, 1.4, 1.5, 2.1, 2.2, 2.3, 2.4, 3.3, NFR 1.3, NFR 1.4, NFR 3.1, NFR 3.3_
+  - _Boundary: adjudicator.sh, adj_validate_decisions, adj_run_for_pr, adj_apply_label_decision, adj_post_decision_comment_
+
+- [ ] 4. pi_general_filter_oos による out-of-scope コメント除外 (P)
+  - `local-watcher/bin/modules/pr-iteration.sh` に `pi_general_filter_oos` を新規追加（`pi_general_filter_excessive`:293 と同パターン。gate ON で `idd-claude:pr-adjudicator-out-of-scope` 含むコメント除外、OFF で jq `.` pass-through）
+  - `pi_collect_general_comments` の filter chain を `self → resolved → excessive → out-of-scope → event_style → truncate` の 6 段に拡張し、サマリログに `filtered_oos=<N>` を追加（NFR 4.1）
+  - gate OFF 時は filter chain が既存件数挙動と完全一致することを保証（NFR 1.1）
+  - `local-watcher/test/pr_iteration_oos_routing_test.sh` に追加: gate ON で oos marker コメント除外、gate OFF で pass-through（件数不変）、`filtered_oos` ログ出力の検証
+  - _Requirements: 2.1, NFR 1.1, NFR 3.1_
+  - _Boundary: pr-iteration.sh, pi_general_filter_oos, pi_collect_general_comments_
+  - _Depends: 1_
+
+- [ ] 5. out-of-scope ルーティング共通ヘルパ pi_route_out_of_scope_escalate
+  - `local-watcher/bin/modules/pr-iteration.sh` に `pi_route_out_of_scope_escalate` を新規追加
+  - `PR_ITERATION_OOS_ROUTE` 解決（`needs-decisions` 既定、`design-reflow`/`spawn-issue` は本 spec では `needs-decisions` に丸める / Req 3.1, 3.2）
+  - `needs-iteration` 除去 + `needs-decisions` 付与 + 追跡コメント（内容・分類根拠を含む）投稿（Req 3.2, 3.3）
+  - 冪等 marker `<!-- idd-claude:pr-iteration-oos-routed sha=<sha> -->` を付与し、同一 PR・同一 SHA で既存検出時は再ルーティング skip（Req 3.5）
+  - PR 番号 `^[0-9]+$` / SHA `^[0-9a-f]{7,40}$` を使用直前検証、gh へ `--` 付与（NFR 3.3）
+  - ラベル / コメント投稿失敗時は WARN 1 行 + silent fail なし（Req 3.4）
+  - 1 行機械抽出可能ログ `reason=out-of-scope route=needs-decisions` を出力（NFR 4.1）
+  - `local-watcher/bin/modules/adjudicator.sh` に `adj_route_out_of_scope` を新規追加し本ヘルパへ委譲（gate OFF / oos ゼロで no-op）
+  - `pr_iteration_oos_routing_test.sh` に追加: 同一 sha 2 回呼び出しで 2 回目 skip（冪等 / Req 3.5）、gh コメント失敗で WARN 非 silent（Req 3.4 failure path）、ルートログ出力、未知 route が needs-decisions に丸まる safety fallback
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, NFR 3.1, NFR 3.3, NFR 4.1_
+  - _Boundary: pr-iteration.sh, pi_route_out_of_scope_escalate, adjudicator.sh, adj_route_out_of_scope_
+  - _Depends: 1_
+
+- [ ] 6. Developer 構造化マーカー検出 pi_detect_developer_oos_marker (P)
+  - `local-watcher/bin/modules/pr-iteration.sh` に `pi_detect_developer_oos_marker` を新規追加
+  - 厳密書式 `^OUT-OF-SCOPE:[[:space:]]+(design|spec-stale)[[:space:]]*$` を `grep -E` で検出、語彙集合外 / 不在は空返し（安全側 / Req 4.2, 4.5）
+  - 入力（Developer 応答ログ）は変数 quote + `grep --` でオプション打ち切り（NFR 3.2）。read-only / fail-safe（ログ不在・不能は空返し）
+  - `local-watcher/test/pr_iteration_oos_no_progress_test.sh` を新規追加: `design` / `spec-stale` 検出、`OUT-OF-SCOPE: foo`（語彙外）は空、マーカー不在は空、未信頼入力（`-` 始まり等）の安全処理を `extract_function` 隔離で検証
+  - _Requirements: 4.2, 4.5, NFR 3.1, NFR 3.2_
+  - _Boundary: pr-iteration.sh, pi_detect_developer_oos_marker_
+  - _Depends: 1_
+
+- [ ] 7. 内容ベース no-progress 判定（fingerprint / streak / marker 永続化）(P)
+  - `local-watcher/bin/modules/pr-iteration.sh` に純粋関数 `pi_oos_fingerprint`（severity/file/message 連結ハッシュ。SHA 非依存 / Req 5.3）を追加
+  - `pi_read_oos_no_progress_streak`（PR body marker `oos-no-progress-streak=K` / `oos-fingerprint=<H>` 読み取り。既存 `pi_read_no_progress_streak`:182 と独立）を追加
+  - `pi_next_oos_no_progress_streak`（fingerprint 同一で +1、変化で 0 リセット / Req 5.1, 5.5。純粋関数）を追加
+  - `pi_write_marker`:486 を gate ON 時のみ `oos-no-progress-streak` / `oos-fingerprint` 追記に拡張（既存 sed `[^>]*` 方式で旧 marker 吸収 / gate OFF は byte 互換 / NFR 1.3）
+  - `pr_iteration_oos_no_progress_test.sh` に追加: 同一 severity/file/message で同一 fingerprint、message 変化で別 fingerprint、fingerprint 同一で streak +1、変化で 0 リセット（Req 5.3 / 5.5 regression）、gate OFF で marker が既存 4 フィールドのまま（NFR 1.3）
+  - _Requirements: 5.1, 5.3, 5.5, NFR 1.3, NFR 3.1_
+  - _Boundary: pr-iteration.sh, pi_oos_fingerprint, pi_read_oos_no_progress_streak, pi_next_oos_no_progress_streak, pi_write_marker_
+  - _Depends: 1_
+
+- [ ] 8. pi_run_iteration への配線（Developer marker 打ち切り / 内容ベース早期打ち切り）
+  - `local-watcher/bin/modules/pr-iteration.sh` の `pi_run_iteration`:1231 に gate ON 時のみの分岐を配線
+  - claude 実行後 `pi_detect_developer_oos_marker "$pi_log_file"` 検出時、当該 round を finalize せず `pi_route_out_of_scope_escalate` へ引き渡し（Req 4.3）
+  - 同一 fingerprint の out-of-scope 連続を `pi_next_oos_no_progress_streak` で加算し、`>= PR_ITERATION_OOS_NO_PROGRESS_LIMIT`（既定 2）で `max_rounds` 到達前に早期打ち切り + ルーティング（Req 5.2）
+  - 打ち切り理由（指摘内容ベース no-progress / 連続回数 / 閾値）を 1 行機械抽出可能ログに記録（Req 5.4 / NFR 4.1）
+  - gate OFF 時は本分岐を完全 skip（既存 round フロー byte 互換 / NFR 1.1）
+  - `pr_iteration_oos_no_progress_test.sh` に追加: Developer marker 検出 → round finalize せずルーティング呼び出し（Req 4.3）、streak 閾値到達で max_rounds 前に打ち切り + ルートログ（Req 5.2 / 5.4 failure path）、gate OFF で既存フロー不変（NFR 1.1 regression）。gh / git は stub して呼び出しトレースで検証
+  - _Requirements: 4.3, 5.2, 5.4, NFR 1.1, NFR 4.1_
+  - _Boundary: pr-iteration.sh, pi_run_iteration_
+  - _Depends: 5, 6, 7_
+
+- [ ] 9. impl Reviewer プロンプト明文化 + root↔repo-template 同期
+  - `.claude/agents/reviewer.md` の「reject しない条件」節に「design.md の確定事項と矛盾する設計レベル指摘を impl PR の reject 理由にしない（設計 iteration / 別 Issue へ回す）」を明記（Req 6.2）
+  - 設計レベル指摘を AC 未カバー / missing test / boundary 逸脱の 3 カテゴリのいずれにも該当しないものとして reject しないことを明記（Req 6.3）
+  - `repo-template/.claude/agents/reviewer.md` に byte 一致で同一内容を反映（Req 6.4 / NFR 2.1）
+  - 反映後に `diff -r .claude/agents repo-template/.claude/agents` が空であることを確認
+  - _Requirements: 6.2, 6.3, 6.4, NFR 2.1, NFR 2.2_
+  - _Boundary: reviewer.md_
+
+- [ ] 10. Developer プロンプト明文化 + README 反映 + 全体検証
+  - `.claude/agents/developer.md` の「PR Iteration」関連節に out-of-scope 構造化マーカー宣言規約（`OUT-OF-SCOPE: design` / `OUT-OF-SCOPE: spec-stale` の書式・出力条件・矛盾根拠併記）を追記（Req 4.1, 4.4）
+  - `repo-template/.claude/agents/developer.md` に byte 一致で反映し `diff -r .claude/agents repo-template/.claude/agents` が空であることを確認（NFR 2.1）
+  - `README.md` のオプション機能一覧 / PR Iteration 節に `PR_ITERATION_OOS_ENABLED`（既定 OFF / opt-in）と 3 env、out-of-scope ルーティング挙動を追記（CLAUDE.md 二重管理鉄則）
+  - `shellcheck local-watcher/bin/modules/*.sh local-watcher/bin/issue-watcher.sh` / `bash -n` でクリーンを確認
+  - _Requirements: 4.1, 4.4, NFR 2.1, NFR 2.2_
+  - _Boundary: developer.md_
+  - _Depends: 9_
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを宣言する。
+`local-watcher/` は repo-template にミラーされないため、同期 diff は `.claude/{agents,rules}`
+のみを対象とする（tasks-generation.md「idd-claude 特有の注意」準拠）。
+
+<!-- stage-a-verify -->
+```sh
+shellcheck local-watcher/bin/modules/adjudicator.sh local-watcher/bin/modules/pr-iteration.sh local-watcher/bin/issue-watcher.sh &&
+  bash -n local-watcher/bin/modules/adjudicator.sh &&
+  bash -n local-watcher/bin/modules/pr-iteration.sh &&
+  bash local-watcher/test/adjudicator_out_of_scope_test.sh &&
+  bash local-watcher/test/pr_iteration_oos_routing_test.sh &&
+  bash local-watcher/test/pr_iteration_oos_no_progress_test.sh &&
+  diff -r .claude/agents repo-template/.claude/agents
+```


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用** です。実装コードは含まれません。
`docs/specs/437-pr-iteration-pr-design-spec-max-rounds/` 配下の requirements / design / tasks を merge するためのゲートです。

impl PR の Adjudicator が「正当だが当該 PR スコープ外（design.md / spec の変更を要求しており impl PR では規約上書き換え不可）」な指摘で収束できず、`max_rounds` 消尽でしか終われず `claude-failed` に落ちる構造問題を解消するための設計です。実装は本 PR に含まれず、merge 後に Developer が別 PR で実装します。

## 対応 Issue

Refs #437

## 含まれる成果物

- `docs/specs/437-pr-iteration-pr-design-spec-max-rounds/requirements.md` — 要件定義（PM 成果物）
- `docs/specs/437-pr-iteration-pr-design-spec-max-rounds/design.md` — 設計書（Architect 成果物）
- `docs/specs/437-pr-iteration-pr-design-spec-max-rounds/tasks.md` — 実装タスク分割

## 関連 Issue / PR

<!-- 関連する Issue / PR を Refs 形式で列挙してください。Closes / Fixes / Resolves は使わないこと -->
<!-- 例: Refs #42 (先行する設計議論)、Refs #50 (関連する仕様変更 PR) -->
<!-- 関連項目が無い場合は「なし」と記載してください -->

なし

## 解決の 4 本柱

1. **Adjudicator 第 3 判定 `out-of-scope` 追加**: 既存の `legitimate` / `excessive` 二値に `out-of-scope` を後方互換に追加。out-of-scope は legitimate にカウントせず iteration round を消費しない。
2. **out-of-scope ルーティング**: `needs-decisions` 既定経路へ追跡コメント + 冪等 marker でルーティング。`spawn-issue` / `design-reflow` は env 値だけ予約し本 spec では `needs-decisions` に丸める段階導入。
3. **Developer 構造化マーカー検出**: 構造化マーカー（`OUT-OF-SCOPE: design` / `OUT-OF-SCOPE: spec-stale`）を Developer が出力し、watcher が機械検出して打ち切り。
4. **指摘内容ベース no-progress 早期打ち切り**: fingerprint（severity/file/message のハッシュ）ベースで同一指摘の連続を検出し、既定 2 round で `max_rounds` 到達前に打ち切り（SHA 非依存）。
5. **reviewer.md / adjudicator プロンプトの明文化**: design 確定事項と矛盾する強化要件を impl reject 理由にしないことを明文化。

## 後方互換 / opt-in

全新挙動を `PR_ITERATION_OOS_ENABLED`（既定 `false` / no-op）で囲い、不正値は安全側に正規化する。既存 env var 名・ラベル名・exit code・ログ書式を変更しない。root ↔ repo-template（reviewer.md / developer.md）は byte 一致同期。

## レビュー観点

- requirements.md の FR / NFR / AC に過不足はないか
- design.md のモジュール構成・公開 IF が FR をカバーしているか
- 既存コードの再利用が検討されているか、重複実装が混じっていないか
- tasks.md の分割粒度が独立コミット可能か

## 設計上の確認事項（人間レビュー要点）

1. **gate 構成（独立追加 gate）**: `PR_ITERATION_OOS_ENABLED` を `PR_REVIEWER_ADJUDICATOR_ENABLED` / `PR_ITERATION_ENABLED` から独立な追加 gate とした（後方互換最優先）。実効動作には adjudicator（marker 投稿）と iteration（filter / 打ち切り）の両経路が必要なため、片方の既存 gate が OFF の環境では新挙動が部分 no-op になる点の確認を要する（本設計は 1 gate で全新挙動を囲い、既存 gate を override しない解釈を採用）。
2. **ルーティング段階導入**: `spawn-issue`（Issue 自動起票 = 外部副作用）/ `design-reflow` は env 値だけ予約し本 spec では未実装（`needs-decisions` に丸める）とした判断の確認。将来別 opt-in で段階導入する想定。
3. **fingerprint ハッシュ手段**: watcher 環境で確実に利用可能なハッシュ（`sha256sum` / `cksum` 等 標準 coreutils）を Developer が選定する。一次情報確認不要（idd-claude 内部完結）。
4. **requirements.md の Open Questions 採用判断**: out-of-scope 既定ルーティング先 = `needs-decisions` 採用 / no-progress 閾値 = 2 round 採用が妥当かの確認。

## 次のステップ

- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回ポーリングで Developer が自動起動し、実装 PR が別途作られます
- 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
- やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください

## 確認事項

base: main / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から `awaiting-design-review` ラベルを外すと実装が自動開始します。
