### PR TITLE
fix(#447): stale-pickup-reaper が残骸 slot lock を live session と誤判定する不具合を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4646,8 +4646,11 @@ Failed Recovery が Issue 単位の通算 attempt budget を持つのに対し�
    `flock -n -x` を試行し、いずれの slot も保持されていない（保持されている slot が 1 つでも
    あれば「アクティブの可能性あり」へ倒す）
 3. **watcher セッション不在**: slot ロックを保持していた pid を `fuser` / `lsof` で取得し、
-   `kill -0 <pid>` で現存確認。pid 取得不能 / OS 差で観測手段が無い場合は「セッション存在の
-   可能性あり」へ倒す（保守的 fallback）
+   `kill -0 <pid>` で現存確認。観測手段（`fuser` / `lsof`）が**双方とも不在**で判定不能な場合のみ
+   「セッション存在の可能性あり」へ倒す（保守的 fallback）。一方、観測手段は利用可能なのに lock file の
+   **保持 pid が空**（= 誰も掴んでいない残骸 lock）だった場合は「保持なし」として扱い、生存 session とは
+   みなさない（#447: 残骸 slot lock を live session と誤判定して `claude-claimed` ゾンビを 45min 閾値
+   超過後も永久 keep してしまう不具合の修正）
 
 **判定根拠取得失敗時は「アクティブの可能性あり」へ倒す** 保守的 fallback を全関数で徹底し、
 誤検出による進行中作業の喪失を構造的に防ぎます（Req 3.4）。判定根拠（age / lock / session）は

--- a/local-watcher/bin/modules/stale-pickup-reaper.sh
+++ b/local-watcher/bin/modules/stale-pickup-reaper.sh
@@ -432,12 +432,18 @@ sr_check_slot_lock() {
 #
 # Args: $1 = marker_json (将来拡張用 / 現状未使用)
 # Returns:
-#   0 = no session detected (lock file 不在 / 全 pid が非生存)
-#   1 = session may be alive (1 件でも pid 生存 / fuser & lsof 不在で判定不能含む safe-side)
+#   0 = no session detected (lock file 不在 / 全 pid が非生存 / 保持 pid の無い残骸 lock のみ)
+#   1 = session may be alive (1 件でも pid 生存 / fuser & lsof 双方不在で判定不能の safe-side)
 #
 # 副作用なし（pid 取得・生存確認のみ）。Linux は `fuser`、macOS は `lsof -t` で
 # lock file 保持 pid を取得し、`kill -0 <pid>` で生存確認する。fuser / lsof どちらも
 # 不在の環境では Req 3.4 の safe-side として rc=1 を返す。
+#
+# #447: pid 取得手段（fuser / lsof）が利用可能であることは per-file ループの前に確認済み。
+# その上で lock file の保持 pid が空だった場合は「誰も掴んでいない残骸 lock（stale）」であり、
+# 生存 session ではない。safe-side（rc=1）に倒すと 45min 閾値を超えても reap されず
+# `claude-claimed` ゾンビが永久 keep されるため、残骸 lock は「保持なし」として次の
+# lock file 検査へ continue する（safe-side は fuser/lsof 双方不在の場合に限定）。
 sr_check_session() {
   # 将来拡張用に引数を受け取るが本実装では未参照（SC2034 を `:` 参照で意図的に抑止）
   local _marker_json="${1:-}"
@@ -482,11 +488,11 @@ sr_check_session() {
     esac
 
     if [ -z "$pids" ]; then
-      # この lock file からは pid を取得できなかった → safe-side で「保持の可能性あり」
-      # （他 lock file で生存 pid を見つけても結論変わらないので即 return しない / 累積判定）
-      # ただし lock file が存在する以上、pid 取得自体ができないのは Req 3.4 の対象として
-      # safe-side 寄りに倒す。次の lock file 検査を続けるが、ここで return 1 しても良い。
-      return 1
+      # #447: pid 取得手段は利用可能（上の command -v で確認済み）なのに保持 pid が空
+      # = この lock file は誰も掴んでいない残骸（stale lock）。生存 session ではないので
+      # 「保持あり（safe-side）」に倒さず、次の lock file 検査へ進む。全 lock file が残骸 /
+      # 全 pid 非生存なら末尾で rc=0（no session）を返し、reaper が 45min 閾値で reap できる。
+      continue
     fi
 
     for pid in $pids; do

--- a/local-watcher/test/stale_pickup_reaper_test.sh
+++ b/local-watcher/test/stale_pickup_reaper_test.sh
@@ -1048,12 +1048,29 @@ else
   assert_rc "Req 3.1 観点 3: 99999 (不在 pid) で rc=0 (no session)" 0 sr_check_session '{}'
 fi
 
-# ── 10d: fuser stub が空文字を返す（pid 取得失敗） → rc=1 (safe-side / Req 3.4) ──
+# ── 10d: fuser stub が空文字を返す（保持 pid 無し = 残骸 lock） → rc=0 (no session / #447) ──
+# #447 回帰: fuser / lsof が利用可能（本 stub 経路）なのに保持 pid が空なのは
+# 「誰も掴んでいない残骸 lock」であり、生存 session ではない。safe-side（rc=1）に倒すと
+# 45min 閾値を超えても reap されず claude-claimed ゾンビが永久 keep されるバグを防ぐ。
 # shellcheck disable=SC2317
 fuser() {
   echo ""
 }
-assert_rc "Req 3.4: pid 取得失敗（空 fuser 出力）で rc=1 (safe-side)" 1 sr_check_session '{}'
+assert_rc "#447: 保持 pid 無しの残骸 lock（空 fuser 出力）で rc=0 (no session / 要 reap)" 0 sr_check_session '{}'
+
+# ── 10d-2: lock file 2 件のうち 1 件が残骸（空）・もう 1 件が生存 pid → rc=1 (session may be alive) ──
+# 残骸 lock を continue でスキップしても、他 lock に生存 pid があれば正しく alive 判定されること。
+touch "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-2.lock"
+# shellcheck disable=SC2317
+fuser() {
+  # slot-1 は空（残骸）、slot-2 は自プロセス pid（生存）を返す
+  case "$1" in
+    *slot-2.lock) echo "$$" ;;
+    *) echo "" ;;
+  esac
+}
+assert_rc "#447: 残骸 lock + 生存 lock 混在で rc=1 (生存 session を優先検出)" 1 sr_check_session '{}'
+rm -f "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-2.lock"
 
 # ── 10e: fuser / lsof どちらも不在 → rc=1 (safe-side / Req 3.4) ──
 # fuser / lsof を unset し、command -v が両方 fail する状態を作る


### PR DESCRIPTION
## 概要

`sr_check_session`（stale-pickup-reaper.sh）が、**保持プロセスの無い残骸 slot lock file を
「live session の可能性あり」と safe-side 誤判定**し、`claude-claimed` / `claude-picked-up` の
ゾンビ Issue を 45min 閾値を超えても永久に keep する不具合を修正する。

実地観測: ae-mdm #39 / #40（2026-06-29）。`stale-pickup: issue=#39 keep age=0 lock=0 sess=1`
が 2.5 時間毎 tick 出続け reap されなかった。

## 根本原因

`sr_check_session` は per-file ループの前に `fuser` / `lsof` の利用可否を確認している。にもかかわらず、
ループ内で保持 pid が空（`pids=""`）だった場合に `return 1`（safe-side「保持の可能性あり」）へ
倒していた。pid 取得手段が利用可能なのに保持 pid が空なのは「誰も掴んでいない残骸 lock」であり、
生存 session ではない。この誤判定で `sess=1` が固定化し、3 観点 AND（age==0 && lock==0 && sess==0）
が永久に成立せず reap されなかった。

## 修正

- 空 `pids`（利用可能な観測手段で保持 pid ゼロ）を **残骸 lock** とみなし、`return 1` ではなく
  `continue` で次の lock file 検査へ進める。全 lock file が残骸 / 全 pid 非生存なら末尾で
  `rc=0`（no session）を返し、reaper が閾値で reap できる。
- safe-side（`rc=1`）は **`fuser` / `lsof` 双方不在で判定不能** な場合に限定（Req 3.4 の本来の意図）。

## テスト

- `stale_pickup_reaper_test.sh` の 10d を是正: 空 fuser 出力 → **rc=0（no session / 要 reap）**。
  旧 assert（rc=1）は本不具合の挙動を固定化していたため、修正後の正しい契約へ追従（assert を
  緩める変更ではなく、バグ修正に伴う契約是正）。
- 残骸 lock + 生存 lock 混在で生存 session を優先検出する 10d-2 を追加（continue で残骸を飛ばしても
  他 lock の生存 pid を取りこぼさないことの回帰）。
- reaper テスト全体 **194/194 PASS**（既存 sr_is_active 8 通り AND 判定含む）、`shellcheck` /
  `bash -n` クリーン。

## 確認事項

- 本 module（`local-watcher/bin/modules/`）は repo-template にミラーされないため byte 同期対象外。
- 挙動変更を README「Stale Pickup Reaper」節の観測点 3 に同一 PR で反映済み。

Closes #447