### PR TITLE
test(watcher): qa_run_claude_stage_test.sh の REPO 未定義 set -u クラッシュを修正 (#481)

### DIFF
--- a/local-watcher/test/qa_run_claude_stage_test.sh
+++ b/local-watcher/test/qa_run_claude_stage_test.sh
@@ -55,6 +55,14 @@ LOG="$TMPDIR_TEST/test.log"
 export LOG
 trap 'rm -rf "$TMPDIR_TEST"' EXIT
 
+# 抽出した qa_log / qa_warn / qa_error（core_utils.sh）は log 行の prefix として `[$REPO]` を
+# 無条件参照する。本テストは `set -euo pipefail`（-u）で走るため、REPO 未定義のままだと
+# opt-in ケースの qa_run_claude_stage → qa_log 呼び出しで "REPO: unbound variable" になり停止する。
+# 他テスト（full_auto_enabled_test.sh 等）と同じく fixture 値を定義しておく。
+# 参照は eval で読み込んだ qa_log 内にあり shellcheck からは見えないため SC2034 を局所抑止。
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+
 # 必要な関数だけを抽出して eval で読み込む。
 extract_function() {
   local script="$1"


### PR DESCRIPTION
## 概要

Fixes #481。`qa_run_claude_stage_test.sh` が `REPO` 未定義のため `set -u` 下で **opt-in ケース全 RED**（`REPO: unbound variable` で即停止）だったのを、fixture 値 `REPO` の定義で解消する。**テストのみの変更**（本番コード不変）。

## 根本原因

- テストは `set -euo pipefail`（`-u` 有効）で走る。
- 抽出した `qa_log`（`modules/core_utils.sh`）は `echo "[...] [$REPO] quota-aware: $*"` と `$REPO` を無条件参照。
- テストは `REPO` を定義していないため、`QUOTA_AWARE_ENABLED=true` の opt-in ケースで `qa_run_claude_stage` → `qa_log` 到達時に unbound variable でクラッシュ。

> 関数の抽出元は #416 で `core_utils.sh` / `quota-aware.sh` を探索するよう修正済み（stale 抽出ではない）。純粋に config 変数の未定義。

## 変更

`REPO="owner/test-repo"` を LOG セットアップ直後に定義（`full_auto_enabled_test.sh` 等と同イディオム）。eval 経由で shellcheck から見えない参照のため SC2034 を局所抑止。

## 検証

- ✅ `bash local-watcher/test/qa_run_claude_stage_test.sh`: **PASS=34 / FAIL=0**（修正前は header 1 行で exit 1）
- ✅ `shellcheck`: 警告ゼロ / `bash -n` OK
- ✅ 全 95 テスト: 本修正で qa は green 化、新規 RED なし

## 備考

- #460（Config 分離）とは無関係の pre-existing 不具合。PR #480 の「確認事項」で切り出しを予告済み。base=main の独立 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
