### PR TITLE
fix(watcher): pr_publish_claude_status の #434 ガードが gate OFF 時に gh を呼ぶ問題を修正 (#482)

### DIFF
--- a/local-watcher/bin/modules/pr-reviewer.sh
+++ b/local-watcher/bin/modules/pr-reviewer.sh
@@ -1287,7 +1287,14 @@ pr_publish_claude_status() {
   # （pr_publish_claude_status_from_branch → pr_publish_claude_status）も自動的に
   # fail-closed 化される（Req 3.1〜3.4）。reject（failure）は gate を閉じる方向なので
   # terminal でもそのまま publish する（ガードは success 経路のみ / Req 3.5）。
-  if [ "$state" = "success" ]; then
+  #
+  # Issue #482 / #349 Req 6.1: status-check gate（PR_REVIEWER_STATUS_CHECK_ENABLED AND
+  # FULL_AUTO_ENABLED）OFF 時は、本 #434 ガードの `gh pr view` も含め外部呼び出しをゼロに保つ。
+  # gate OFF なら後段 pr_publish_commit_status が publish 自体を抑止（return 1）するため、
+  # publish を前提とする terminal ラベル再取得はそもそも不要。gate ON 時のみ本ガードを実行する
+  # ことで、#434 の fail-closed 安全性（success を publish する直前の terminal 判定）は publish が
+  # 実際に走る gate ON 経路で完全に保たれる。
+  if [ "$state" = "success" ] && pr_status_check_enabled; then
     # Req 4.1: 現在のラベル集合を再取得して terminal 判定する。
     local cur_labels_json gh_rc=0
     cur_labels_json=$(timeout "${PR_REVIEWER_GIT_TIMEOUT:-120}" \

--- a/local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
+++ b/local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
@@ -133,6 +133,12 @@ gh() {
   return 0
 }
 
+# Issue #482: #434 terminal ラベルガードは publish 有効時（status-check gate ON）のみ発火する。
+# 本テストは gate ON 前提でガード挙動を検証するため、gate 判定を enabled 固定に stub する
+# （gate OFF 時の inert 挙動は pr_publish_commit_status_test.sh Req 6.1 側で検証）。
+# shellcheck disable=SC2317
+pr_status_check_enabled() { return 0; }
+
 # pr_publish_commit_status stub: 呼び出しと引数を記録（実 publish が走ったかの観測）
 # shellcheck disable=SC2317
 pr_publish_commit_status() {


### PR DESCRIPTION
## 概要

Fixes #482。`pr_publish_claude_status` の **#434 terminal ラベル fail-closed ガードが status-check gate 判定より前に `gh pr view` を呼ぶ**ため、gate OFF 時でも gh を 1 回呼び、#349 Req 6.1「gate OFF なら外部呼び出しゼロ」（`pr_publish_commit_status_test.sh`）を破っていたのを修正する。

## 根本原因（#434 と #349 の要件衝突）

- **#349 Req 6.1**: status-check gate OFF なら publish 系関数は外部呼び出しゼロで inert（当リポジトリの opt-in 原則）。codex 版はこれを満たす。
- **#434 Defect B**: `pr_publish_claude_status` は approve(success) の publish 直前に terminal ラベル（`claude-failed`/`needs-decisions`）を再取得する `gh pr view`（`pr-reviewer.sh`）を呼ぶが、これが gate 判定（後段 `pr_publish_commit_status` 内）**より前**にある。
- 結果: gate OFF + approve で gate を見る前に `gh pr view` が 1 回走り Req 6.1 に反する。後発 #434 が先発 #349 の不変条件を claude 経路で破った状態。

## 設計判断

**#349 の「gate OFF → 完全 inert」を優先**。gate OFF 時は後段 `pr_publish_commit_status` が publish 自体を抑止する（`return 1`）ため、**publish を前提とする #434 terminal ラベル再取得はそもそも不要**。gate ON（＝実際に publish する）時のみガードを動かせば #434 の fail-closed 安全性は完全に保たれる。

> 代替案（#349 Req 6.1 を「gh 1 回」に緩める）は opt-in inert 原則を弱めるため非採用。**安全側ガードの発火条件に触れる変更のため、この設計判断の妥当性をレビューで確認いただきたい。**

## 変更

1. **`pr-reviewer.sh`**: ガード発火条件を `if [ "$state" = "success" ] && pr_status_check_enabled; then` に（gate ON 時のみ terminal ラベル再取得）。
2. **`pr_reviewer_claude_status_fail_closed_test.sh`**（#434 テスト / gate 未設定でガードに依存する唯一のテスト）: 本テストは publish 有効時のガード挙動を検証するため `pr_status_check_enabled() { return 0; }` を stub 追加（gate ON 固定）。gate OFF 時の inert 挙動は `pr_publish_commit_status_test.sh` Req 6.1 が担保。

## 検証

- ✅ `pr_publish_commit_status_test.sh`（#349 Req 6.1 claude）: **GREEN**（修正前 RED）
- ✅ `pr_reviewer_claude_status_fail_closed_test.sh`（#434 全 Section: terminal skip / 通常 publish / fail-open）: **GREEN 維持**
- ✅ `bash -n` OK / `shellcheck`（pr-reviewer.sh・当該テスト）警告ゼロ
- ✅ 全 95 テスト: 本 PR で新規 RED なし（別 Issue #481 の qa は本 PR 対象外）

## 備考

- #460（Config 分離）とは無関係の pre-existing 不具合。PR #480 の「確認事項」で切り出しを予告済み。base=main の独立 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
