### PR TITLE
refactor(test): extract_function / assert 共通ヘルパーを test/lib/ へ集約し全テストを移行

### DIFF
--- a/local-watcher/test/adj_classify_test.sh
+++ b/local-watcher/test/adj_classify_test.sh
@@ -33,6 +33,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 
 if [ ! -f "$ADJ_SH" ]; then
@@ -48,16 +51,6 @@ adj_warn() {
 }
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$ADJ_SH" "adj_classify_findings")"
 # shellcheck disable=SC1090,SC2086
@@ -75,21 +68,6 @@ export REPO="test/test"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── stub claude PATH 戦略 ───
 # stub claude を PATH 先頭の tempdir に置き、`claude --output-format json ...` 呼び出しを

--- a/local-watcher/test/adj_extract_findings_test.sh
+++ b/local-watcher/test/adj_extract_findings_test.sh
@@ -22,6 +22,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 
 if [ ! -f "$ADJ_SH" ]; then
@@ -39,16 +42,6 @@ adj_warn() {
 }
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$ADJ_SH" "adj_extract_findings")"
 
@@ -62,21 +55,6 @@ export REPO="test/test"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── ケース (1): 空 ───
 

--- a/local-watcher/test/adj_integration_no_op_test.sh
+++ b/local-watcher/test/adj_integration_no_op_test.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
 
@@ -41,16 +44,6 @@ if [ ! -f "$PR_MOD" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # adj_run_for_pr が依存する関数群を adjudicator.sh から抽出。
 # gate OFF 経路では adj_gate_enabled の rc=1 で即 return するため、後続関数は呼ばれない
 # 前提だが、関数定義としては読み込んでおき、stub で副作用を捕捉可能にしておく。
@@ -78,21 +71,6 @@ done
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_file_empty() {
   local label="$1"

--- a/local-watcher/test/adj_oos_prompt_test.sh
+++ b/local-watcher/test/adj_oos_prompt_test.sh
@@ -30,6 +30,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 TMPL="$SCRIPT_DIR/../bin/adjudicator-prompt.tmpl"
 
@@ -82,18 +85,6 @@ assert_not_contains() {
     FAIL_COUNT=$((FAIL_COUNT + 1))
   else
     echo "PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
-  fi
-}
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
   fi
 }
 

--- a/local-watcher/test/adj_out_of_scope_test.sh
+++ b/local-watcher/test/adj_out_of_scope_test.sh
@@ -30,6 +30,9 @@ set -euo pipefail
 # PR_ITERATION_OOS_ENABLED / PR_REVIEWER_OOS_ROUTE_LABEL / REPO 等は抽出関数本体から参照される。
 # shellcheck disable=SC2034
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 
 if [ ! -f "$ADJ_SH" ]; then
@@ -38,16 +41,6 @@ if [ ! -f "$ADJ_SH" ]; then
 fi
 
 # 既存テストと同じ extract_function イディオム。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$ADJ_SH" "adj_oos_enabled")"
 # shellcheck disable=SC1090,SC2086
@@ -77,31 +70,6 @@ PR_REVIEWER_OOS_ROUTE_LABEL="needs-decisions"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1" haystack="$2" needle="$3"
-  case "$haystack" in
-    *"$needle"*) echo "PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1" haystack="$2" needle="$3"

--- a/local-watcher/test/adj_publish_decision_test.sh
+++ b/local-watcher/test/adj_publish_decision_test.sh
@@ -55,6 +55,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer-publish.sh"
 
@@ -68,16 +71,6 @@ if [ ! -f "$PR_MOD" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # adjudicator.sh から 4 関数を抽出（adj_apply_status_decision は pr_publish_claude_status を
 # 呼ぶため、pr_publish_claude_status / pr_publish_commit_status / pr_status_check_enabled も
 # pr-reviewer-publish.sh から抽出して同一プロセスに読み込む / #470 で pr-reviewer.sh から移動）。
@@ -116,39 +109,6 @@ LABEL_NEEDS_ITERATION="needs-iteration"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1"

--- a/local-watcher/test/adj_resolve_gate_test.sh
+++ b/local-watcher/test/adj_resolve_gate_test.sh
@@ -24,6 +24,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 
 if [ ! -f "$ADJ_SH" ]; then
@@ -32,16 +35,6 @@ if [ ! -f "$ADJ_SH" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$ADJ_SH" "adj_gate_enabled")"
 
@@ -56,21 +49,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # adjudicator.sh 内の adj_gate_enabled は `$PR_REVIEWER_ADJUDICATOR_ENABLED` を読むため、
 # 各ケースで export して env として渡す（test の中の関数呼び出しでも env として可視）。

--- a/local-watcher/test/ar_additive_test.sh
+++ b/local-watcher/test/ar_additive_test.sh
@@ -28,6 +28,9 @@ set -euo pipefail
 # 見える。本ファイル全体で SC2034 を抑止する。
 # shellcheck disable=SC2034
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/auto-rebase.sh"
 FIXTURE_DIR="$SCRIPT_DIR/../../docs/specs/438--bootstrap-cmd-main-di-issue-merge-confl/test-fixtures"
 
@@ -42,16 +45,6 @@ fi
 
 # 既存テスト（ar_semantic_test.sh）と同じイディオム: 対象スクリプトから 1 関数だけを
 # awk で切り出して eval で読み込む。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # ar_classify_diff は内部で ar_classify_additive を呼ぶため、隔離抽出の特性上
 # 依存関数も明示 source する必要がある。
 # shellcheck disable=SC1090,SC2086
@@ -124,21 +117,6 @@ reset_git_stub() {
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # 1 行目 / 2 行目を取り出すヘルパ（呼び出しと rc を捕捉）。
 LAST_RC=0

--- a/local-watcher/test/ar_semantic_test.sh
+++ b/local-watcher/test/ar_semantic_test.sh
@@ -31,6 +31,9 @@ set -euo pipefail
 # static 解析（shellcheck）からは未使用に見える。本ファイル全体で SC2034 を抑止する。
 # shellcheck disable=SC2034
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/auto-rebase.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 
@@ -45,16 +48,6 @@ fi
 
 # 既存テスト（fr_state_test.sh / full_auto_enabled_test.sh）と同じイディオム:
 # 対象スクリプトから 1 関数だけを awk で切り出して eval で読み込む。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: 8 関数を同一 module から取り出す
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "ar_semantic_enabled")"
@@ -96,38 +89,6 @@ ar_warn() {
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 new_state_dir() {
   local d

--- a/local-watcher/test/auto-merge-design_test.sh
+++ b/local-watcher/test/auto-merge-design_test.sh
@@ -45,6 +45,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 AMD_MOD="$SCRIPT_DIR/../bin/modules/auto-merge-design.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 
@@ -59,16 +62,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を auto-merge-design.sh から読み込む
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$AMD_MOD" "amd_log")"
@@ -144,38 +137,6 @@ AUTO_MERGE_DESIGN_HEAD_PATTERN='^claude/issue-.*-design'
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ── stub state ──
 reset_stub_state() {

--- a/local-watcher/test/auto-merge-disarm_test.sh
+++ b/local-watcher/test/auto-merge-disarm_test.sh
@@ -34,6 +34,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 AMX_MOD="$SCRIPT_DIR/../bin/modules/auto-merge-disarm.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 
@@ -52,16 +55,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を auto-merge-disarm.sh から読み込む
 for fn in amx_log amx_warn amx_error amx_resolve_gate_enabled amx_should_disarm_for_pr amx_disarm_pr process_auto_merge_disarm; do
   # shellcheck disable=SC1090,SC2086
@@ -97,38 +90,6 @@ AUTO_MERGE_DESIGN_HEAD_PATTERN='^claude/issue-.*-design'
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ── stub state ──
 reset_stub_state() {

--- a/local-watcher/test/auto-merge-merged_test.sh
+++ b/local-watcher/test/auto-merge-merged_test.sh
@@ -36,6 +36,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 AMM_MOD="$SCRIPT_DIR/../bin/modules/auto-merge-merged.sh"
 
 if [ ! -f "$AMM_MOD" ]; then
@@ -48,16 +51,6 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # extract_function イディオム
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を auto-merge-merged.sh から読み込む
 for fn in amm_log amm_warn amm_error amm_resolve_gate_enabled amm_state_dir amm_state_path amm_save_pending amm_remove_pending amm_list_pending_pr_numbers amm_check_one_pending process_auto_merge_merged; do
   # shellcheck disable=SC1090,SC2086
@@ -142,38 +135,6 @@ REPO_SLUG="owner-test-repo"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 reset_state() {
   : >"$LOG_OUT"

--- a/local-watcher/test/auto-merge_test.sh
+++ b/local-watcher/test/auto-merge_test.sh
@@ -39,6 +39,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 AM_MOD="$SCRIPT_DIR/../bin/modules/auto-merge.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 
@@ -53,16 +56,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を auto-merge.sh から読み込む
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$AM_MOD" "am_log")"
@@ -135,38 +128,6 @@ AUTO_MERGE_HEAD_PATTERN='^claude/issue-.*-impl'
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ── stub state ──
 reset_stub_state() {

--- a/local-watcher/test/dc_cycle_sweep_test.sh
+++ b/local-watcher/test/dc_cycle_sweep_test.sh
@@ -35,6 +35,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/dep-cycle-detect.sh"
 # #465 で dr_extract_deps / dr_unblock_gate_enabled は modules/dependency-resolver.sh へ分離された。
@@ -44,16 +47,6 @@ if [ ! -f "$WATCHER_SH" ] || [ ! -f "$MODULE_SH" ] || [ ! -f "$DR_SH" ]; then
   echo "ERROR: cannot find watcher or module" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # dep-cycle-detect.sh の関数群を抽出ロード
 # shellcheck disable=SC1090,SC2086
@@ -99,39 +92,6 @@ DC_CYCLE_MARKER='<!-- idd-claude:dep-cycle-detected:v1 -->'
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1"

--- a/local-watcher/test/dr_resolve_one_stdout_test.sh
+++ b/local-watcher/test/dr_resolve_one_stdout_test.sh
@@ -39,6 +39,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #465 で dr_log / dr_warn / dr_error / dr_resolve_one は modules/dependency-resolver.sh へ分離された。
 DR_SH="$SCRIPT_DIR/../bin/modules/dependency-resolver.sh"
@@ -54,16 +57,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を読み込む（#465 より modules/dependency-resolver.sh から）。dr_resolve_one が
 # dr_gh_graphql_closed_by / dr_log / dr_warn を呼ぶため、実体を抽出して読み込む（本 Issue の
 # 根因は dr_log 実体の stdout echo であり、stub に置き換えると見逃すため）。
@@ -102,39 +95,6 @@ MERGE_QUEUE_GIT_TIMEOUT="60"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_empty() {
   local label="$1"

--- a/local-watcher/test/dr_unblock_sweep_test.sh
+++ b/local-watcher/test/dr_unblock_sweep_test.sh
@@ -40,6 +40,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #465 で dr_* 関数群（Dependency Resolver / Auto-Unblock Sweep）は
 # modules/dependency-resolver.sh へ分離された。
@@ -56,16 +59,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を読み込む（#465 より modules/dependency-resolver.sh から）。dr_extract_deps と
 # dr_resolve_one は dr_unblock_resolve_one_issue が遅延束縛で呼ぶため明示的に読み込む。
 # shellcheck disable=SC1090,SC2086
@@ -138,39 +131,6 @@ DR_UNBLOCK_MARKER_ORPHAN='<!-- idd-claude:dep-unblock-orphan-marker:v1 -->'
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1"

--- a/local-watcher/test/env-loader_test.sh
+++ b/local-watcher/test/env-loader_test.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/env-loader.sh"
 
 if [ ! -f "$MODULE_SH" ]; then

--- a/local-watcher/test/fr_attempt_test.sh
+++ b/local-watcher/test/fr_attempt_test.sh
@@ -29,6 +29,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery-attempt.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -37,16 +40,6 @@ if [ ! -f "$MODULE_SH" ]; then
 fi
 
 # 既存テスト（fr_invoke_test.sh / fr_state_test.sh）と同じ extract_function イディオム
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: orchestrator layer の 4 関数
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_should_recover")"
@@ -106,21 +99,6 @@ LOG_DIR="/tmp/fr-attempt-test-stub-logs"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_rc() {
   local label="$1"

--- a/local-watcher/test/fr_fetch_test.sh
+++ b/local-watcher/test/fr_fetch_test.sh
@@ -25,6 +25,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -34,16 +37,6 @@ fi
 
 # 既存テスト（fr_state_test.sh / auto-merge_test.sh）と同じイディオム:
 # 対象スクリプトから 1 関数だけを awk で切り出して eval で読み込む。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象 2 関数を抽出
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_fetch_failed_issues")"
@@ -103,21 +96,6 @@ FAILED_RECOVERY_GIT_TIMEOUT=60
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_grep() {
   local label="$1"

--- a/local-watcher/test/fr_immediate_fail_test.sh
+++ b/local-watcher/test/fr_immediate_fail_test.sh
@@ -31,6 +31,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 # #471 で failed-recovery.sh は family 分割された。fr_resolve_dedicated_log_path /
 # fr_prepare_repo_worktree は failed-recovery-invoke.sh、それ以外は failed-recovery-attempt.sh。
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery-attempt.sh"
@@ -46,16 +49,6 @@ if [ ! -f "$INVOKE_SH" ]; then
 fi
 
 # 既存テストと同じ extract_function イディオム
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: #411 で追加 / 既存利用の関数
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$INVOKE_SH" "fr_resolve_dedicated_log_path")"
@@ -108,18 +101,6 @@ BASE_BRANCH="main"
 PASS_COUNT=0
 FAIL_COUNT=0
 
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 assert_rc() {
   local label="$1" expected_rc="$2" actual_rc="$3"
   if [ "$expected_rc" = "$actual_rc" ]; then

--- a/local-watcher/test/fr_invoke_test.sh
+++ b/local-watcher/test/fr_invoke_test.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery-invoke.sh"
 QUOTA_AWARE_SH="$SCRIPT_DIR/../bin/modules/quota-aware.sh"
 
@@ -41,16 +44,6 @@ fi
 
 # 既存テスト（fr_state_test.sh / fr_fetch_test.sh / fr_no_progress_test.sh）と同じ
 # イディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval で読み込む。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: failed-recovery.sh から 4 関数 + quota-aware.sh から qa_detect_rate_limit
 # #411: fr_invoke_claude が fr_classify_immediate_failure を呼ぶため、同 module から
 # 当該関数も抽出して同セッションに load する。
@@ -87,21 +80,6 @@ FAILED_RECOVERY_IMMEDIATE_FAIL_SECONDS=10
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_rc() {
   local label="$1"

--- a/local-watcher/test/fr_is_enabled_test.sh
+++ b/local-watcher/test/fr_is_enabled_test.sh
@@ -24,6 +24,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -33,16 +36,6 @@ fi
 
 # 既存テスト（full_auto_enabled_test.sh）と同じイディオム: 対象スクリプトから 1
 # 関数だけを awk で切り出して eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_is_enabled")"
 
@@ -53,23 +46,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ============================================================
 # Section 1: 両方 ON（Req 1.1）

--- a/local-watcher/test/fr_no_progress_test.sh
+++ b/local-watcher/test/fr_no_progress_test.sh
@@ -21,6 +21,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery-attempt.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -30,16 +33,6 @@ fi
 
 # 既存テスト（fr_state_test.sh / fr_fetch_test.sh）と同じイディオム:
 # 対象スクリプトから 1 関数だけを awk で切り出して eval で読み込む。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_compute_failure_signature")"
 # shellcheck disable=SC1090,SC2086
@@ -54,21 +47,6 @@ done
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_rc() {
   local label="$1"

--- a/local-watcher/test/fr_process_test.sh
+++ b/local-watcher/test/fr_process_test.sh
@@ -33,6 +33,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -41,16 +44,6 @@ if [ ! -f "$MODULE_SH" ]; then
 fi
 
 # 既存テスト（fr_attempt_test.sh / fr_terminate_test.sh）と同じ extract_function イディオム
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: orchestrator entry 2 関数（process_failed_recovery / _fr_dispatch_candidate）
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "_fr_dispatch_candidate")"
@@ -74,21 +67,6 @@ FAILED_RECOVERY_MAX_PRS=3
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_rc() {
   local label="$1"

--- a/local-watcher/test/fr_state_test.sh
+++ b/local-watcher/test/fr_state_test.sh
@@ -29,6 +29,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery-attempt.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 
@@ -43,16 +46,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: 3 関数を同一 module から取り出す
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_state_path")"
@@ -80,38 +73,6 @@ fr_warn() {
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # テスト隔離環境を作成する helper（各 Section で別ディレクトリを使う）
 new_state_dir() {

--- a/local-watcher/test/fr_terminate_idempotent_test.sh
+++ b/local-watcher/test/fr_terminate_idempotent_test.sh
@@ -32,22 +32,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery-attempt.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
   echo "ERROR: cannot find failed-recovery-attempt.sh at $MODULE_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # 対象: terminate 関数 + 依存ヘルパー + 状態管理関数
 # shellcheck disable=SC1090,SC2086
@@ -88,21 +81,6 @@ FAILED_RECOVERY_MAX_ATTEMPTS=4
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_rc() {
   local label="$1"

--- a/local-watcher/test/fr_terminate_test.sh
+++ b/local-watcher/test/fr_terminate_test.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/failed-recovery-attempt.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -36,16 +39,6 @@ fi
 
 # 既存テスト（fr_attempt_test.sh / fr_invoke_test.sh / fr_state_test.sh）と同じ
 # extract_function イディオム。関数本体を行単位で抽出して eval する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: termination layer の 2 関数 + 依存する fr_post_attempt_comment
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "fr_post_attempt_comment")"
@@ -90,21 +83,6 @@ FAILED_RECOVERY_MAX_ATTEMPTS=4
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_rc() {
   local label="$1"

--- a/local-watcher/test/full_auto_enabled_load_order_test.sh
+++ b/local-watcher/test/full_auto_enabled_load_order_test.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 
 if [ ! -f "$WATCHER_SH" ]; then

--- a/local-watcher/test/full_auto_enabled_test.sh
+++ b/local-watcher/test/full_auto_enabled_test.sh
@@ -30,6 +30,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #465 で dr_unblock_gate_enabled / dr_unblock_sweep は modules/dependency-resolver.sh へ分離された。
 DR_SH="$SCRIPT_DIR/../bin/modules/dependency-resolver.sh"
@@ -45,16 +48,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を読み込む。dr_unblock_sweep は内部で dr_unblock_gate_enabled を呼ぶため
 # それも合わせて読み込む。
 # shellcheck disable=SC1090,SC2086
@@ -80,56 +73,6 @@ LABEL_NEEDS_DECISIONS="needs-decisions"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 # ── stub state for dr_unblock_sweep gh-call observability ──
 reset_stub_state() {

--- a/local-watcher/test/lib/test-helpers.sh
+++ b/local-watcher/test/lib/test-helpers.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# =============================================================================
+# idd-claude test helpers（#474）
+#
+# local-watcher/test/*.sh の大多数が個別にコピーしていた extract_function /
+# assert_eq / assert_contains / assert_rc を集約する共有ライブラリ。各テストは
+# 先頭の SCRIPT_DIR 解決の直後に
+#   . "$SCRIPT_DIR/lib/test-helpers.sh"
+# として source する。トップレベル副作用なし（関数定義のみ）。PASS_COUNT /
+# FAIL_COUNT の初期化・最終サマリ出力・exit は各テストに残置する（テストごとに
+# サマリ表記が異なり、一律の共通化は表示文言を変えてしまうため対象外とした。
+# 詳細は #474 PR 本文「確認事項」参照）。
+#
+# 配置先: local-watcher/test/lib/test-helpers.sh
+# 依存: 呼び出し側テストが PASS_COUNT / FAIL_COUNT をグローバル変数として
+#       事前初期化していること（`PASS_COUNT=0` / `FAIL_COUNT=0`）。
+#
+# 対象外（各テストにそのまま残置。無理に共通化しない）:
+#   - 引数順序 / メッセージ文言 / カウンタ変数名が多数派と異なる assert_eq /
+#     assert_contains / assert_rc（call site 変換すると出力文言が変わってしまうため）
+#   - assert_contains / assert_rc 以外の assert_* ヘルパー（assert_not_contains /
+#     assert_grep 等。単一テストにしか無い、または #474 issue 本文で明示されていない）
+# =============================================================================
+
+# extract_function <script> <fn_name> [<extra_script>...]
+#   対象スクリプトから 1 関数だけを awk で切り出して stdout に返す（eval 用イディオム）。
+#   fn_name が <script> 内に見つからない場合に備え、<extra_script> を追加で渡すと
+#   同じ awk 呼び出しで追加検索する（#177 以降の module 分割で定義が別ファイルへ
+#   移動したテスト向け。多数派の 2 引数呼び出しは shift 2 後の "$@" が空になるだけで
+#   挙動は従来と完全に同一）。
+extract_function() {
+  local script="$1"
+  local fn_name="$2"
+  shift 2
+  awk -v fn="${fn_name}() {" '
+    $0 == fn { in_fn = 1 }
+    in_fn { print }
+    in_fn && $0 == "}" { in_fn = 0 }
+  ' "$script" "$@"
+}
+
+# assert_eq <label> <expected> <actual>
+#   $expected と $actual を文字列比較し、PASS/FAIL を stdout に記録して
+#   PASS_COUNT / FAIL_COUNT を加算する。
+assert_eq() {
+  local label="$1"
+  local expected="$2"
+  local actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected: $(printf '%q' "$expected")"
+    echo "  actual  : $(printf '%q' "$actual")"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# assert_contains <label> <haystack> <needle>
+#   $haystack に $needle が部分文字列として含まれるかを判定する。
+assert_contains() {
+  local label="$1"
+  local haystack="$2"
+  local needle="$3"
+  case "$haystack" in
+    *"$needle"*)
+      echo "PASS: $label"
+      PASS_COUNT=$((PASS_COUNT + 1))
+      ;;
+    *)
+      echo "FAIL: $label"
+      echo "  expected to contain: $(printf '%q' "$needle")"
+      echo "  actual             : $(printf '%q' "$haystack")"
+      FAIL_COUNT=$((FAIL_COUNT + 1))
+      ;;
+  esac
+}
+
+# assert_rc <label> <expected_rc> <cmd...>
+#   <cmd...> を実行し、その終了コードが <expected_rc> と一致するかを判定する。
+assert_rc() {
+  local label="$1"
+  local expected_rc="$2"
+  shift 2
+  local actual_rc=0
+  "$@" >/dev/null 2>&1 || actual_rc=$?
+  if [ "$expected_rc" = "$actual_rc" ]; then
+    echo "PASS: $label"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: $label"
+    echo "  expected rc: $expected_rc"
+    echo "  actual rc  : $actual_rc"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}

--- a/local-watcher/test/mgv_merge_gate_visibility_test.sh
+++ b/local-watcher/test/mgv_merge_gate_visibility_test.sh
@@ -19,22 +19,15 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_SH="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
 
 if [ ! -f "$PR_SH" ]; then
   echo "ERROR: cannot find pr-reviewer.sh at $PR_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # 対象関数群を読み込む（mgv_* と依存先 pr_warn / timeout はテスト内で stub）。
 # shellcheck disable=SC1090,SC2086

--- a/local-watcher/test/module_loader_missing_test.sh
+++ b/local-watcher/test/module_loader_missing_test.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 BIN_DIR="$SCRIPT_DIR/../bin"
 WATCHER_SH="$BIN_DIR/issue-watcher.sh"
 # #460: issue-watcher.sh は module loader より前に同階層 watcher-config.sh を source する。
@@ -50,19 +53,6 @@ fi
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1" needle="$2" haystack="$3"

--- a/local-watcher/test/needs_decisions_auto_test.sh
+++ b/local-watcher/test/needs_decisions_auto_test.sh
@@ -38,6 +38,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 NDA_MOD="$SCRIPT_DIR/../bin/modules/needs-decisions-auto.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #460: NEEDS_DECISIONS_MODE の正規化ブロックは Config 分離で watcher-config.sh へ移動した。
@@ -59,16 +62,6 @@ fi
 
 # 既存テスト同イディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # nda module から対象関数を抽出
 for fn in nda_log nda_warn nda_error \
   nda_resolve_mode_enabled \
@@ -137,38 +130,6 @@ NUMBER="42"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ── stub state for nda_auto_continue / nda_evaluate_auto_continue gh observability ──
 GH_CALL_LOG=""

--- a/local-watcher/test/normalize_slug_test.sh
+++ b/local-watcher/test/normalize_slug_test.sh
@@ -18,6 +18,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #466 で _normalize_slug は modules/slot-worker.sh へ分離された。
 SLOT_WORKER_SH="$SCRIPT_DIR/../bin/modules/slot-worker.sh"
@@ -33,16 +36,6 @@ fi
 
 # modules/slot-worker.sh から `_normalize_slug` のみを抽出する（#466）。
 # awk で「関数開始行」から最初の単独 `}` までを抜き出す。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$SLOT_WORKER_SH" "_normalize_slug")"
 
@@ -54,21 +47,6 @@ fi
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── テストケース（Req 5.1 の正規化規則を網羅） ───
 

--- a/local-watcher/test/parse_review_result_test.sh
+++ b/local-watcher/test/parse_review_result_test.sh
@@ -16,6 +16,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 FIXTURE_DIR="$SCRIPT_DIR/fixtures/parse_review_result"
 
@@ -26,16 +29,6 @@ fi
 
 # issue-watcher.sh から該当関数 2 個だけを抽出する。
 # awk で「関数開始行」から最初の単独 `}` までを抜き出す（インデント無し close brace を境界とする）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 関数定義のみを current shell に読み込む。
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$WATCHER_SH" "extract_review_result_token")"
@@ -55,21 +48,6 @@ fi
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_rc() {
   local label="$1"

--- a/local-watcher/test/pdr_already_processed_test.sh
+++ b/local-watcher/test/pdr_already_processed_test.sh
@@ -23,6 +23,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 
 if [ ! -f "$PDR_SH" ]; then
@@ -31,16 +34,6 @@ if [ ! -f "$PDR_SH" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PDR_SH" "pdr_already_processed")"
 
@@ -57,39 +50,6 @@ PR_REVIEWER_GIT_TIMEOUT="120"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1"

--- a/local-watcher/test/pdr_apply_decision_test.sh
+++ b/local-watcher/test/pdr_apply_decision_test.sh
@@ -42,6 +42,9 @@ set -euo pipefail
 
 # shellcheck disable=SC2034
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer-publish.sh"
 
@@ -53,16 +56,6 @@ if [ ! -f "$PR_MOD" ]; then
   echo "ERROR: cannot find pr-reviewer-publish.sh at $PR_MOD" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # pr-design-reviewer.sh から 3 関数を抽出
 # shellcheck disable=SC1090,SC2086
@@ -97,39 +90,6 @@ LABEL_NEEDS_ITERATION="needs-iteration"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1"

--- a/local-watcher/test/pdr_classify_design_pr_test.sh
+++ b/local-watcher/test/pdr_classify_design_pr_test.sh
@@ -24,6 +24,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 
 if [ ! -f "$PDR_SH" ]; then
@@ -32,16 +35,6 @@ if [ ! -f "$PDR_SH" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PDR_SH" "pdr_classify_design_pr")"
 
@@ -52,21 +45,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # DESIGN_REVIEWER_HEAD_PATTERN を既定値 (issue-watcher.sh Config と同一) で設定。
 # pdr_classify_design_pr は extract_function で抽出された関数本体内で参照される。

--- a/local-watcher/test/pdr_default_on_test.sh
+++ b/local-watcher/test/pdr_default_on_test.sh
@@ -131,6 +131,9 @@ echo ""
 echo "--- pdr_gate_enabled contract (unchanged after #432) ---"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 if [ ! -f "$PDR_SH" ]; then
   echo "ERROR: cannot find pr-design-reviewer.sh at $PDR_SH" >&2

--- a/local-watcher/test/pdr_fail_closed_pending_test.sh
+++ b/local-watcher/test/pdr_fail_closed_pending_test.sh
@@ -26,22 +26,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 
 if [ ! -f "$PDR_SH" ]; then
   echo "ERROR: cannot find pr-design-reviewer.sh at $PDR_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # 被テスト関数 + 内部で呼ぶ純粋 helper（pdr_parse_verdict / pdr_validate_verdict）を抽出。
 # 副作用を伴う依存（pdr_invoke_reviewer / pdr_classify_design_pr / pdr_already_processed /
@@ -61,39 +54,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 # ── 観測ファイル（subshell をまたいでも残す） ──
 SIDE_LOG=""        # 副作用系（status/label/comment）の呼び出しトレース

--- a/local-watcher/test/pdr_invoke_reviewer_spec_fetch_test.sh
+++ b/local-watcher/test/pdr_invoke_reviewer_spec_fetch_test.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 
 if [ ! -f "$PDR_SH" ]; then
@@ -36,16 +39,6 @@ if [ ! -f "$PDR_SH" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PDR_SH" "pdr_invoke_reviewer")"
 
@@ -56,39 +49,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1"

--- a/local-watcher/test/pdr_no_op_test.sh
+++ b/local-watcher/test/pdr_no_op_test.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 
 if [ ! -f "$PDR_SH" ]; then
@@ -52,21 +55,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # stub state
 reset_stub_state() {

--- a/local-watcher/test/pdr_parse_verdict_test.sh
+++ b/local-watcher/test/pdr_parse_verdict_test.sh
@@ -45,6 +45,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 TMPL_PATH="$SCRIPT_DIR/../bin/design-review-prompt.tmpl"
 
@@ -52,16 +55,6 @@ if [ ! -f "$PDR_SH" ]; then
   echo "ERROR: cannot find pr-design-reviewer.sh at $PDR_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PDR_SH" "pdr_parse_verdict")"
@@ -81,21 +74,6 @@ pdr_warn() { :; }
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── P.1: template 存在 + 9 プレースホルダ確認 ────────────────────────────────
 echo "--- P.1: design-review-prompt.tmpl の必須プレースホルダ揃いを確認 ---"

--- a/local-watcher/test/pdr_resolve_gate_test.sh
+++ b/local-watcher/test/pdr_resolve_gate_test.sh
@@ -24,25 +24,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PDR_SH="$SCRIPT_DIR/../bin/modules/pr-design-reviewer.sh"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── (a) Config ブロックの正規化挙動を直接シミュレート（#432 既定 ON / opt-out） ─────────
 # issue-watcher.sh の Config ブロックと同じ `case false) :;; *) true` パターンで安全側正規化が

--- a/local-watcher/test/pi_classify_round_outcome_test.sh
+++ b/local-watcher/test/pi_classify_round_outcome_test.sh
@@ -18,6 +18,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_ITERATION_SH="$SCRIPT_DIR/../bin/modules/pr-iteration-state.sh"
 
 if [ ! -f "$PR_ITERATION_SH" ]; then
@@ -27,16 +30,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PR_ITERATION_SH" "pi_classify_round_outcome")"
 
@@ -47,21 +40,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── 正常系: commit_pushed=true → success ─────────────────────────────────────
 echo "--- pi_classify_round_outcome: success cases (Req 3.1〜3.3) ---"

--- a/local-watcher/test/pi_detect_quota_soft_fail_test.sh
+++ b/local-watcher/test/pi_detect_quota_soft_fail_test.sh
@@ -18,6 +18,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 FIXTURE_DIR="$SCRIPT_DIR/fixtures/pi_detect_quota_soft_fail"
 # #181 Part 3 で PR Iteration Processor の関数群（pi_detect_quota_soft_fail ほか）は
@@ -39,16 +42,6 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PR_ITERATION_SH" "pi_detect_quota_soft_fail")"
 
@@ -60,21 +53,6 @@ fi
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 detect_all() {
   local fx="$1"

--- a/local-watcher/test/pi_general_filter_excessive_test.sh
+++ b/local-watcher/test/pi_general_filter_excessive_test.sh
@@ -21,6 +21,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_ITERATION_SH="$SCRIPT_DIR/../bin/modules/pr-iteration-comments.sh"
 
 if [ ! -f "$PR_ITERATION_SH" ]; then
@@ -30,16 +33,6 @@ fi
 
 # 既存テスト (pi_general_filter_self_test.sh / adj_resolve_gate_test.sh) と同じイディオム:
 # 対象スクリプトから 1 関数だけを awk で切り出して eval する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PR_ITERATION_SH" "pi_general_filter_excessive")"
 # 既存 self-filter との非衝突確認に流用するため pi_general_filter_self も読み込む。
@@ -60,21 +53,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── pi_general_filter_excessive: gate ON で marker 除外 (Req 2.4 / 2.5) ───
 

--- a/local-watcher/test/pi_general_filter_self_test.sh
+++ b/local-watcher/test/pi_general_filter_self_test.sh
@@ -19,6 +19,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_ITERATION_SH="$SCRIPT_DIR/../bin/modules/pr-iteration-comments.sh"
 
 if [ ! -f "$PR_ITERATION_SH" ]; then
@@ -27,16 +30,6 @@ if [ ! -f "$PR_ITERATION_SH" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PR_ITERATION_SH" "pi_general_filter_self")"
 # shellcheck disable=SC1090,SC2086
@@ -53,21 +46,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── pi_general_filter_self (Issue #400 Req 1 / Req 2) ───
 

--- a/local-watcher/test/pi_max_rounds_kind_test.sh
+++ b/local-watcher/test/pi_max_rounds_kind_test.sh
@@ -19,6 +19,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #181 Part 3 で PR Iteration Processor の関数群は modules/pr-iteration.sh へ切り出され、
 # #469 の family 分割で pi_resolve_max_rounds は orchestrator（pr-iteration.sh）に残置、
@@ -42,16 +45,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # pi_warn / pi_log / pi_error は本テストで stderr に出すだけで良い（実装では env
 # 依存だが、ここでは副作用の確認は不要）。stub を定義しておく。
 pi_warn()  { echo "WARN: $*" >&2; }
@@ -74,21 +67,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ─── pi_resolve_max_rounds (Issue #122 Req 1) ───
 

--- a/local-watcher/test/pi_no_progress_invariant_test.sh
+++ b/local-watcher/test/pi_no_progress_invariant_test.sh
@@ -30,6 +30,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_ITERATION_SH="$SCRIPT_DIR/../bin/modules/pr-iteration-state.sh"
 
 if [ ! -f "$PR_ITERATION_SH" ]; then
@@ -39,16 +42,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PR_ITERATION_SH" "pi_round_commit_pushed")"
 # shellcheck disable=SC1090,SC2086
@@ -65,21 +58,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # 40 桁の擬似 SHA（実 git に依存しないテスト用の固定値）
 SHA_A="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

--- a/local-watcher/test/po_apply_awaiting_slot_test.sh
+++ b/local-watcher/test/po_apply_awaiting_slot_test.sh
@@ -24,6 +24,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PATH_OVERLAP_SH="$SCRIPT_DIR/../bin/modules/path-overlap.sh"
 
 if [ ! -f "$PATH_OVERLAP_SH" ]; then
@@ -33,16 +36,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数 + 本文整形ヘルパー（po_format_holders_table_md）を実物で読み込む。
 # #320: po_apply_awaiting_slot が呼ぶ sticky comment 共通ヘルパー 2 つも実物で読み込む
 # （extract_function は単一関数を隔離抽出するため、依存ヘルパーは明示的に読み込む必要がある）。
@@ -80,39 +73,6 @@ LABEL_AWAITING_SLOT="awaiting-slot"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 # ─── 各テストケースで使う stub の状態 ───
 # gh の振る舞いはケースごとに環境変数で制御する:

--- a/local-watcher/test/po_sticky_comment_helpers_test.sh
+++ b/local-watcher/test/po_sticky_comment_helpers_test.sh
@@ -20,6 +20,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PATH_OVERLAP_SH="$SCRIPT_DIR/../bin/modules/path-overlap.sh"
 
 if [ ! -f "$PATH_OVERLAP_SH" ]; then
@@ -29,16 +32,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PATH_OVERLAP_SH" "po_extract_comment_id_from_url")"
 # shellcheck disable=SC1090,SC2086
@@ -55,21 +48,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 echo "--- po_extract_comment_id_from_url cases ---"
 

--- a/local-watcher/test/pp_extract_linked_issues_test.sh
+++ b/local-watcher/test/pp_extract_linked_issues_test.sh
@@ -23,6 +23,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PP_MOD="$SCRIPT_DIR/../bin/modules/promote-pipeline.sh"
 
 if [ ! -f "$PP_MOD" ]; then
@@ -36,16 +39,6 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # extract_function イディオム（既存テスト sn_callsite_promote_test.sh と同形式）
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # pp_extract_linked_issues のみを抽出（純関数なので依存関数 stub は不要）
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PP_MOD" "pp_extract_linked_issues")"
@@ -57,21 +50,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 REPO_OWNER="owner"
 

--- a/local-watcher/test/pp_remove_ready_for_review_test.sh
+++ b/local-watcher/test/pp_remove_ready_for_review_test.sh
@@ -31,6 +31,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PROMOTE_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/promote-pipeline.sh"
 
 if [ ! -f "$PROMOTE_PIPELINE_SH" ]; then
@@ -46,16 +49,6 @@ fi
 # 既存テスト pp_extract_linked_issues_test.sh / po_apply_awaiting_slot_test.sh と
 # 同形式の extract_function イディオム。対象関数とその依存ヘルパーを 1 関数ずつ
 # 隔離抽出して読み込む。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数 + 依存ヘルパー（pp_issue_has_label）を実物で読み込む。
 # pp_issue_has_label は gh / jq に依存するが、本テストでは gh を stub する。
 # shellcheck disable=SC1090,SC2086
@@ -82,39 +75,6 @@ PROMOTE_GIT_TIMEOUT=60
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 # ─── stub 状態 ───
 # gh の振る舞いをケースごとに環境変数で制御:

--- a/local-watcher/test/pr_already_processed_pagination_test.sh
+++ b/local-watcher/test/pr_already_processed_pagination_test.sh
@@ -27,6 +27,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
 
 if [ ! -f "$PR_MOD" ]; then
@@ -35,16 +38,6 @@ if [ ! -f "$PR_MOD" ]; then
 fi
 
 # extract_function イディオム（pr_reviewer_exec_fail_streak_test.sh と同一）
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 for fn in pr_already_processed pr_build_marker; do
   # shellcheck disable=SC1090,SC2086
   eval "$(extract_function "$PR_MOD" "$fn")"
@@ -62,34 +55,6 @@ PR_REVIEWER_GIT_TIMEOUT="120"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_rc() {
-  local label="$1"; local expected_rc="$2"; shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_eq() {
-  local label="$1"; local expected="$2"; local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ── 共通 stub ─────────────────────────────────────────────────────────────────
 # timeout: 第 1 引数（秒数）を捨てて残りを実行する素通し stub

--- a/local-watcher/test/pr_catchup_suppression_test.sh
+++ b/local-watcher/test/pr_catchup_suppression_test.sh
@@ -30,6 +30,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
 
@@ -43,16 +46,6 @@ if [ ! -f "$PR_MOD" ]; then
 fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # pr_catchup_should_defer_for_adjudicator は adj_gate_enabled を呼ぶため、両関数を抽出
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$ADJ_SH" "adj_gate_enabled")"
@@ -68,21 +61,6 @@ done
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ── stub state ──
 # gh stub をシナリオで切り替えるために、stub gh は GH_STUB_MODE / GH_STUB_BODY を読む。

--- a/local-watcher/test/pr_default_prompt_test.sh
+++ b/local-watcher/test/pr_default_prompt_test.sh
@@ -29,6 +29,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 MODULE_PATH="$REPO_ROOT/local-watcher/bin/modules/pr-reviewer-exec.sh"
 

--- a/local-watcher/test/pr_iteration_oos_no_progress_test.sh
+++ b/local-watcher/test/pr_iteration_oos_no_progress_test.sh
@@ -26,22 +26,15 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_ITERATION_SH="$SCRIPT_DIR/../bin/modules/pr-iteration-oos.sh"
 
 if [ ! -f "$PR_ITERATION_SH" ]; then
   echo "ERROR: cannot find pr-iteration-oos.sh at $PR_ITERATION_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 for fn in pi_detect_developer_oos_marker pi_oos_fingerprint \
           pi_read_oos_no_progress_streak pi_read_oos_fingerprint \
@@ -56,18 +49,6 @@ done
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_ne() {
   local label="$1" a="$2" b="$3"

--- a/local-watcher/test/pr_iteration_oos_routing_test.sh
+++ b/local-watcher/test/pr_iteration_oos_routing_test.sh
@@ -26,6 +26,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 # #469 の family 分割で pi_route_out_of_scope_escalate は pr-iteration-oos.sh、
 # pi_general_filter_oos は filter chain 側の pr-iteration-comments.sh へ切り出された。
 # 関数ごとに抽出元 family を使い分ける。
@@ -42,16 +45,6 @@ if [ ! -f "$PR_ITERATION_COMMENTS_SH" ]; then
 fi
 
 # 既存テストと同じ extract_function イディオム（awk で 1 関数だけ切り出して eval）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PR_ITERATION_COMMENTS_SH" "pi_general_filter_oos")"
 # shellcheck disable=SC1090,SC2086
@@ -70,30 +63,6 @@ REPO="owner/test-repo"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1" haystack="$2" needle="$3"
-  case "$haystack" in
-    *"$needle"*) echo "PASS: $label"; PASS_COUNT=$((PASS_COUNT + 1)) ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1)) ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1" haystack="$2" needle="$3"

--- a/local-watcher/test/pr_publish_claude_status_from_branch_test.sh
+++ b/local-watcher/test/pr_publish_claude_status_from_branch_test.sh
@@ -35,6 +35,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
 PR_PUBLISH_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer-publish.sh"
 
@@ -49,16 +52,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を読み込む（pr_status_check_enabled / pr_publish_claude_status /
 # pr_publish_commit_status / pr_detect_iteration_keyword は本テスト stub 経由で
 # 呼ばれるため一緒に読み込み、外部副作用（gh）を stub で受ける）。
@@ -93,39 +86,6 @@ PR_REVIEWER_GIT_TIMEOUT="120"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 # ── stub state ──
 reset_stub_state() {

--- a/local-watcher/test/pr_publish_commit_status_test.sh
+++ b/local-watcher/test/pr_publish_commit_status_test.sh
@@ -37,6 +37,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer-publish.sh"
 
 if [ ! -f "$PR_MOD" ]; then
@@ -46,16 +49,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を読み込む。pr_publish_codex_status は pr_detect_iteration_keyword を
 # 呼ぶためそれも合わせて読み込む。
 # shellcheck disable=SC1090,SC2086
@@ -83,56 +76,6 @@ PR_REVIEWER_ITERATION_PATTERN='^[[:space:]]*VERDICT:[[:space:]]*needs-iteration[
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"
-  local haystack="$2"
-  local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 # ── stub state ──
 reset_stub_state() {

--- a/local-watcher/test/pr_reviewer_adjudicator_default_on_test.sh
+++ b/local-watcher/test/pr_reviewer_adjudicator_default_on_test.sh
@@ -132,6 +132,9 @@ echo ""
 echo "--- adj_gate_enabled contract (unchanged after #412) ---"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 ADJ_SH="$SCRIPT_DIR/../bin/modules/adjudicator.sh"
 if [ ! -f "$ADJ_SH" ]; then
   echo "ERROR: cannot find adjudicator.sh at $ADJ_SH" >&2

--- a/local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
+++ b/local-watcher/test/pr_reviewer_claude_status_fail_closed_test.sh
@@ -28,6 +28,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer-publish.sh"
 
 if [ ! -f "$PR_MOD" ]; then
@@ -40,16 +43,6 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # extract_function イディオム
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数を pr-reviewer-publish.sh から読み込む（#470 で pr-reviewer.sh から移動）
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PR_MOD" "pr_publish_claude_status")"
@@ -71,21 +64,6 @@ PR_REVIEWER_GIT_TIMEOUT=60
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 count_logs() {
   local file="$1"

--- a/local-watcher/test/pr_reviewer_exec_fail_streak_test.sh
+++ b/local-watcher/test/pr_reviewer_exec_fail_streak_test.sh
@@ -36,6 +36,9 @@ set -euo pipefail
 # shellcheck disable=SC2034
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PR_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer.sh"
 PR_EXEC_MOD="$SCRIPT_DIR/../bin/modules/pr-reviewer-exec.sh"
 
@@ -49,16 +52,6 @@ if [ ! -f "$PR_EXEC_MOD" ]; then
 fi
 
 # pr_publish_commit_status_test.sh と同じ extract_function イディオム
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 対象関数群を読み込む。pr_increment_exec_fail_streak / pr_reset_exec_fail_streak は
 # pr_read_exec_fail_streak / pr_write_exec_fail_streak / pr_extract_exec_fail_streak に
 # 依存するため、合わせて抽出する（#470 で pr-reviewer-exec.sh へ移動）。
@@ -115,50 +108,6 @@ PR_REVIEWER_STDERR_ARTIFACT_MAX_BYTES="1048576"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"; local expected="$2"; local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"; local expected_rc="$2"; shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1"; local haystack="$2"; local needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual             : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 # ── stub state ──
 reset_stub_state() {

--- a/local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
+++ b/local-watcher/test/pr_reviewer_parse_review_result_load_order_test.sh
@@ -34,6 +34,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 
 if [ ! -f "$WATCHER_SH" ]; then

--- a/local-watcher/test/pt_check_fail_fast_test.sh
+++ b/local-watcher/test/pt_check_fail_fast_test.sh
@@ -25,6 +25,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #461 で per-task loop 前半関数は modules/per-task-loop.sh へ分離された。
 PER_TASK_LOOP_SH="$SCRIPT_DIR/../bin/modules/per-task-loop.sh"
@@ -44,16 +47,6 @@ if [ ! -d "$FIXTURE_DIR" ]; then
 fi
 
 # issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PER_TASK_LOOP_SH" "pt_check_fail_fast")"
 
@@ -80,21 +73,6 @@ git() {
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/pt_extract_debugger_section_test.sh
+++ b/local-watcher/test/pt_extract_debugger_section_test.sh
@@ -17,6 +17,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #461 で per-task loop 前半関数は modules/per-task-loop.sh へ分離された。
 PER_TASK_LOOP_SH="$SCRIPT_DIR/../bin/modules/per-task-loop.sh"
@@ -37,16 +40,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PER_TASK_LOOP_SH" "pt_extract_debugger_section")"
 
@@ -57,21 +50,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/pt_extract_findings_block_test.sh
+++ b/local-watcher/test/pt_extract_findings_block_test.sh
@@ -17,6 +17,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #461 で per-task loop 前半関数は modules/per-task-loop.sh へ分離された。
 PER_TASK_LOOP_SH="$SCRIPT_DIR/../bin/modules/per-task-loop.sh"
@@ -37,16 +40,6 @@ fi
 
 # 既存テストと同じイディオム: 対象スクリプトから 1 関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PER_TASK_LOOP_SH" "pt_extract_findings_block")"
 
@@ -57,21 +50,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/pt_post_marker_classify_test.sh
+++ b/local-watcher/test/pt_post_marker_classify_test.sh
@@ -30,6 +30,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #461 で per-task loop 前半関数は modules/per-task-loop.sh へ分離された。
 PER_TASK_LOOP_SH="$SCRIPT_DIR/../bin/modules/per-task-loop.sh"
@@ -44,16 +47,6 @@ if [ ! -f "$PER_TASK_LOOP_SH" ]; then
 fi
 
 # issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # pt_warn は pt_classify_post_marker_paths / pt_handle_post_marker_commits から
 # 呼ばれるため stub で隔離する（実体は date / hostname / >&2 への副作用を含むため）。
 pt_warn() {
@@ -122,21 +115,6 @@ git() {
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/pt_resolve_diff_range_test.sh
+++ b/local-watcher/test/pt_resolve_diff_range_test.sh
@@ -39,6 +39,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #461 で per-task loop 前半関数は modules/per-task-loop.sh へ分離された。
 PER_TASK_LOOP_SH="$SCRIPT_DIR/../bin/modules/per-task-loop.sh"
@@ -53,16 +56,6 @@ if [ ! -f "$PER_TASK_LOOP_SH" ]; then
 fi
 
 # issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PER_TASK_LOOP_SH" "pt_resolve_diff_range")"
 
@@ -106,21 +99,6 @@ BASE_BRANCH="main"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/publish_terminal_failure_artifacts_test.sh
+++ b/local-watcher/test/publish_terminal_failure_artifacts_test.sh
@@ -31,6 +31,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #458 で Debugger Gate（run_debugger_stage 等）は modules/debugger-gate.sh へ分離された。
 # debugger-notes-invalid の呼出は run_debugger_stage 内にあるため、探索元に含める。
@@ -60,16 +63,6 @@ fi
 
 # publish_terminal_failure_artifacts は内部で mark_issue_failed を呼ぶため、
 # 関数定義のみを抽出して current shell に load する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$IMPL_PIPELINE_SH" "publish_terminal_failure_artifacts")"
 
@@ -170,19 +163,6 @@ setup_work_without_upstream() {
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1" needle="$2" haystack="$3"

--- a/local-watcher/test/qa_detect_rate_limit_test.sh
+++ b/local-watcher/test/qa_detect_rate_limit_test.sh
@@ -22,6 +22,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #180 Part 2 で qa_detect_rate_limit は modules/quota-aware.sh へ分離された。
 # 関数抽出の探索元に quota-aware.sh も含める。
@@ -44,23 +47,13 @@ fi
 
 # issue-watcher.sh / modules から qa_detect_rate_limit() のみを抽出する。
 # awk で「関数開始行」から最初の単独 `}` までを抜き出す。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script" "$QUOTA_AWARE_SH"
-}
-
 # Issue #416: qa_detect_rate_limit は内部で qa_parse_session_limit_reset を呼ぶため、
 # 当該ヘルパーも extract して同 shell に読み込む（extract_function イディオムの依存関数
 # 追従 / CLAUDE.md「7. テストの近接配置」）。
 # shellcheck disable=SC1090,SC2086
-eval "$(extract_function "$WATCHER_SH" "qa_parse_session_limit_reset")"
+eval "$(extract_function "$WATCHER_SH" "qa_parse_session_limit_reset" "$QUOTA_AWARE_SH")"
 # shellcheck disable=SC1090,SC2086
-eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit")"
+eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit" "$QUOTA_AWARE_SH")"
 
 if ! declare -F qa_detect_rate_limit >/dev/null; then
   echo "ERROR: qa_detect_rate_limit not loaded" >&2
@@ -74,21 +67,6 @@ fi
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # fixture を qa_detect_rate_limit に流し、最終検出行（または "$path<TAB>$epoch"）を返す。
 # 検出が無ければ空文字列を返す。

--- a/local-watcher/test/qa_run_claude_stage_test.sh
+++ b/local-watcher/test/qa_run_claude_stage_test.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #177 Part 1 で低レベル共通ユーティリティ（qa_log 等のロガーを含む）は
 # modules/core_utils.sh へ分離された。関数抽出の探索元に core_utils.sh も含める。
@@ -64,32 +67,22 @@ trap 'rm -rf "$TMPDIR_TEST"' EXIT
 REPO="owner/test-repo"
 
 # 必要な関数だけを抽出して eval で読み込む。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script" "$CORE_UTILS_SH" "$QUOTA_AWARE_SH"
-}
-
 # qa_log / qa_warn / qa_error は qa_run_claude_stage が呼ぶので必ず loaded する
 # shellcheck disable=SC1090
-eval "$(extract_function "$WATCHER_SH" "qa_log")"
+eval "$(extract_function "$WATCHER_SH" "qa_log" "$CORE_UTILS_SH" "$QUOTA_AWARE_SH")"
 # shellcheck disable=SC1090
-eval "$(extract_function "$WATCHER_SH" "qa_warn")"
+eval "$(extract_function "$WATCHER_SH" "qa_warn" "$CORE_UTILS_SH" "$QUOTA_AWARE_SH")"
 # shellcheck disable=SC1090
-eval "$(extract_function "$WATCHER_SH" "qa_error")"
+eval "$(extract_function "$WATCHER_SH" "qa_error" "$CORE_UTILS_SH" "$QUOTA_AWARE_SH")"
 # Issue #416: qa_detect_rate_limit は内部で qa_parse_session_limit_reset を呼ぶため、
 # 当該ヘルパーも extract して同 shell に読み込む（extract_function イディオムの依存関数
 # 追従 / CLAUDE.md「7. テストの近接配置」）。
 # shellcheck disable=SC1090
-eval "$(extract_function "$WATCHER_SH" "qa_parse_session_limit_reset")"
+eval "$(extract_function "$WATCHER_SH" "qa_parse_session_limit_reset" "$CORE_UTILS_SH" "$QUOTA_AWARE_SH")"
 # shellcheck disable=SC1090
-eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit")"
+eval "$(extract_function "$WATCHER_SH" "qa_detect_rate_limit" "$CORE_UTILS_SH" "$QUOTA_AWARE_SH")"
 # shellcheck disable=SC1090
-eval "$(extract_function "$WATCHER_SH" "qa_run_claude_stage")"
+eval "$(extract_function "$WATCHER_SH" "qa_run_claude_stage" "$CORE_UTILS_SH" "$QUOTA_AWARE_SH")"
 
 for fn in qa_log qa_warn qa_error qa_parse_session_limit_reset qa_detect_rate_limit qa_run_claude_stage; do
   if ! declare -F "$fn" >/dev/null; then
@@ -101,21 +94,6 @@ done
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # fake-claude: fixture を stdout にダンプし、指定された exit code を返す。
 # qa_run_claude_stage は "$@" を実行するため、引数として fixture と rc を受け取る。

--- a/local-watcher/test/repo_prefix_log_test.sh
+++ b/local-watcher/test/repo_prefix_log_test.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #177 Part 1 で低レベル共通ユーティリティ（qa_log / mq_log / pi_log / drr_log 等の
 # ロガーを含む）は modules/core_utils.sh へ分離された。関数抽出の探索元に core_utils.sh も含める。
@@ -51,16 +54,6 @@ if [ ! -f "$MERGE_QUEUE_SH" ]; then
 fi
 
 # issue-watcher.sh / modules から関数 1 つだけを抽出する（normalize_slug_test.sh と同じ awk）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script" "$CORE_UTILS_SH" "$MERGE_QUEUE_SH"
-}
-
 # テスト用に REPO を固定値で上書き（cron 起動時の `REPO=owner/your-repo` を模倣）
 REPO="owner/test-repo"
 export REPO
@@ -76,7 +69,7 @@ LOGGER_FUNCS=(
 
 for fn in "${LOGGER_FUNCS[@]}"; do
   # shellcheck disable=SC1090,SC2086
-  eval "$(extract_function "$WATCHER_SH" "$fn")"
+  eval "$(extract_function "$WATCHER_SH" "$fn" "$CORE_UTILS_SH" "$MERGE_QUEUE_SH")"
   if ! declare -F "$fn" >/dev/null; then
     echo "ERROR: $fn not loaded from $WATCHER_SH" >&2
     exit 2

--- a/local-watcher/test/reviewer_max_turns_flow_test.sh
+++ b/local-watcher/test/reviewer_max_turns_flow_test.sh
@@ -16,6 +16,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #464 で impl pipeline 後半関数は modules/impl-pipeline.sh へ分離された。
 IMPL_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/impl-pipeline.sh"
@@ -28,16 +31,6 @@ if [ ! -f "$IMPL_PIPELINE_SH" ]; then
   echo "ERROR: cannot find impl-pipeline.sh at $IMPL_PIPELINE_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # 検証対象本体を抽出
 # shellcheck disable=SC1090,SC2086

--- a/local-watcher/test/reviewer_max_turns_retry_test.sh
+++ b/local-watcher/test/reviewer_max_turns_retry_test.sh
@@ -16,6 +16,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #460: Config ブロックが watcher-config.sh へ分離され、reviewer_normalize_extended_max_turns /
 # reviewer_is_error_max_turns の定義も config 側（source 時に config 行から呼ばれるため同伴）へ
@@ -35,16 +38,6 @@ if [ ! -f "$TU_SH" ]; then
   echo "ERROR: cannot find token-usage.sh at $TU_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # reviewer_normalize_extended_max_turns / reviewer_is_error_max_turns を隔離抽出。
 # reviewer_is_error_max_turns は tu_extract_last_result_json に依存するため、その依存関数も

--- a/local-watcher/test/reviewer_skip_files_match_test.sh
+++ b/local-watcher/test/reviewer_skip_files_match_test.sh
@@ -14,6 +14,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #464 で impl pipeline 後半関数は modules/impl-pipeline.sh へ分離された。
 IMPL_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/impl-pipeline.sh"
@@ -26,16 +29,6 @@ if [ ! -f "$IMPL_PIPELINE_SH" ]; then
   echo "ERROR: cannot find impl-pipeline.sh at $IMPL_PIPELINE_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$IMPL_PIPELINE_SH" "reviewer_skip_files_match")"

--- a/local-watcher/test/slug_match_guard_test.sh
+++ b/local-watcher/test/slug_match_guard_test.sh
@@ -24,6 +24,9 @@ set -euo pipefail
 # （個別の関数定義先頭で disable する）。
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #466 で _normalize_slug / _stage_checkpoint_assert_slug_match は modules/slot-worker.sh へ分離された。
 SLOT_WORKER_SH="$SCRIPT_DIR/../bin/modules/slot-worker.sh"
@@ -36,16 +39,6 @@ if [ ! -f "$SLOT_WORKER_SH" ]; then
   echo "ERROR: cannot find slot-worker.sh at $SLOT_WORKER_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # ─── 依存関数のうち副作用を持つものを stub する ───
 #
@@ -91,21 +84,6 @@ fi
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/sn_build_payload_388_test.sh
+++ b/local-watcher/test/sn_build_payload_388_test.sh
@@ -24,6 +24,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/slack-notify.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -36,16 +39,6 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # 関数抽出イディオム
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # sn_warn / sn_log は env 由来副作用なし → スタブで /dev/null
 sn_warn() { :; }
 sn_log() { :; }

--- a/local-watcher/test/sn_build_payload_test.sh
+++ b/local-watcher/test/sn_build_payload_test.sh
@@ -25,6 +25,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/slack-notify.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -38,16 +41,6 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # 関数抽出イディオム（fr_is_enabled_test.sh と同形式）
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # sn_warn / sn_log は env 由来副作用なし & stderr/stdout 出力のみ → スタブで /dev/null に流す
 sn_warn() { :; }
 sn_log() { :; }

--- a/local-watcher/test/sn_callsite_promote_test.sh
+++ b/local-watcher/test/sn_callsite_promote_test.sh
@@ -21,6 +21,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 PP_MOD="$SCRIPT_DIR/../bin/modules/promote-pipeline.sh"
 
 if [ ! -f "$PP_MOD" ]; then
@@ -29,16 +32,6 @@ if [ ! -f "$PP_MOD" ]; then
 fi
 
 # extract_function イディオム（既存テストと同形式）
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # pp_do_promote のみを抽出。pp_log / pp_warn / pp_notify_promote_failure は本テスト用の stub
 # で上書きするため、依存関数として個別に抽出しない。
 # shellcheck disable=SC1090,SC2086
@@ -101,21 +94,6 @@ PP_PROMOTE_FAILED_COUNT=0
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ============================================================
 # Section 1: 正常 path（rc=0）→ sn_notify が 1 回 promote-success で発火

--- a/local-watcher/test/sn_is_enabled_test.sh
+++ b/local-watcher/test/sn_is_enabled_test.sh
@@ -20,6 +20,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/slack-notify.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -28,16 +31,6 @@ if [ ! -f "$MODULE_SH" ]; then
 fi
 
 # 既存テスト（fr_is_enabled_test.sh）と同じイディオム: awk で関数本体だけを抽出して eval。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "sn_is_enabled")"
 
@@ -48,23 +41,6 @@ fi
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ============================================================
 # Section 1: ON（Req 1.2 / 厳密一致）

--- a/local-watcher/test/sn_notify_test.sh
+++ b/local-watcher/test/sn_notify_test.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/slack-notify.sh"
 
 if [ ! -f "$MODULE_SH" ]; then

--- a/local-watcher/test/stage_a_verify_path_missing_test.sh
+++ b/local-watcher/test/stage_a_verify_path_missing_test.sh
@@ -40,6 +40,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/stage-a-verify.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -53,21 +56,6 @@ source "$MODULE_SH"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/stage_a_verify_round1_defer_test.sh
+++ b/local-watcher/test/stage_a_verify_round1_defer_test.sh
@@ -32,6 +32,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #464 で impl pipeline 後半関数は modules/impl-pipeline.sh へ分離された。
 IMPL_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/impl-pipeline.sh"
@@ -46,16 +49,6 @@ if [ ! -f "$IMPL_PIPELINE_SH" ]; then
 fi
 
 # issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$IMPL_PIPELINE_SH" "stage_a_verify_round1_defer")"
 

--- a/local-watcher/test/stage_a_verify_timeout_pgkill_test.sh
+++ b/local-watcher/test/stage_a_verify_timeout_pgkill_test.sh
@@ -37,6 +37,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/stage-a-verify.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -58,21 +61,6 @@ source "$MODULE_SH"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_le() {
   # actual <= bound を assert（経過秒数の上限検証用）

--- a/local-watcher/test/stage_a_verify_tool_missing_test.sh
+++ b/local-watcher/test/stage_a_verify_tool_missing_test.sh
@@ -56,6 +56,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/stage-a-verify.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -69,21 +72,6 @@ source "$MODULE_SH"
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/stage_c_existing_pr_guard_test.sh
+++ b/local-watcher/test/stage_c_existing_pr_guard_test.sh
@@ -33,6 +33,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #459 で stage_c_existing_pr_guard は modules/stage-checkpoint.sh へ分離された。
 STAGE_CHECKPOINT_SH="$SCRIPT_DIR/../bin/modules/stage-checkpoint.sh"
@@ -48,16 +51,6 @@ fi
 
 # issue-watcher.sh / modules から該当関数 1 個だけを抽出する。
 # awk で「関数開始行」から最初の単独 `}`（インデント無し close brace）までを抜き出す。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$STAGE_CHECKPOINT_SH" "stage_c_existing_pr_guard")"
 
@@ -92,35 +85,6 @@ gh() {
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_contains() {
-  local label="$1" haystack="$2" needle="$3"
-  case "$haystack" in
-    *"$needle"*)
-      echo "PASS: $label"
-      PASS_COUNT=$((PASS_COUNT + 1))
-      ;;
-    *)
-      echo "FAIL: $label"
-      echo "  expected to contain: $(printf '%q' "$needle")"
-      echo "  actual            : $(printf '%q' "$haystack")"
-      FAIL_COUNT=$((FAIL_COUNT + 1))
-      ;;
-  esac
-}
 
 assert_not_contains() {
   local label="$1" haystack="$2" needle="$3"

--- a/local-watcher/test/stage_checkpoint_pending_tasks_test.sh
+++ b/local-watcher/test/stage_checkpoint_pending_tasks_test.sh
@@ -17,6 +17,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #461 で per-task loop 前半関数は modules/per-task-loop.sh へ分離された。
 PER_TASK_LOOP_SH="$SCRIPT_DIR/../bin/modules/per-task-loop.sh"
@@ -29,15 +32,6 @@ if [ ! -f "$PER_TASK_LOOP_SH" ]; then
   echo "ERROR: cannot find per-task-loop.sh at $PER_TASK_LOOP_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1" fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PER_TASK_LOOP_SH" "pt_extract_pending_tasks")"

--- a/local-watcher/test/stage_checkpoint_resumable_state_test.sh
+++ b/local-watcher/test/stage_checkpoint_resumable_state_test.sh
@@ -23,6 +23,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #466 で _stage_checkpoint_has_resumable_state は modules/slot-worker.sh へ分離された。
 SLOT_WORKER_SH="$SCRIPT_DIR/../bin/modules/slot-worker.sh"
@@ -35,15 +38,6 @@ if [ ! -f "$SLOT_WORKER_SH" ]; then
   echo "ERROR: cannot find slot-worker.sh at $SLOT_WORKER_SH" >&2
   exit 2
 fi
-
-extract_function() {
-  local script="$1" fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
 
 # ─── 対象関数の load ───
 # shellcheck disable=SC1090,SC2086

--- a/local-watcher/test/stagec_pr_verify_fallback_test.sh
+++ b/local-watcher/test/stagec_pr_verify_fallback_test.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #464 で impl pipeline 後半関数は modules/impl-pipeline.sh へ分離された。
 IMPL_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/impl-pipeline.sh"
@@ -43,16 +46,6 @@ fi
 
 # issue-watcher.sh から verify_stagec_pr_or_retry の関数定義のみを抽出して
 # current shell に load する。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$IMPL_PIPELINE_SH" "verify_stagec_pr_or_retry")"
 
@@ -129,19 +122,6 @@ export NUMBER REPO BRANCH
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1" needle="$2" haystack="$3"

--- a/local-watcher/test/stagec_pr_verify_retry_test.sh
+++ b/local-watcher/test/stagec_pr_verify_retry_test.sh
@@ -28,6 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #464 で impl pipeline 後半関数は modules/impl-pipeline.sh へ分離された。
 IMPL_PIPELINE_SH="$SCRIPT_DIR/../bin/modules/impl-pipeline.sh"
@@ -43,16 +46,6 @@ fi
 
 # issue-watcher.sh から verify_stagec_pr_or_retry の関数定義のみを抽出して
 # current shell に load する。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$IMPL_PIPELINE_SH" "verify_stagec_pr_or_retry")"
 
@@ -118,19 +111,6 @@ export NUMBER REPO BRANCH
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1" needle="$2" haystack="$3"

--- a/local-watcher/test/stagec_pr_verify_test.sh
+++ b/local-watcher/test/stagec_pr_verify_test.sh
@@ -19,6 +19,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #464 で impl pipeline 後半（verify_stagec_pr_or_retry / run_impl_pipeline 内 Stage C 配線を
 # 含む）は modules/impl-pipeline.sh へ分離された。サニティ grep の探索元を module に切り替える。
@@ -101,19 +104,6 @@ gh() { :; }
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # 共通 env（実装側の echo / qa_warn は本テストの仕様再現関数に含めていないため
 # NUMBER は未参照になる。実装側ログのフォーマットには含まれることを覚書として残す）

--- a/local-watcher/test/stale_pickup_reaper_test.sh
+++ b/local-watcher/test/stale_pickup_reaper_test.sh
@@ -56,6 +56,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/stale-pickup-reaper.sh"
 
@@ -72,16 +75,6 @@ fi
 # 対象スクリプトから 1 関数だけを awk で切り出して eval で読み込む。
 # トップレベル副作用は回避する（task 2 以降は modules/stale-pickup-reaper.sh 側を
 # 抽出元とする / task 1 の暫定配置は本体側から module 側へ移送済み）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 # 抽出: 9 関数を modules/stale-pickup-reaper.sh から取り出す
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "sr_is_enabled")"
@@ -129,38 +122,6 @@ new_state_dir() {
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
-
-assert_rc() {
-  local label="$1"
-  local expected_rc="$2"
-  shift 2
-  local actual_rc=0
-  "$@" >/dev/null 2>&1 || actual_rc=$?
-  if [ "$expected_rc" = "$actual_rc" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected rc: $expected_rc"
-    echo "  actual rc  : $actual_rc"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 # ============================================================
 # Section 0: Config ブロック正規化（Req 1.3 / 4.1 / 4.3 / 4.4）

--- a/local-watcher/test/tu_token_usage_test.sh
+++ b/local-watcher/test/tu_token_usage_test.sh
@@ -19,6 +19,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 MODULE_SH="$SCRIPT_DIR/../bin/modules/token-usage.sh"
 
 if [ ! -f "$MODULE_SH" ]; then
@@ -29,16 +32,6 @@ fi
 # 既存テストと同じイディオム: 対象スクリプトから関数だけを awk で切り出して
 # eval で読み込む。トップレベル副作用は回避する（本モジュールは関数定義のみだが
 # 他テストとの一貫性のため同じ方式を採る）。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script"
-}
-
 for fn in tu_enabled tu_mark_log_offset tu_extract_last_result_json tu_format_usage_kv tu_report_stage_usage tu_emit_issue_summary; do
   # shellcheck disable=SC1090,SC2086
   eval "$(extract_function "$MODULE_SH" "$fn")"
@@ -50,21 +43,6 @@ done
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1"
-  local expected="$2"
-  local actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1"

--- a/local-watcher/test/verify_pushed_or_retry_test.sh
+++ b/local-watcher/test/verify_pushed_or_retry_test.sh
@@ -27,6 +27,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
 WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
 # #177 Part 1 で低レベル共通ユーティリティ（qa_log 等のロガーを含む）は
 # modules/core_utils.sh へ分離された。関数抽出の探索元に core_utils.sh も含める。
@@ -50,25 +53,15 @@ fi
 
 # issue-watcher.sh から verify_pushed_or_retry / qa_log / qa_warn / qa_error の
 # 関数定義のみを抽出して current shell に load する。トップレベル副作用は回避する。
-extract_function() {
-  local script="$1"
-  local fn_name="$2"
-  awk -v fn="${fn_name}() {" '
-    $0 == fn { in_fn = 1 }
-    in_fn { print }
-    in_fn && $0 == "}" { in_fn = 0 }
-  ' "$script" "$CORE_UTILS_SH"
-}
-
 # qa_log / qa_warn / qa_error は verify_pushed_or_retry 内部で呼ばれる
 # shellcheck disable=SC1090,SC2086
-eval "$(extract_function "$WATCHER_SH" "qa_log")"
+eval "$(extract_function "$WATCHER_SH" "qa_log" "$CORE_UTILS_SH")"
 # shellcheck disable=SC1090,SC2086
-eval "$(extract_function "$WATCHER_SH" "qa_warn")"
+eval "$(extract_function "$WATCHER_SH" "qa_warn" "$CORE_UTILS_SH")"
 # shellcheck disable=SC1090,SC2086
-eval "$(extract_function "$WATCHER_SH" "qa_error")"
+eval "$(extract_function "$WATCHER_SH" "qa_error" "$CORE_UTILS_SH")"
 # shellcheck disable=SC1090,SC2086
-eval "$(extract_function "$IMPL_PIPELINE_SH" "verify_pushed_or_retry")"
+eval "$(extract_function "$IMPL_PIPELINE_SH" "verify_pushed_or_retry" "$CORE_UTILS_SH")"
 
 for fn in qa_log qa_warn qa_error verify_pushed_or_retry; do
   if ! declare -F "$fn" >/dev/null; then
@@ -176,19 +169,6 @@ add_local_commit() {
 # ─── アサーションヘルパ ───
 PASS_COUNT=0
 FAIL_COUNT=0
-
-assert_eq() {
-  local label="$1" expected="$2" actual="$3"
-  if [ "$expected" = "$actual" ]; then
-    echo "PASS: $label"
-    PASS_COUNT=$((PASS_COUNT + 1))
-  else
-    echo "FAIL: $label"
-    echo "  expected: $(printf '%q' "$expected")"
-    echo "  actual  : $(printf '%q' "$actual")"
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-  fi
-}
 
 assert_contains() {
   local label="$1" needle="$2" haystack="$3"


### PR DESCRIPTION
Closes #474

## 概要

95 本のテストが各自コピーしていた `extract_function` / `assert_eq` / `assert_contains` /
`assert_rc` を `local-watcher/test/lib/test-helpers.sh` に集約し、全テストを source 方式へ
移行する。**各テストの検証内容・assert 文言・PASS/FAIL 件数は不変**。

## 事前調査で判明した実態（想定より変動が大きかった）

着手前に全 95 ファイルの実装をハッシュ比較したところ、issue 本文が想定していたより
バリエーションが多いことが判明した:

| 関数 | 定義ファイル数 | 多数派ハッシュに一致 | 差異内容 |
|---|---|---|---|
| `extract_function` | 82 | 76 + cosmetic 6 = 82（**全件**） | 4 件は cross-module 検索用の追加ファイル引数をハードコードしていた |
| `assert_eq` | 82 | 79（cosmetic/counter-rename 込み） | 3 件はメッセージ文言が異なる（`(=$actual)` 付記等）+ 1 件は引数順序・カウンタ変数名・出力言語すべて異なる |
| `assert_contains` | 37 | 17 | **20 件**が引数順序（needle/haystack 逆転）+ FAIL 時の診断ラベル文言が異なる |
| `assert_rc` | 25 | 14 | **11 件**が呼び出し規約自体が異なる（コマンド実行ではなく計算済み rc を直接渡す形） |

## 移行方針（判断結果）

- **多数派ハッシュと完全一致 または cosmetic 差異のみ**（`local` 宣言の 1 行/3 行スタイル差、
  `;` での行結合、FAIL 診断行の桁揃え空白 1 個等、出力テキストが変わらない差異）→ ローカル定義を
  削除し共有版に委譲
- **引数順序 / メッセージ文言 / カウンタ変数名 / 呼び出し規約が異なる**→ ローカル定義を
  **そのまま温存**（source 後方で再定義され共有版を shadow するため挙動は完全不変）。
  無理に call site 変換すると FAIL 時の出力文言が変わってしまうため、`assert 文言は不変`
  の制約を優先した
- **PASS・FAIL カウンタ**: 91/95 ファイルが `PASS_COUNT`/`FAIL_COUNT` を使用（残り 4 は
  `PASS`/`FAIL`）。共有ライブラリは多数派の `PASS_COUNT`/`FAIL_COUNT` を前提にする
- **サマリ出力**: 最終行の PASS/FAIL 表示は 3 種類以上の書式が混在しており多数派が
  弱い（91 ファイル中最大グループでも 33 件 ≈ 36%）ため、**今回は対象外とした**
  （issue 本文が「サマリ出力」も集約対象として挙げていたが、実態を見て意図的にスコープを
  絞った。将来的にフォーマット統一が必要なら別 Issue で）
- **assert_not_contains / assert_grep 等その他 14 種の assert_\* ヘルパー**は issue 本文に
  明記されていないため対象外（各テストにそのまま残置）

### extract_function の一般化

多数派の 2 引数形はそのまま、`shift 2` 後に `"$@"` を awk へ追加ファイルとして渡す形へ
一般化。既存の 2 引数呼び出し（78 ファイル）は `"$@"` が空になるだけで挙動は従来と完全に
同一。4 ファイル（`repo_prefix_log_test.sh` / `verify_pushed_or_retry_test.sh` /
`qa_detect_rate_limit_test.sh` / `qa_run_claude_stage_test.sh`）はローカル定義が
`CORE_UTILS_SH` 等の追加検索ファイルをハードコードしていたため、削除の代わりに
call site 側へ同じ追加ファイルを明示引数として機械変換した。

### 実装中に発見した特殊ケース（2 ファイル）

`pdr_default_on_test.sh` / `pr_reviewer_adjudicator_default_on_test.sh` は
`SCRIPT_DIR` 解決より **前**に `assert_eq` / `extract_function` を定義・使用する
（純 bash 正規化ロジックを検証する前半ブロックと、`SCRIPT_DIR` 経由で実関数を extract する
後半ブロックの 2 部構成）。全ファイル一律で「`SCRIPT_DIR` 直後に source」する方針だと
この 2 ファイルの前半ブロックが `assert_eq: command not found` で red 化したため、
この 2 ファイルは `extract_function` / `assert_eq` のローカル定義を温存する例外とした
（気づいた経緯: 移行直後の全件テスト実行で 2 件 red を検出し、原因を特定して除外した）。

## 手順（2 commit 構成、issue 本文の指示通り）

1. **commit 1**: `test/lib/test-helpers.sh` 新設 + 代表 10 本（多数派そのまま /
   cosmetic variant / 特殊 call-site 書き換え / 複数の除外ケース）を先行移行、green 確認
2. **commit 2**: 残り 85 本を一括移行

## 検証結果

```
$ bash -n（全 95 本 + lib）→ syntax OK
$ 全 95 本実行 → red=0
```

**PASS/FAIL 件数の不変性確認**:
- issue 指定の 5 本サンプリング（`git worktree` で移行前 HEAD を並行チェックアウトし、
  相対パス解決を壊さない状態で比較）:

  | ファイル | 移行前 PASS/FAIL/rc | 移行後 PASS/FAIL/rc |
  |---|---|---|
  | adj_classify_test.sh（完全移行） | 28/1/0 | 28/1/0 |
  | fr_attempt_test.sh（assert_rc 除外） | 60/0/0 | 60/0/0 |
  | pdr_default_on_test.sh（SCRIPT_DIR順序例外） | 18/1/0 | 18/1/0 |
  | repo_prefix_log_test.sh（特殊 call-site 書換） | 37/0/0 | 37/0/0 |
  | stage_a_verify_round1_defer_test.sh（完全除外） | 0/0/0 | 0/0/0 |

- 全 95 本の集計値でも確認: **PASS=3085 FAIL=17（移行前後で完全一致）**

**shellcheck**: `local-watcher/test/*.sh` は CLAUDE.md の零警告ゲート対象外
（`shellcheck local-watcher/bin/*.sh install.sh setup.sh .github/scripts/*.sh` に
test/ は含まれない）だが参考のため実施。新規に発生した警告種別はゼロ（既存警告
`SC2034`/`SC2016`/`SC1072`/`SC1073` の総数は移行前後で不変。後者 2 つは
`pr_publish_commit_status_test.sh` の既存バグ — 別途 spawn_task で切り出し済み、
本 PR の変更対象外）。

**重複定義なし**: 移行対象の関数は削除ファイル側で 0 件・共有ライブラリ側で 1 件のみ。
除外ファイルはローカル定義を温存しているため共有版を shadow する（bash の関数再定義は
後勝ちのため安全に共存）。

**root ↔ repo-template 同期**: 本 PR は test/ のみが対象のため無関係。念のため
`diff -r .claude/agents repo-template/.claude/agents` / `rules` 版とも空を確認。

## 確認事項（レビュワー判断ポイント）

1. **「サマリ出力」の集約を見送った**: issue 本文は "PASS・FAIL カウンタ / サマリ出力" も
   集約対象として挙げていたが、実際には最終行の書式が 3 種類以上に分かれており
   （`RESULT: PASS=$N FAIL=$M` / `PASS: $N, FAIL: $M` / 2 行に分割 等）、多数派も
   36% 程度と弱いため、無理に統一すると表示文言が変わってしまう。今回はスコープ外とした
2. **assert_contains 20 件 / assert_rc 11 件がローカル定義のまま**: 引数順序が
   needle/haystack 逆転しているものが大半で、FAIL 時の診断ラベルも異なる。call site の
   機械変換だけでは出力文言が変わってしまうため、あえて共通化しなかった
3. **assert_not_contains 等 14 種の assert_\* は対象外**: issue 本文に明記された
   4 関数（`extract_function`/`assert_eq`/`assert_contains`/`assert_rc`）のみ対応した
4. `pr_publish_commit_status_test.sh` の shellcheck SC1072/1073（コメント文言が
   `# shellcheck` で始まり誤認識される既存バグ、#473 で見つけたのと同種）は本 PR 内で
   直接直さず spawn_task で別セッションへ切り出した（本 PR の変更対象ファイルではないため）

## スタック運用について

本 PR は #455 tracking issue の子 issue 群の一部として、base を `main` ではなく
`claude/issue-473-install-restructure`（直前 issue #473 のブランチ）にしている。
先行 PR が `main` に merge され次第、base を付け替える。

🤖 Generated with [Claude Code](https://claude.com/claude-code)