### PR TITLE
docs(claude): §7 テスト近接配置に test/lib/test-helpers.sh の source 利用を明記（#474 追随）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,13 @@ watcher は Issue/PR 本文・コメント・ラベル・ブランチ名・branc
   純粋関数（副作用なし）は入出力 fixture で、副作用を伴う関数は `gh` / `git` を stub して
   呼び出しトレースで検証する。**ヘルパーを抽出したら、それを呼ぶ既存テストの抽出リストにも
   追随させる**（隔離抽出の特性上、依存関数を明示 source する必要がある）。
+- `extract_function` / `assert_eq` / `assert_contains` / `assert_rc` は
+  **`local-watcher/test/lib/test-helpers.sh` を source して利用する**（#474 で共通化済み。
+  新規テストで自前コピーしない）。定型は `SCRIPT_DIR` 解決直後に
+  `. "$SCRIPT_DIR/lib/test-helpers.sh"`。共有実装と異なる引数順・文言が必要な場合のみ、
+  source の**後**にローカル定義で shadow する（#474 の少数派温存パターン）。heredoc 内に
+  行頭 `}` を含む関数は共通 `extract_function` では切り出せないため、従来どおり
+  テスト内の専用抽出を使う（例: `adj_oos_prompt_test.sh`）。
 
 ### 8. 機能追加 PR 提出前チェックリスト
 


### PR DESCRIPTION
## 概要

#474 で `extract_function` / `assert_eq` / `assert_contains` / `assert_rc` が
`local-watcher/test/lib/test-helpers.sh` へ共通化されたが、CLAUDE.md「機能追加ガイドライン
§7 テストの近接配置」が旧イディオム（各テストが自前定義）のままだった。この文言に従う
新規テスト作成者（auto-dev エージェント含む）がヘルパーを source せず自前コピーしてしまう
drift を防ぐため、§7 に以下を追記する:

- 共通ヘルパーを source して利用する（自前コピーしない）+ source 定型
- 引数順・文言が異なる場合の shadow パターン（#474 の少数派温存に整合）
- heredoc 内に行頭 `}` を含む関数は共通 extract_function 対象外（既存例外の明文化）

## 確認事項

- ドキュメントのみの変更（コード・テスト不変）
- root CLAUDE.md は consumer 固有のため repo-template 同期対象外（`diff -r .claude/{agents,rules}` 不変を確認済み）