### PR TITLE
feat(#508): size ラベルに応じた Developer モデル解決を追加する（モデルルーティング Phase 2）

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ idd-claude/
     │   │   ├── auto-merge-disarm.sh      #   auto-merge 取り消しプロセッサ（#434）
     │   │   ├── promote-pipeline.sh       #   Promote Pipeline プロセッサ（#15 / #181 Part 3 / #472 で path-overlap.sh を分離）
     │   │   ├── path-overlap.sh           #   Path Overlap Checker プロセッサ（#18 Phase E / #472 で promote-pipeline.sh から分割）
-    │   │   ├── model-router.sh           #   Model Routing（Triage complexity → size ラベル永続化 / #507 Phase 1）
+    │   │   ├── model-router.sh           #   Model Routing（#507 Phase 1: size ラベル永続化 / #508 Phase 2: Developer モデル解決）
     │   │   ├── pr-iteration.sh           #   PR Iteration プロセッサ orchestrator（#181 Part 3 / #469 で family 分割）
     │   │   ├── pr-iteration-comments.sh  #   └ family: 一般コメント収集 + filter chain（#469）
     │   │   ├── pr-iteration-state.sh     #   └ family: PR body marker read/write + no-progress streak（#469）
@@ -636,6 +636,12 @@ cron / launchd 側でリポジトリを指定する運用にします（単一 r
 | `DEV_MODEL` | `claude-opus-4-8` | Stage A 系（PM + Developer）/ design モード / Per-Task Impl |
 | `PJM_MODEL` | `claude-sonnet-4-6` | **Stage C（PjM / 実装 PR 作成）**。機械的作業のため軽量既定（#328） |
 | `REVIEWER_MODEL` | `claude-opus-4-8` | Reviewer（独立レビューゲート）/ Per-Task Reviewer |
+| `DEV_MODEL_SMALL` | **（空）** | `size:small` ラベル付き Issue の Developer 実行。空のままなら `DEV_MODEL`（#508 / opt-in） |
+| `DEV_MODEL_MEDIUM` | **（空）** | `size:medium` ラベル付き Issue の Developer 実行。空のままなら `DEV_MODEL`（#508 / opt-in） |
+
+> `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` は **`MODEL_ROUTING_ENABLED=true` かつ値の明示**という
+> 二重 opt-in で初めて効きます（既定は空 = 全 Issue が `DEV_MODEL`）。詳細と既知の制約は
+> [Model Routing Phase 2: size ラベル → Developer モデル (#508)](#model-routing-phase-2-size-ラベル--developer-モデル-508) を参照してください。
 
 > **Migration note（#328 / `PJM_MODEL` 導入）**: #328 以前の Stage C は `DEV_MODEL`
 > （既定 Opus）で起動されていました。PR 作成は review-notes の commit / `gh pr create` /
@@ -1573,6 +1579,7 @@ idd-claude は基本フロー（Triage → 実装 → PR 作成）以外の機�
 | **Slack 通知 emitter**（自動 merge armed / 自動 merge merged 完了 / failed-recovery 終端 / needs-decisions 自動続行 / promote 完了 / impl 着手（claude-pickup）といった人間が能動的に把握すべき重要イベントを Slack Incoming Webhook 経由で push 通知する補助的な観測チャネル（D-18・低優先）。通常運用は `run-summary` + watcher ログで完結し、本機能は「Slack を見ていれば異常終端・自動マージ完了・実装着手に気付ける」程度の補助的可視化を担う。完全な opt-in（gate OFF 時は本機能導入前と完全に等価で gh / git API 呼び出しゼロ・curl 呼び出しゼロ・ラベル遷移ゼロ）。webhook URL は env 経由のみで受け取り、コードベース・ログ・テストフィクスチャに実値を残さない。通知失敗（HTTP 4xx/5xx / curl 非ゼロ exit / payload 整形失敗）はパイプライン本体に伝播せず WARN ログ 1 行のみ残す（fail-open）。payload には event 種別識別子・repo 識別子・Issue/PR 番号・GitHub URL・result status・detail（secret scrub 済）を含み、Slack Block Kit `section` ブロック + フォールバック `text` フィールドで構成される。secret scrub は GitHub token prefix（`ghp_` 等）/ Slack webhook URL / 32 桁以上連続英数字を `[REDACTED]` に置換する best-effort 防御。**通知対象イベント**: auto-merge armed（実装 PR / `result=armed`）/ auto-merge-design armed（設計 PR / `result=armed`）/ **auto-merge-merged**（実装 PR の実 merge 完了 / `SLACK_NOTIFY_MERGED_ENABLED=true` でのみ発火 / #388）/ **auto-merge-design-merged**（設計 PR の実 merge 完了 / 同上 / #388）/ failed-recovery 終端 3 種（recovered / max-attempts / no-progress）/ needs-decisions auto-continue 成功 / promote 完了 / claude-pickup（impl 着手時のラベル付け替え成功 / #390）。**Migration Note (#388)**: 旧バージョンでは auto-merge / auto-merge-design の armed 通知（GitHub auto-merge を有効化した時点）が `result=success` で発火し Slack 上で「merge 完了」と誤読される問題があった。本修正で armed 通知は `result=armed` + detail に `armed (squash on green checks)` 明示に変更され、実際の merge 完了は新規 event_type `auto-merge-merged` / `auto-merge-design-merged` で別途通知される。`SLACK_NOTIFY_ENABLED=true` 既存ユーザは armed 文面が変わる（`result=success` ではなく `result=armed`）点に注意。新規 merged 通知の発火は `SLACK_NOTIFY_MERGED_ENABLED=true` 厳密一致でのみ有効（未設定なら本機能導入前と等価で armed 通知のみ）。merged 検知は GitHub auto-merge enable 成功時に PR 番号を `$HOME/.issue-watcher/auto-merge-pending/<repo-slug>/pr-<N>.json` に積み、後続サイクルで `gh pr view` の `state=MERGED` 観測時に 1 度だけ通知 + state 削除する方式。人間が手動 merge した PR は state に積まれていないため通知されない） | `SLACK_NOTIFY_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `TRUE` / `1` / `on` / `yes` / typo / 前後空白付き）はすべて OFF に正規化（外部副作用ゼロで sn_notify が早期 return） | **必須**: `SLACK_WEBHOOK_URL`（Slack Incoming Webhook URL。secret 値。リポジトリにコミットしない。`SLACK_NOTIFY_ENABLED=true` かつ本 env が未設定 / 空のときは sn_warn 1 行 + no-op で起動可）。推奨: `SLACK_NOTIFY_TIMEOUT`（秒。curl `--max-time` に渡す HTTP POST タイムアウト上限。既定 `5`。非数値 / 負数 / 空は既定 5 に正規化）。**#388 で追加**: `SLACK_NOTIFY_MERGED_ENABLED`（`=true` 厳密一致で auto-merge-merged / auto-merge-design-merged 通知を有効化。既定 `false` で未設定環境は本機能導入前と等価）、`AUTO_MERGE_MERGED_STATE_DIR`（pending state 配置先。既定 `$HOME/.issue-watcher/auto-merge-pending/<repo-slug>` / 通常変更不要）、`AUTO_MERGE_MERGED_MAX_CHECKS`（1 サイクルあたりの `gh pr view` 呼び出し上限。既定 `50`）、`AUTO_MERGE_MERGED_GH_TIMEOUT`（1 件あたりの gh タイムアウト秒。既定 `60`） | — | #370, #388, #390 |
 | **Full-Auto Kill Switch**（full-auto 系 processor の単一 kill switch。**AND セマンティクス**で個別 gate と並列に作用し、`FULL_AUTO_ENABLED=true` かつ個別 gate=true の場合のみ full-auto 系 processor が発火する二重 opt-in。不具合発生時に env 1 つで全 full-auto 挙動を即時 no-op に倒すための運用 knob。**現在の配線対象**は Dependency Auto-Unblock Sweep (#346) + Auto-Merge (#352) + Design Auto-Merge (#354) + PR Reviewer Commit Status (#349) + Failed Recovery (#359) + needs-decisions Auto-Continue (#362) の 6 系統。semantic conflict / blocked cascade は未実装のため将来追加時に同じ kill switch を参照する設計。既存 opt-in 機能（merge-queue / auto-rebase / promote-pipeline / pr-iteration / pr-reviewer / security-review / design-review-release / stage-checkpoint / stage-a-verify / quota-aware / debugger / hooks）は **本フラグ配下に入れず** 個別 gate で独立制御を維持） | `FULL_AUTO_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / `True` / `TRUE` / `1` / `on` / `False` / 空文字 / 前後空白付き / typo）はすべて OFF に正規化（外部副作用ゼロで早期 return + suppression ログ 1 行）。本機能導入前と完全に等価（NFR 1.1） | — | (本表の各 full-auto processor 行を参照) | #348 |
 | **Model Routing Phase 1**（Triage が出力した変更規模 `complexity` を `size:small` / `size:medium` / `size:large` ラベルとして Issue に永続化する。Triage を再実行しないサイクル（impl-resume / PR Iteration / Failed Recovery）でも判定結果を sticky に参照でき、人間が事前にラベルを貼れば Triage 判定を override できる。既存 `size:*` ラベルが 1 つでもあれば追加・付け替え・削除のいずれも行わない（先に存在するラベル優先 / 人間 override と過去 Triage 由来を区別しない）。`skip-triage` / impl-resume 経路は Triage ブロックごと迂回されるため付与されない。値の不正は WARN のみで継続（fail-safe）、GitHub 操作の失敗も WARN のみで当該サイクルを中断しない（fail-open）。gate OFF 時は本機能に起因する GitHub API 呼び出し 0 回・ログ 0 行で本機能導入前と完全に等価。**Triage 側の `complexity` / `complexity_reason` 出力は gate に依らず常時行われる**（gate は watcher 側の永続化のみを制御）） | `MODEL_ROUTING_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `TRUE` / `1` / `on` / `off` / typo）はすべて安全側 OFF に正規化 | **前提**: `bash .github/scripts/idd-claude-labels.sh` で `size:small` / `size:medium` / `size:large` ラベルを作成済みであること（未作成の repo では付与が毎回失敗し WARN が出る / 処理自体は継続） | [Model Routing Phase 1: Triage complexity → size ラベル (#507)](#model-routing-phase-1-triage-complexity--size-ラベル-507) | #507 |
+| **Model Routing Phase 2**（Issue に付いた `size:*` ラベルを読んで、その Issue の **Developer 実行モデル**（`DEV_MODEL`）を slot 内で切り替える。**gate 有効化だけではモデルは変わらない二重 opt-in**（`DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` に値を明示して初めて適用される）。解決は **slot 起動時点のラベル集合に基づく 1 回のみ**で、追加の GitHub API 呼び出し・LLM 実行はゼロ。size ラベル不在 / `size:*` 複数付与 / 許可値外はすべて `DEV_MODEL` へ fail-safe。適用先は当該 slot 内の Developer 実行（design セッション / 実装 Stage 群 / per-task ループ）のみで、Triage / Reviewer / PjM / slot 外プロセッサは対象外。gate OFF 時は本機能に起因する外部コマンド呼び出し 0 回・ログ 0 行で導入前と完全に等価） | `MODEL_ROUTING_ENABLED`（Phase 1 と**共通の単一 gate**。Phase 別 gate は設けない） | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `TRUE` / `1` / `on` / `off` / typo）はすべて安全側 OFF に正規化 | **必須（これが無いと何も変わらない）**: `DEV_MODEL_SMALL` および / または `DEV_MODEL_MEDIUM`（**既定はいずれも空**。モデル ID は埋め込まれていないため運用者が明示指定する。例: `DEV_MODEL_SMALL=claude-sonnet-4-6`）。`size:large` 専用 env は無く `large` は `DEV_MODEL` を使う | [Model Routing Phase 2: size ラベル → Developer モデル (#508)](#model-routing-phase-2-size-ラベル--developer-モデル-508) | #508 |
 | **GitHub Actions ワークフロー**（local watcher の代替実行基盤） | `IDD_CLAUDE_USE_ACTIONS`（GitHub Repository Variable。**env var ではない**） | 未設定 = 無効 | Repository Variable に `true` を厳密一致で設定。未設定 / `true` 以外（`on` / `True` / `1` 等）はワークフロー発火を停止 | — | [Step 3-B. GitHub Actions をセットアップ](#step-3-b-github-actions-をセットアップ代替) | #10 |
 
 各機能は**互いに独立**に制御できます。例えば `MERGE_QUEUE_RECHECK_ENABLED=false` だけを
@@ -2451,9 +2458,11 @@ cd ~/.idd-claude && git pull && ./install.sh --local
    （`auto-dev` ラベル運用と同型の運用ゲート）
 
 > **本 Phase のスコープ**: 判定結果の**永続化まで**です。size ラベルに基づく Developer
-> モデル ID の解決（Phase 2 / #508）と、tasks 件数超過時の子 Issue 分割案コメント
-> （Phase 3 / #509）は本 Phase には含まれません。したがって現時点で gate を有効化しても、
-> 起きることは size ラベルの付与のみです。
+> モデル ID の解決は [Phase 2 (#508)](#model-routing-phase-2-size-ラベル--developer-モデル-508)、
+> tasks 件数超過時の子 Issue 分割案コメント（Phase 3 / #509）は本 Phase には含まれません。
+> Phase 2 も同じ `MODEL_ROUTING_ENABLED` gate 配下ですが、**size 別モデルを明示しない限り
+> モデルは変わりません**（二重 opt-in）。したがって gate だけを有効化した状態で起きることは
+> size ラベルの付与のみです。
 
 ### size ラベルの意味
 
@@ -2532,6 +2541,134 @@ MODEL_ROUTING_ENABLED=true \
 
 `local-watcher/bin/modules/model-router.sh`（新規）/ `local-watcher/bin/watcher-config.sh` /
 `local-watcher/bin/triage-prompt.tmpl` を変更する PR を merge しただけでは、cron / launchd が
+実行する `$HOME/bin/` 配下は古いままです。反映するには以下を実施してください:
+
+```bash
+cd ~/.idd-claude && git pull && ./install.sh --local
+```
+
+---
+
+## Model Routing Phase 2: size ラベル → Developer モデル (#508)
+
+Phase 1 で Issue に永続化された `size:*` ラベルを読み、**その Issue の Developer 実行モデル**
+（`DEV_MODEL`）を slot 内で切り替えます。軽微な Issue で最上位モデルの quota / コストを
+消費しないための機能です。
+
+**モデルが変わるには 2 つの条件が両方必要です（二重 opt-in）**:
+
+1. `MODEL_ROUTING_ENABLED=true`（Phase 1 と**共通の単一 gate**。Phase 別 gate はありません）
+2. `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` に**モデル ID を明示**（既定はいずれも**空**）
+
+gate を有効化しただけではモデルは変わりません（silent にモデルが下がる事故を避けるため、
+既定値に具体的なモデル ID を埋め込んでいません）。
+
+### 設定値
+
+| env | 既定 | 意味 |
+|---|---|---|
+| `DEV_MODEL_SMALL` | **（空）** | `size:small` の Issue に適用する Developer モデル ID。空なら `DEV_MODEL` |
+| `DEV_MODEL_MEDIUM` | **（空）** | `size:medium` の Issue に適用する Developer モデル ID。空なら `DEV_MODEL` |
+
+`size:large` 専用の env はありません（`large` は `DEV_MODEL` を使います）。設定値はモデル ID の
+許可値リストと照合されず、指定した文字列がそのまま `--model` に渡ります。
+
+### 解決結果の一覧
+
+| Issue のラベル状態 | 適用される Developer モデル |
+|---|---|
+| `size:small` あり + `DEV_MODEL_SMALL` 設定あり | `DEV_MODEL_SMALL` |
+| `size:small` あり + `DEV_MODEL_SMALL` 空 | `DEV_MODEL`（fallback） |
+| `size:medium` あり + `DEV_MODEL_MEDIUM` 設定あり | `DEV_MODEL_MEDIUM` |
+| `size:medium` あり + `DEV_MODEL_MEDIUM` 空 | `DEV_MODEL`（fallback） |
+| `size:large` あり | `DEV_MODEL` |
+| `size:*` ラベルなし | `DEV_MODEL`（fallback） |
+| `size:*` ラベルが 2 つ以上 | `DEV_MODEL`（どれも採用しない fail-safe） |
+| 不正値（`size:huge` / `size:Small` / 末尾に空白 等） | `DEV_MODEL`（fail-safe） |
+| `MODEL_ROUTING_ENABLED` が `true` 以外 | `DEV_MODEL`（機能そのものが動かない） |
+
+ラベル名は `^size:(small|medium|large)$` に**厳密一致**した場合のみ採用されます
+（大文字混じり・前後空白・部分一致はすべて fallback）。
+
+### 適用範囲と対象外
+
+**適用されるもの**（当該 slot 内の Developer 実行すべてに同一モデルが一貫して適用されます）:
+
+- design セッション（PM → Architect → PjM の単一セッション実行）
+- 実装 Stage 群（Stage A / A' / B）
+- per-task ループ（Implementer）
+
+**適用されないもの**（本機能では一切変更しません）:
+
+- `TRIAGE_MODEL`（Triage）/ `REVIEWER_MODEL`（Reviewer・Per-Task Reviewer）/ `PJM_MODEL`（Stage C）
+  — Reviewer は品質ゲートのため上位モデルを維持します
+- slot 外プロセッサのモデル: `PR_ITERATION_DEV_MODEL`（PR Iteration）/
+  `FAILED_RECOVERY_DEV_MODEL`（Failed Recovery）/ `AUTO_REBASE_MODEL` / `DEBUGGER_MODEL` 等
+- `DEV_MODEL` 自体の既定値・意味・上書き方法（変更していません）
+
+### 適用タイミングと既知の制約（重要）
+
+モデル解決は **slot 起動時点のラベル集合スナップショットに基づき、1 Issue の 1 slot 実行に
+つき 1 回だけ**行われます（追加の GitHub API 呼び出しは 0 回）。Triage 実行後の再解決は
+行いません。
+
+> **⚠️ 初回 Triage 経路では効きません**: 新規 Issue が同一 slot 実行内で「Triage → size ラベル
+> 付与 → 実装」と進む経路では、slot 起動時点のスナップショットに `size:*` がまだ含まれないため
+> `DEV_MODEL` へ fallback します。これは**意図された既知の制約**であり不具合ではありません。
+
+したがって本機能が実際に効くのは次の 3 経路です:
+
+1. **人間が事前に size ラベルを貼った Issue**（初回の slot 実行から適用されます）
+2. **`skip-triage` 経路**（既に付いている size ラベルが使われます）
+3. **impl-resume / 再 pickup サイクル**（前サイクルで付与された size ラベルが使われます）
+
+誤って `size:small` を貼った Issue は、ラベルを剥がすまで下位モデルで実装され続けます。
+訂正手順は Phase 1 と同じく「ラベルを剥がす → 次回 Triage で再付与」です。
+
+### 有効化
+
+```bash
+MODEL_ROUTING_ENABLED=true \
+  DEV_MODEL_SMALL=claude-sonnet-4-6 \
+  DEV_MODEL_MEDIUM=claude-sonnet-4-6 \
+  REPO=owner/name REPO_DIR=$HOME/src/name $HOME/bin/issue-watcher.sh
+```
+
+（上記のモデル ID は**記入例**です。実際に使うモデルは運用方針に合わせて指定してください。）
+
+### ログ（可観測性）
+
+gate 有効時は、解決のたびに `model-router:` prefix 付きのログが cron ログ / slot ログへ
+**1 行**残ります（すべての分岐でログを残し silent fail を作りません）:
+
+```text
+model-router: issue=#123 size=small dev_model=claude-sonnet-4-6
+model-router: issue=#124 size=none dev_model=claude-opus-4-8 fallback=DEV_MODEL（理由: size ラベル不在）
+model-router: issue=#125 size=multiple dev_model=claude-opus-4-8 fallback=DEV_MODEL（理由: size:* ラベルが複数付与）
+model-router: issue=#126 size=invalid dev_model=claude-opus-4-8 fallback=DEV_MODEL（理由: size ラベル値が許可値に不一致）
+```
+
+`fallback=DEV_MODEL` の有無で「size 別モデルが適用されたか」を判別できます。未信頼な
+ラベル値そのものはログへ出力せず、判定結果を表す固定トークン（`none` / `multiple` /
+`invalid`）のみを出します。
+
+### migration note（後方互換）
+
+- `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` は **新規追加・既定空**です。未設定環境では
+  `MODEL_ROUTING_ENABLED` の値に関わらず全 Issue が従来どおり `DEV_MODEL` で実行されます
+- gate OFF 時は本機能に起因する外部コマンド呼び出し **0 回**・ログ **0 行**で、本機能導入前と
+  完全に同一の挙動になります
+- 既存 env var 名（`DEV_MODEL` / `TRIAGE_MODEL` / `REVIEWER_MODEL` / `PJM_MODEL` /
+  `PR_ITERATION_DEV_MODEL` / `FAILED_RECOVERY_DEV_MODEL` / `MODEL_ROUTING_ENABLED`）の
+  名称・既定値・解決順序はいずれも変更していません。ラベル遷移契約 / exit code の意味 /
+  ログ出力先 / cron 登録文字列も不変です
+- slot 内で確定した Developer モデルは**当該サブシェル内に閉じ**、親プロセスや他 slot の
+  設定へは伝播しません（slot ごとに独立して解決されます）
+
+### ⚠️ merge 後の再配置が必要
+
+`local-watcher/bin/modules/model-router.sh` / `local-watcher/bin/modules/slot-worker.sh` /
+`local-watcher/bin/watcher-config.sh` を変更する PR を merge しただけでは、cron / launchd が
 実行する `$HOME/bin/` 配下は古いままです。反映するには以下を実施してください:
 
 ```bash

--- a/docs/specs/508-feat-watcher-size-developer-phase-2/impl-notes.md
+++ b/docs/specs/508-feat-watcher-size-developer-phase-2/impl-notes.md
@@ -1,0 +1,135 @@
+# 実装ノート: #508 Model Routing Phase 2（size ラベル → Developer モデル）
+
+> 分量が目安の 120 行を超過（132 行）。requirements.md の AC が 8 要件 × 計 41 項目あり、
+> 1 要件 1 行の traceability 表だけで 31 行を占めるため（重複説明・コード転載はしていない）。
+
+design.md / tasks.md は本 Issue には存在しない（requirements.md のみが入力・正準）。以下は
+requirements.md の AC に忠実に実装した結果と、実装時に下した判断の記録。
+
+## 変更ファイル
+
+| ファイル | 変更内容 |
+|---|---|
+| `local-watcher/bin/modules/model-router.sh` | 純粋関数 `mr_extract_size_label` / `mr_resolve_dev_model` を追加（module 冒頭ヘッダも Phase 2 を反映） |
+| `local-watcher/bin/modules/slot-worker.sh` | `_slot_apply_dev_model_routing` を追加し `_slot_run_issue` 冒頭から 1 回呼ぶ（family マニフェストも更新） |
+| `local-watcher/bin/watcher-config.sh` | `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM`（既定は空）を追加 |
+| `local-watcher/test/model_router_test.sh` | Phase 2 の近接テスト（Unit P1 / P2、Integration P3、Wiring P4）を追加 |
+| `README.md` | オプション機能一覧の行 / ステージ別モデル表 / Phase 2 専用節 / Phase 1 節のリンク / ディレクトリ構成 |
+
+`repo-template/` に `local-watcher/` は存在しない（`.claude` と `.github` のみ）ため、modules の
+ミラー同期は対象外。`install.sh` は `modules/*.sh` を glob 配布するため installer 変更も不要。
+
+## 設計判断
+
+1. **gate 判定は Slot Runner 側に置き、Model Router には持たせない**（Req 1.7 / 1.8 / 5.2）。
+   Req 1.8 が解決結果の入力を「size 値 + `DEV_MODEL` / `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM`」に
+   **限定列挙**しているため、`MODEL_ROUTING_ENABLED` を解決規則の入力に加えると決定性の定義が
+   ぶれる。gate 無効時に「読み取りも解決も行わない」責務は Req 5.2 / 5.3 が Slot Runner に
+   置いている。Phase 1 の `mr_persist_size_label` は副作用（gh 呼び出し）を持つため
+   defense-in-depth の gate を内包しているが、純粋関数である Phase 2 の解決規則には同じ理由が
+   成り立たないと判断した（テスト P2-8 で「gate 値に依存しない」ことを固定）。
+2. **ラベル読み取りを純粋関数として model-router.sh 側に分離**（`mr_extract_size_label`）。
+   Req 3.2〜3.5 の判定（0 件 / 2 件以上 / 厳密一致失敗）を `_slot_run_issue` の巨大関数内に
+   inline すると近接テストで検証できないため、判定を rc（1/2/3）で返す純粋関数に切り出し、
+   適用と log のみを slot 側の小関数に置いた。これにより Req 8.5 / 8.6 / 8.7 が
+   `extract_function` の既存イディオムで直接検証できる。
+3. **正規表現照合に外部コマンドを使わない**。`^size:(small|medium|large)$` は bash `case` の
+   完全一致で表現し、未信頼なラベル名を `grep` 等へ一切渡さない（NFR 3.1 / 3.2）。結果として
+   `--` によるオプション解釈打ち切りが不要な構造になった（Phase 1 の `gh --add-label=` 逸脱と
+   同種の落とし穴を最初から回避）。
+4. **差し込み位置は `LABELS` 確定直後ではなく `exec > >(tee -a "$SLOT_LOG")` の直後**
+   （`slot_log "Worker 起動"` の次行）。理由は (a) ログを cron ログと slot ログの双方に残すため
+   （Req 6.3）、(b) worktree 初期化・Triage よりは前で「slot 起動時点のラベル集合」の意味を
+   保てるため（Req 3.1 / 4.1）。テスト P4-7 で「LABELS 行より後・`_worktree_ensure` より前」を
+   構造的に固定した。
+5. **fallback 理由をログに出す**（Req 6.2）。size 表示は固定トークン（`none` / `multiple` /
+   `invalid`）のみで、未信頼なラベル生値はログへ出さない（NFR 3.3 / テスト P3-6 で固定）。
+6. **`DEV_MODEL` が空という想定外状態では再代入しない**（fail-open / Req 5.6）。WARN を 1 行
+   残して処理を継続する。
+
+## AC トレーサビリティ
+
+| 要件 | 担保するテスト（`local-watcher/test/model_router_test.sh`） |
+|---|---|
+| 1.1 / 1.2 / 1.3 | P2-1（3 値 × 対応設定あり）/ P2-4（片側設定の独立性） |
+| 1.4 | P2-2（`huge` / `SMALL` / 空 / 引数省略 → `DEV_MODEL`） |
+| 1.5 | P2-3（空文字 / unset）/ P3-3（二重 opt-in） |
+| 1.6 | P2-5（未知のモデル ID をそのまま返す） |
+| 1.7 | P2-7（gh 0 回 / ログ 0 行 / 入力変数を書き換えない）/ P1-5 |
+| 1.8 | P2-6（同一入力 → 同一出力）/ P2-8 / P3-9（冪等） |
+| 2.1 / 2.2 | P4-1（既定空の宣言行）/ P4-2（モデル ID 非埋め込み） |
+| 2.3 | P3-3（gate 有効 + 設定なし → `DEV_MODEL`） |
+| 2.4 / 2.6 | P4-4（`DEV_MODEL` 宣言行の不変） |
+| 2.5 | P4-3（追加は 2 個のみ / `DEV_MODEL_LARGE` なし） |
+| 3.1 | P3-2（適用）/ P4-7（call site が LABELS 確定後） |
+| 3.2 | P1-1（厳密一致 3 種 / 無関係ラベル混在） |
+| 3.3 | P1-2 / P3-4（size ラベルなし → `DEV_MODEL`） |
+| 3.4 | P1-3 / P3-5（`size:*` 複数 → `DEV_MODEL`） |
+| 3.5 | P1-4 / P3-6（`size:huge` / `size:Small` / 末尾空白 / 注入狙い） |
+| 3.6 | P3-8（サブシェル内で解決結果が有効）/ P4-7（worktree 初期化前の 1 回解決） |
+| 3.7 | P3-8（親プロセスの `DEV_MODEL` 不変） |
+| 3.8 / 3.9 | P4-6（適用ヘルパー / model-router.sh が他の `*_MODEL` を参照しない） |
+| 4.1 | P4-7（call site 1 箇所）/ P3-9 |
+| 4.2 / 4.3 | P4-8（call site が Triage 消費部より前 = 再解決しない） |
+| 4.4 / 4.5 / 4.6 | P3-2（起動時ラベルに `size:*` があれば適用。3 経路とも同一コードパス） |
+| 5.1 | P4-5（gate は `mr_is_enabled` のみ / 独自 gate 変数なし）/ 既存 W4 |
+| 5.2 / 5.3 | P3-1（gate 8 表現 + unset で `DEV_MODEL` 据え置き・ログ 0 行・外部コマンド 0 回） |
+| 5.4 | P3-1（`True` / `TRUE` / `1` / `on` / typo を安全側へ正規化） |
+| 5.5 | P4-9（`--model "$DEV_MODEL"` call site 不変）/ P4-4 |
+| 5.6 | P3-7（解決結果が空 → 据え置き + WARN 1 行 + rc=0） |
+| 6.1 | P3-2（Issue 番号 / size 値 / モデル ID の 3 項目を 1 行に含む） |
+| 6.2 | P3-3 / P3-4 / P3-5 / P3-6（`fallback=DEV_MODEL` と理由） |
+| 6.3 | 差し込み位置（`exec > >(tee -a "$SLOT_LOG")` 直後 / `mr_log` は既存 processor と同一経路） |
+| 6.4 | 各ケースの「ログは 1 行」アサーション / P3-7（WARN 1 行） |
+| 7.1〜7.6 | README（オプション機能一覧 / ステージ別モデル表 / Phase 2 節 / 実装と同一 PR） |
+| 8.1〜8.7 | 下記「検証結果」/ P1〜P4 一式 |
+
+## 検証結果
+
+| コマンド | 結果 |
+|---|---|
+| `bash -n`（変更 4 ファイル） | すべて OK（AC 8.2） |
+| `shellcheck local-watcher/bin/*.sh local-watcher/bin/modules/*.sh install.sh setup.sh .github/scripts/*.sh` | 警告ゼロ（AC 8.1） |
+| `shellcheck local-watcher/test/model_router_test.sh` | 警告ゼロ |
+| `bash local-watcher/test/model_router_test.sh` | PASS 309 / FAIL 0（Phase 1 の 146 を含む。Phase 2 で 163 追加） |
+| `local-watcher/test/*.sh` 全 99 本 | 98 pass / 1 flaky（下記） |
+| `diff -r .claude/agents repo-template/.claude/agents` / `.claude/rules` | 差分なし |
+
+- **Red → Green 確認**: 実装を一時的に壊して（small 解決を `DEV_MODEL` 固定 / 複数ラベル
+  fail-safe の閾値変更 / gate 判定の除去）24 件が FAIL することを確認し、復元後 0 FAIL に
+  戻ることを確認した。
+- **flaky（本変更とは無関係 / 既存）**: `publish_terminal_failure_artifacts_test.sh` が
+  数回に 1 回 rc=141（SIGPIPE）で終了する。FAIL アサーションは 0 件で、`printf ... | grep -q`
+  イディオムと `pipefail` の組み合わせに起因する既存の不安定性。**変更前の HEAD を別 worktree に
+  展開して同様に再現する**ことを確認済み（本 PR の変更は pr-reviewer 系に一切触れていない）。
+
+## Open Questions への対応状況
+
+| Open Question | 対応 |
+|---|---|
+| 適用タイミングのギャップの受容可否（最重要） | requirements.md の暫定採用（受容 / Req 4.2 の既知の制約）に従って実装。Triage 後の再解決は行っていない。README に「⚠️ 初回 Triage 経路では効きません」と効く 3 経路を明記した。**人間判断は未確定**（下記「確認事項」1） |
+| design セッションへの適用可否 | Req 3.6 に従い design セッションにも適用（除外していない）。README「適用範囲」に design セッションを含むと明記した |
+| `DEV_MODEL_LARGE` を将来追加するか | 本 Phase では追加しない（Req 1.3 / 2.5）。additive で追加できる形は維持（`mr_resolve_dev_model` の `large` 分岐にコメントで明示） |
+| 既定値を空にする判断の是非 | requirements.md の二重 opt-in を採用（既定空 / モデル ID 非埋め込み） |
+| 誤付与ラベルの運用手順 | README Phase 2 節に「ラベルを剥がす → 次回 Triage で再付与」を Phase 2 固有の注意として再掲した |
+| fallback 時のログ粒度 | 可観測性優先で 1 行出力（Req 6.2）。`fallback=DEV_MODEL` で機械的に絞り込める形式にした |
+
+## 確認事項（レビュワー判断ポイント）
+
+1. **初回 Triage 経路で routing が効かない件**（requirements.md 最重要 Open Question）。本実装は
+   Issue 本文および Req 4.1〜4.3 の指示どおり「slot 起動時点の 1 回解決」で確定しており、
+   Triage 直後の再解決は行っていない。実運用で最も多い経路（新規 Issue の Triage → 実装）では
+   コスト削減効果が出ないため、**Triage 直後の再解決を別 Issue として起票するかどうか**は
+   人間判断が必要。
+2. **`_slot_apply_dev_model_routing` を slot-worker.sh に置いた分割**。Issue の指示は
+   「`_slot_run_issue` 冒頭に差し込み」だったが、近接テスト（Req 8.5 / 8.6 / 8.7）が
+   `_slot_run_issue` 全体を隔離抽出できないため、gate + 適用 + ログを小関数へ切り出し
+   call site を 1 行にした。要件上の subject（Slot Runner）と実装ファイルは一致している。
+3. **fallback ログのノイズ**。gate 有効かつ size ラベル未付与の Issue が大半の環境では
+   `fallback=DEV_MODEL` 行が毎 Issue 出る。requirements.md の可観測性優先方針に従ったが、
+   運用開始後にノイズが問題になれば出力条件の見直しを別 Issue で検討したい。
+4. **`size:large` に対する `DEV_MODEL_LARGE` 不在**。`large` は `DEV_MODEL` 固定のため、
+   将来 `large` だけ別モデルにしたくなった時点で `DEV_MODEL` の位置づけ（既定値か `large` 専用か）
+   の再定義が必要（requirements.md の Open Question をそのまま残置）。
+
+STATUS: complete

--- a/docs/specs/508-feat-watcher-size-developer-phase-2/requirements.md
+++ b/docs/specs/508-feat-watcher-size-developer-phase-2/requirements.md
@@ -1,0 +1,237 @@
+# Requirements Document
+
+## Introduction
+
+idd-claude の Developer 実行は現在すべての Issue で単一の `DEV_MODEL` を使うため、軽微な Issue でも
+最上位モデルの quota / コストを消費する。Phase 1（#507）で Triage の変更規模判定が `size:small` /
+`size:medium` / `size:large` ラベルとして Issue に永続化されたため、本 Phase 2 では **そのラベルを
+読んで当該 Issue の Developer 実行モデルを決める**。既定挙動（`DEV_MODEL` 一本）は完全に温存し、
+`MODEL_ROUTING_ENABLED=true` かつ size 別モデル設定の明示という **二重 opt-in** が揃ったときにのみ
+モデルが変わる。判定結果を使った子 Issue 分割提案（Phase 3 / #509）は本書の対象外。
+
+## 関連
+
+- Depends on: #507
+- Sibling: #509
+- Related: #328
+
+## 用語と subject の定義
+
+本書の AC で用いる subject は以下の論理的な責務を指す。module 名・関数名・関数 prefix・
+ファイル分割は `design.md` の領分であり、本書では規定しない。
+
+| subject | 指すもの |
+|---|---|
+| the Model Router | size 値と設定値からモデル ID を決める **解決規則そのもの**（副作用を持たない） |
+| the Slot Runner | 1 Issue を 1 slot（サブシェル）で処理する watcher の実行単位 |
+| the watcher | 設定値の宣言・正規化を含む watcher 全体 |
+| the README | 運用者向け主要ドキュメント |
+
+## Requirements
+
+### Requirement 1: size 値から Developer モデル ID を解決する規則
+
+**Objective:** As a watcher 運用者, I want size 値に対する Developer モデル ID の解決規則が一意に定まること, so that どの Issue でどのモデルが使われるかを設定値だけから予測できる
+
+#### Acceptance Criteria
+
+1. When size 値が `small` であり `DEV_MODEL_SMALL` が非空であるとき, the Model Router shall `DEV_MODEL_SMALL` の値を解決結果として返す
+2. When size 値が `medium` であり `DEV_MODEL_MEDIUM` が非空であるとき, the Model Router shall `DEV_MODEL_MEDIUM` の値を解決結果として返す
+3. When size 値が `large` であるとき, the Model Router shall `DEV_MODEL` の値を解決結果として返す
+4. If size 値が許可値（`small` / `medium` / `large`）以外・空文字・未指定のいずれかであるとき, the Model Router shall `DEV_MODEL` の値を解決結果として返す（fail-safe）
+5. If size 値に対応する設定（`small` に対する `DEV_MODEL_SMALL` / `medium` に対する `DEV_MODEL_MEDIUM`）が未設定または空文字であるとき, the Model Router shall `DEV_MODEL` の値を解決結果として返す
+6. The Model Router shall 設定された値を許可値リストとの照合・変換・補完のいずれも行わずそのまま解決結果として返す（モデル ID の許可値リストを持たない）
+7. The Model Router shall 解決処理を副作用なし（GitHub API 呼び出し / ラベル変更 / ファイル書き込み / 呼び出し元の状態変更のいずれも伴わない）で行い、解決結果のみを出力する
+8. The Model Router shall 同一の入力（size 値 + `DEV_MODEL` / `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` の値）に対して常に同一の解決結果を返す
+
+### Requirement 2: size 別モデル設定の追加と既定値
+
+**Objective:** As a watcher 運用者, I want size 別モデルを設定値で明示指定できること, so that gate を有効化しただけでモデルが黙って下がる事故を避けられる
+
+#### Acceptance Criteria
+
+1. The watcher shall `DEV_MODEL_SMALL` と `DEV_MODEL_MEDIUM` の 2 つの設定値を提供し、いずれも既定値を空文字とする
+2. The watcher shall `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` の既定値として具体的なモデル ID を埋め込まない
+3. Where `MODEL_ROUTING_ENABLED` が有効であり、かつ `DEV_MODEL_SMALL` と `DEV_MODEL_MEDIUM` がいずれも未設定または空文字であるとき, the Slot Runner shall すべての Issue で `DEV_MODEL` を適用する（gate 単独では挙動が変わらない二重 opt-in）
+4. The watcher shall `DEV_MODEL` の既定値・意味・上書き方法のいずれも変更しない
+5. The watcher shall 本要件で `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` 以外の新規設定値を追加しない
+6. The watcher shall 既存の設定値名（`DEV_MODEL` / `TRIAGE_MODEL` / `REVIEWER_MODEL` / `PJM_MODEL` / `PR_ITERATION_DEV_MODEL` / `FAILED_RECOVERY_DEV_MODEL` / `MODEL_ROUTING_ENABLED` 等）の名称・既定値・解決順序のいずれも変更しない
+
+### Requirement 3: slot での size ラベル読み取りとモデル適用
+
+**Objective:** As a watcher 運用者, I want slot が当該 Issue の size ラベルに応じた Developer モデルで実装を進めること, so that 小規模 Issue の quota / コストを節約できる
+
+#### Acceptance Criteria
+
+1. While `MODEL_ROUTING_ENABLED` が有効であるとき, when slot が 1 件の Issue の処理を開始したとき, the Slot Runner shall 当該 slot が起動時点で取得済みの Issue ラベル集合から size 値を読み取り、解決結果を当該 Issue の Developer 実行に適用する
+2. The Slot Runner shall ラベル名が `^size:(small|medium|large)$` に厳密一致する場合に限り、そのラベルから size 値を切り出して使用する
+3. If `size:` prefix を持つラベルが 1 つも存在しないとき, the Slot Runner shall `DEV_MODEL` を適用する
+4. If `size:` prefix を持つラベルが 2 つ以上存在するとき, the Slot Runner shall いずれの値も採用せず `DEV_MODEL` を適用する（fail-safe）
+5. If `size:` prefix を持つラベルが 1 つ存在するが厳密一致に失敗する（`size:huge` / `size:Small` / 前後に空白を含む 等）とき, the Slot Runner shall `DEV_MODEL` を適用する（fail-safe）
+6. When モデル解決を適用したとき, the Slot Runner shall 当該 slot 内の Developer 実行（design セッション / 実装 Stage 群 / per-task ループを含む）すべてに同一のモデル ID を一貫して適用する
+7. The Slot Runner shall 解決結果を当該 slot のサブシェル境界内に閉じ、他 slot および親プロセスの Developer モデル設定へ伝播させない
+8. The Slot Runner shall Triage / Reviewer / PjM / Architect 専用モデル設定に本機能起因の変更を与えない
+9. The watcher shall 本機能に起因して slot 外プロセッサ（PR Iteration / Failed Recovery 等）が用いるモデル設定を変更しない
+
+### Requirement 4: 適用タイミングと既知の制約
+
+**Objective:** As a watcher 運用者, I want モデル解決がいつ効くかが明確に定義されていること, so that 「gate を有効にしたのにモデルが変わらない」ケースを不具合と誤認しない
+
+#### Acceptance Criteria
+
+1. The Slot Runner shall モデル解決を 1 Issue の 1 slot 実行につき 1 回だけ、当該 slot 起動時点のラベル集合に基づいて行う
+2. While 同一 slot 実行内で Triage が size ラベルを新規付与する経路であるとき, the Slot Runner shall 当該実行では `DEV_MODEL` を適用する（slot 起動時点のラベル集合に当該ラベルが含まれないため）
+3. The Slot Runner shall Triage 実行後にモデル解決を再実行しない
+4. When 同一 Issue が次サイクル以降（impl-resume / 再 pickup）で slot 実行されたとき, the Slot Runner shall 既に付与済みの size ラベルに基づく解決結果を適用する
+5. Where 人間が事前に size ラベルを付与した Issue が処理されるとき, the Slot Runner shall 初回の slot 実行からモデル解決を適用する
+6. Where `skip-triage` ラベルにより Triage を実行しない経路で Issue が処理されるとき, the Slot Runner shall 既存の size ラベルに基づく解決結果を適用する
+
+> **Note（AC 4.2 は意図された既知の制約）**: 新規 Issue が同一 slot 実行内で「Triage → size ラベル
+> 付与 → 実装」と進む経路では、slot 起動時点のラベルスナップショットに `size:*` が含まれないため
+> `DEV_MODEL` へ fallback する。本 Phase では **slot 起動時点の 1 回解決のみ**をスコープとし、
+> Triage 後の再解決は行わない（Out of Scope）。したがって本機能が実際に効くのは (a) 人間が事前に
+> size ラベルを貼った Issue、(b) `skip-triage` 経路、(c) impl-resume / 再 pickup サイクルである。
+> この方針の妥当性は Open Questions に確認事項として残す。
+
+### Requirement 5: opt-in gate と gate 無効時の完全 no-op
+
+**Objective:** As a watcher 運用者, I want 未設定環境で本機能導入前と完全に同一の挙動が保たれること, so that 既存 consumer 環境へ無告知の影響が及ばない
+
+#### Acceptance Criteria
+
+1. The watcher shall モデルルーティング機能 family を単一の gate `MODEL_ROUTING_ENABLED` で制御し、本 Phase 用の追加 gate を設けない
+2. While gate が無効であるとき, the Slot Runner shall size ラベルの読み取りとモデル解決のいずれも行わず `DEV_MODEL` をそのまま適用する
+3. While gate が無効であるとき, the Slot Runner shall 本機能に起因するログを 1 行も出力しない
+4. If `MODEL_ROUTING_ENABLED` に `true` 以外の値（未設定 / 空文字 / `false` / `off` / `True` / `1` / typo）が与えられたとき, the watcher shall 当該 gate を安全側（無効）へ正規化する
+5. The watcher shall gate の有効・無効いずれの場合も、本機能に起因して既存のラベル遷移契約・exit code の意味・ログ出力先・cron 登録文字列を変更しない
+6. If モデル解決処理が想定外の状態（設定値の読み取り不能等）に陥ったとき, the Slot Runner shall `DEV_MODEL` を適用して当該 Issue の処理を継続する（fail-open）
+
+### Requirement 6: 解決結果の可観測性
+
+**Objective:** As a watcher 運用者, I want どの Issue にどのモデルが適用されたかがログから追えること, so that コスト削減効果と誤適用を事後に検証できる
+
+#### Acceptance Criteria
+
+1. When gate 有効下でモデル解決を実行したとき, the Slot Runner shall Issue 番号・採用した size 値・適用した Developer モデル ID の 3 項目を含む 1 行のログを出力する
+2. When size ラベル不在・複数付与・不正値のいずれかにより `DEV_MODEL` へ fallback したとき, the Slot Runner shall fallback したことを判別できる 1 行のログを出力する
+3. The Slot Runner shall 上記ログを既存 processor 系ログと同一の出力先（cron ログ経路）へ書き出す
+4. The Slot Runner shall 本機能に起因する分岐を silent fail させない（すべての分岐でログ 1 行を残す。ただし gate 無効時は AC 5.3 を優先し無出力とする）
+
+### Requirement 7: 運用ドキュメントの更新
+
+**Objective:** As a watcher 運用者, I want 新しい設定値と有効化条件が README から読み取れること, so that 実装を読まずに安全に導入判断できる
+
+#### Acceptance Criteria
+
+1. The README shall `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` の意味・既定値（空）・設定方法をオプション機能一覧に含める
+2. The README shall gate 有効化と size 別モデル設定の両方が揃って初めてモデルが変わる二重 opt-in の挙動を記述する
+3. The README shall モデル解決が slot 起動時点のラベルに基づく 1 回解決であること、および初回 Triage 経路では `DEV_MODEL` へ fallback する既知の制約（Requirement 4）を記述する
+4. The README shall 本機能の適用対象外（Reviewer / PjM / Architect 専用モデル、slot 外プロセッサのモデル）を明記する
+5. The README shall size 値ごとの解決結果（`small` / `medium` / `large` / ラベルなし / 不正値）を一覧で示す
+6. The repository shall 上記ドキュメント更新を本機能の実装と同一 PR で行う
+
+### Requirement 8: 検証可能性（受け入れ確認手段）
+
+**Objective:** As a reviewer, I want 本機能の受け入れ確認手段が事前に定義されていること, so that PR レビュー時に AC 充足を機械的に確認できる
+
+#### Acceptance Criteria
+
+1. The 変更後の bash スクリプト shall `shellcheck` を警告ゼロで通過する
+2. The 変更後の bash スクリプト shall `bash -n` の構文検査を通過する
+3. The repository shall 本機能で追加された解決規則に対する近接テストを `local-watcher/test/` 配下の既存命名規約に沿って追加する
+4. The 近接テスト shall 解決規則について「`small` / `medium` / `large` の 3 値 × 対応設定あり / なし」「許可値以外」「空文字」の各ケースを検証する
+5. The 近接テスト shall slot 適用について「size ラベルなし」「`size:*` ラベル複数」「不正値ラベル」「gate 無効」の各ケースで `DEV_MODEL` が適用されることを検証する
+6. The 近接テスト shall gate 無効時に本機能起因のログが 0 行であることを検証する
+7. The 検証手順 shall 解決結果が当該 slot のサブシェル境界を越えて親プロセスへ伝播しないことの確認を含む
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While gate が無効であるとき, the watcher shall 本機能導入前と同一のログ出力・ラベル遷移・exit code の意味を保つ
+2. The watcher shall 新規設定値を未設定のまま既存 consumer 環境が動作したときに、本機能導入前と同一の外部挙動を提供する
+3. The watcher shall 本機能に起因して Developer 実行以外の Stage（Triage / Reviewer / PjM / design 以外の外部プロセッサ）のモデル選択契約を変更しない
+
+### NFR 2: 性能・コスト
+
+1. While gate が無効であるとき, the Slot Runner shall 本機能に起因する外部コマンド呼び出しを 0 回、ログ出力を 0 行とする
+2. Where gate が有効であるとき, the Slot Runner shall 本機能に起因する GitHub API 呼び出しを 0 回とする（slot 起動時点で取得済みのラベル集合のみを用いる）
+3. The Slot Runner shall 本機能のために追加の LLM 実行（Claude の追加起動）を発生させない
+4. The Slot Runner shall 1 Issue の 1 slot 実行あたり本機能に起因する解決処理を 1 回以下に抑える
+
+### NFR 3: セキュリティ（未信頼入力の取り扱い）
+
+1. The Slot Runner shall 未信頼入力である Issue ラベル名を、許可パターン（`^size:(small|medium|large)$`）との厳密一致検証を通過する前に外部コマンド引数・パス・解決規則の入力として使用しない
+2. When 未信頼値を外部コマンドへ渡すとき, the Slot Runner shall 変数展開をクォートし、オプション解釈の打ち切りを行う
+3. The Slot Runner shall 解決したモデル ID をモデル指定とログ出力以外の用途（パス構成 / ラベル名構成 / コマンド組み立て）に用いない
+4. The repository shall `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` に具体的なモデル ID をハードコードせず、運用者の明示設定にのみ依存する
+
+## Out of Scope
+
+- **Triage 実行後のモデル再解決**（初回 Triage で size ラベルが付いた直後の同一 slot 実行内で解決をやり直すこと）。本 Phase は slot 起動時点の 1 回解決のみ（Requirement 4 / Note 参照）
+- Reviewer / PjM / Architect 専用モデル（`REVIEWER_MODEL` / `PJM_MODEL` 等）の size 連動 routing — Reviewer は品質ゲートのため上位モデルを維持する
+- slot 外プロセッサ（`PR_ITERATION_DEV_MODEL` / `FAILED_RECOVERY_DEV_MODEL`）への波及 — 必要になれば将来 Issue
+- Developer モデルを参照している既存の個別実行箇所（10 箇所以上）の書き換え — 本 Phase では一切変更しない
+- `size:large` 専用の設定値（`DEV_MODEL_LARGE` 等）の追加 — `large` は `DEV_MODEL` を用いる（Requirement 1.3）
+- Phase 1（#507）が担う size ラベルの判定・付与・冪等性ロジックの変更（`complexity` の判定基準、ラベル命名、labels script のプロビジョニング）
+- Phase 3（#509）: tasks 件数超過時の子 Issue 分割案コメント投稿
+- gate の分割（Phase 1 用 / Phase 2 用に別 gate を設けること）
+- 既存 Issue への size ラベル遡及付与（retrofit）、および人間が誤付与したラベルの自動訂正
+- モデル解決結果の Issue 上への永続化（コメント / 本文編集）— 本 Phase ではログ出力に留める
+- コスト実測・quota 消費量のレポーティング / ダッシュボード化
+- GitHub Actions 版 workflow への反映（slot 実行経路が存在しないため対象外）
+- module 名・関数名・関数 prefix・解決処理の差し込み位置の具体設計・設定値の正規化実装方式（`design.md` の領分）
+
+## Open Questions
+
+- **適用タイミングのギャップを本 Phase で受容してよいか（最重要 / 要人間判断）**: Issue 本文は
+  「slot 冒頭に差し込み」と指示しており、本書は Requirement 4 でそれに忠実に従った。その結果、
+  新規 Issue が同一 slot 実行内で Triage → size ラベル付与 → 実装と進む経路（= 最も一般的な経路）
+  では routing が効かず `DEV_MODEL` に fallback する。routing が実際に効くのは (a) 人間が事前に
+  size ラベルを貼った Issue、(b) `skip-triage` 経路、(c) impl-resume / 再 pickup サイクルに限られる。
+  この「初回 Triage 経路では効かない」挙動を **意図された既知の制約として受容する**か、それとも
+  Triage 直後（Phase 1 のラベル付与直後）での再解決を別 Issue として起票するかは人間判断に委ねる。
+  本書では前者を暫定採用し、後者を Out of Scope に置いた。
+- **design セッションへの適用可否**: 解決結果は同一 slot 内の design セッションにも及ぶ。Phase 1 の
+  判定基準では `needs_architect: true` が `size:large` に倒れるため実運用上は `DEV_MODEL` のままに
+  なる想定だが、人間が `size:small` を手で貼った Issue が design 経路に入ると設計セッションが下位
+  モデルで実行される。これを許容するか（許容しない場合は Requirement 3.6 の適用範囲を design 除外へ
+  縮退させる必要があり、最小 diff 方針とトレードオフになる）。
+- **`DEV_MODEL_LARGE` を将来追加するか**: 本 Phase では `large` を `DEV_MODEL` に固定した
+  （Requirement 1.3 / Out of Scope）。将来 `large` だけ別モデルに振りたくなった場合の追加は additive
+  で済むが、その時点で `DEV_MODEL` の位置づけ（既定値なのか `large` 専用なのか）を再定義する必要がある。
+- **既定値を空にする判断の是非**: Issue 本文の「確認事項」に挙がっているとおり、`DEV_MODEL_SMALL` に
+  下位モデル ID を env default で置く選択もあり得る。本書は「gate 有効化だけで silent にモデルが
+  下がる事故を避ける」ため二重 opt-in（既定空）を採用した（Requirement 2.1 / 2.3）。
+- **誤付与ラベルによる意図しない下位モデル固定の運用手順**: 人間が誤って `size:small` を貼った
+  Issue は、ラベルを剥がすまで下位モデルで実装され続ける。Phase 1 README に記載済みの訂正手順
+  （ラベルを剥がす → 次回 Triage で再付与）で十分か、Phase 2 固有の注意喚起を README に追記するかは
+  Requirement 7.3 の記述粒度に影響する。
+- **fallback 時のログ粒度**: Requirement 6.2 は「fallback したことを判別できる 1 行」を要求するが、
+  gate 有効かつ size ラベル不在の Issue が大半を占める運用ではログノイズになり得る。fallback 時の
+  ログを DEBUG 相当に落とす / 出力しない選択肢もあるが、本書は可観測性を優先して 1 行出力を採用した。
+
+---
+
+## 自己レビュー結果（要件レビューゲート）
+
+- **Mechanical Checks**: 全要件見出しが numeric ID（Requirement 1〜8 / NFR 1〜3）。各要件に EARS 形式
+  AC（`When` / `If` / `While` / `Where` / `The <subject> shall`）が 1 件以上存在。AC 本文には
+  設定値名・ラベル名・ラベル許可パターンという **外部契約** のみを含め、module 名・関数名・関数
+  prefix・差し込み行位置等の実装語彙は混入させていない（subject は「用語と subject の定義」節で
+  論理責務として定義）。
+- **EARS・テスト可能性**: 全 AC が observable / testable。数値は具体化済み（GitHub API 呼び出し
+  0 回、ログ 0 行、解決処理 1 回以下、追加設定値 2 個、ラベル許可パターンの厳密一致）。
+- **スコープ・カバレッジ**: Issue 本文の AC 案 1.1〜1.4 / 2.1〜2.5 / 3.1 をすべて対応付けたうえで、
+  PM として (a) 二重 opt-in の明示（Req 2.3）、(b) 適用タイミングのギャップの要件化（Req 4 / Note）、
+  (c) 複数 / 不正ラベルの fail-safe 細分（Req 3.4 / 3.5）、(d) 境界 AC（Req 3.8 / 3.9 = Reviewer・
+  PjM・slot 外プロセッサ不変）、(e) fallback ログ（Req 6.2）、(f) 検証手段（Req 8）、(g) 性能・
+  セキュリティ NFR を補完した。
+- **既存整合**: Phase 1（#507）の gate 単一化方針（Req 3.6）、`= "true"` 厳密一致の正規化慣習、
+  fail-safe / fail-open パターン、slot がサブシェルで起動され slot 内の設定変更が親へ伝播しない
+  既存構造、`PJM_MODEL`（#328）の役割別モデル env 先例と矛盾しないことを確認した。
+- **2 パス目の補正**: 初稿では可観測性を機能要件と NFR の双方に書いていたため、機能要件
+  （Requirement 6）へ一本化し NFR 側の重複を削除した。また初稿の「Triage 直後に再解決する」記述を
+  Issue 本文の指示（slot 冒頭差し込み）に合わせて削除し、Requirement 4 + Note + Open Questions
+  （最重要項目）へ移送してスコープ拡大を防いだ。
+- 残存する曖昧性は Open Questions に暫定採用値付きで列挙。レビューは 2 パスで確定。

--- a/docs/specs/508-feat-watcher-size-developer-phase-2/review-notes.md
+++ b/docs/specs/508-feat-watcher-size-developer-phase-2/review-notes.md
@@ -1,0 +1,101 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-22T23:23:34Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-508-impl-feat-watcher-size-developer-phase-2
+- HEAD commit: 4a9aec4775b808ba4373e5a8f386c8df65bc1f13
+- Compared to: main..HEAD
+- 変更ファイル: `local-watcher/bin/modules/model-router.sh` / `local-watcher/bin/modules/slot-worker.sh` /
+  `local-watcher/bin/watcher-config.sh` / `local-watcher/test/model_router_test.sh` / `README.md` /
+  spec 配下 2 ファイル（計 7 ファイル / +1177 -21）
+- 本 Issue は design-less impl（`design.md` / `tasks.md` 不在）のため、`_Boundary:_` アノテーションは
+  存在しない。boundary 判定は `requirements.md` の Out of Scope 節を境界の正本として実施した。
+
+## Verified Requirements
+
+- 1.1 — `mr_resolve_dev_model` の `small` 分岐が `DEV_MODEL_SMALL` 非空時に当該値を返す（model-router.sh:309-314）/ テスト P2-1
+- 1.2 — 同 `medium` 分岐（model-router.sh:316-320）/ テスト P2-1
+- 1.3 — `large` 分岐は no-op で末尾の `DEV_MODEL` 合流点へ落ちる（model-router.sh:322-323, 332）/ テスト P2-1・P2-3
+- 1.4 — `*)` 分岐で許可値以外・空・引数省略をすべて `DEV_MODEL` へ fail-safe（model-router.sh:325-327）/ テスト P2-2（`huge` / `SMALL` / `Small` / `small medium` / `--model` / 空 / 引数省略）
+- 1.5 — size 別設定が空／unset のとき条件分岐を抜けて `DEV_MODEL` へ合流 / テスト P2-3（空文字・unset 双方）
+- 1.6 — 許可値リストを持たず `printf '%s\n'` でそのまま返す / テスト P2-5（`not-a-real-model-id-xyz` がそのまま返る）
+- 1.7 — 外部コマンド・ログ・状態変更なしの純粋関数 / テスト P2-7（gh 0 回 / ログ 0 行 / `DEV_MODEL`・`DEV_MODEL_SMALL` 不変）
+- 1.8 — 決定性 / テスト P2-6（同一入力 → 同一出力）、P2-8（gate 値に依存しない）
+- 2.1 — `DEV_MODEL_SMALL="${DEV_MODEL_SMALL:-}"` / `DEV_MODEL_MEDIUM="${DEV_MODEL_MEDIUM:-}"`（watcher-config.sh:1240-1241）/ テスト P4-1
+- 2.2 — 既定値にモデル ID を埋め込まない / テスト P4-2（`claude-` 出現 0 件）
+- 2.3 — gate 有効かつ size 別モデル未設定なら `DEV_MODEL`（二重 opt-in）/ テスト P3-3
+- 2.4 — `DEV_MODEL="${DEV_MODEL:-claude-opus-4-8}"` 行は不変（diff で追加のみ）/ テスト P4-4
+- 2.5 — 追加設定値は 2 個のみ / テスト P4-3（`^DEV_MODEL_[A-Z]+=` が 2 件・`DEV_MODEL_LARGE` 0 件）
+- 2.6 — 既存モデル系 env の宣言行に diff なし（`git diff` は watcher-config.sh に +20 行の追加のみ）/ テスト P4-4
+- 3.1 — `_slot_run_issue` 冒頭で `LABELS`（起動時スナップショット）を入力に `_slot_apply_dev_model_routing` を呼び `DEV_MODEL` を確定（slot-worker.sh:294-313）/ テスト P3-2・P4-7
+- 3.2 — `mr_extract_size_label` の `case` 完全一致（`size:small|size:medium|size:large`）/ テスト P1-1（無関係ラベル混在含む）
+- 3.3 — `size:` prefix 0 件 → rc=1 → `DEV_MODEL` / テスト P1-2・P3-4
+- 3.4 — `size:` prefix 2 件以上 → rc=2 → `DEV_MODEL` / テスト P1-3・P3-5（異値併存・同値重複・有効値+不正値）
+- 3.5 — 1 件だが厳密一致失敗 → rc=3 → `DEV_MODEL` / テスト P1-4（8 パターン）・P3-6
+- 3.6 — グローバル `DEV_MODEL` 再代入を worktree 初期化前に 1 回行い、以降の design セッション（slot-worker.sh:842）／実装 Stage 群（impl-pipeline.sh:319, 439, 597, 719）／per-task ループ（per-task-loop-exec.sh:124, 196）がいずれも同一の `$DEV_MODEL` を参照する（grep で確認）/ テスト P4-7・P3-8
+- 3.7 — `_slot_run_issue` は `( _slot_run_issue "$slot" "$issue" ) &`（issue-watcher.sh:855）でサブシェル fork され再代入が親へ伝播しない / テスト P3-8（親の `DEV_MODEL` 不変）
+- 3.8 — 適用ヘルパー／model-router.sh とも `TRIAGE_MODEL` / `REVIEWER_MODEL` / `PJM_MODEL` を参照しない / テスト P4-6
+- 3.9 — `PR_ITERATION_DEV_MODEL` / `FAILED_RECOVERY_DEV_MODEL` は config ロード時（親プロセス）に確定し slot 内再代入の影響を受けない / テスト P4-6
+- 4.1 — call site は 1 箇所のみ / テスト P4-7（`grep -c` = 1）
+- 4.2 — call site が Triage 消費部より前のため、同一 slot で Triage が付与したラベルは使われない / テスト P4-8・README の「⚠️ 初回 Triage 経路では効きません」
+- 4.3 — Triage 後の再解決コードなし / テスト P4-8（call site 行番号 < `mr_persist_size_label` 呼び出し行番号）
+- 4.4 / 4.5 / 4.6 — MODE 分岐（impl-resume / skip-triage / 初回）より前の共通パスに差し込まれているため 3 経路とも同一コードで解決される（slot-worker.sh の call site 位置で確認）/ テスト P3-2
+- 5.1 — gate は `mr_is_enabled`（= `MODEL_ROUTING_ENABLED`）のみ / テスト P4-5（独自 gate 変数参照 0 件）
+- 5.2 — `mr_is_enabled || return 0` で読み取りも解決も行わない（slot-worker.sh:216）/ テスト P3-1
+- 5.3 — gate 無効時ログ 0 行 / テスト P3-1（9 パターン: 空 / `false` / `off` / `True` / `TRUE` / `1` / `yes` / `ture` / unset）
+- 5.4 — `[ "${MODEL_ROUTING_ENABLED:-false}" = "true" ]` の厳密一致（model-router.sh:66-68）/ テスト P3-1
+- 5.5 — ラベル遷移・exit code・ログ出力先・cron 文字列への変更は diff 上に存在しない（追加は新関数と新 env 2 個のみ）/ テスト P4-9
+- 5.6 — 解決結果が空なら再代入せず WARN 1 行 + rc=0（slot-worker.sh:225-229）/ テスト P3-7
+- 6.1 — `mr_log "issue=#... size=... dev_model=..."` の 3 項目 1 行（slot-worker.sh:254-256）/ テスト P3-2
+- 6.2 — fallback 時は `fallback=DEV_MODEL（理由: ...）` を付与 / テスト P3-3・P3-4・P3-5・P3-6
+- 6.3 — `mr_log` は stdout へ出力し、call site が `exec > >(tee -a "$SLOT_LOG") 2>&1` の直後にあるため cron ログ / slot ログ双方に残る（既存 processor と同一経路）
+- 6.4 — 全分岐でログ 1 行（正常 / fallback / WARN）/ テスト P3-2・P3-3・P3-4・P3-7 の「ログは 1 行」アサーション
+- 7.1 — README「ステージ別モデル」表に `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM`（既定「（空）」）を追加
+- 7.2 — README Phase 2 節「モデルが変わるには 2 つの条件が両方必要です（二重 opt-in）」+ オプション機能一覧の必須欄
+- 7.3 — README「適用タイミングと既知の制約（重要）」節（1 回解決 + ⚠️ 初回 Triage 経路 + 効く 3 経路）
+- 7.4 — README「適用範囲と対象外」節（Triage / Reviewer / PjM / slot 外プロセッサを明記）
+- 7.5 — README「解決結果の一覧」表（9 行 / small・medium・large・なし・複数・不正値・gate OFF）
+- 7.6 — README 更新は実装と同一 PR（同一ブランチ commit 70b7b3e）
+- 8.1 — `shellcheck` を reviewer 側で再実行し警告ゼロを確認（model-router.sh / slot-worker.sh / watcher-config.sh / model_router_test.sh）
+- 8.2 — `bash -n` を上記 4 ファイルで再実行し通過を確認
+- 8.3 — 近接テストは既存命名規約どおり `local-watcher/test/model_router_test.sh` に追加（+416 行）
+- 8.4 — Unit P2（3 値 × 設定あり／なし・許可値以外・空文字）が該当ケースを網羅
+- 8.5 — Integration P3-1 / P3-4 / P3-5 / P3-6（gate 無効 / ラベルなし / 複数 / 不正値）で `DEV_MODEL` 適用を検証
+- 8.6 — P3-1 が `wc -l` でログ 0 行を検証（gate 9 表現）
+- 8.7 — P3-8 がサブシェル境界（子で適用・親で不変）を検証
+- NFR 1.1 / 1.2 / 1.3 — gate OFF 時の完全 no-op（P3-1）、未設定既定での従来挙動（P3-1 unset ケース）、他 Stage モデル契約不変（P4-6）
+- NFR 2.1 / 2.2 / 2.3 / 2.4 — gate OFF で外部コマンド 0 回（P3-1）、gate ON でも gh 0 回（P3-2 / P3-6）、LLM 追加起動なし（diff 上に claude 呼び出し追加なし）、1 slot 1 回（P4-7）
+- NFR 3.1 / 3.2 / 3.3 / 3.4 — ラベル名は bash `case` の完全一致のみで検証し外部コマンドへ渡さない（`grep` / `sed` 不使用）、ログには固定トークンのみ（P3-6 の生値非出力アサーション）、モデル ID ハードコードなし（P4-2）
+
+### reviewer 側で再実行した検証
+
+| コマンド | 結果 |
+|---|---|
+| `bash -n`（変更 4 スクリプト） | OK |
+| `shellcheck`（変更 4 スクリプト） | 警告ゼロ |
+| `bash local-watcher/test/model_router_test.sh` | PASS 309 / FAIL 0 |
+| slot-worker.sh 参照テスト 4 本 + watcher-config.sh 参照テスト 3 本 | すべて FAIL 0（回帰なし） |
+
+## Findings
+
+なし
+
+## Summary
+
+`requirements.md` の Requirement 1〜8 および NFR 1〜3 の全 numeric ID について、実装またはテストの
+対応を確認できた。追加分は純粋関数 2 本（model-router.sh）+ slot 適用ヘルパー 1 本（slot-worker.sh）
++ 既定空の env 2 個 + 近接テスト 163 件 + README 節で、gate OFF 時は完全 no-op（P3-1 で 9 表現を検証）。
+Out of Scope（既存 `DEV_MODEL` 個別 call site の書き換え / `DEV_MODEL_LARGE` 追加 / slot 外プロセッサ
+への波及 / Actions workflow）に触れる変更はなく、`local-watcher/` は `repo-template/` にミラーされない
+ため同期ドリフトも発生しない。reviewer 側で shellcheck / `bash -n` / 近接テスト（309 PASS 0 FAIL）と
+周辺テストの回帰なしを再確認した。
+
+なお impl-notes.md「確認事項 1」の「初回 Triage 経路では routing が効かない」は、確定済み
+requirements.md（Req 4.2 / Note / Out of Scope）が意図された既知の制約として明示採用したもので、
+本 impl PR は現行確定 spec を正しく満たしている。仕様を強化する（Triage 直後に再解決する）べきか
+どうかは設計レベルの指摘であり、本 impl PR の reject 理由には含めない（別 Issue / 設計 iteration へ
+還流すべき人間判断事項）。
+
+RESULT: approve

--- a/local-watcher/bin/modules/model-router.sh
+++ b/local-watcher/bin/modules/model-router.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
-# model-router.sh — watcher のモデルルーティングモジュール (#507, Phase 1)
+# model-router.sh — watcher のモデルルーティングモジュール (#507 Phase 1 / #508 Phase 2)
 #
 # 用途:
-#   Triage が出力した変更規模判定 `complexity` を安全に解釈し、`size:<complexity>`
-#   ラベルとして Issue に冪等・fail-open で永続化する。ラベルに永続化することで、
-#   Triage を再実行しないサイクル（impl-resume / PR Iteration / Failed Recovery）でも
-#   判定結果を sticky に参照でき、人間が事前にラベルを貼ることで判定を override できる。
-#   mr_is_enabled / mr_parse_triage_complexity / mr_has_size_label /
-#   mr_persist_size_label ほか。
+#   Phase 1 (#507): Triage が出力した変更規模判定 `complexity` を安全に解釈し、
+#   `size:<complexity>` ラベルとして Issue に冪等・fail-open で永続化する。ラベルに
+#   永続化することで、Triage を再実行しないサイクル（impl-resume / PR Iteration /
+#   Failed Recovery）でも判定結果を sticky に参照でき、人間が事前にラベルを貼ることで
+#   判定を override できる。mr_is_enabled / mr_parse_triage_complexity /
+#   mr_has_size_label / mr_persist_size_label。
 #
-#   本 Phase（#507）はサイズ判定の永続化までを担当し、判定結果を使ったモデル解決
-#   （Phase 2 / #508）と分割提案（Phase 3 / #509）は含まない。gate は Phase 共通の
-#   単一変数 `MODEL_ROUTING_ENABLED` とし、Phase 別 gate は設けない（Req 3.6）。
+#   Phase 2 (#508): 永続化された `size:*` ラベルから当該 Issue の Developer 実行モデル ID を
+#   決める **解決規則**（副作用なしの純粋関数）を提供する。mr_extract_size_label /
+#   mr_resolve_dev_model。gate 判定・`DEV_MODEL` への適用・ログ出力は呼び出し側
+#   （slot-worker.sh の Slot Runner = `_slot_apply_dev_model_routing`）が担い、本 module 側は
+#   「size 値と設定値からモデル ID を決める」責務のみを持つ（#508 Req 1.7 / 1.8）。
+#
+#   分割提案（Phase 3 / #509）は含まない。gate は Phase 共通の単一変数
+#   `MODEL_ROUTING_ENABLED` とし、Phase 別 gate は設けない（#507 Req 3.6 / #508 Req 5.1）。
 #
 # 配置先:
 #   $HOME/bin/modules/model-router.sh（install.sh が local-watcher/bin/modules/ から配置する）
@@ -22,16 +27,20 @@
 #   - `set -euo pipefail` は本体側で宣言済みのため、本モジュールでは宣言せず関数定義のみを持つ。
 #   - ロガー mr_log / mr_warn は本モジュール内で定義する（新規 module のため。
 #     path-overlap.sh の po_log / po_warn と同型）。
-#   - グローバル変数（$REPO / $MODEL_ROUTING_ENABLED）は watcher-config.sh の Config
-#     ブロックで定義済み。bash の遅延束縛により呼び出し時に解決される。
-#   - slot-worker.sh の Triage 消費部（Triage 直後の 1 箇所のみ）から呼ばれる。
-#   - 外部 CLI: gh / jq。
+#   - グローバル変数（$REPO / $MODEL_ROUTING_ENABLED / $DEV_MODEL / $DEV_MODEL_SMALL /
+#     $DEV_MODEL_MEDIUM）は watcher-config.sh の Config ブロックで定義済み。bash の
+#     遅延束縛により呼び出し時に解決される。
+#   - slot-worker.sh から呼ばれる（Phase 1: Triage 消費部の 1 箇所 / Phase 2: Slot Runner
+#     `_slot_run_issue` 冒頭の 1 箇所）。
+#   - 外部 CLI: gh / jq（Phase 1 の永続化系のみ。Phase 2 の解決系は外部コマンドを使わない）。
 #
 # 関数 prefix: mr_
 #
 # セットアップ参照先:
 #   - 設計: docs/specs/507-feat-watcher-triage-complexity-size-phas/design.md
+#   - 要件: docs/specs/508-feat-watcher-size-developer-phase-2/requirements.md
 #   - README「Model Routing Phase 1: Triage complexity → size ラベル (#507)」節
+#   - README「Model Routing Phase 2: size ラベル → Developer モデル (#508)」節
 
 mr_log() {
   echo "[$(date '+%F %T')] [$REPO] model-router: $*"
@@ -214,5 +223,112 @@ mr_persist_size_label() {
 
   # rc=0: 付与成功。Issue 番号と確定した complexity 値をログに残す（Req 4.1 / NFR 2.1）。
   mr_log "issue=#${issue_number} size ラベルを付与しました complexity=${complexity} label=${label_name}"
+  return 0
+}
+
+# ─── Phase 2: Size Label Extractor (#508 Req 3.2〜3.5 / NFR 3.1 / 3.2) ───
+# slot 起動時点で取得済みの Issue ラベル集合（`jq -r '.labels[].name'` 由来の改行区切り
+# リスト）から、`^size:(small|medium|large)$` に **厳密一致** するラベルがちょうど 1 つ
+# 存在する場合に限り size 値を stdout へ返す純粋関数。
+#
+# 未信頼入力（Issue ラベル名）は外部コマンドへ一切渡さず、bash の `case` による完全一致
+# のみで検証する（grep / sed を経由しないため、`-` 始まりのラベル名によるオプション注入も
+# 正規表現メタ文字の解釈も構造的に発生しない / NFR 3.1 / 3.2）。
+#
+# 副作用を持たず、同一入力に対して常に同一の出力を返す（Req 1.7 / 1.8 と同じ性質）。
+# 判定不能・fail-safe のケースは stdout を空にし、rc で理由を返す（呼び出し側がログの
+# fallback 理由を判別できるようにするため / Req 6.2）。
+#
+# Args: $1 = ラベル名の改行区切りリスト
+# Stdout: 厳密一致した size 値（small|medium|large）。それ以外のケースでは無出力。
+# Return:
+#   0 = size 値を 1 つ確定（Req 3.2）
+#   1 = `size:` prefix を持つラベルが 0 件（Req 3.3）
+#   2 = `size:` prefix を持つラベルが 2 件以上（採用しない / Req 3.4）
+#   3 = `size:` prefix ラベルが 1 件だが厳密一致に失敗（`size:huge` / `size:Small` /
+#       末尾に空白を含む 等 / Req 3.5）
+# 注: 先頭に空白を含むラベル（` size:small`）は prefix 判定に一致しないため rc=1
+#     （0 件）へ倒れる。いずれの rc でも呼び出し側の適用結果は `DEV_MODEL` で同一。
+mr_extract_size_label() {
+  local labels="${1:-}"
+  local line candidate="" count=0
+
+  while IFS= read -r line; do
+    case "$line" in
+      "size:"*) ;;
+      *) continue ;;
+    esac
+    count=$((count + 1))
+    candidate="$line"
+  done <<<"$labels"
+
+  if [ "$count" -eq 0 ]; then
+    return 1
+  fi
+  if [ "$count" -gt 1 ]; then
+    return 2
+  fi
+
+  # 許可値集合との完全一致（= `^size:(small|medium|large)$` の厳密一致 / Req 3.2）。
+  case "$candidate" in
+    "size:small") echo "small" ;;
+    "size:medium") echo "medium" ;;
+    "size:large") echo "large" ;;
+    *) return 3 ;;
+  esac
+  return 0
+}
+
+# ─── Phase 2: Developer Model Resolver (#508 Req 1.1〜1.8) ───
+# size 値と設定値から Developer 実行モデル ID を決める **解決規則そのもの**（the Model
+# Router）。副作用を一切持たず（GitHub API / ラベル変更 / ファイル書き込み / 呼び出し元の
+# 状態変更のいずれも行わない）、解決結果のみを stdout へ出力する（Req 1.7）。
+#
+# 解決規則:
+#   small  かつ DEV_MODEL_SMALL  が非空 → DEV_MODEL_SMALL   （Req 1.1）
+#   medium かつ DEV_MODEL_MEDIUM が非空 → DEV_MODEL_MEDIUM  （Req 1.2）
+#   large                               → DEV_MODEL         （Req 1.3 / `DEV_MODEL_LARGE` は持たない）
+#   許可値以外 / 空 / 未指定             → DEV_MODEL         （fail-safe / Req 1.4）
+#   size 値に対応する設定が未設定・空文字 → DEV_MODEL         （Req 1.5）
+#
+# 設定された値は許可値リストとの照合・変換・補完のいずれも行わずそのまま返す
+# （モデル ID の許可値リストを持たない / Req 1.6）。同一入力（size 値 + DEV_MODEL /
+# DEV_MODEL_SMALL / DEV_MODEL_MEDIUM）に対して常に同一の結果を返す（Req 1.8）。
+#
+# gate（MODEL_ROUTING_ENABLED）は **本関数では判定しない**。Req 1.8 が解決結果の入力を
+# 上記 4 値に限定しており、gate を解決規則へ持ち込むと決定性の定義がぶれるため。gate 無効時
+# に「読み取りも解決も行わない」責務は Req 5.2 / 5.3 のとおり Slot Runner 側にある
+# （呼び出し側 `_slot_apply_dev_model_routing` が gate 判定して本関数を呼ばない）。
+#
+# Args: $1 = size 値（small|medium|large|それ以外|空）
+# Stdout: 適用すべき Developer モデル ID（DEV_MODEL 未設定という想定外状態では空文字）
+# Return: 0 always（fail-safe。呼び出し側は rc を分岐に使わない）
+mr_resolve_dev_model() {
+  local size="${1:-}"
+
+  case "$size" in
+    small)
+      if [ -n "${DEV_MODEL_SMALL:-}" ]; then
+        printf '%s\n' "$DEV_MODEL_SMALL"
+        return 0
+      fi
+      ;;
+    medium)
+      if [ -n "${DEV_MODEL_MEDIUM:-}" ]; then
+        printf '%s\n' "$DEV_MODEL_MEDIUM"
+        return 0
+      fi
+      ;;
+    large)
+      : # large は常に DEV_MODEL（専用設定値を設けない / Req 1.3）
+      ;;
+    *)
+      : # 許可値以外 / 空文字 / 未指定 → fail-safe（Req 1.4）
+      ;;
+  esac
+
+  # Req 1.3 / 1.4 / 1.5 の合流点。DEV_MODEL 自体が未設定という想定外状態では空文字を返し、
+  # 呼び出し側が「再代入しない」判断をできるようにする（fail-open / Req 5.6）。
+  printf '%s\n' "${DEV_MODEL:-}"
   return 0
 }

--- a/local-watcher/bin/modules/slot-worker.sh
+++ b/local-watcher/bin/modules/slot-worker.sh
@@ -6,12 +6,13 @@
 #   （本ファイル）と 1 つの sub-file が family を構成する（dispatcher_ / pclp_ / slot_ /
 #   _resume_* / _slot_* 等が混在する非 prefix 統一系のため、単一の共有 prefix は持たない）。
 #   分割マニフェスト（どの関数がどのファイルにあるか）:
-#     - slot-worker.sh          … 本ファイル: Slot Runner 本体 + ロガー + slot 失敗処理（計 12）
+#     - slot-worker.sh          … 本ファイル: Slot Runner 本体 + ロガー + slot 失敗処理（計 13）
 #         dispatcher_log / dispatcher_warn / dispatcher_error : Dispatcher 共通ロガー
 #         pclp_log / pclp_warn / pclp_error                   : pre-claim filter 共通ロガー
 #         _parallel_validate_slots                            : PARALLEL_SLOTS 設定値検証
 #         slot_log / slot_warn / slot_error                   : Slot Worker 共通ロガー
 #         _slot_mark_failed                                   : slot 失敗時の claude-failed 遷移
+#         _slot_apply_dev_model_routing                       : size ラベル → DEV_MODEL 適用（#508）
 #         _slot_run_issue                                     : Slot Runner 本体（モード別ディスパッチ / #467）
 #     - slot-worker-resume.sh   … resume / slug 判定 / pre-claim / status publish（計 13）
 #         check_existing_impl_pr / check_open_design_pr / _resume_normalize_flag /
@@ -177,6 +178,86 @@ $(build_recovery_hint "unknown")"
   gh issue comment "$NUMBER" --repo "$REPO" --body "$body" >/dev/null 2>&1 || true
 }
 
+# ─── Model Routing Phase 2: size ラベル → Developer モデル適用 (Issue #508) ───
+#
+# 当該 slot が起動時点で取得済みの Issue ラベル集合から size 値を読み取り、Model Router
+# （modules/model-router.sh の純粋関数）が解決した Developer モデル ID を **当該 slot 内の**
+# グローバル `DEV_MODEL` へ再代入する（Req 3.1）。以降の Developer 実行（design セッション /
+# 実装 Stage 群 / per-task ループ）はすべてこの `DEV_MODEL` を参照するため、1 Issue 内で
+# モデルが混在しない（Req 3.6）。
+#
+# `_slot_run_issue` 冒頭からのみ呼ばれる（1 slot 実行あたり 1 回 / Req 4.1 / NFR 2.4）。
+# 追加の GitHub API 呼び出し・LLM 実行は発生しない（NFR 2.2 / 2.3）。
+#
+# 引数:
+#   $1 = Issue 番号（ログ用）
+#   $2 = ラベル名の改行区切りリスト（`jq -r '.labels[].name'` 由来 / 未信頼入力）
+# 戻り値: 常に 0（fail-open。本機能が Issue 処理を止めることはない / Req 5.6）
+#
+# 副作用:
+#   - `DEV_MODEL` の再代入。`_slot_run_issue` は Dispatcher からサブシェルで fork される
+#     ため、親プロセス・他 slot の `DEV_MODEL` へは伝播しない（Req 3.7）。後段の
+#     `REPO_DIR="$WT"`（Issue #76）と同じサブシェル境界に依拠する。
+#   - `mr_log` / `mr_warn` を 1 行（gate 有効時のみ / Req 6.1 / 6.2 / 6.4）。
+#
+# gate 判定を本関数側に置く理由: Model Router（mr_resolve_dev_model）は Req 1.7 / 1.8 が
+# 副作用なし・入力を「size 値 + DEV_MODEL / DEV_MODEL_SMALL / DEV_MODEL_MEDIUM」に限定した
+# 純粋関数と規定しているため、gate を解決規則へ持ち込まない。gate 無効時に「読み取りも解決も
+# 行わない」責務は Req 5.2 / 5.3 のとおり Slot Runner 側にある。
+_slot_apply_dev_model_routing() {
+  local issue_number="${1:-}"
+  local labels="${2:-}"
+
+  # gate 無効（未設定 / 空 / `false` / `True` / `1` / typo はすべて安全側で無効）→ 即 return。
+  # size ラベルの読み取りもモデル解決も行わず、ログ 0 行・外部コマンド 0 回で
+  # 本機能導入前と完全に同一の挙動になる（Req 5.2 / 5.3 / NFR 1.1 / 2.1）。
+  mr_is_enabled || return 0
+
+  # 未信頼入力（ラベル名）は Model Router 側の `case` 厳密一致のみで検証され、外部コマンド
+  # へは渡らない（NFR 3.1 / 3.2）。rc は fallback 理由のログ出力にのみ用いる。
+  local _mr_size="" _mr_rc=0
+  _mr_size=$(mr_extract_size_label "$labels") || _mr_rc=$?
+
+  local _mr_resolved=""
+  _mr_resolved=$(mr_resolve_dev_model "$_mr_size") || _mr_resolved=""
+
+  # 解決結果が空（`DEV_MODEL` 自体が未設定という想定外状態）のときは再代入せず現状維持
+  # （fail-open / Req 5.6）。silent fail にしないため WARN を 1 行残す（Req 6.4）。
+  if [ -z "$_mr_resolved" ]; then
+    mr_warn "issue=#${issue_number} Developer モデルの解決結果が空のため DEV_MODEL を変更しません（DEV_MODEL の設定を確認してください）"
+    return 0
+  fi
+
+  # ログ用の size 表示と fallback 理由（Req 6.1 / 6.2）。未信頼なラベル値そのものは
+  # ログへ出さず、判定結果を表す固定トークンのみを出す（NFR 3.3）。
+  local _mr_size_token="$_mr_size" _mr_fallback=""
+  case "$_mr_rc" in
+    0)
+      # size は確定したが、対応する size 別モデルが未設定なら DEV_MODEL へ倒れる（Req 1.5）。
+      # `large` は仕様として DEV_MODEL を使うため fallback 扱いにしない（Req 1.3）。
+      case "$_mr_size" in
+        small) [ -n "${DEV_MODEL_SMALL:-}" ] || _mr_fallback="DEV_MODEL_SMALL 未設定" ;;
+        medium) [ -n "${DEV_MODEL_MEDIUM:-}" ] || _mr_fallback="DEV_MODEL_MEDIUM 未設定" ;;
+        *) : ;;
+      esac
+      ;;
+    1) _mr_size_token="none"; _mr_fallback="size ラベル不在" ;;
+    2) _mr_size_token="multiple"; _mr_fallback="size:* ラベルが複数付与" ;;
+    3) _mr_size_token="invalid"; _mr_fallback="size ラベル値が許可値に不一致" ;;
+    *) _mr_size_token="unknown"; _mr_fallback="size 判定不能" ;;
+  esac
+
+  # サブシェル境界内でのみ有効な再代入（Req 3.7）。
+  DEV_MODEL="$_mr_resolved"
+
+  if [ -n "$_mr_fallback" ]; then
+    mr_log "issue=#${issue_number} size=${_mr_size_token} dev_model=${DEV_MODEL} fallback=DEV_MODEL（理由: ${_mr_fallback}）"
+  else
+    mr_log "issue=#${issue_number} size=${_mr_size_token} dev_model=${DEV_MODEL}"
+  fi
+  return 0
+}
+
 # ─── Slot Runner 本体: _slot_run_issue (Issue #16 / #467 で本体から移動) ───
 
 # 1 Issue を 1 slot worktree で処理する Worker 本体。
@@ -213,6 +294,24 @@ _slot_run_issue() {
   exec > >(tee -a "$SLOT_LOG") 2>&1
 
   slot_log "Worker 起動 (LOG=$LOG SLOT_LOG=$SLOT_LOG)"
+
+  # ── Model Routing Phase 2: size ラベル → Developer モデル解決（#508 / Req 3.1, 4.1） ──
+  # 直上で確定した $LABELS（slot 起動時点のラベル集合スナップショット）だけを入力に
+  # **1 slot 実行につき 1 回だけ** 解決し、当該 slot 内の DEV_MODEL を確定させる
+  # （追加の GitHub API 呼び出しは 0 回 / NFR 2.2）。log 出力先を SLOT_LOG へ束ねる
+  # `exec > >(tee ...)` の直後に置くことで、解決結果が cron ログと slot ログの双方に残る
+  # （Req 6.3）。worktree 初期化や Triage より前に解決するため、以降の Developer 実行
+  # （design セッション / 実装 Stage 群 / per-task ループ）すべてに一貫して適用される
+  # （Req 3.6）。
+  #
+  # Triage 実行後の再解決は行わない（Req 4.3 / Out of Scope）。同一 slot 実行内で Triage が
+  # size ラベルを新規付与する経路では、slot 起動時点のスナップショットに当該ラベルが
+  # 含まれないため DEV_MODEL へ倒れる（意図された既知の制約 / Req 4.2）。
+  #
+  # 本サブシェル内の再代入であり親 dispatcher・他 slot へは伝播しない（Req 3.7 / 後段の
+  # `REPO_DIR="$WT"` と同じ境界）。gate 無効時は即 return し、ログ 0 行・外部コマンド 0 回
+  # （Req 5.2 / 5.3）。rc は常に 0 だが fail-open を明示するため `|| true` で吸収する。
+  _slot_apply_dev_model_routing "$NUMBER" "$LABELS" || true
 
   # ── per-run evidence サマリの初期化と終端 emit 配線（#239 / Req 1.1, 1.3, 1.5） ──
   # rs_init で per-slot 状態変数を既定値にし、Issue 番号を確定。EXIT trap は本サブシェル

--- a/local-watcher/bin/watcher-config.sh
+++ b/local-watcher/bin/watcher-config.sh
@@ -1220,6 +1220,26 @@ DEV_MAX_TURNS="${DEV_MAX_TURNS:-60}"
 # design モード（PM → Architect → PjM の単一セッション）は対象外（DEV_MODEL のまま）。
 PJM_MODEL="${PJM_MODEL:-claude-sonnet-4-6}"
 
+# ─── Model Routing Phase 2: size 別 Developer モデル (#508) ───
+# `size:small` / `size:medium` ラベルが付いた Issue の Developer 実行に用いるモデル ID。
+# **既定はいずれも空文字**（Req 2.1）。`MODEL_ROUTING_ENABLED=true` にしただけではモデルは
+# 変わらず、ここに値を明示したときに初めて当該 size の Issue へ適用される（gate 有効化だけで
+# silent にモデルが下がる事故を避ける二重 opt-in / Req 2.3）。
+#
+# - 具体的なモデル ID を既定値として埋め込まない（運用者の明示設定にのみ依存 / Req 2.2 /
+#   NFR 3.4）。設定例: `DEV_MODEL_SMALL=claude-sonnet-4-6`
+# - `size:large` 専用の設定値は設けない。`large` は `DEV_MODEL` を用いる（Req 1.3）。
+# - size ラベル不在 / `size:*` 複数付与 / 許可値外はすべて `DEV_MODEL` へ fail-safe。
+# - 適用先は **slot 内の Developer 実行のみ**（design セッション / 実装 Stage 群 /
+#   per-task ループ）。Triage / Reviewer / PjM / slot 外プロセッサ
+#   （`PR_ITERATION_DEV_MODEL` / `FAILED_RECOVERY_DEV_MODEL`）は対象外（Req 3.8 / 3.9）。
+# - 解決は slot 起動時点のラベル集合に基づく 1 回のみ。初回 Triage で size ラベルが付いた
+#   同一 slot 実行内では `DEV_MODEL` に倒れる（既知の制約 / Req 4.2。詳細は README
+#   「Model Routing Phase 2: size ラベル → Developer モデル (#508)」節）。
+# - `DEV_MODEL` の既定値・意味・上書き方法は変更していない（Req 2.4）。
+DEV_MODEL_SMALL="${DEV_MODEL_SMALL:-}"
+DEV_MODEL_MEDIUM="${DEV_MODEL_MEDIUM:-}"
+
 # Triage の --bare 実行 (#332, opt-in)。`true` 厳密一致のみ有効（それ以外はすべて OFF）。
 # --bare は CLAUDE.md / .claude/rules / hooks / skills / MCP の自動ロードをスキップし、
 # Triage の固定 context を排除する（Triage の判定基準は triage-prompt.tmpl 内で自己完結。

--- a/local-watcher/test/model_router_test.sh
+++ b/local-watcher/test/model_router_test.sh
@@ -4,16 +4,28 @@
 #       近接テスト。Triage の complexity 解釈と size ラベル永続化を fixture / gh stub で
 #       検証する。
 #
-#       対象関数:
+#       対象関数（Phase 1 / #507）:
 #         - mr_is_enabled              (Req 3.1 / 3.2 / 3.3)
 #         - mr_parse_triage_complexity (Req 2.3 / 2.4 / 5.1 / 5.2 / NFR 4.1)
 #         - mr_has_size_label          (Req 4.2 / 4.3 / 5.4 / NFR 4.2)
 #         - mr_persist_size_label      (Req 3.4 / 4.1〜4.4 / 4.7 / 5.1〜5.6 / NFR 2.1 / 2.2 / 3.1 / 3.2)
 #
+#       対象関数（Phase 2 / #508）:
+#         - mr_extract_size_label        (#508 Req 3.2〜3.5 / NFR 3.1 / 3.2)
+#         - mr_resolve_dev_model         (#508 Req 1.1〜1.8)
+#         - _slot_apply_dev_model_routing(#508 Req 3.1 / 3.6 / 3.7 / 5.2 / 5.3 / 5.6 / 6.1〜6.4)
+#           （slot-worker.sh 側の適用ヘルパー。extract_function で隔離抽出する）
+#
 #       検証する AC（docs/specs/507-feat-watcher-triage-complexity-size-phas/requirements.md）:
 #         Req 8.4 が要求する 5 ケース（許可値 3 種の正常付与 / complexity 欠落 / 不正値 /
 #         既存 size:* ラベルあり / gate 無効）を Integration I1〜I5 で網羅し、
 #         I6（labels 取得失敗 / 付与失敗）と I7（gh 呼び出し回数 2 回以下）を追加する。
+#
+#       検証する AC（docs/specs/508-feat-watcher-size-developer-phase-2/requirements.md）:
+#         #508 Req 8.4（解決規則の 3 値 × 設定あり／なし・許可値以外・空文字）を Unit P1 / P2、
+#         Req 8.5（size ラベルなし / 複数 / 不正値 / gate 無効で DEV_MODEL 適用）と
+#         Req 8.6（gate 無効時のログ 0 行）を Integration P3、Req 8.7（サブシェル境界を
+#         越えない）を P3 の最終ケース、設定値と call site の配線を Wiring P4 で検証する。
 #
 #       既存テスト（po_apply_awaiting_slot_test.sh 等）と同じ awk extract_function
 #       イディオムを踏襲し、gh / mr_log / mr_warn を stub して呼び出しトレースを観測する。
@@ -42,7 +54,8 @@ fi
 # 対象関数を実物から隔離抽出する（トップレベル副作用は回避）。
 # extract_function は単一関数のみを切り出すため、mr_persist_size_label が呼ぶ
 # 依存関数（mr_is_enabled / mr_has_size_label）も明示的に読み込む。
-for _fn in mr_is_enabled mr_parse_triage_complexity mr_has_size_label mr_persist_size_label; do
+for _fn in mr_is_enabled mr_parse_triage_complexity mr_has_size_label mr_persist_size_label \
+           mr_extract_size_label mr_resolve_dev_model; do
   # shellcheck disable=SC1090,SC2086
   eval "$(extract_function "$MODEL_ROUTER_SH" "$_fn")"
   if ! declare -F "$_fn" >/dev/null; then
@@ -51,6 +64,20 @@ for _fn in mr_is_enabled mr_parse_triage_complexity mr_has_size_label mr_persist
   fi
 done
 unset _fn
+
+# Phase 2 (#508): slot 側の適用ヘルパーも同じイディオムで隔離抽出する。
+# 本関数は mr_is_enabled / mr_extract_size_label / mr_resolve_dev_model / mr_log / mr_warn を
+# 遅延束縛で呼ぶため、上のループと後述の stub で依存が揃っている必要がある。
+if [ ! -f "$SLOT_WORKER_SH" ]; then
+  echo "ERROR: cannot find slot-worker.sh at $SLOT_WORKER_SH" >&2
+  exit 2
+fi
+# shellcheck disable=SC1090
+eval "$(extract_function "$SLOT_WORKER_SH" "_slot_apply_dev_model_routing")"
+if ! declare -F _slot_apply_dev_model_routing >/dev/null; then
+  echo "ERROR: _slot_apply_dev_model_routing not loaded" >&2
+  exit 2
+fi
 
 # グローバル env（遅延束縛で抽出した関数本体から参照される）
 # shellcheck disable=SC2034  # 抽出した mr_persist_size_label 本体が遅延束縛で参照
@@ -577,6 +604,391 @@ done
 persist_call_line="$(sed -n "${persist_line}p" "$SLOT_WORKER_SH")"
 assert_contains "W9: mr_persist_size_label の戻り値を吸収して後続へ伝播させない（Req 2.4 / 5.3）" \
   "$persist_call_line" "|| true"
+
+# ════════════════════════════════════════════════════════════════════
+# ここから Phase 2（#508: size ラベル → Developer モデル解決）
+#   参照要件: docs/specs/508-feat-watcher-size-developer-phase-2/requirements.md
+#   以下のコメント内 "Req x.y" はすべて #508 の requirements.md を指す。
+# ════════════════════════════════════════════════════════════════════
+
+# ════════════════════════════════════════════════════════════════════
+# Unit P1: mr_extract_size_label（Req 3.2〜3.5 / 8.5 / NFR 3.1 / 3.2）
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "--- Unit P1: mr_extract_size_label (#508) ---"
+
+# ラベル集合を渡し、stdout の size 値と rc の両方を検証する。
+# rc: 0=確定 / 1=size: ラベル 0 件 / 2=2 件以上 / 3=厳密一致に失敗
+assert_extract() {
+  local label="$1" labels="$2" expected_out="$3" expected_rc="$4"
+  local out="" rc=0
+  out=$(mr_extract_size_label "$labels") || rc=$?
+  assert_eq "${label}（値）" "$expected_out" "$out"
+  assert_eq "${label}（rc）" "$expected_rc" "$rc"
+}
+
+# P1-1: 許可値 3 種の厳密一致（Req 3.2）
+assert_extract "P1-1: size:small 単独 → small（Req 3.2）" "size:small" "small" "0"
+assert_extract "P1-1: size:medium 単独 → medium（Req 3.2）" "size:medium" "medium" "0"
+assert_extract "P1-1: size:large 単独 → large（Req 3.2）" "size:large" "large" "0"
+
+# 無関係ラベルが混在しても size 値は切り出せる（実際の Issue ラベル集合を模す）
+assert_extract "P1-1: 無関係ラベル混在でも size:medium を切り出す（Req 3.2）" \
+  "auto-dev
+claude-claimed
+size:medium" "medium" "0"
+
+# P1-2: size: prefix ラベル 0 件 → rc=1 / 値なし（Req 3.3）
+assert_extract "P1-2: ラベルなし（空文字入力）→ 値なし・rc=1（Req 3.3）" "" "" "1"
+assert_extract "P1-2: 無関係ラベルのみ → 値なし・rc=1（Req 3.3）" \
+  "auto-dev
+claude-claimed" "" "1"
+assert_extract "P1-2: prefix が部分一致しない sizes:small → 値なし・rc=1（Req 3.3）" \
+  "sizes:small" "" "1"
+assert_extract "P1-2: 先頭に空白を含む ' size:small' は prefix 不一致 → 値なし・rc=1（Req 3.5 と同じ DEV_MODEL 適用）" \
+  " size:small" "" "1"
+
+# P1-3: size: prefix ラベルが 2 件以上 → 値なし・rc=2（Req 3.4 fail-safe）
+assert_extract "P1-3: size:small + size:large の併存 → 値なし・rc=2（Req 3.4）" \
+  "size:small
+size:large" "" "2"
+assert_extract "P1-3: 同一値の重複付与でも採用しない → 値なし・rc=2（Req 3.4）" \
+  "size:small
+size:small" "" "2"
+assert_extract "P1-3: 有効値 + 不正値の併存も採用しない → 値なし・rc=2（Req 3.4）" \
+  "size:small
+size:huge" "" "2"
+
+# P1-4: 1 件だが厳密一致に失敗 → 値なし・rc=3（Req 3.5 fail-safe / NFR 3.1）
+for bad in "size:huge" "size:Small" "size:SMALL" "size:" "size:small " "size:small,size:large" "size:small; rm -rf /" "size:--add-label"; do
+  assert_extract "P1-4: 不正ラベル '${bad}' → 値なし・rc=3（Req 3.5 / NFR 3.1）" "$bad" "" "3"
+done
+
+# P1-5: 副作用なし（外部コマンドを呼ばない / NFR 3.1 / 3.2）
+reset_stub_state 0 '{"labels":[]}' 0
+_ignored=$(mr_extract_size_label "size:small")
+assert_eq "P1-5: 抽出は gh を呼ばない（未信頼値を外部コマンドへ渡さない / NFR 3.1）" \
+  "0" "$(count_calls 'gh ')"
+assert_eq "P1-5: 抽出はログを出さない（純粋関数 / Req 1.7 と同じ性質）" \
+  "" "$(cat "$LOG_LOG")$(cat "$WARN_LOG")"
+cleanup_stub_state
+
+# ════════════════════════════════════════════════════════════════════
+# Unit P2: mr_resolve_dev_model（Req 1.1〜1.8 / 8.4）
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "--- Unit P2: mr_resolve_dev_model (#508) ---"
+
+# 抽出した関数本体が遅延束縛で参照するグローバル（SC2034 は誤検知）。
+# shellcheck disable=SC2034
+DEV_MODEL="dev-default"
+# shellcheck disable=SC2034
+DEV_MODEL_SMALL="small-model"
+# shellcheck disable=SC2034
+DEV_MODEL_MEDIUM="medium-model"
+
+# P2-1: 3 値 × 対応設定あり（Req 1.1 / 1.2 / 1.3 / 8.4）
+assert_eq "P2-1: small かつ DEV_MODEL_SMALL 設定あり → DEV_MODEL_SMALL（Req 1.1）" \
+  "small-model" "$(mr_resolve_dev_model small)"
+assert_eq "P2-1: medium かつ DEV_MODEL_MEDIUM 設定あり → DEV_MODEL_MEDIUM（Req 1.2）" \
+  "medium-model" "$(mr_resolve_dev_model medium)"
+assert_eq "P2-1: large は設定の有無に関わらず DEV_MODEL（Req 1.3 / DEV_MODEL_LARGE を持たない）" \
+  "dev-default" "$(mr_resolve_dev_model large)"
+
+# P2-2: 許可値以外 / 空文字 / 引数省略 → DEV_MODEL（fail-safe / Req 1.4 / 8.4）
+for bad in "huge" "SMALL" "Small" "small medium" "--model" ""; do
+  assert_eq "P2-2: 許可値以外 '${bad}' → DEV_MODEL（fail-safe / Req 1.4）" \
+    "dev-default" "$(mr_resolve_dev_model "$bad")"
+done
+assert_eq "P2-2: 引数省略（未指定）→ DEV_MODEL（fail-safe / Req 1.4）" \
+  "dev-default" "$(mr_resolve_dev_model)"
+
+# P2-3: 3 値 × 対応設定なし（未設定 / 空文字）→ DEV_MODEL（Req 1.5 / 8.4）
+DEV_MODEL_SMALL=""
+DEV_MODEL_MEDIUM=""
+assert_eq "P2-3: small かつ DEV_MODEL_SMALL 空 → DEV_MODEL（Req 1.5）" \
+  "dev-default" "$(mr_resolve_dev_model small)"
+assert_eq "P2-3: medium かつ DEV_MODEL_MEDIUM 空 → DEV_MODEL（Req 1.5）" \
+  "dev-default" "$(mr_resolve_dev_model medium)"
+assert_eq "P2-3: large かつ size 別設定なし → DEV_MODEL（Req 1.3 / 1.5）" \
+  "dev-default" "$(mr_resolve_dev_model large)"
+
+unset DEV_MODEL_SMALL DEV_MODEL_MEDIUM
+assert_eq "P2-3: DEV_MODEL_SMALL 未設定（unset）→ DEV_MODEL（Req 1.5）" \
+  "dev-default" "$(mr_resolve_dev_model small)"
+assert_eq "P2-3: DEV_MODEL_MEDIUM 未設定（unset）→ DEV_MODEL（Req 1.5）" \
+  "dev-default" "$(mr_resolve_dev_model medium)"
+
+# P2-4: 片側だけ設定した場合の独立性（Req 1.1 / 1.2 / 1.5）
+# shellcheck disable=SC2034
+DEV_MODEL_SMALL="small-only"
+assert_eq "P2-4: small だけ設定 → small は small-only（Req 1.1）" \
+  "small-only" "$(mr_resolve_dev_model small)"
+assert_eq "P2-4: small だけ設定 → medium は DEV_MODEL（Req 1.5）" \
+  "dev-default" "$(mr_resolve_dev_model medium)"
+
+# P2-5: 許可値リストを持たず設定値をそのまま返す（Req 1.6）
+# shellcheck disable=SC2034
+DEV_MODEL_SMALL="not-a-real-model-id-xyz"
+assert_eq "P2-5: 未知のモデル ID も照合・変換・補完せずそのまま返す（Req 1.6）" \
+  "not-a-real-model-id-xyz" "$(mr_resolve_dev_model small)"
+
+# P2-6: 決定性（同一入力 → 同一出力 / Req 1.8）
+# shellcheck disable=SC2034
+DEV_MODEL_SMALL="small-model"
+first="$(mr_resolve_dev_model small)"
+second="$(mr_resolve_dev_model small)"
+assert_eq "P2-6: 同一入力に対して常に同一結果（Req 1.8）" "$first" "$second"
+
+# P2-7: 副作用なし（gh 呼び出し 0 回 / ログ 0 行 / 入力側変数を書き換えない / Req 1.7）
+reset_stub_state 0 '{"labels":[]}' 0
+_ignored="$(mr_resolve_dev_model small)"
+assert_eq "P2-7: 解決は gh を呼ばない（Req 1.7 / NFR 2.2）" "0" "$(count_calls 'gh ')"
+assert_eq "P2-7: 解決はログを出さない（Req 1.7）" "" "$(cat "$LOG_LOG")$(cat "$WARN_LOG")"
+assert_eq "P2-7: 解決は DEV_MODEL を書き換えない（呼び出し元の状態を変更しない / Req 1.7）" \
+  "dev-default" "$DEV_MODEL"
+assert_eq "P2-7: 解決は DEV_MODEL_SMALL を書き換えない（Req 1.7）" "small-model" "$DEV_MODEL_SMALL"
+cleanup_stub_state
+
+# P2-8: gate を解決規則へ持ち込まない（gate 判定は呼び出し側 / Req 1.8 / 5.1）
+MODEL_ROUTING_ENABLED="false"
+assert_eq "P2-8: 解決規則は gate 値に依存しない（gate 判定は Slot Runner 側 / Req 1.8）" \
+  "small-model" "$(mr_resolve_dev_model small)"
+
+# ════════════════════════════════════════════════════════════════════
+# Integration P3: _slot_apply_dev_model_routing
+#   Req 3.1〜3.7 / 4.1 / 5.2 / 5.3 / 5.6 / 6.1〜6.4 / 8.5 / 8.6 / 8.7 / NFR 2.1 / 2.2
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "--- Integration P3: _slot_apply_dev_model_routing (#508) ---"
+
+# 1 ケース分の初期状態を作る（gate 値 / size 別モデル設定を引数で切り替える）。
+# DEV_MODEL は常に "dev-default" から開始し、適用結果を観測する。
+setup_routing_case() {
+  MODEL_ROUTING_ENABLED="$1"
+  DEV_MODEL="dev-default"
+  DEV_MODEL_SMALL="$2"
+  DEV_MODEL_MEDIUM="$3"
+  reset_stub_state 0 '{"labels":[]}' 0
+}
+
+# ── P3-1: gate 無効の各表現で DEV_MODEL 据え置き・ログ 0 行（Req 5.2 / 5.3 / 8.5 / 8.6） ──
+for gate in "" "false" "off" "True" "TRUE" "1" "yes" "ture"; do
+  setup_routing_case "$gate" "small-model" "medium-model"
+  _slot_apply_dev_model_routing 42 "size:small"
+  assert_eq "P3-1: gate='${gate}' では DEV_MODEL を適用（Req 5.2 / 8.5）" "dev-default" "$DEV_MODEL"
+  assert_eq "P3-1: gate='${gate}' では本機能起因のログが 0 行（Req 5.3 / 8.6 / NFR 2.1）" \
+    "0" "$(( $(wc -l <"$LOG_LOG") + $(wc -l <"$WARN_LOG") ))"
+  assert_eq "P3-1: gate='${gate}' では外部コマンド呼び出し 0 回（NFR 2.1）" "0" "$(count_calls 'gh ')"
+  cleanup_stub_state
+done
+
+# gate 未設定（unset）も同様（既存 consumer 環境の既定状態 / NFR 1.2）
+unset MODEL_ROUTING_ENABLED
+DEV_MODEL="dev-default"
+DEV_MODEL_SMALL="small-model"
+DEV_MODEL_MEDIUM="medium-model"
+reset_stub_state 0 '{"labels":[]}' 0
+_slot_apply_dev_model_routing 42 "size:small"
+assert_eq "P3-1: gate 未設定（unset）でも DEV_MODEL を適用（NFR 1.2 / 8.5）" "dev-default" "$DEV_MODEL"
+assert_eq "P3-1: gate 未設定（unset）では本機能起因のログが 0 行（Req 5.3 / 8.6）" \
+  "0" "$(( $(wc -l <"$LOG_LOG") + $(wc -l <"$WARN_LOG") ))"
+cleanup_stub_state
+
+# ── P3-2: gate 有効 + size 別モデル設定あり（二重 opt-in 成立 / Req 3.1 / 6.1） ──
+setup_routing_case "true" "small-model" "medium-model"
+_slot_apply_dev_model_routing 42 "auto-dev
+size:small"
+assert_eq "P3-2: size:small → DEV_MODEL_SMALL を適用（Req 3.1 / 1.1）" "small-model" "$DEV_MODEL"
+log_out="$(cat "$LOG_LOG")"
+assert_eq "P3-2: ログは 1 行（Req 6.1 / 6.4）" "1" "$(( $(wc -l <"$LOG_LOG") ))"
+assert_contains "P3-2: ログに Issue 番号を含む（Req 6.1）" "$log_out" "#42"
+assert_contains "P3-2: ログに採用した size 値を含む（Req 6.1）" "$log_out" "size=small"
+assert_contains "P3-2: ログに適用したモデル ID を含む（Req 6.1）" "$log_out" "dev_model=small-model"
+assert_eq "P3-2: 正常適用時は WARN を出さない" "" "$(cat "$WARN_LOG")"
+assert_eq "P3-2: GitHub API 呼び出しは 0 回（slot 起動時のラベル集合のみ使用 / NFR 2.2）" \
+  "0" "$(count_calls 'gh ')"
+cleanup_stub_state
+
+setup_routing_case "true" "small-model" "medium-model"
+_slot_apply_dev_model_routing 7 "size:medium"
+assert_eq "P3-2: size:medium → DEV_MODEL_MEDIUM を適用（Req 3.1 / 1.2）" "medium-model" "$DEV_MODEL"
+assert_contains "P3-2: medium のログに size 値とモデル ID を含む（Req 6.1）" \
+  "$(cat "$LOG_LOG")" "size=medium dev_model=medium-model"
+cleanup_stub_state
+
+setup_routing_case "true" "small-model" "medium-model"
+_slot_apply_dev_model_routing 7 "size:large"
+assert_eq "P3-2: size:large → DEV_MODEL を適用（Req 1.3）" "dev-default" "$DEV_MODEL"
+log_out="$(cat "$LOG_LOG")"
+assert_contains "P3-2: large も 1 行のログを残す（Req 6.4）" "$log_out" "size=large dev_model=dev-default"
+assert_eq "P3-2: large は仕様どおりの解決であり fallback 表記を付けない（Req 1.3）" \
+  "0" "$( { grep -c 'fallback' "$LOG_LOG" || true; } )"
+cleanup_stub_state
+
+# ── P3-3: 二重 opt-in（gate だけ有効で size 別モデル未設定）→ DEV_MODEL（Req 2.3 / 1.5） ──
+for sz in small medium; do
+  setup_routing_case "true" "" ""
+  _slot_apply_dev_model_routing 42 "size:${sz}"
+  assert_eq "P3-3: gate 有効でも size 別モデル未設定なら DEV_MODEL（二重 opt-in / Req 2.3）" \
+    "dev-default" "$DEV_MODEL"
+  assert_contains "P3-3: ${sz} の fallback 理由をログで判別できる（Req 6.2）" \
+    "$(cat "$LOG_LOG")" "fallback=DEV_MODEL"
+  assert_eq "P3-3: ${sz} でもログは 1 行（Req 6.4）" "1" "$(( $(wc -l <"$LOG_LOG") ))"
+  cleanup_stub_state
+done
+
+# ── P3-4: size ラベルなし → DEV_MODEL（Req 3.3 / 6.2 / 8.5） ──
+setup_routing_case "true" "small-model" "medium-model"
+_slot_apply_dev_model_routing 42 "auto-dev
+claude-claimed"
+assert_eq "P3-4: size ラベルなし → DEV_MODEL（Req 3.3 / 8.5）" "dev-default" "$DEV_MODEL"
+log_out="$(cat "$LOG_LOG")"
+assert_contains "P3-4: fallback したことを判別できるログ（Req 6.2）" "$log_out" "fallback=DEV_MODEL"
+assert_contains "P3-4: size 不在を表すトークンをログに含む（Req 6.2）" "$log_out" "size=none"
+assert_eq "P3-4: ログは 1 行（Req 6.4）" "1" "$(( $(wc -l <"$LOG_LOG") ))"
+cleanup_stub_state
+
+# ── P3-5: size:* ラベル複数 → DEV_MODEL（Req 3.4 / 8.5） ──
+setup_routing_case "true" "small-model" "medium-model"
+_slot_apply_dev_model_routing 42 "size:small
+size:large"
+assert_eq "P3-5: size:* 複数付与 → DEV_MODEL（fail-safe / Req 3.4 / 8.5）" "dev-default" "$DEV_MODEL"
+log_out="$(cat "$LOG_LOG")"
+assert_contains "P3-5: 複数付与の fallback をログで判別できる（Req 6.2）" "$log_out" "size=multiple"
+assert_contains "P3-5: 複数付与でも fallback 表記を含む（Req 6.2）" "$log_out" "fallback=DEV_MODEL"
+cleanup_stub_state
+
+# ── P3-6: 不正値ラベル → DEV_MODEL（Req 3.5 / 8.5 / NFR 3.1） ──
+for bad in "size:huge" "size:Small" "size:small " "size:small; rm -rf /"; do
+  setup_routing_case "true" "small-model" "medium-model"
+  _slot_apply_dev_model_routing 42 "$bad"
+  assert_eq "P3-6: 不正ラベル '${bad}' → DEV_MODEL（fail-safe / Req 3.5 / 8.5）" \
+    "dev-default" "$DEV_MODEL"
+  assert_contains "P3-6: 不正ラベル '${bad}' の fallback をログで判別できる（Req 6.2）" \
+    "$(cat "$LOG_LOG")" "size=invalid"
+  # 未信頼なラベル値そのものはログへ出さない（固定トークンのみ / NFR 3.3）
+  assert_eq "P3-6: 不正ラベル '${bad}' の生値をログへ出さない（NFR 3.3）" \
+    "0" "$( { grep -cF -- "$bad" "$LOG_LOG" || true; } )"
+  assert_eq "P3-6: 不正ラベル '${bad}' でも gh 呼び出し 0 回（NFR 2.2 / 3.1）" "0" "$(count_calls 'gh ')"
+  cleanup_stub_state
+done
+
+# ── P3-7: 想定外状態（DEV_MODEL 自体が空）は fail-open で据え置き（Req 5.6 / 6.4） ──
+# 抽出した関数本体が遅延束縛で参照するグローバル（SC2034 は誤検知）。
+# shellcheck disable=SC2034
+MODEL_ROUTING_ENABLED="true"
+DEV_MODEL=""
+DEV_MODEL_SMALL=""
+# shellcheck disable=SC2034
+DEV_MODEL_MEDIUM=""
+reset_stub_state 0 '{"labels":[]}' 0
+rc=0
+_slot_apply_dev_model_routing 42 "size:small" || rc=$?
+assert_eq "P3-7: 想定外状態でも rc=0 で処理を継続（fail-open / Req 5.6）" "0" "$rc"
+assert_eq "P3-7: 解決結果が空なら DEV_MODEL を書き換えない（Req 5.6）" "" "$DEV_MODEL"
+assert_eq "P3-7: 想定外状態でも WARN 1 行を残す（silent fail させない / Req 6.4）" \
+  "1" "$(( $(wc -l <"$WARN_LOG") ))"
+cleanup_stub_state
+
+# ── P3-8: サブシェル境界を越えない（Req 3.7 / 8.7） ──
+# `_slot_run_issue` は Dispatcher からサブシェルで fork されるため、slot 内の DEV_MODEL
+# 再代入は親プロセス・他 slot へ伝播しない。同じ境界をサブシェルで再現して検証する。
+setup_routing_case "true" "small-model" "medium-model"
+child_model="$( _slot_apply_dev_model_routing 42 "size:small" >/dev/null 2>&1; echo "$DEV_MODEL" )"
+assert_eq "P3-8: サブシェル内では解決結果が適用される（Req 3.6 / 8.7）" "small-model" "$child_model"
+assert_eq "P3-8: 親プロセスの DEV_MODEL は変化しない（Req 3.7 / 8.7）" "dev-default" "$DEV_MODEL"
+cleanup_stub_state
+
+# ── P3-9: 1 slot 実行あたり 1 回の解決で以降一貫（Req 3.6 / 4.1 / NFR 2.4） ──
+# 同一 slot 内で 2 度呼ばれない前提だが、呼ばれても結果は同一（冪等）であることを確認する。
+setup_routing_case "true" "small-model" "medium-model"
+_slot_apply_dev_model_routing 42 "size:small"
+applied_once="$DEV_MODEL"
+_slot_apply_dev_model_routing 42 "size:small"
+assert_eq "P3-9: 再適用しても解決結果は同一（冪等 / Req 1.8）" "$applied_once" "$DEV_MODEL"
+cleanup_stub_state
+
+# ════════════════════════════════════════════════════════════════════
+# Wiring P4（grep ベース / 実行なし）: 設定値宣言と call site（Req 2.1 / 2.2 / 2.5 / 3.1 / 4.1 / 5.1）
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "--- Wiring P4: 設定値宣言 / slot-worker.sh call site (#508) ---"
+
+# P4-1: DEV_MODEL_SMALL / DEV_MODEL_MEDIUM が既定空で宣言されている（Req 2.1 / 2.2 / NFR 3.4）
+small_decl="$(grep -E '^DEV_MODEL_SMALL=' "$WATCHER_CONFIG_SH" || true)"
+medium_decl="$(grep -E '^DEV_MODEL_MEDIUM=' "$WATCHER_CONFIG_SH" || true)"
+# 期待値は「宣言行そのもの」のリテラルなので単一引用符での展開抑止が意図的（SC2016 抑止）。
+# shellcheck disable=SC2016
+assert_eq "P4-1: DEV_MODEL_SMALL は既定空で宣言される（Req 2.1 / 2.2）" \
+  'DEV_MODEL_SMALL="${DEV_MODEL_SMALL:-}"' "$small_decl"
+# shellcheck disable=SC2016
+assert_eq "P4-1: DEV_MODEL_MEDIUM は既定空で宣言される（Req 2.1 / 2.2）" \
+  'DEV_MODEL_MEDIUM="${DEV_MODEL_MEDIUM:-}"' "$medium_decl"
+
+# P4-2: 具体的なモデル ID を既定値に埋め込まない（NFR 3.4）
+model_id_hits=$( { grep -E '^DEV_MODEL_(SMALL|MEDIUM)=' "$WATCHER_CONFIG_SH" | grep -c 'claude-' || true; } )
+assert_eq "P4-2: size 別モデルの既定値にモデル ID を埋め込まない（Req 2.2 / NFR 3.4）" \
+  "0" "$((model_id_hits))"
+
+# P4-3: 追加設定値は 2 個のみ（DEV_MODEL_LARGE 等を増やさない / Req 2.5 / Out of Scope）
+large_decl_hits=$( { grep -cE '^DEV_MODEL_LARGE=' "$WATCHER_CONFIG_SH" || true; } )
+assert_eq "P4-3: DEV_MODEL_LARGE は追加しない（large は DEV_MODEL / Req 1.3 / 2.5）" \
+  "0" "$((large_decl_hits))"
+new_decl_hits=$( { grep -cE '^DEV_MODEL_[A-Z]+=' "$WATCHER_CONFIG_SH" || true; } )
+assert_eq "P4-3: 追加した DEV_MODEL_* 設定値は 2 個のみ（Req 2.5）" "2" "$((new_decl_hits))"
+
+# P4-4: 既存 DEV_MODEL の宣言を変更していない（Req 2.4 / 2.6）
+# shellcheck disable=SC2016
+assert_contains "P4-4: DEV_MODEL の既定値・上書き方法は不変（Req 2.4）" \
+  "$(grep -E '^DEV_MODEL=' "$WATCHER_CONFIG_SH" || true)" 'DEV_MODEL="${DEV_MODEL:-claude-opus-4-8}"'
+
+# P4-5: Phase 2 用の追加 gate を設けていない（単一 gate / Req 5.1）
+#       適用ヘルパーが参照する gate は mr_is_enabled（= MODEL_ROUTING_ENABLED）のみ。
+apply_def_line=$(line_of '^_slot_apply_dev_model_routing\(\) \{' "$SLOT_WORKER_SH")
+assert_rc "P4-5: slot-worker.sh に _slot_apply_dev_model_routing 定義がある" 0 \
+  test "$apply_def_line" -gt 0
+apply_body="$(extract_function "$SLOT_WORKER_SH" "_slot_apply_dev_model_routing")"
+assert_contains "P4-5: 適用ヘルパーは family 共通 gate（mr_is_enabled）で制御される（Req 5.1）" \
+  "$apply_body" "mr_is_enabled || return 0"
+routing_gate_hits=$( { printf '%s\n' "$apply_body" | grep -cE '(MODEL_ROUTING|_ROUTING_ENABLED)' || true; } )
+assert_eq "P4-5: 適用ヘルパー内で独自 gate 変数を参照しない（Req 5.1）" "0" "$((routing_gate_hits))"
+
+# P4-6: 適用対象外（Reviewer / PjM / Triage / slot 外プロセッサ）に触れない（Req 3.8 / 3.9）
+for v in REVIEWER_MODEL PJM_MODEL TRIAGE_MODEL PR_ITERATION_DEV_MODEL FAILED_RECOVERY_DEV_MODEL DEBUGGER_MODEL; do
+  hits=$( { printf '%s\n' "$apply_body" | grep -c -- "$v" || true; } )
+  assert_eq "P4-6: 適用ヘルパーは ${v} を参照しない（Req 3.8 / 3.9）" "0" "$((hits))"
+  mr_hits=$( { grep -c -- "$v" "$MODEL_ROUTER_SH" || true; } )
+  assert_eq "P4-6: model-router.sh は ${v} を参照しない（Req 3.8 / 3.9）" "0" "$((mr_hits))"
+done
+
+# P4-7: call site は 1 箇所のみ・LABELS 確定後・worktree 初期化前（Req 3.1 / 4.1 / NFR 2.4）
+# grep へ渡す ERE リテラル中の `$` は展開させたくないため単一引用符が意図的（SC2016 抑止）。
+# shellcheck disable=SC2016
+apply_call_count=$( { grep -cE '^[[:space:]]*_slot_apply_dev_model_routing "\$NUMBER"' "$SLOT_WORKER_SH" || true; } )
+assert_eq "P4-7: 適用ヘルパーの呼び出しは 1 箇所のみ（1 slot 実行 1 回 / Req 4.1 / NFR 2.4）" \
+  "1" "$((apply_call_count))"
+# shellcheck disable=SC2016
+labels_line=$(line_of '^[[:space:]]*LABELS=\$\(echo "\$issue" \| jq -r' "$SLOT_WORKER_SH")
+# shellcheck disable=SC2016
+apply_call_line=$(line_of '^[[:space:]]*_slot_apply_dev_model_routing "\$NUMBER"' "$SLOT_WORKER_SH")
+worktree_line=$(line_of '^[[:space:]]*if ! _worktree_ensure' "$SLOT_WORKER_SH")
+assert_rc "P4-7: call site は LABELS 確定より後（起動時ラベル集合を入力にする / Req 3.1）" 0 \
+  test "$apply_call_line" -gt "$labels_line"
+assert_rc "P4-7: call site は worktree 初期化より前 = _slot_run_issue 冒頭（Req 3.1 / 3.6）" 0 \
+  test "$apply_call_line" -lt "$worktree_line"
+
+# P4-8: Triage 実行後の再解決を行わない（Req 4.3 / Out of Scope）
+#       Triage 消費部（mr_persist_size_label 呼び出し）より前に 1 回だけ解決する。
+assert_rc "P4-8: call site は Triage 消費部より前 = Triage 後の再解決をしない（Req 4.3）" 0 \
+  test "$apply_call_line" -lt "$persist_line"
+
+# P4-9: 既存の DEV_MODEL 個別 call site を書き換えていない（Out of Scope / NFR 1.3）
+#       slot-worker.sh の `--model "$DEV_MODEL"` は従来どおり 1 箇所のまま。
+# shellcheck disable=SC2016  # ERE リテラル中の `$` を展開させない意図
+model_flag_hits=$( { grep -cE '^[[:space:]]*--model "\$DEV_MODEL" ' "$SLOT_WORKER_SH" || true; } )
+assert_eq "P4-9: slot-worker.sh の --model \"\$DEV_MODEL\" は 1 箇所のまま（Out of Scope）" \
+  "1" "$((model_flag_hits))"
 
 echo ""
 echo "==========================================="


### PR DESCRIPTION
## 概要

idd-claude の Developer 実行は従来すべての Issue で単一の `DEV_MODEL` を使っていた。Phase 1（#507）で付与された `size:small` / `size:medium` / `size:large` ラベルを読み取り、Issue の規模に応じて Developer 実行モデルを自動で切り替える Phase 2 を実装した。`MODEL_ROUTING_ENABLED=true` かつ `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` の明示設定という **二重 opt-in** が揃ったときのみ動作し、未設定環境では完全に従来動作を維持する。

変更は model-router.sh（純粋関数 2 本追加）・slot-worker.sh（slot 冒頭への 1 回呼び出し追加）・watcher-config.sh（設定値 2 個追加）・model_router_test.sh（近接テスト 163 件追加）・README.md（Phase 2 節 + ドキュメント）の 5 ファイルに限定される。

## 対応 Issue

Closes #508

## 関連 PR

なし（design-less impl: design.md / tasks.md は不在）

## 実装内容

- (Req 1 / Unit P1・P2) `mr_extract_size_label` — `LABELS` 集合から size 値を厳密一致で抽出する純粋関数を model-router.sh へ追加（0件/複数件/不正値は rc=1/2/3）
- (Req 1) `mr_resolve_dev_model` — size 値と設定値（`DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` / `DEV_MODEL`）からモデル ID を返す純粋関数を model-router.sh へ追加（許可値以外・空・未指定は `DEV_MODEL` fail-safe）
- (Req 2) `watcher-config.sh` に `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM`（既定値は空）を追加（モデル ID のハードコードなし）
- (Req 3) `_slot_apply_dev_model_routing` を slot-worker.sh に追加し `_slot_run_issue` 冒頭（`exec > >(tee ...)` 直後）から 1 回呼ぶ。サブシェル境界内での `DEV_MODEL` 再代入のため親プロセスへ伝播しない
- (Req 5) gate 無効時（`MODEL_ROUTING_ENABLED` が `true` 以外）は読み取り・解決・ログ出力のすべてを skip（完全 no-op）
- (Req 6) 適用時は `issue=#N size=<値> dev_model=<ID>` を、fallback 時は `fallback=DEV_MODEL（理由）` を 1 行ログ出力
- (Req 7) README にオプション機能一覧 / ステージ別モデル表 / Phase 2 専用節（二重 opt-in 解説 / 既知制約 / 適用範囲 / 解決結果一覧）を追加

## 受入基準チェック

- [x] Req 1.1〜1.8: `mr_resolve_dev_model` の解決規則（3 値・設定なし・許可値外・副作用なし・決定性）← model_router_test.sh P2-1〜P2-8
- [x] Req 2.1〜2.6: `DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM`（既定空・モデル ID 非埋め込み・二重 opt-in）← P4-1〜P4-4
- [x] Req 3.1〜3.9: slot 適用（厳密一致・ラベルなし/複数/不正値の fail-safe・サブシェル境界）← P3-2〜P3-9、P1-1〜P1-5
- [x] Req 4.1〜4.6: 1 回解決・Triage 後再解決なし・3 経路（impl-resume / skip-triage / 人間事前付与）← P4-7〜P4-8
- [x] Req 5.1〜5.6: gate 無効時 no-op・ログ 0 行・安全側正規化・fail-open ← P3-1（9 表現）、P3-7
- [x] Req 6.1〜6.4: 解決結果ログ 1 行（Issue 番号 / size 値 / モデル ID）+ fallback ログ ← P3-2〜P3-6
- [x] Req 7.1〜7.6: README 更新（実装と同一 PR）
- [x] Req 8.1〜8.7: shellcheck 警告ゼロ / bash -n 通過 / 近接テスト 163 件（Phase 2 分）

## テスト結果

```
bash local-watcher/test/model_router_test.sh
PASS 309 / FAIL 0
（Phase 1 の 146 件 + Phase 2 で追加した 163 件）

shellcheck local-watcher/bin/*.sh local-watcher/bin/modules/*.sh install.sh setup.sh .github/scripts/*.sh
警告ゼロ

shellcheck local-watcher/test/model_router_test.sh
警告ゼロ

bash -n（変更 4 スクリプト: model-router.sh / slot-worker.sh / watcher-config.sh / model_router_test.sh）
すべて OK

diff -r .claude/agents repo-template/.claude/agents
差分なし

diff -r .claude/rules repo-template/.claude/rules
差分なし

local-watcher/test/*.sh 全 99 本
98 pass / 1 flaky（publish_terminal_failure_artifacts_test.sh — 既存の不安定性。本 PR 変更とは無関係）
```

## 実装上の判断

1. **gate 判定は Slot Runner 側に置き、Model Router には持たせない**: `mr_resolve_dev_model` は決定性が要件（Req 1.8）なので `MODEL_ROUTING_ENABLED` を解決規則の入力に加えない。gate 判定は `_slot_apply_dev_model_routing` の先頭に置いた（P2-8 で「gate 値に依存しない」ことを固定）。
2. **ラベル読み取りを純粋関数として model-router.sh 側に分離**: `_slot_run_issue` 全体を隔離抽出するのが困難なため、判定を rc（1/2/3）で返す `mr_extract_size_label` として切り出した。近接テストの `extract_function` イディオムで直接検証可能。
3. **ラベル照合に外部コマンドを使わない**: `^size:(small|medium|large)$` は bash `case` の完全一致で表現し、未信頼なラベル名を `grep` 等へ渡さない（NFR 3.1 / 3.2）。
4. **fallback ログの未信頼値非出力**: fallback 理由は固定トークン（`none` / `multiple` / `invalid`）のみを使い、ラベル生値はログへ出さない（NFR 3.3、P3-6 で固定）。

詳細は `docs/specs/508-feat-watcher-size-developer-phase-2/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- **design-less impl: 単一 PR で完了のため Closes を採用**（tasks.md 不在）
- base: main / baseRefName: main / OK（作成後に検証済み）
- **初回 Triage 経路で routing が効かない件（最重要・人間判断）**: 新規 Issue が同一 slot 実行内で Triage → size ラベル付与 → 実装と進む最も一般的な経路では、slot 起動時点のラベルスナップショットに `size:*` が含まれないため `DEV_MODEL` へ fallback する。Triage 直後の再解決を別 Issue として起票するかどうかの判断を依頼する（requirements.md 最重要 Open Question / impl-notes.md 確認事項 1）。
- **fallback ログのノイズ**: gate 有効かつ size ラベル未付与 Issue が大半の環境では `fallback=DEV_MODEL（理由: none）` が毎 Issue 出力される。可観測性優先の方針に従ったが、運用上ノイズになれば別 Issue で出力条件見直しを検討したい（impl-notes.md 確認事項 3）。
- Reviewer による検証結果: `docs/specs/508-feat-watcher-size-developer-phase-2/review-notes.md` 参照（RESULT: approve / PASS 309 / FAIL 0）。

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #508 のコメントを参照してください。
