### PR TITLE
feat(#509): tasks-count-gate escalate 時に子 Issue 分割案コメントを投稿する（TC_SPLIT_PROPOSAL_ENABLED）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1580,6 +1580,7 @@ idd-claude は基本フロー（Triage → 実装 → PR 作成）以外の機�
 | **Full-Auto Kill Switch**（full-auto 系 processor の単一 kill switch。**AND セマンティクス**で個別 gate と並列に作用し、`FULL_AUTO_ENABLED=true` かつ個別 gate=true の場合のみ full-auto 系 processor が発火する二重 opt-in。不具合発生時に env 1 つで全 full-auto 挙動を即時 no-op に倒すための運用 knob。**現在の配線対象**は Dependency Auto-Unblock Sweep (#346) + Auto-Merge (#352) + Design Auto-Merge (#354) + PR Reviewer Commit Status (#349) + Failed Recovery (#359) + needs-decisions Auto-Continue (#362) の 6 系統。semantic conflict / blocked cascade は未実装のため将来追加時に同じ kill switch を参照する設計。既存 opt-in 機能（merge-queue / auto-rebase / promote-pipeline / pr-iteration / pr-reviewer / security-review / design-review-release / stage-checkpoint / stage-a-verify / quota-aware / debugger / hooks）は **本フラグ配下に入れず** 個別 gate で独立制御を維持） | `FULL_AUTO_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / `True` / `TRUE` / `1` / `on` / `False` / 空文字 / 前後空白付き / typo）はすべて OFF に正規化（外部副作用ゼロで早期 return + suppression ログ 1 行）。本機能導入前と完全に等価（NFR 1.1） | — | (本表の各 full-auto processor 行を参照) | #348 |
 | **Model Routing Phase 1**（Triage が出力した変更規模 `complexity` を `size:small` / `size:medium` / `size:large` ラベルとして Issue に永続化する。Triage を再実行しないサイクル（impl-resume / PR Iteration / Failed Recovery）でも判定結果を sticky に参照でき、人間が事前にラベルを貼れば Triage 判定を override できる。既存 `size:*` ラベルが 1 つでもあれば追加・付け替え・削除のいずれも行わない（先に存在するラベル優先 / 人間 override と過去 Triage 由来を区別しない）。`skip-triage` / impl-resume 経路は Triage ブロックごと迂回されるため付与されない。値の不正は WARN のみで継続（fail-safe）、GitHub 操作の失敗も WARN のみで当該サイクルを中断しない（fail-open）。gate OFF 時は本機能に起因する GitHub API 呼び出し 0 回・ログ 0 行で本機能導入前と完全に等価。**Triage 側の `complexity` / `complexity_reason` 出力は gate に依らず常時行われる**（gate は watcher 側の永続化のみを制御）） | `MODEL_ROUTING_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `TRUE` / `1` / `on` / `off` / typo）はすべて安全側 OFF に正規化 | **前提**: `bash .github/scripts/idd-claude-labels.sh` で `size:small` / `size:medium` / `size:large` ラベルを作成済みであること（未作成の repo では付与が毎回失敗し WARN が出る / 処理自体は継続） | [Model Routing Phase 1: Triage complexity → size ラベル (#507)](#model-routing-phase-1-triage-complexity--size-ラベル-507) | #507 |
 | **Model Routing Phase 2**（Issue に付いた `size:*` ラベルを読んで、その Issue の **Developer 実行モデル**（`DEV_MODEL`）を slot 内で切り替える。**gate 有効化だけではモデルは変わらない二重 opt-in**（`DEV_MODEL_SMALL` / `DEV_MODEL_MEDIUM` に値を明示して初めて適用される）。解決は **slot 起動時点のラベル集合に基づく 1 回のみ**で、追加の GitHub API 呼び出し・LLM 実行はゼロ。size ラベル不在 / `size:*` 複数付与 / 許可値外はすべて `DEV_MODEL` へ fail-safe。適用先は当該 slot 内の Developer 実行（design セッション / 実装 Stage 群 / per-task ループ）のみで、Triage / Reviewer / PjM / slot 外プロセッサは対象外。gate OFF 時は本機能に起因する外部コマンド呼び出し 0 回・ログ 0 行で導入前と完全に等価） | `MODEL_ROUTING_ENABLED`（Phase 1 と**共通の単一 gate**。Phase 別 gate は設けない） | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `TRUE` / `1` / `on` / `off` / typo）はすべて安全側 OFF に正規化 | **必須（これが無いと何も変わらない）**: `DEV_MODEL_SMALL` および / または `DEV_MODEL_MEDIUM`（**既定はいずれも空**。モデル ID は埋め込まれていないため運用者が明示指定する。例: `DEV_MODEL_SMALL=claude-sonnet-4-6`）。`size:large` 専用 env は無く `large` は `DEV_MODEL` を使う | [Model Routing Phase 2: size ラベル → Developer モデル (#508)](#model-routing-phase-2-size-ラベル--developer-モデル-508) | #508 |
+| **Tasks Count Gate: 子 Issue 分割案コメント**（[Tasks Count Gate](#tasks-count-gate-147) が escalate（既定 ≥ 11 件）と判定した Issue に対し、`tasks.md` の最上位・未完了タスクから機械生成した **子 Issue 分割案**をコメント 1 件で投稿する。既定は最上位タスク 1 件 = 子 Issue 案 1 件で、`_Depends:_` 由来の依存が **循環** するタスク群のみ 1 案へ統合する（子タスク ID 参照は最上位 ID へ正規化）。各案はタイトル案 / 含む最上位タスク ID / `Split from:` / `Parent:` / 案間依存の `Depends on:` / `gh issue create` の雛形を持つ。**提案のみで子 Issue の自動起票は行わない**（起票・調整は人間）。LLM の追加起動なし（bash の文字列処理のみ）。投稿は専用マーカー`<!-- idd-claude:tasks-count-split-proposal ... -->` で冪等化され、既存 escalation コメントのマーカーとは独立に判定する。生成・投稿の失敗は WARN 1 行のみで escalation コメント投稿と `needs-decisions` 付与は完了する（fail-open）。gate OFF 時は本機能に起因する GitHub API 呼び出し 0 回・ログ 0 行で本機能導入前と完全に等価） | `TC_SPLIT_PROPOSAL_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `false` / `off` / `True` / `TRUE` / `1` / typo）はすべて安全側 OFF に正規化 | **前提**: `TC_ENABLED`（既定 `true`）が opt-out されていないこと（tasks-count gate 自体が走らなければ本機能も起動しない）。閾値は既存の `TC_ESCALATE_LOWER`（既定 `11`）をそのまま使う | [子 Issue 分割案コメント（#509 / opt-in）](#子-issue-分割案コメント509--opt-in) | #509, #147 |
 | **GitHub Actions ワークフロー**（local watcher の代替実行基盤） | `IDD_CLAUDE_USE_ACTIONS`（GitHub Repository Variable。**env var ではない**） | 未設定 = 無効 | Repository Variable に `true` を厳密一致で設定。未設定 / `true` 以外（`on` / `True` / `1` 等）はワークフロー発火を停止 | — | [Step 3-B. GitHub Actions をセットアップ](#step-3-b-github-actions-をセットアップ代替) | #10 |
 
 各機能は**互いに独立**に制御できます。例えば `MERGE_QUEUE_RECHECK_ENABLED=false` だけを
@@ -7020,9 +7021,11 @@ Budget overflow check と同一件数を返します（#216）。両者は別実
 | `TC_WARN_LOWER` | `8` | 既定値推奨 | 警告レンジの下限件数 |
 | `TC_WARN_UPPER` | `10` | 既定値推奨 | 警告レンジの上限件数 |
 | `TC_ESCALATE_LOWER` | `11` | 既定値推奨 | エスカレーション（Developer 抑止）の下限件数 |
+| `TC_SPLIT_PROPOSAL_ENABLED` | `false` | 分割案コメントが欲しい場合のみ `true` | escalate 時に子 Issue 分割案コメントを投稿する（#509 / opt-in。後述） |
 
 閾値 env var が非整数の場合は warning ログを出して既定値（8 / 10 / 11）にフォールバック
-します（fail-safe）。
+します（fail-safe）。`TC_SPLIT_PROPOSAL_ENABLED` はリテラル `true` の厳密一致のみ有効で、
+未設定 / 空文字 / `false` / `off` / `True` / `1` / typo はすべて安全側（無効）へ正規化されます。
 
 ### cron 例
 
@@ -7070,6 +7073,72 @@ opt-out したい場合:
 - Issue #131 由来で既に `needs-decisions` ラベルが付与済みの Issue には重複適用しません
   （Req 4.4）
 
+### 子 Issue 分割案コメント（#509 / opt-in）
+
+`TC_SPLIT_PROPOSAL_ENABLED=true` を明示すると、**escalate 判定（既定 ≥ 11 件）と同時に**
+`tasks.md` の最上位・未完了タスクから機械生成した **子 Issue 分割案**をコメント 1 件で
+投稿します。人間の作業を「ゼロから分割を考える」から「提示された案の承認・調整・起票」へ
+軽減することが目的です。既定は無効（`false`）で、未設定環境では本機能導入前と完全に同一の
+escalate 挙動（escalation コメント本文・`needs-decisions` 付与・ログ行）を保ちます。
+
+> **注**: 本機能は **提案のみ**で、watcher は子 Issue を **自動起票しません**。
+> LLM の追加起動も行わず（bash の文字列処理のみ）、escalate 1 件あたりの GitHub API 呼び出しは
+> 既投稿確認 1 回 + コメント投稿 1 回の **計 2 回以下**です。
+
+#### 分割案の作り方（グルーピング規則）
+
+- 構成単位は `tasks.md` の**最上位・未完了タスク**（計数と同じ正準 regex `^- \[ \]\*? [0-9]+\. `）。
+  子タスク（`1.1` 等）・完了済みタスク（`- [x]` / `- [x]*`）は独立した案になりません
+- 既定は **最上位タスク 1 件 = 子 Issue 案 1 件**
+- `_Depends:_` 由来の依存が **循環する**（相互に到達可能な）タスク群のみ **1 案へ統合**します。
+  一方向の依存連鎖（1 → 2 → 3）は統合せず、案間の `Depends on:` として表現します
+- `_Depends:_` が子タスク ID（`3.1` 等）を参照している場合は対応する最上位 ID（`3`）へ正規化します。
+  子タスク行に書かれた `_Depends:_` は、その親（最上位）タスクの依存として集約します
+- 案の並びは `tasks.md` の出現順で、同一入力に対して常に同一の分割案を生成します（決定論的）
+
+#### コメントに含まれる情報
+
+- 検知件数と適用閾値（`TC_ESCALATE_LOWER`）、生成した子 Issue 案の件数
+- 案ごとに: タイトル案（120 文字以内）/ 含む最上位タスクの numeric ID 一覧 /
+  `Split from: #<元 Issue>` / `Parent: #<元 Issue>` / 案間依存がある場合の `Depends on: 案 <番号>`
+- 起票コマンド（`gh issue create`）の雛形。**人間が内容を確認してから実行**する提示に留めます
+- 末尾の冪等マーカー `<!-- idd-claude:tasks-count-split-proposal issue=<N> count=<C> proposals=<G> -->`
+
+関係種別のキーは [`.claude/rules/issue-dependency.md`](.claude/rules/issue-dependency.md) の
+canonical 記法（`Depends on:` / `Parent:` / `Split from:`）の英語表記のみを使い、alias 表記
+（`前提依存:` / `Blocked by:` / `親 Issue:` / `分割元:`）と逆ブロッキング表記 `Blocks:` は出力しません。
+
+#### 人間が取る次アクション
+
+1. **案を読んで承認 / 調整する** — 粒度が粗い・細かい場合は案をまとめる / 分けるを人手で判断
+2. **子 Issue を起票する** — コメント内の `gh issue create` 雛形を編集して実行（そのまま実行してもよい）
+3. **`Depends on:` の参照先を実 Issue 番号へ置き換える** — 未起票時点では案番号（`案 1` 等）で
+   表現されているため、起票後に `#<番号>` へ差し替えます
+4. **元 Issue の扱いを決める** — 分割後は元 Issue から `needs-decisions` を外して閉じる / 親として
+   残す等の運用判断を行います（本機能はラベル操作を追加しません）
+
+#### 冪等性と縮退挙動
+
+- 同一 Issue のコメント履歴に本機能の専用マーカーが 1 件でもあれば再投稿しません。判定は
+  **既存 escalation コメントのマーカー（`tasks-count-overflow`）とは独立**で、escalation コメントが
+  冪等 skip されても分割案の投稿可否には影響しません
+- コメント履歴の取得に失敗した場合はマーカー不在として扱います（影響は重複コメント 1 件まで）
+- 最上位・未完了タスクを 1 件も抽出できなかった場合は投稿せず、理由をログに残します
+- 本文が 60,000 文字に達する場合は先頭から詰めて残りを省略し、省略した旨を本文に明記します
+- `tasks.md` の内容は未信頼入力として扱い、HTML コメント記法やマーカー相当の文字列、
+  シェルのクォート文字は無害化してから本文へ埋め込みます
+
+#### 有効化
+
+```cron
+*/2 * * * * REPO=owner/your-repo REPO_DIR=$HOME/work/your-repo \
+  TC_SPLIT_PROPOSAL_ENABLED=true \
+  $HOME/bin/issue-watcher.sh >> $HOME/.issue-watcher/cron.log 2>&1
+```
+
+`TC_ENABLED=false` で tasks-count gate 自体を opt-out している場合、
+`TC_SPLIT_PROPOSAL_ENABLED` の値にかかわらず分割案は投稿されません。
+
 ### 失敗・異常系
 
 - **tasks.md 不在 / 読み取り不可**: skip + `tc_log reason=tasks-md-missing` を記録
@@ -7102,6 +7171,11 @@ body の主な形式:
 - `issue=#<N> posted escalation-comment count=<C>` — エスカレーション投稿成功
 - `issue=#<N> added label=needs-decisions` — ラベル付与成功
 - `issue=#<N> already-warned skip duplicate comment` — 冪等 skip
+- `issue=#<N> posted split-proposal-comment count=<C> proposals=<G>` — 子 Issue 分割案の投稿成功（#509 / opt-in）
+- `issue=#<N> split-proposal skip reason=already-posted` — 分割案の冪等 skip（#509）
+- `issue=#<N> split-proposal skip reason=no-top-level-tasks` — 分割案の入力タスクが 0 件（#509）
+- `WARN: issue=#<N> split-proposal 生成失敗 reason=<理由>（fail-open で続行）` — 分割案の生成失敗（#509 / stderr）
+- `WARN: issue=#<N> gh issue comment 失敗（split-proposal 投稿、fail-open で続行）` — 分割案の投稿失敗（#509 / stderr）
 
 ### Migration Note（既存ユーザー向け）
 

--- a/docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/impl-notes.md
+++ b/docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/impl-notes.md
@@ -1,0 +1,92 @@
+# 実装ノート: #509 tasks-count-gate escalate 時の子 Issue 分割案コメント
+
+## 実装方針の要約
+
+- 実装先は既存 module `local-watcher/bin/modules/tasks-count-gate.sh`（prefix `tc_` 維持 / 新 module なし）。
+  393 行 → 966 行で family 分割閾値（1,200 行）には未到達。
+- opt-in gate `TC_SPLIT_PROPOSAL_ENABLED`（既定 `false` / リテラル `true` 厳密一致のみ有効）を
+  `watcher-config.sh` に追加。`TC_ENABLED` / `MODEL_ROUTING_ENABLED` とは独立。
+- **純粋関数と副作用関数を分離**: 抽出 / グルーピング / 本文生成は GitHub API を触らない純粋関数、
+  投稿系のみ副作用（`tc_post_split_proposal_comment` / `tc_split_proposal_already_posted`）。
+- LLM 追加起動なし（bash の文字列処理のみ / NFR 3.1）。escalate 1 件あたりの追加 API 呼び出しは
+  既投稿確認 1 回 + 投稿 1 回の計 2 回（NFR 3.2）、gate OFF 時は 0 回 + ログ 0 行（NFR 3.3 / 1.4）。
+- 既存 escalate 処理の**後ろに追加**する形で呼び出し（`tc_run_post_architect_check` の escalate 分岐、
+  `|| true` 付き）。生成・投稿の失敗は WARN のみで rc=0（fail-open / Req 6.5, 6.6）。
+
+### 追加関数（`local-watcher/bin/modules/tasks-count-gate.sh`）
+
+| 関数 | 種別 | 役割 |
+|---|---|---|
+| `tc_split_proposal_enabled` | 純粋 | gate 判定（`true` 厳密一致） |
+| `tc_sanitize_text` | 純粋 | 未信頼 tasks.md 断片の無害化 |
+| `tc_truncate_title` | 純粋 | タイトル案 120 文字上限 |
+| `tc_extract_top_level_tasks` | 純粋（read） | 最上位・未完了タスク + `_Depends:_` 正規化 |
+| `tc_group_tasks` | 純粋 | 相互到達（SCC）併合によるグルーピング |
+| `tc_build_split_proposal_body` | 純粋（read） | コメント本文生成（rc: 0 / 1 失敗 / 2 タスク 0 件） |
+| `tc_split_proposal_already_posted` | 副作用 | 専用マーカーによる冪等判定（gh view 1 回） |
+| `tc_post_split_proposal_comment` | 副作用 | gate → 生成 → 冪等 → 投稿の orchestrator |
+
+## AC トレーサビリティ
+
+| 要件 | 実現箇所 / 検証テスト |
+|---|---|
+| Req 1.1〜1.6（gate / 既定無効 / 独立性） | `tc_split_proposal_enabled` + config。Case E1〜E5（無効値 7 種 / 未設定 / API 0 回 / ログ 0 行） |
+| Req 2.1〜2.3（escalate のみ / 既存を置換しない） | `tc_run_post_architect_check` escalate 分岐。Case E6〜E9 |
+| Req 2.4（タスク 0 件） | `tc_build_split_proposal_body` rc=2 → skip ログ。Case D1〜D3 |
+| Req 2.5（同一 tasks.md を入力） | 呼び出し元が計数と同じ `$tasks_path` を渡す。Case E7 |
+| Req 2.6（design 経由しない経路） | hook が design 分岐内側のみ（既存構造 / 追加変更なし） |
+| Req 3.1〜3.3（構成単位 / 子・完了除外 / 計数一致） | `tc_extract_top_level_tasks`（正準 regex 一致）。Case A1〜A3, B1, B2, B5 |
+| Req 3.4, 3.5（循環併合 / 子 ID 正規化） | `tc_group_tasks` + 抽出時の正規化。Case C1〜C3, C5 |
+| Req 3.6, 3.7（網羅性 / 決定論性） | グルーピングの構成上保証。Case A4, A19, C7 |
+| Req 4.1〜4.4, 4.11（タイトル / ID / Split from / Parent / 件数・閾値） | 本文生成。Case A5〜A8, A13, A14 |
+| Req 4.5, 4.6（案間依存 / 案番号の置換注意） | `Depends on: 案 N` + 本文注記。Case C6, A17 |
+| Req 4.7, 4.8（canonical 記法 / `Blocks:` 非出力） | 本文テンプレ。Case A9, A10 |
+| Req 4.9, 4.10（提案のみ / 起票コマンド雛形） | 本文テンプレ。Case A11, A12, H5 |
+| Req 5.1〜5.7（冪等） | `tc_split_proposal_already_posted`（専用マーカー）。Case A15, A16, F1〜F4 |
+| Req 6.1〜6.4（既存挙動不変） | 既存関数・マーカー文字列・閾値は未変更。Case E6, A16 |
+| Req 6.5, 6.6, 6.9（fail-open / silent fail 禁止） | WARN + rc=0。Case G3〜G7 |
+| Req 6.7（tasks.md 非改変） | read のみ。Case J1 |
+| Req 6.8（exit code 不変） | 呼び出しは `|| true`、関数は常に rc=0 |
+| Req 7.1〜7.5（README） | README opt-in 表 / tasks-count gate 節（分割案節・env 表・ログ行） |
+| Req 8.1〜8.6 | 下記「検証」 |
+| NFR 1.1〜1.3 | Case E4〜E6（gate OFF 等価） |
+| NFR 2.1〜2.4 | `tasks-count:` prefix の 1 行ログ。Case D3, F2, G2, G4, G6 |
+| NFR 3.1〜3.6 | LLM 追加なし / API ≤2（Case G1）/ 本文 60,000 上限（Case A18 + 300 件手動計測 59,418 文字）/ タイトル 120（Case I1〜I4）/ 30 タスク 0.07s |
+| NFR 4.1〜4.4 | `tc_sanitize_text` + Issue 番号 `^[0-9]+$` 検証 + `grep -F --`。Case G8〜G10, H1〜H7 |
+
+## 検証（実行コマンドと結果）
+
+- `shellcheck local-watcher/bin/*.sh local-watcher/bin/modules/*.sh install.sh setup.sh .github/scripts/*.sh` → 警告ゼロ
+- `shellcheck local-watcher/test/tasks_count_gate_split_proposal_test.sh` → 警告ゼロ
+- `bash -n`（module / config / test）→ OK
+- `bash local-watcher/test/tasks_count_gate_split_proposal_test.sh` → **PASS 76 / FAIL 0**
+- `local-watcher/test/*_test.sh` 全 100 本 → 新規テスト含め回帰なし。
+  `publish_terminal_failure_artifacts_test.sh` は rc=141（SIGPIPE）で **main でも同様に間欠失敗**する
+  既存の flaky（本変更前後で同じ挙動を確認済み）。
+- `diff -r .claude/agents repo-template/.claude/agents` / `diff -r .claude/rules repo-template/.claude/rules` → 差分なし
+- installer: `install-lib.sh:1317` が `modules/*.sh` を glob 配布するため変更不要（確認のみ）
+
+## Open Questions への判断（requirements.md より）
+
+1. **統合条件**: 暫定採用どおり **相互依存（循環）のみ統合**。一方向連鎖は統合せず案間 `Depends on:` で表現。
+2. **コメント単位**: **独立コメント**を採用（既存 escalation コメント本文とマーカーを一切変更しないため / Req 6.4）。
+3. **タイトル生成**: 最上位タスク要約を無害化 → 末尾 ` (P)` 除去 → 統合案は ` / ` 連結 → 120 文字で切り詰め（末尾 `…`）。
+4. **`_Requirements:_` の同梱**: 本 Issue の必須項目に無いため**含めない**（AC 追加が必要なため人間判断待ち。下記「確認事項」）。
+5. **warn レンジでの提示**: 要件どおり escalate のみ（Req 2.2）。
+6. **gate 名称**: `TC_SPLIT_PROPOSAL_ENABLED` を採用。
+7. **本文長上限時の縮退**: 未規定だったため **先頭から詰めて残りを省略 + 省略件数を本文に明記**する決定論的な縮退を実装。
+
+## 確認事項（人間 / PM・Architect 判断）
+
+- **`_Requirements:_` の子 Issue 案への同梱**（Open Question 4）: 起票後のトレーサビリティは上がるが
+  Requirement 4 への AC 追加が必要。要件更新があれば `tc_extract_top_level_tasks` の 3 列目と同様に
+  4 列目として追加できる構造にしてある。
+- **`tc_sanitize_text` の除去文字**: 起票コマンド雛形（単一引用符で囲む）の破壊を防ぐため、要約から
+  `'` `"` `` ` `` `$` `\` を**除去**している。表示上の情報が僅かに落ちる（例: `` `tasks.md` `` → `tasks.md`）。
+  エスケープ方式に変えるべきかは運用フィードバック待ち。
+- **`- [x]` 配下の `_Depends:_`**: 完了済み最上位タスク配下の依存注釈は帰属先なしとして読み飛ばす実装。
+  完了タスクは案の構成単位にならないため実害はないが、仕様として明文化されていない。
+- **タイトル案のロケール依存**: `${s:0:N}` は UTF-8 ロケールで文字単位、C ロケールでバイト単位。
+  C ロケールでも文字数上限は満たすが、切り詰め位置が保守的になる（最大 1 文字余分に短くなる）。
+
+STATUS: complete

--- a/docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/requirements.md
+++ b/docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/requirements.md
@@ -1,0 +1,197 @@
+# Requirements Document
+
+## Introduction
+
+tasks-count-gate（#147 / #216）は Architect が `tasks.md` を確定した直後に最上位・未完了タスクを
+機械的に再カウントし、11 件以上で `needs-decisions` を付与して Developer 自動起動を抑止する。
+しかし現行のエスカレーションは「分割を検討してください」という警告コメントに留まり、実際の分割
+作業（どのタスクをどの子 Issue に束ねるか、依存関係をどう表すか）はすべて人間が担っている。
+本書は、escalate 時に **親タスク単位の子 Issue 分割案** をコメントとして機械生成・投稿し、人間の
+作業を「案の承認・調整・起票」に軽減する Phase 3 の要件を定義する。子 Issue の自動起票は行わず
+提案に留め、既定無効の opt-in gate により未設定環境では現行と完全に同一の挙動を保つ。
+
+## 関連
+
+- Depends on: #507
+- Sibling: #508
+- Related: #131 #147 #216
+
+## Requirements
+
+### Requirement 1: opt-in gate と既定無効
+
+**Objective:** As a watcher 運用者, I want 分割案の投稿を環境変数で明示的に有効化できること, so that 未設定環境では本機能導入前と完全に同一の挙動が保たれる
+
+#### Acceptance Criteria
+
+1. The tasks-count gate shall `TC_SPLIT_PROPOSAL_ENABLED` の既定値を無効として扱い、当該変数が宣言されていない環境でも無効とする
+2. Where `TC_SPLIT_PROPOSAL_ENABLED` がリテラル文字列 `true` に設定されているとき, the tasks-count gate shall 分割案コメントの生成と投稿を実行する
+3. If `TC_SPLIT_PROPOSAL_ENABLED` に `true` 以外の値（空文字列 / `false` / `off` / `True` / `1` / typo）が与えられたとき, the tasks-count gate shall 当該 gate を安全側（無効）へ正規化する
+4. While gate が無効であるとき, the tasks-count gate shall 本機能に起因する GitHub API 呼び出しとログ出力を一切行わない
+5. The tasks-count gate shall 本機能の gate を既存の `TC_ENABLED` および `MODEL_ROUTING_ENABLED` とは独立した変数で制御する
+6. While `TC_ENABLED` による opt-out で tasks-count gate 自体が実行されないとき, the tasks-count gate shall `TC_SPLIT_PROPOSAL_ENABLED` の値にかかわらず分割案コメントを投稿しない
+
+### Requirement 2: 投稿トリガ条件
+
+**Objective:** As a watcher 運用者, I want 分割案が escalate 時にのみ投稿されること, so that 正常・警告レンジの Issue にノイズコメントが増えない
+
+#### Acceptance Criteria
+
+1. While gate が有効であるとき, when 件数分類が escalate と確定したとき, the tasks-count gate shall 当該 Issue に子 Issue 分割案を含むコメントを投稿する
+2. While gate が有効であるとき, when 件数分類が normal または warn であるとき, the tasks-count gate shall 分割案コメントを投稿しない
+3. The tasks-count gate shall 分割案の投稿を既存 escalation コメント投稿および `needs-decisions` ラベル付与に **追加する形**で行い、それらを置き換えない
+4. If 分割案の入力となる最上位・未完了タスクを 1 件も抽出できなかったとき, the tasks-count gate shall 分割案コメントを投稿せず理由をログに残す
+5. The tasks-count gate shall 分割案の生成に、当該サイクルの escalate 判定で計数した `tasks.md` と同一のファイルを入力として用いる
+6. While design フェーズを経由しない経路（impl-resume / Stage Checkpoint Resume 等、tasks-count gate 自体が起動しない経路）で Issue が処理されるとき, the tasks-count gate shall 分割案コメントを投稿しない
+
+### Requirement 3: 分割案のグルーピング規則
+
+**Objective:** As a Issue 分割を担当する人間, I want 分割案の粒度と依存の扱いが決定論的であること, so that 提示された案をそのまま検証・調整できる
+
+#### Acceptance Criteria
+
+1. The tasks-count gate shall 分割案の構成単位を `tasks.md` の最上位・未完了タスクとし、既定で最上位タスク 1 件につき子 Issue 案 1 件を生成する
+2. The tasks-count gate shall 子タスク（小数階層 numeric ID）および完了済みタスク（`- [x]` / `- [x]*`）を独立した子 Issue 案として生成しない
+3. The tasks-count gate shall 最上位タスクの抽出条件を tasks-count gate の既存計数規約（正準 regex を持つ最上位・未完了タスク行の判定）と一致させ、同一 `tasks.md` に対して escalate 判定の件数と抽出件数を一致させる
+4. When 最上位タスク間に `_Depends:_` アノテーション由来の相互依存（依存関係が循環する関係）が存在するとき, the tasks-count gate shall 当該タスク群を 1 件の子 Issue 案に統合する
+5. When `_Depends:_` の値が子タスクの numeric ID を参照しているとき, the tasks-count gate shall 当該参照を対応する最上位タスクの ID に正規化して扱う
+6. The tasks-count gate shall 抽出したすべての最上位・未完了タスクを、いずれか 1 件の子 Issue 案へ欠落・重複なく 1 回だけ割り当てる
+7. The tasks-count gate shall 子 Issue 案を `tasks.md` 上の最上位タスクの出現順で並べ、同一入力に対して常に同一の分割案を生成する
+
+### Requirement 4: 分割案コメントの内容
+
+**Objective:** As a Issue 分割を担当する人間, I want 各子 Issue 案が起票に必要な情報を備えること, so that 案を読んだだけで子 Issue を起票・調整できる
+
+#### Acceptance Criteria
+
+1. The tasks-count gate shall 各子 Issue 案にタイトル案を 1 件含める
+2. The tasks-count gate shall 各子 Issue 案に、当該案が含む最上位タスクの numeric ID 一覧を含める
+3. The tasks-count gate shall 各子 Issue 案に、分割元となった Issue を指す `Split from: #<元 Issue 番号>` を含める
+4. The tasks-count gate shall 各子 Issue 案に、親を指す `Parent: #<元 Issue 番号>` を含める
+5. When 子 Issue 案の間に依存関係が存在するとき, the tasks-count gate shall 依存する側の案に `Depends on:` 行を含める
+6. While 子 Issue が未起票で Issue 番号が確定していないとき, the tasks-count gate shall `Depends on:` の参照先を分割案内の案番号で表し、起票後に実 Issue 番号へ置き換える必要がある旨をコメント本文に明記する
+7. The tasks-count gate shall 関係種別のキー文字列を canonical 記法（`Depends on:` / `Parent:` / `Split from:`）の英語表記で出力し、alias 表記（`前提依存:` / `Blocked by:` / `親 Issue:` / `分割元:`）を用いない
+8. The tasks-count gate shall 逆ブロッキング表記（`Blocks:`）を出力しない
+9. The tasks-count gate shall 本コメントが提案であり子 Issue の自動起票を行わない旨をコメント本文に明記する
+10. The tasks-count gate should 人間が次に取る操作（子 Issue 起票コマンドの雛形）をコメント本文に含める
+11. The tasks-count gate shall 検知件数と適用閾値を分割案コメントから参照できる形で含める
+
+### Requirement 5: 冪等性
+
+**Objective:** As a watcher 運用者, I want 分割案コメントが同一 Issue に重複投稿されないこと, so that 再実行や次サイクルの評価でコメント欄が汚れない
+
+#### Acceptance Criteria
+
+1. The tasks-count gate shall 分割案コメントに、本機能由来であることを機械的に識別できる固定マーカーを含める
+2. If 同一 Issue のコメント履歴に本機能のマーカーが既に存在するとき, the tasks-count gate shall 分割案コメントを再投稿しない
+3. The tasks-count gate shall 分割案コメントの既投稿判定を、既存 escalation コメントのマーカーとは独立したマーカーで行う
+4. When 既存 escalation コメントがマーカー検知によりスキップされたとき, the tasks-count gate shall 分割案コメントの投稿可否を本機能のマーカーのみで判定する
+5. When 同一 Issue に対して本機能が複数サイクルにわたり評価されたとき, the tasks-count gate shall 分割案コメントを 1 件のみ存在させる
+6. If コメント履歴の取得に失敗したとき, the tasks-count gate shall マーカー不在として扱い、影響を重複コメント 1 件までに留める
+7. When 分割案コメントの投稿をスキップしたとき, the tasks-count gate shall スキップ理由を判別できるログを出力する
+
+### Requirement 6: 既存挙動の不変性と fail-open
+
+**Objective:** As a watcher 運用者, I want 本機能の失敗が既存の escalate 処理を止めないこと, so that 補助機能の不調で Developer 抑止という本来の保護が失われない
+
+#### Acceptance Criteria
+
+1. While gate が無効であるとき, the tasks-count gate shall 本機能導入前と同一の escalate 挙動（escalation コメント本文・`needs-decisions` ラベル付与・ログ行）を保つ
+2. The tasks-count gate shall 既存 env var（`TC_ENABLED` / `TC_WARN_LOWER` / `TC_WARN_UPPER` / `TC_ESCALATE_LOWER`）の名前・既定値・意味のいずれも変更しない
+3. The tasks-count gate shall 既存の判定レンジ境界（normal / warn 8〜10 件 / escalate 11 件以上）と分類結果を変更しない
+4. The tasks-count gate shall 既存 escalation コメントの本文と識別マーカー文字列を変更しない
+5. If 分割案の生成が失敗したとき, the tasks-count gate shall WARN ログを残したうえで escalate 本体の処理（escalation コメント投稿・`needs-decisions` ラベル付与）を完了させる
+6. If 分割案コメントの投稿が失敗したとき, the tasks-count gate shall WARN ログを残し、呼び出し元の処理を中断せず継続する
+7. The tasks-count gate shall 分割案の生成にあたり `tasks.md` を書き換えない
+8. The tasks-count gate shall 本機能に起因して design 分岐の成功／失敗判定および exit code の意味を変更しない
+9. The tasks-count gate shall 本機能に起因する失敗を silent fail させない
+
+### Requirement 7: ドキュメント更新と配布物の同期
+
+**Objective:** As a repository 管理者, I want 新 gate の説明と配布物の同期が同一 PR で完了すること, so that README と実挙動の乖離や consumer repo へのドリフトが発生しない
+
+#### Acceptance Criteria
+
+1. The README shall `TC_SPLIT_PROPOSAL_ENABLED` の既定値・正規化規則・有効化方法をオプション機能一覧の opt-in 節に含める
+2. The README shall 分割案コメントに含まれる情報と、人間が取る次アクション（案の承認・調整・子 Issue 起票）を tasks-count gate の節に記述する
+3. The README shall 本機能が追加するログ行の形式を tasks-count gate の観測方法の記述に含める
+4. Where root と repo-template で二重管理される配布物を変更したとき, the repository shall 双方を同一 PR で同期する
+5. The repository shall 上記ドキュメント更新を本機能の実装と同一 PR で行う
+
+### Requirement 8: 検証可能性
+
+**Objective:** As a reviewer, I want 本機能の受け入れ確認手段が事前に定義されていること, so that PR レビュー時に AC 充足を機械的に確認できる
+
+#### Acceptance Criteria
+
+1. The 変更後の bash スクリプト shall `shellcheck` を警告ゼロで通過する
+2. The 変更後の bash スクリプト shall `bash -n` の構文検査を通過する
+3. The repository shall 分割案生成の純粋関数に対する近接テストを `local-watcher/test/` 配下に既存命名規約で追加する
+4. The 近接テスト shall fixture の `tasks.md` を入力として、期待される子 Issue 案の件数・対象タスク ID・依存表現を検証する
+5. The 近接テスト shall 最上位 11 件のフラット構成 / 子タスクと完了済みタスクを含む構成 / `_Depends:_` による相互依存を含む構成 / 最上位タスク 0 件 / gate 無効 の 5 ケースを含む
+6. The 検証手順 shall gate 無効時に既存 escalate 挙動が変化しないことの確認を含む
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While gate が無効であるとき, the watcher shall 本機能導入前と同一のログ出力・ラベル遷移・exit code の意味を保つ
+2. The watcher shall 既存 env var 名・既存ラベル名・cron 登録文字列・ログ出力先のいずれも変更しない
+3. The watcher shall 新規 env var を未設定のまま既存 consumer 環境が動作したときに、本機能導入前と同一の外部挙動を提供する
+
+### NFR 2: 可観測性
+
+1. When 分割案コメントを投稿したとき, the tasks-count gate shall 既存の `tasks-count:` prefix・Issue 番号・生成した子 Issue 案の件数を含む 1 行のログを出力する
+2. When 分割案コメントの投稿をスキップしたとき, the tasks-count gate shall スキップ理由を含む 1 行のログを出力する
+3. If 分割案の生成または投稿が失敗したとき, the tasks-count gate shall Issue 番号と失敗理由を含む WARN 行を標準エラー出力へ出す
+4. The tasks-count gate shall 本機能のログを既存の一括抽出手段（`tasks-count:` prefix による grep）で取得できる形式で出力する
+
+### NFR 3: 性能・コスト
+
+1. The tasks-count gate shall 分割案の生成に追加の LLM 実行（Claude の追加起動）を発生させない
+2. Where gate が有効であるとき, the tasks-count gate shall 1 Issue の escalate あたり本機能に起因する GitHub API 呼び出しを 2 回以下（既投稿確認 1 回 + コメント投稿 1 回）に抑える
+3. Where gate が無効であるとき, the tasks-count gate shall 本機能に起因する GitHub API 呼び出しを 0 回とする
+4. The 分割案コメント本文 shall GitHub のコメント本文長上限（65,536 文字）に対して 60,000 文字を超えない
+5. The 各子 Issue 案のタイトル案 shall 120 文字以内に収まる
+6. Where gate が有効であるとき, the tasks-count gate shall 分割案の生成による design 分岐の実行時間の増分を 1 秒以内に収める
+
+### NFR 4: セキュリティ（未信頼入力の取り扱い）
+
+1. The tasks-count gate shall ブランチ上の `tasks.md` の内容を未信頼入力として扱い、検証なしにコマンドとして解釈・実行しない
+2. If タスク要約に HTML コメント記法または本機能のマーカーと同一の文字列が含まれるとき, the tasks-count gate shall 冪等判定を誤らせない形で当該文字列を無害化する
+3. The tasks-count gate shall Issue 番号を数値として検証したうえで `#N` 参照記法の構成に用いる
+4. The tasks-count gate shall コメント本文に含める起票コマンドの雛形を人間が確認して実行する提示に留め、watcher 自身が実行しない
+
+## Out of Scope
+
+- **子 Issue の自動起票**（`gh issue create` 相当の実行）。本 Issue は提案コメントの投稿までとし、起票は人間が行う
+- **Triage 時点（`tasks.md` 確定前）の事前分割判定**。Issue 本文だけでは精度が低いため対象外
+- **既存 tasks-count gate 挙動の変更**（escalate 閾値・レンジ境界・`needs-decisions` 付与・警告レンジ 8〜10 件の挙動・既存 escalation コメント本文とマーカー文字列）
+- **LLM によるタイトル案生成**（将来の opt-in 拡張。本 Issue は bash による機械生成のみ）
+- Architect 側の `design.md` `## Split Proposal` 生成ロジック（#131）の変更、および本機能との統合
+- 本機能導入前に escalate 済みの Issue への遡及投稿（retrofit）
+- 分割案の承認・却下・反映状況を追跡する状態管理（専用ラベル / sticky comment / 本文編集等）
+- 分割案に基づく `tasks.md` の自動書き換え・分割反映
+- GitHub Actions 版 workflow への反映（tasks-count gate 相当の hook を持たないため対象外）
+- `size:*` ラベル（#507）や Developer モデル解決（#508）との連動・分割案への反映
+- module 名・関数名・関数 prefix・コメント本文の具体テンプレート文字列・パース実装方式・データ構造（design.md の領分）
+
+## Open Questions（確認事項）
+
+- **タスク群を統合する条件の確定**: Issue 本文の実装メモは「`_Depends:_` で強結合なタスク群は同一案にまとめる」とするが「強結合」の定義が無い。本書は検証可能性のため Requirement 3.4 で **相互依存（依存が循環する関係）のみを統合対象**とする決定論的規則を暫定採用した。一方向の依存連鎖（1 → 2 → 3）も統合対象に含めるかは運用判断であり、含める場合は分割案の件数が大きく減るため要件更新が必要。
+- **投稿するコメントの単位**: 既存 escalation コメントへの統合（1 コメント）か独立コメントかは Issue 本文で設計判断に委ねられている。本書は冪等マーカーの独立性（Requirement 5.3）のみを規定し、コメントの物理的な単位は規定していない。統合方式を採る場合、Requirement 6.4（既存 escalation コメント本文を変更しない）との整合を design 段階で確認する必要がある。
+- **タイトル案の生成方式と長さ上限**: 本書は NFR 3.5 で 120 文字以内を暫定採用した。最上位タスク行の要約文をどこまで加工するか（記号除去 / 先頭 N 文字の切り詰め / 末尾省略記号）は未確定で、値が変わる場合は NFR 3.5 のみ差し替えれば他 AC は不変。
+- **`_Requirements:_` numeric ID を子 Issue 案に含めるか**: Architect 側の `## Split Proposal` テンプレ（`architect.md`）は「対応 requirement」を含むが、Issue #509 本文の必須項目には含まれていない。含めると起票後のトレーサビリティが上がるため、Requirement 4 への AC 追加要否を人間判断に委ねる。
+- **警告レンジ（8〜10 件）での分割案提示ニーズ**: 本書は Issue 本文に従い escalate のみを対象とした（Requirement 2.2）。warn レンジでも案が欲しいという運用要求が出た場合は gate 粒度を含めて再検討が必要。
+- **gate 名称の最終確定**: 本書は Issue 本文の記載どおり `TC_SPLIT_PROPOSAL_ENABLED` を採用した。既存 tasks-count gate 系 env が `TC_` prefix で統一されているため整合するが、命名変更が入る場合は Requirement 1.1〜1.3 と Requirement 7.1 の文字列のみ差し替えれば他 AC は不変。
+- **コメント長上限に達した場合の縮退挙動**: NFR 3.4 の 60,000 文字上限に接触するケース（極端に多い最上位タスク / 長大なタスク要約）で、案を省略するか本文を切り詰めるかは未確定。実運用では 11〜20 件程度が想定され接触可能性は低いと判断し、本書では規定していない。
+
+---
+
+## 自己レビュー結果（要件レビューゲート）
+
+- **Mechanical Checks**: 全要件見出しが numeric ID（Requirement 1〜8 / NFR 1〜4）。各要件に EARS 形式 AC（`When` / `If` / `While` / `Where` / `The <subject> shall`）が 1 件以上存在。AC 本文には env var 名・canonical 記法キー・ラベル名という外部契約と、`tasks.md` のアノテーション記法（`_Depends:_` / checkbox 表記）という Architect 成果物の既存仕様のみを含め、module 名・関数名・関数 prefix・regex・jq 表現等の実装語彙は混入させていない。
+- **EARS・テスト可能性**: 全 AC が observable / testable。曖昧語は具体化済み（「強結合」→ 依存が循環する関係、GitHub API 呼び出し 2 回以下 / 0 回、コメント本文 60,000 文字以内、タイトル案 120 文字以内、実行時間増分 1 秒以内、テスト 5 ケース）。
+- **スコープ・カバレッジ**: Issue 本文の受入基準ドラフト 1.1〜3.2 を Requirement 1〜8 に対応付けた（1.1→Req 2.1 / 1.2→Req 4.1〜4.4 / 1.3→Req 4.5 / 1.4→Req 4.9 + Out of Scope / 1.5→Req 5 / 2.1→Req 1 + NFR 1 / 2.2→Req 6.2〜6.4 / 2.3→Req 6.5・6.6 / 3.1→Req 7 / 3.2→Req 8）。PM として (a) 投稿トリガの境界（warn / normal / タスク 0 件 / gate 従属関係）、(b) グルーピングの決定論性と網羅性（Req 3.6 / 3.7）、(c) 未起票子 Issue の `Depends on:` 参照表現（Req 4.6）、(d) コメント履歴取得失敗時の安全側（Req 5.6）、(e) 可観測性・性能・セキュリティ NFR を補完した。
+- **既存整合**: 既存 tasks-count gate の 3 段階レンジ・冪等マーカー方式・fail-open 方針、`.claude/rules/issue-dependency.md` の canonical 記法と `Blocks:` 非採用方針、`.claude/rules/design-review-gate.md` を正準とする最上位タスク計数規約、`.claude/rules/tasks-generation.md` の `_Depends:_` アノテーション規約、README のオプション機能一覧（opt-in 節）の記載フォーマット、#507 で確立した「既定 false / `true` 厳密一致 / 不正値は安全側」という gate 正規化慣習と矛盾しないことを確認した。
+- 残存する曖昧性は Open Questions に暫定採用値付きで列挙。レビューは 2 パスで確定。

--- a/docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/review-notes.md
+++ b/docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/review-notes.md
@@ -1,0 +1,98 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-23T09:20:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-509-impl-feat-watcher-tasks-count-gate-escalate-i
+- HEAD commit: b13d98a4aba1819c90e8a14352293e644bb2990a
+- Compared to: main..HEAD
+- 変更ファイル: `local-watcher/bin/modules/tasks-count-gate.sh`（+573）/ `local-watcher/bin/watcher-config.sh`（+19）/ `local-watcher/test/tasks_count_gate_split_proposal_test.sh`（新規 +458）/ `README.md`（+76/-1）/ spec 配下 2 件
+- 備考: 本 Issue は design フェーズを経由しない実装経路のため `design.md` / `tasks.md` は不在。`_Boundary:_` アノテーションが存在しないため、boundary 判定は requirements.md の Out of Scope（既存 tasks-count gate 挙動 / Architect 側 #131 / GitHub Actions 版 / 自動起票）を境界として評価した。
+- CLAUDE.md に `## Feature Flag Protocol` 節は存在しないため、flag 観点の細目判定は行わず通常の 3 カテゴリ判定のみを適用。
+
+## Verified Requirements
+
+- 1.1 — `tc_split_proposal_enabled`（`[ "${TC_SPLIT_PROPOSAL_ENABLED:-false}" = "true" ]`）+ `watcher-config.sh` の `TC_SPLIT_PROPOSAL_ENABLED="${TC_SPLIT_PROPOSAL_ENABLED:-false}"` / テスト E2（未設定は無効）
+- 1.2 — リテラル `true` 厳密一致でのみ rc=0 / テスト E3, E7
+- 1.3 — 無効値 7 種（空 / `false` / `off` / `True` / `TRUE` / `1` / `ture`）を安全側へ正規化 / テスト E1
+- 1.4 — gate 無効時は `tc_post_split_proposal_comment` が最初に早期 return（ログ・API なし）/ テスト E4（API 0 回）, E5（ログ 0 行）
+- 1.5 — `TC_ENABLED` / `MODEL_ROUTING_ENABLED` と独立の新規変数（config diff / gate 関数は他 gate を参照しない）
+- 1.6 — 呼び出し点が `tc_run_post_architect_check` の escalate 分岐内で、先頭の `tc_should_run`（`TC_ENABLED != true` で return 1）を通過しない限り到達しない構造
+- 2.1 — escalate 分岐末尾で `tc_post_split_proposal_comment "$NUMBER" "$count" "$tasks_path"` を呼ぶ / テスト E7
+- 2.2 — warn / normal 分岐に呼び出しなし / テスト E8, E9
+- 2.3 — 既存 `tc_post_escalation_comment` + `tc_add_needs_decisions_label` の**後に追加**（既存 2 行は無改変）/ テスト E6, E7
+- 2.4 — `tc_build_split_proposal_body` rc=2 → `split-proposal skip reason=no-top-level-tasks` ログのみ / テスト D1〜D3
+- 2.5 — orchestrator が `tc_count_tasks` と同一の `$tasks_path` を引数で渡す（tasks-count-gate.sh:935, 959）/ テスト E7
+- 2.6 — hook は design 分岐 rc=0 の orchestrator 内のみ（呼び出し点追加以外に call site なし。既存構造を変更していない）
+- 3.1 — `tc_group_tasks` の既定は 1 タスク = 1 グループ / テスト A3
+- 3.2 — 抽出 regex が `- [ ]` / `- [ ]*` の最上位のみに一致、`- [x]` 行は対象外 / テスト B1, B5, B6
+- 3.3 — 抽出 regex `^- \[ \]\*? [0-9]+\. ` が `tc_count_tasks` の正準 regex と同一 / テスト A2, B2（`tc_count_tasks` 実物との件数一致）
+- 3.4 — 推移閉包後の相互到達ノードを併合（強連結成分相当）/ テスト C3, C4
+- 3.5 — `_Depends:_` の値から先頭整数部を取り出し最上位 ID へ正規化、子タスク行の注釈は親へ集約 / テスト C1, C2
+- 3.6 — `group_of[]` により全ノードが 1 グループへ 1 回だけ割り当て / テスト A19
+- 3.7 — 出現順で走査・出力し決定論的 / テスト A4, C7（同一入力で本文完全一致）
+- 4.1 — 案ごとに `### 案 N: <タイトル案>` / テスト A5
+- 4.2 — `- 含む最上位タスク: \`id\`, ...` / テスト A6, C5
+- 4.3 — `- Split from: #<N>` / テスト A7
+- 4.4 — `- Parent: #<N>` / テスト A8
+- 4.5 — 直接依存辺から `- Depends on: 案 N` を生成 / テスト C6
+- 4.6 — header に「案番号であり起票後に実 Issue 番号へ置き換える」旨を明記 / テスト A17
+- 4.7 — canonical 記法のみ出力（alias 非出力）/ テスト A10
+- 4.8 — `Blocks:` を出力しない / テスト A9
+- 4.9 — 「watcher は子 Issue を自動起票しません」を header に明記 / テスト A11
+- 4.10 — `gh issue create` 雛形セクション / テスト A12
+- 4.11 — 検知件数と適用閾値（`TC_ESCALATE_LOWER`）を header に出力 / テスト A13, A14
+- 5.1 — `<!-- idd-claude:tasks-count-split-proposal issue=N count=C proposals=G -->` を末尾に付与 / テスト A15
+- 5.2 — `tc_split_proposal_already_posted` 検出時は投稿せず skip / テスト F1
+- 5.3 — 既存 `tasks-count-overflow` マーカーとは別文字列（本文にも非出力）/ テスト A16
+- 5.4 — 判定は自機能マーカー prefix のみを `grep -qF --` / テスト F3
+- 5.5 — 冪等 skip により 1 件のみ存在 / テスト F1
+- 5.6 — `gh issue view` 失敗時は return 1（marker 不在扱い）/ テスト F4
+- 5.7 — skip 時に `reason=already-posted` / `reason=no-top-level-tasks` ログ / テスト F2, D3
+- 6.1 — gate 無効時の escalate は既存 2 アクションのみ / テスト E6
+- 6.2 — `TC_ENABLED` / `TC_WARN_LOWER` / `TC_WARN_UPPER` / `TC_ESCALATE_LOWER` の定義行は diff 上無改変
+- 6.3 — `tc_classify` / 閾値ロジックは diff 上無改変
+- 6.4 — `tc_post_escalation_comment` 本文・マーカーは diff 上無改変 / テスト A16
+- 6.5 — 生成失敗は `tc_warn` + rc=0（escalate 本体は呼び出し前に完了済み）/ テスト G5, G6, G7
+- 6.6 — 投稿失敗は `tc_warn` + rc=0 / テスト G3, G4
+- 6.7 — 読み取りのみ（`tasks.md` への書き込みなし）/ テスト J1（cksum 一致）
+- 6.8 — 呼び出しは `|| true`、関数は常に rc=0（design 分岐 rc に非干渉）
+- 6.9 — 失敗経路はすべて `tc_warn`（stderr）ないし `tc_log` を残す / テスト D3, F2, G4, G6
+- 7.1 — README「オプション機能一覧」opt-in 表に `TC_SPLIT_PROPOSAL_ENABLED`（既定 `false` / `=true` 厳密一致 / 正規化規則）を追加
+- 7.2 — README tasks-count gate 節に「子 Issue 分割案コメント（#509 / opt-in）」を追加（含まれる情報 + 人間が取る次アクション 4 項目）
+- 7.3 — README のログ形式一覧に成功 / skip 2 種 / WARN 2 種の 5 行を追加
+- 7.4 — 二重管理配布物（`.claude/agents` / `.claude/rules` / workflow / labels）に変更なし。`diff -r .claude/agents repo-template/.claude/agents` および `diff -r .claude/rules repo-template/.claude/rules` を実行し差分なしを確認。`local-watcher/` は `repo-template/` にミラーされない系統（install.sh の `modules/*.sh` glob 配布で追従）
+- 7.5 — README 更新は同一 PR（commit 0f9b1e6）に含まれる
+- 8.1 — `shellcheck local-watcher/bin/modules/tasks-count-gate.sh local-watcher/bin/watcher-config.sh local-watcher/test/tasks_count_gate_split_proposal_test.sh` を再実行し rc=0 / 警告ゼロを確認
+- 8.2 — `bash -n`（module / config）を再実行し OK を確認
+- 8.3 — `local-watcher/test/tasks_count_gate_split_proposal_test.sh` を既存命名規約で追加、`lib/test-helpers.sh` + `extract_function` イディオムを踏襲
+- 8.4 — fixture `tasks.md` 5 種を `mktemp -d` 配下に生成し、案件数・対象タスク ID・依存表現を検証
+- 8.5 — Case A（フラット 11 件）/ B（子タスク・完了済み混在）/ C（相互依存）/ D（0 件）/ E（gate 無効）の 5 ケースを網羅
+- 8.6 — Case E6 が gate 無効時の escalate 挙動（既存 2 アクションのみ）を検証
+- NFR 1.1〜1.3 — gate OFF で API 0 回 / ログ 0 行 / 既存 escalate 挙動同一（テスト E4, E5, E6）。既存 env var 名・ラベル名・ログ出力先の変更なし
+- NFR 2.1〜2.4 — `tc_log` の `tasks-count:` prefix を経由し、投稿成功ログに Issue 番号・件数・案件数を含む（テスト G2）。skip / 失敗は 1 行ログ（D3, F2, G4, G6）
+- NFR 3.1〜3.6 — Claude 追加起動なし（bash 文字列処理のみ）/ 投稿時 API 呼び出し 2 回（テスト G1）/ gate OFF で 0 回（E4）/ 本文長 60,000 以内（A18 + `max_body` 打ち切り実装）/ タイトル 120 文字（I1〜I4）
+- NFR 4.1〜4.4 — `tc_sanitize_text` による HTML コメント記法分断・クォート除去（H1〜H4, H6, H7）/ Issue 番号 `^[0-9]+$` 検証（G8〜G10）/ `grep -qF --` によるパターン注入防止 / 起票コマンドは提示のみ（H5）
+
+## Findings
+
+なし
+
+## Summary
+
+差分は tasks-count-gate module + config + README + 新規近接テストに限定され、requirements.md の
+Requirement 1〜8 / NFR 1〜4 のすべてに実装またはテストの対応が確認できた。reviewer 側で
+`tasks_count_gate_split_proposal_test.sh`（PASS 76 / FAIL 0）、`shellcheck`（rc=0）、`bash -n`、
+`diff -r .claude/{agents,rules}`（差分なし）を再実行し green を確認。gate OFF 時は API 0 回・
+ログ 0 行で既存 escalate 挙動が保たれており、Out of Scope（自動起票 / 既存閾値・マーカー変更 /
+Actions 版）への侵食も無い。
+
+補足（reject 理由には含めない / 設計 iteration・別 Issue 還流の候補）: (a) Req 1.6（`TC_ENABLED`
+opt-out 時の非投稿）は `tc_should_run` の既存ガードによる構造的保証で、専用テストは無い
+（Req 8.5 が要求する 5 ケースには含まれておらず現行確定 spec は充足）。(b) NFR 3.4 の本文長
+打ち切り分岐は自動テスト未到達で impl-notes の手動計測（300 件 / 59,418 文字）に依拠している。
+(c) impl-notes の「確認事項」に挙がる `_Requirements:_` 同梱可否・サニタイズ方式は requirements.md
+の Open Questions に属し、AC 追加を要するため本 impl PR の範囲外。
+
+RESULT: approve

--- a/local-watcher/bin/modules/tasks-count-gate.sh
+++ b/local-watcher/bin/modules/tasks-count-gate.sh
@@ -16,7 +16,18 @@
 #   - tc_add_needs_decisions_label                 : `needs-decisions` ラベル付与
 #   - tc_run_post_architect_check                  : design rc=0 hook の orchestrator
 #
+#   Phase 3（#509 / opt-in `TC_SPLIT_PROPOSAL_ENABLED`）: escalate 時の子 Issue 分割案
+#   - tc_split_proposal_enabled                    : 分割案機能の opt-in gate
+#   - tc_sanitize_text                             : 未信頼 tasks.md 断片の無害化（純粋）
+#   - tc_truncate_title                            : タイトル案の文字数上限適用（純粋）
+#   - tc_extract_top_level_tasks                   : 最上位・未完了タスクの抽出（純粋）
+#   - tc_group_tasks                               : 相互依存併合によるグルーピング（純粋）
+#   - tc_build_split_proposal_body                 : 分割案コメント本文の生成（純粋）
+#   - tc_split_proposal_already_posted             : 分割案専用の冪等マーカー検知
+#   - tc_post_split_proposal_comment               : 分割案コメント投稿（fail-open）
+#
 #   設計参照: docs/specs/147-feat-harness-tasks-md-task-auto-dev-issu/design.md
+#            docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/requirements.md
 #   関連    : Issue #131（Architect 側 budget overflow 検知）と独立かつ重畳に作用する
 #
 # 配置先:
@@ -342,6 +353,563 @@ tc_add_needs_decisions_label() {
   return 0
 }
 
+# =============================================================================
+# Phase 3 (#509): escalate 時の子 Issue 分割案コメント
+#
+# escalate（既定 ≥ 11 件）と確定した Issue に対し、`tasks.md` の最上位・未完了
+# タスクから **子 Issue 分割案** を機械生成してコメント投稿する（Req 2.1）。
+# LLM 追加起動は行わず bash の文字列処理のみで生成する（NFR 3.1）。
+#
+# opt-in gate `TC_SPLIT_PROPOSAL_ENABLED`（既定 false / `true` 厳密一致のみ有効）
+# の配下にあり、無効時は本機能に起因する GitHub API 呼び出しもログ出力も 0 件
+# （Req 1.1〜1.4 / NFR 1.1 / NFR 3.3）。
+#
+# 既存 escalate 処理（escalation コメント投稿 + `needs-decisions` 付与）は
+# **置き換えず追加**であり、本機能の失敗は WARN ログのみで既存処理を中断しない
+# （Req 2.3 / 6.5 / 6.6）。
+# =============================================================================
+
+# ─── tc_split_proposal_enabled ───
+#
+# 分割案機能の opt-in gate（Req 1.1〜1.3 / 1.5）。
+# `TC_SPLIT_PROPOSAL_ENABLED` がリテラル `true` に厳密一致するときのみ rc=0。
+# 未設定 / 空 / `false` / `off` / `True` / `1` / typo はすべて安全側（無効）へ
+# 正規化する。既存 gate 慣習（`MODEL_ROUTING_ENABLED` / `PATH_OVERLAP_CHECK` の
+# `= "true"` 厳密一致）と同型で、`TC_ENABLED` / `MODEL_ROUTING_ENABLED` とは
+# 独立した変数で制御する（Req 1.5）。
+#
+# 入力: 環境変数 TC_SPLIT_PROPOSAL_ENABLED
+# 戻り値: 0 = 有効 / 1 = 無効
+# 副作用: なし（無効時もログを出さない / Req 1.4）
+tc_split_proposal_enabled() {
+  [ "${TC_SPLIT_PROPOSAL_ENABLED:-false}" = "true" ]
+}
+
+# ─── tc_sanitize_text ───
+#
+# `tasks.md` 由来の未信頼テキスト断片を、コメント本文・起票コマンド雛形に
+# 埋め込んでも安全な形へ無害化する純粋関数（NFR 4.1 / 4.2）。
+#
+#   - CR / TAB を半角スペースへ（レコード区切り TAB の混入防止）
+#   - HTML コメント記法 `<!--` / `-->` を半角スペース挿入で分断（本機能の冪等
+#     マーカーと同一文字列が混入しても marker 検知を誤らせない / NFR 4.2）。
+#     置換後の文字列は `<` の直後が半角スペースになるため新たな `<!--` を
+#     生成せず、bash の `${var//pat/rep}` が置換結果を再走査しない性質と併せて
+#     多重入れ子（`<<!--!--` 等）でもマーカー再構成は起こらない。
+#     実体参照（`&lt;`）は使わない（bash の置換文字列では `&` がマッチ全体に
+#     展開されるため / 検証済み）
+#   - シェル・markdown で解釈されうる文字（`` ` `` / `$` / `\` / `"` / `'`）を除去
+#     （起票コマンド雛形は単一引用符で囲むため `'` の除去でクォート破壊を防ぐ）
+#   - 連続スペースの圧縮と前後トリム
+#
+# 入力: 第 1 引数 = 生テキスト
+# stdout: 無害化済みテキスト（改行なし）
+# 戻り値: 常に 0 / 副作用: なし
+tc_sanitize_text() {
+  local s="$1"
+  s="${s//$'\r'/ }"
+  s="${s//$'\t'/ }"
+  s="${s//<!--/< !--}"
+  s="${s//-->/-- >}"
+  s="${s//\`/}"
+  s="${s//\$/}"
+  s="${s//\\/}"
+  s="${s//\"/}"
+  s="${s//\'/}"
+  while [ "${s}" != "${s//  / }" ]; do
+    s="${s//  / }"
+  done
+  # 前後の空白をトリム（bash パラメータ展開のみで外部コマンドを起動しない）
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# ─── tc_truncate_title ───
+#
+# タイトル案を最大文字数（既定 120 / NFR 3.5）に収める純粋関数。
+# 上限超過時は末尾 1 文字分を省略記号 `…` に置き換える。
+#
+# ロケール差の扱い: bash の `${s:0:N}` は UTF-8 ロケールでは文字単位、C / POSIX
+# ロケールではバイト単位で切り出す。後者では日本語（3 バイト）の途中で切れた
+# 壊れたバイト列が残りうるため、マルチバイト非対応ロケールと判定した場合のみ
+# 末尾の非 ASCII バイトを巻き戻す（表示が数文字短くなるだけで、いずれのロケール
+# でも「120 文字以内」を満たす）。
+#
+# 入力: 第 1 引数 = タイトル案 / 第 2 引数 = 最大文字数（既定 120）
+# stdout: 上限内に収めたタイトル案
+# 戻り値: 常に 0 / 副作用: なし
+tc_truncate_title() {
+  local s="$1"
+  local max="${2:-120}"
+  if ! [[ "$max" =~ ^[0-9]+$ ]] || [ "$max" -lt 2 ]; then
+    max=120
+  fi
+  if [ "${#s}" -le "$max" ]; then
+    printf '%s' "$s"
+    return 0
+  fi
+  local cut="${s:0:$((max - 1))}"
+  local probe='あ'
+  if [ "${#probe}" -ne 1 ]; then
+    # C / POSIX ロケール = バイト単位スライス。末尾の UTF-8 継続バイト（0x80〜0xBF）を
+    # 落とし、先頭バイト（0xC0 以上）を 1 つ落とした時点で文字境界が確定する。
+    # 失われるのは最大 1 文字分に留まる。
+    local last code
+    while [ -n "$cut" ]; do
+      last="${cut: -1}"
+      code=$(printf '%d' "'$last" 2>/dev/null || echo 0)
+      code="${code:-0}"
+      if [ "$code" -lt 0 ]; then
+        code=$((code + 256))
+      fi
+      if [ "$code" -lt 128 ]; then
+        break
+      fi
+      cut="${cut%?}"
+      if [ "$code" -ge 192 ]; then
+        break
+      fi
+    done
+  fi
+  printf '%s…' "$cut"
+}
+
+# ─── tc_extract_top_level_tasks ───
+#
+# `tasks.md` から **最上位・未完了タスク**を抽出する純粋関数（Req 3.1〜3.3, 3.5）。
+#
+# 抽出条件は tc_count_tasks の正準 regex `^- \[ \]\*? [0-9]+\. ` に厳密一致させる。
+# したがって同一 `tasks.md` に対して escalate 判定の件数と抽出件数は一致し
+# （Req 3.3）、子タスク（`1.1` 等）と完了済みタスク（`- [x]` / `- [x]*`）は
+# 独立した抽出単位にならない（Req 3.2）。
+#
+# `_Depends:_` アノテーションは、直前に現れた最上位・未完了タスクの配下（その
+# 子タスク行を含む）に属するものとして集約し、参照先 ID は先頭の整数部だけを
+# 取り出して最上位タスク ID へ正規化する（Req 3.5。例: `_Depends: 2.1_` → `2`）。
+# 自己参照と重複は除去する。完了済み最上位タスク配下のアノテーションは
+# 直前タスクへ誤って帰属させないよう、対象タスクを解除して読み飛ばす。
+#
+# 入力: 第 1 引数 = tasks.md の絶対パス
+# stdout: 1 行 1 タスクの TAB 区切りレコード
+#         `<最上位 ID>\t<無害化済み要約>\t<正規化済み依存 ID（半角スペース区切り）>`
+# 戻り値: 0 = 抽出成功（0 件でも 0）/ 1 = ファイル不在・読み取り不可
+# 副作用: なし（pure read。tasks.md は書き換えない / Req 6.7）
+tc_extract_top_level_tasks() {
+  local tasks_path="$1"
+  if [ ! -f "$tasks_path" ] || [ ! -r "$tasks_path" ]; then
+    return 1
+  fi
+  local -a out_ids=() out_summaries=() out_deps=()
+  local line cur_id="" cur_index=-1
+  local summary raw tok top
+  local -a toks=()
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    # 最上位・未完了タスク行（正準 regex と同一条件）
+    if [[ "$line" =~ ^-\ \[\ \]\*?\ ([0-9]+)\.\ (.*)$ ]]; then
+      cur_id="${BASH_REMATCH[1]}"
+      summary=$(tc_sanitize_text "${BASH_REMATCH[2]}")
+      # 並列マーカー `(P)` はタイトル案に持ち込まない（起票時のノイズになるため）
+      summary="${summary% (P)}"
+      out_ids+=("$cur_id")
+      out_summaries+=("$summary")
+      out_deps+=("")
+      cur_index=$((${#out_ids[@]} - 1))
+      continue
+    fi
+    # 完了済み最上位タスク行 → 以降のアノテーションは帰属先なしとして読み飛ばす
+    if [[ "$line" =~ ^-\ \[x\]\*?\ [0-9]+\.\  ]]; then
+      cur_id=""
+      cur_index=-1
+      continue
+    fi
+    # `_Depends: 1, 2.1_` 形式のアノテーション（帰属先が確定している場合のみ）
+    if [ "$cur_index" -ge 0 ] && [[ "$line" =~ _Depends:[[:space:]]*([^_]*)_ ]]; then
+      raw="${BASH_REMATCH[1]}"
+      raw="${raw//,/ }"
+      toks=()
+      read -ra toks <<< "$raw"
+      for tok in "${toks[@]}"; do
+        [[ "$tok" =~ ^([0-9]+)(\.[0-9]+)*$ ]] || continue
+        top="${BASH_REMATCH[1]}"
+        [ "$top" != "$cur_id" ] || continue
+        case " ${out_deps[$cur_index]} " in
+          *" $top "*) continue ;;
+        esac
+        out_deps[cur_index]="${out_deps[$cur_index]}${out_deps[$cur_index]:+ }$top"
+      done
+    fi
+  done < "$tasks_path"
+  local i
+  for ((i = 0; i < ${#out_ids[@]}; i++)); do
+    printf '%s\t%s\t%s\n' "${out_ids[$i]}" "${out_summaries[$i]}" "${out_deps[$i]}"
+  done
+  return 0
+}
+
+# ─── tc_group_tasks ───
+#
+# 抽出済みタスクレコードを子 Issue 案の単位へグルーピングする純粋関数
+# （Req 3.1, 3.4, 3.6, 3.7）。
+#
+# 既定は最上位タスク 1 件 = 子 Issue 案 1 件（Req 3.1）。ただし `_Depends:_` 由来の
+# 依存関係が **循環する**（相互到達可能な）タスク群は 1 件の案へ統合する（Req 3.4）。
+# 実装は依存辺の推移閉包（Floyd–Warshall 形式）を取り、`i → j` かつ `j → i` の
+# 双方が成立するノードを同一グループへ併合する（強連結成分と等価）。
+# 存在しない ID への依存辺は無視する。
+#
+# 出力順は `tasks.md` の出現順（グループ内も出現順）で、同一入力に対して常に
+# 同一の結果を返す（Req 3.7）。すべての入力タスクはいずれか 1 グループへ
+# 過不足なく 1 回だけ現れる（Req 3.6）。
+#
+# 入力: stdin = tc_extract_top_level_tasks 形式の TAB 区切りレコード
+# stdout: 1 行 1 グループ。半角スペース区切りの最上位タスク ID 列
+# 戻り値: 常に 0 / 副作用: なし
+tc_group_tasks() {
+  local -a ids=() deps=()
+  local _id _sum _dep
+  while IFS=$'\t' read -r _id _sum _dep; do
+    [ -n "$_id" ] || continue
+    ids+=("$_id")
+    deps+=("$_dep")
+  done
+  local n=${#ids[@]}
+  if [ "$n" -eq 0 ]; then
+    return 0
+  fi
+  local i j k
+  local -A idx_of=()
+  for ((i = 0; i < n; i++)); do
+    idx_of["${ids[$i]}"]=$i
+  done
+  # 直接依存辺（存在しない ID / 自己参照は除外）
+  local -A reach=()
+  local -a dep_toks=()
+  local d di
+  for ((i = 0; i < n; i++)); do
+    dep_toks=()
+    read -ra dep_toks <<< "${deps[$i]}"
+    for d in "${dep_toks[@]:-}"; do
+      [ -n "$d" ] || continue
+      di="${idx_of[$d]:-}"
+      [ -n "$di" ] || continue
+      [ "$di" -ne "$i" ] || continue
+      reach["$i,$di"]=1
+    done
+  done
+  # 推移閉包（n は最上位タスク件数のみ = 実運用で数十件のため n^3 で十分）
+  for ((k = 0; k < n; k++)); do
+    for ((i = 0; i < n; i++)); do
+      [ -n "${reach["$i,$k"]:-}" ] || continue
+      for ((j = 0; j < n; j++)); do
+        if [ -n "${reach["$k,$j"]:-}" ]; then
+          reach["$i,$j"]=1
+        fi
+      done
+    done
+  done
+  # 相互到達（循環依存）を同一グループへ併合
+  local -a group_of=()
+  for ((i = 0; i < n; i++)); do
+    group_of[i]=-1
+  done
+  local g=0
+  for ((i = 0; i < n; i++)); do
+    [ "${group_of[$i]}" -eq -1 ] || continue
+    group_of[i]=$g
+    for ((j = i + 1; j < n; j++)); do
+      [ "${group_of[$j]}" -eq -1 ] || continue
+      if [ -n "${reach["$i,$j"]:-}" ] && [ -n "${reach["$j,$i"]:-}" ]; then
+        group_of[j]=$g
+      fi
+    done
+    g=$((g + 1))
+  done
+  local out
+  for ((k = 0; k < g; k++)); do
+    out=""
+    for ((i = 0; i < n; i++)); do
+      if [ "${group_of[$i]}" -eq "$k" ]; then
+        out="${out}${out:+ }${ids[$i]}"
+      fi
+    done
+    printf '%s\n' "$out"
+  done
+  return 0
+}
+
+# ─── tc_build_split_proposal_body ───
+#
+# 分割案コメントの本文を生成する純粋関数（Req 4.1〜4.11 / 5.1 / NFR 3.4）。
+#
+# 各子 Issue 案には以下を含める:
+#   - タイトル案（Req 4.1 / NFR 3.5 で 120 文字以内）
+#   - 含む最上位タスクの numeric ID 一覧（Req 4.2）
+#   - `Split from: #<元 Issue>` / `Parent: #<元 Issue>`（Req 4.3 / 4.4）
+#   - 案間依存がある場合の `Depends on: 案 <番号>`（Req 4.5 / 4.6）
+# 関係種別のキーは canonical 記法の英語表記のみを使い、alias 表記と逆ブロッキング
+# 表記 `Blocks:` は出力しない（Req 4.7 / 4.8。`.claude/rules/issue-dependency.md`）。
+# 併せて検知件数・適用閾値（Req 4.11）、提案であり自動起票しない旨（Req 4.9）、
+# 起票コマンドの雛形（Req 4.10 / NFR 4.4）、冪等マーカー（Req 5.1）を含める。
+#
+# 本文が NFR 3.4 の上限（60,000 文字）に接触する場合は、以降の案の詳細を省略した
+# 旨を明記して打ち切る（決定論的に先頭から詰める）。
+#
+# 入力: 第 1 引数 = Issue 番号 / 第 2 引数 = 検知件数 / 第 3 引数 = tasks.md パス
+# stdout: コメント本文
+# 戻り値: 0 = 生成成功 / 1 = 生成失敗（引数不正・ファイル不在）/
+#         2 = 入力となる最上位・未完了タスクが 0 件（Req 2.4）
+# 副作用: なし（GitHub API 呼び出しなし / tasks.md は書き換えない）
+tc_build_split_proposal_body() {
+  local issue_number="$1"
+  local count="$2"
+  local tasks_path="$3"
+  # Issue 番号は数値として検証してから `#N` 参照記法に用いる（NFR 4.3）
+  if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+  if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+    count=0
+  fi
+  local records
+  records=$(tc_extract_top_level_tasks "$tasks_path") || return 1
+  if [ -z "$records" ]; then
+    return 2
+  fi
+
+  local -a ids=() summaries=() deps=()
+  local _id _sum _dep
+  while IFS=$'\t' read -r _id _sum _dep; do
+    [ -n "$_id" ] || continue
+    ids+=("$_id")
+    summaries+=("$_sum")
+    deps+=("$_dep")
+  done <<< "$records"
+  local n=${#ids[@]}
+  if [ "$n" -eq 0 ]; then
+    return 2
+  fi
+
+  local groups
+  groups=$(printf '%s\n' "$records" | tc_group_tasks)
+  local -a group_members=()
+  local gline
+  while IFS= read -r gline; do
+    [ -n "$gline" ] || continue
+    group_members+=("$gline")
+  done <<< "$groups"
+  local gn=${#group_members[@]}
+  if [ "$gn" -eq 0 ]; then
+    return 2
+  fi
+
+  local i g
+  local -A summary_of=() deps_of=() group_no_of=()
+  for ((i = 0; i < n; i++)); do
+    summary_of["${ids[$i]}"]="${summaries[$i]}"
+    deps_of["${ids[$i]}"]="${deps[$i]}"
+  done
+  local -a members=()
+  local m
+  for ((g = 0; g < gn; g++)); do
+    members=()
+    read -ra members <<< "${group_members[$g]}"
+    for m in "${members[@]:-}"; do
+      [ -n "$m" ] || continue
+      group_no_of["$m"]=$((g + 1))
+    done
+  done
+
+  # 案間依存は直接 `_Depends:_` 辺のみを採用する（推移閉包は表示ノイズになるため使わない）
+  local -A group_dep_pairs=()
+  local -a dep_toks=()
+  local d from_no to_no
+  for ((g = 0; g < gn; g++)); do
+    members=()
+    read -ra members <<< "${group_members[$g]}"
+    from_no=$((g + 1))
+    for m in "${members[@]:-}"; do
+      [ -n "$m" ] || continue
+      dep_toks=()
+      read -ra dep_toks <<< "${deps_of[$m]:-}"
+      for d in "${dep_toks[@]:-}"; do
+        [ -n "$d" ] || continue
+        to_no="${group_no_of[$d]:-}"
+        [ -n "$to_no" ] || continue
+        [ "$to_no" -ne "$from_no" ] || continue
+        group_dep_pairs["$from_no,$to_no"]=1
+      done
+    done
+  done
+
+  local nl=$'\n'
+  local -a titles=()
+  local title parts
+  for ((g = 0; g < gn; g++)); do
+    members=()
+    read -ra members <<< "${group_members[$g]}"
+    parts=""
+    for m in "${members[@]:-}"; do
+      [ -n "$m" ] || continue
+      parts="${parts}${parts:+ / }${summary_of[$m]:-タスク $m}"
+    done
+    [ -n "$parts" ] || parts="タスク分割案 $((g + 1))"
+    title=$(tc_truncate_title "$parts" 120)
+    titles+=("$title")
+  done
+
+  local header
+  header="🧩 **Tasks Count Gate — 子 Issue 分割案 (harness, #509)**: escalate 判定に伴い、\`tasks.md\` の最上位・未完了タスクから機械生成した分割案を提示します${nl}${nl}"
+  header="${header}- 検知件数: **${count} 件**（最上位 numeric ID の未完了タスクのみ。子タスク \`1.1\` / 完了済み \`- [x]\` は計数対象外）${nl}"
+  header="${header}- 適用閾値: ${TC_ESCALATE_LOWER:-11} 件以上でエスカレーション（参考: ${TC_WARN_LOWER:-8}〜${TC_WARN_UPPER:-10} 件は警告のみ）${nl}"
+  header="${header}- 生成した子 Issue 案: **${gn} 件**${nl}"
+  header="${header}- ⚠️ 本コメントは **提案のみ** です。watcher は子 Issue を自動起票しません（起票・調整は人間が行います）${nl}"
+  header="${header}- ⚠️ \`Depends on:\` の参照先は本コメント内の **案番号**（\`案 1\` 等）です。子 Issue 起票後に **実 Issue 番号 \`#<番号>\` へ置き換えてください**${nl}${nl}"
+
+  local footer_marker
+  footer_marker="${nl}<!-- idd-claude:tasks-count-split-proposal issue=${issue_number} count=${count} proposals=${gn} -->${nl}"
+
+  # 本文長上限（NFR 3.4）。先頭から詰め、超過分は省略した旨を明記する
+  local max_body=60000
+  local blocks="" cmds="" omitted=0 truncated=0
+  local block cmd id_list body_lines dep_line
+  for ((g = 0; g < gn; g++)); do
+    if [ "$truncated" -eq 1 ]; then
+      omitted=$((omitted + 1))
+      continue
+    fi
+    members=()
+    read -ra members <<< "${group_members[$g]}"
+    id_list=""
+    body_lines=""
+    for m in "${members[@]:-}"; do
+      [ -n "$m" ] || continue
+      id_list="${id_list}${id_list:+, }\`${m}\`"
+      body_lines="${body_lines}- ${m}. ${summary_of[$m]:-}${nl}"
+    done
+    block="### 案 $((g + 1)): ${titles[$g]}${nl}${nl}"
+    block="${block}- 含む最上位タスク: ${id_list}${nl}"
+    block="${block}- Split from: #${issue_number}${nl}"
+    block="${block}- Parent: #${issue_number}${nl}"
+    dep_line=""
+    for ((i = 1; i <= gn; i++)); do
+      if [ -n "${group_dep_pairs["$((g + 1)),$i"]:-}" ]; then
+        dep_line="${dep_line}${dep_line:+, }案 ${i}"
+      fi
+    done
+    if [ -n "$dep_line" ]; then
+      block="${block}- Depends on: ${dep_line}${nl}"
+    fi
+    block="${block}${nl}"
+    cmd="gh issue create --repo <owner/repo> \\${nl}"
+    cmd="${cmd}  --title '${titles[$g]}' \\${nl}"
+    cmd="${cmd}  --body '## 関連${nl}${nl}- Split from: #${issue_number}${nl}- Parent: #${issue_number}${nl}${nl}## 対象タスク（元 Issue #${issue_number} の tasks.md 最上位タスク）${nl}${nl}${body_lines}'${nl}${nl}"
+    if [ $((${#header} + ${#blocks} + ${#block} + ${#cmds} + ${#cmd} + ${#footer_marker} + 512)) -gt "$max_body" ]; then
+      truncated=1
+      omitted=$((omitted + 1))
+      continue
+    fi
+    blocks="${blocks}${block}"
+    cmds="${cmds}${cmd}"
+  done
+
+  local cmd_section
+  cmd_section="### 起票コマンドの雛形${nl}${nl}"
+  cmd_section="${cmd_section}> 内容を確認・調整したうえで **人間が実行** してください（watcher は実行しません）。起票後に \`auto-dev\` ラベルを付けると通常の自動フローに乗ります。${nl}${nl}"
+  cmd_section="${cmd_section}\`\`\`bash${nl}${cmds%$'\n'}\`\`\`${nl}"
+
+  local omit_note=""
+  if [ "$omitted" -gt 0 ]; then
+    omit_note="${nl}> **注**: コメント本文長の上限（${max_body} 文字）に達したため、残り ${omitted} 件の案は省略しました。省略分は \`tasks.md\` の残りの最上位タスクに対応します。${nl}"
+  fi
+
+  printf '%s' "${header}${blocks}${cmd_section}${omit_note}${footer_marker}"
+  return 0
+}
+
+# ─── tc_split_proposal_already_posted ───
+#
+# Issue コメント履歴に **分割案専用**の冪等マーカーが既に存在するか検知する
+# （Req 5.1〜5.4）。
+#
+# 固定マーカー: `<!-- idd-claude:tasks-count-split-proposal issue=<N> ... -->`
+# 既存 escalation コメントのマーカー（`tasks-count-overflow`）とは独立しており、
+# escalation コメントがマーカー検知で skip された場合でも本判定には影響しない
+# （Req 5.3 / 5.4）。
+#
+# gh API 失敗時は marker 不在（return 1）として扱う。影響は重複コメント 1 件まで
+# に留まる（Req 5.6）。
+#
+# 入力: 第 1 引数 = Issue 番号
+# 戻り値: 0 = marker 検出済み（skip 推奨）/ 1 = 未検出（投稿可）
+# 副作用: gh issue view 1 回（NFR 3.2）
+tc_split_proposal_already_posted() {
+  local issue_number="$1"
+  local bodies
+  if ! bodies=$(gh issue view "$issue_number" --repo "$REPO" \
+      --json comments --jq '.comments[].body' 2>/dev/null); then
+    return 1
+  fi
+  local marker_prefix="<!-- idd-claude:tasks-count-split-proposal issue=$issue_number"
+  # 未信頼なコメント本文を pattern として解釈させないため -F、
+  # `-` 始まりの pattern を option 解釈させないため -- で打ち切る
+  if printf '%s' "$bodies" | grep -qF -- "$marker_prefix"; then
+    return 0
+  fi
+  return 1
+}
+
+# ─── tc_post_split_proposal_comment ───
+#
+# escalate 時に子 Issue 分割案コメントを冪等・fail-open で投稿する
+# （Req 2.1〜2.5 / 5.2 / 5.5 / 5.7 / 6.5 / 6.6 / NFR 2.1〜2.4 / 3.2 / 3.3）。
+#
+# 順序（GitHub API 呼び出しを 2 回以下に抑えるため本文生成を先に行う / NFR 3.2）:
+#   1. gate 無効 → 何もせず return 0（ログ 0 行 / API 0 回 / Req 1.4 / NFR 3.3）
+#   2. Issue 番号の数値検証（NFR 4.3）
+#   3. 本文生成（ローカル処理のみ）。タスク 0 件なら skip ログ（Req 2.4）
+#   4. 分割案専用マーカーの既投稿判定（gh issue view 1 回 / Req 5.2）
+#   5. コメント投稿（gh issue comment 1 回）
+#
+# 入力: 第 1 引数 = Issue 番号 / 第 2 引数 = 件数 / 第 3 引数 = tasks.md パス
+# 戻り値: 常に 0（fail-open。失敗は WARN ログのみで呼び出し元を中断しない）
+tc_post_split_proposal_comment() {
+  local issue_number="$1"
+  local count="$2"
+  local tasks_path="$3"
+  if ! tc_split_proposal_enabled; then
+    return 0
+  fi
+  if ! [[ "$issue_number" =~ ^[0-9]+$ ]]; then
+    tc_warn "issue=#${issue_number} split-proposal 生成失敗 reason=invalid-issue-number（fail-open で続行）"
+    return 0
+  fi
+  local body rc=0
+  body=$(tc_build_split_proposal_body "$issue_number" "$count" "$tasks_path") || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    tc_log "issue=#${issue_number} split-proposal skip reason=no-top-level-tasks"
+    return 0
+  fi
+  if [ "$rc" -ne 0 ] || [ -z "$body" ]; then
+    tc_warn "issue=#${issue_number} split-proposal 生成失敗 reason=build-failed rc=${rc}（fail-open で続行）"
+    return 0
+  fi
+  if tc_split_proposal_already_posted "$issue_number"; then
+    tc_log "issue=#${issue_number} split-proposal skip reason=already-posted"
+    return 0
+  fi
+  local proposals
+  proposals=$(printf '%s' "$body" | grep -cE '^### 案 [0-9]+:' || true)
+  proposals="${proposals:-0}"
+  if gh issue comment "$issue_number" --repo "$REPO" --body "$body" >/dev/null 2>&1; then
+    tc_log "issue=#${issue_number} posted split-proposal-comment count=${count} proposals=${proposals}"
+  else
+    tc_warn "issue=#${issue_number} gh issue comment 失敗（split-proposal 投稿、fail-open で続行）"
+  fi
+  return 0
+}
+
 # ─── tc_run_post_architect_check ───
 #
 # design 分岐 rc=0 直後に呼ばれる orchestrator。本機能の単一エントリポイント
@@ -355,6 +923,8 @@ tc_add_needs_decisions_label() {
 #      - normal   → ログのみ
 #      - warn     → tc_post_warning_comment
 #      - escalate → tc_post_escalation_comment + tc_add_needs_decisions_label
+#                   （+ TC_SPLIT_PROPOSAL_ENABLED=true のとき
+#                     tc_post_split_proposal_comment / #509 Req 2.1, 2.3）
 #
 # 戻り値: 常に 0（呼び出し元 design 分岐 rc=0 の挙動を変えない / fail-open）
 # 副作用: ログ書き込み、gh issue edit/comment
@@ -384,6 +954,9 @@ tc_run_post_architect_check() {
       tc_log "issue=#${NUMBER:-?} count=${count} range=escalate action=needs-decisions+escalation-comment"
       tc_post_escalation_comment "$NUMBER" "$count" || true
       tc_add_needs_decisions_label "$NUMBER" || true
+      # 子 Issue 分割案（#509 / opt-in）。既存 escalate 処理を置き換えず追加し、
+      # 失敗しても escalate 本体は完了済み（Req 2.3 / 6.5 / 6.6）
+      tc_post_split_proposal_comment "$NUMBER" "$count" "$tasks_path" || true
       ;;
     *)
       tc_warn "issue=#${NUMBER:-?} unknown classification='$range' count=${count} (fail-open)"

--- a/local-watcher/bin/watcher-config.sh
+++ b/local-watcher/bin/watcher-config.sh
@@ -1105,6 +1105,25 @@ TC_WARN_LOWER="${TC_WARN_LOWER:-8}"
 TC_WARN_UPPER="${TC_WARN_UPPER:-10}"
 TC_ESCALATE_LOWER="${TC_ESCALATE_LOWER:-11}"
 
+# ─── Tasks Count Gate: 子 Issue 分割案コメント (#509, モデルルーティング Phase 3) ───
+# 新規 opt-in 機能。明示的に `=true`（リテラル文字列 / 厳密一致）を指定したときだけ、
+# escalate 判定（既定 ≥ 11 件）に伴って `tasks.md` の最上位・未完了タスクから
+# 機械生成した **子 Issue 分割案** をコメント投稿する（Req 1.2 / 2.1）。
+# `=true` 以外（未設定 / 空 / `false` / `off` / `True` / `1` / typo 等）はすべて
+# 安全側（無効）へ正規化する（Req 1.1 / 1.3）。無効時は本機能に起因する
+# GitHub API 呼び出しもログ出力も 0 件で、本機能導入前と完全に同一の escalate
+# 挙動になる（Req 1.4 / 6.1 / NFR 1.1）。
+#
+# 本 gate は `TC_ENABLED`（tasks-count gate 自体の opt-out）および
+# `MODEL_ROUTING_ENABLED`（#507）とは **独立した変数** で制御する（Req 1.5）。
+# ただし `TC_ENABLED=false` で tasks-count gate 自体が走らない場合、本機能も
+# 構造的に起動しない（Req 1.6）。
+# 子 Issue の自動起票は行わず提案コメントの投稿までに留める（Out of Scope）。
+# 本フラグは新規追加 = opt-in 制 + 既定無効が要件のため、上記「デフォルト有効化
+# フラグの値正規化」ループには **含めない**（#112 の 8 種反転対象とは別扱い）。
+# 詳細は docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/requirements.md を参照。
+TC_SPLIT_PROPOSAL_ENABLED="${TC_SPLIT_PROPOSAL_ENABLED:-false}"
+
 # ─── Phase E: Path Overlap Checker 設定 (#18) ───
 # 新規 opt-in 機能。明示的に `=true` を指定したときだけ起動する（Req 1.1〜1.4）。
 # `=true` 以外（未設定 / 空 / `false` / `0` / `True` / `1` / typo 等）はすべて off

--- a/local-watcher/test/tasks_count_gate_split_proposal_test.sh
+++ b/local-watcher/test/tasks_count_gate_split_proposal_test.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/tasks-count-gate.sh に追加した
+#       「escalate 時の子 Issue 分割案コメント」（#509 モデルルーティング Phase 3）の
+#       近接テスト。fixture の tasks.md を入力に、純粋関数（抽出 / グルーピング /
+#       本文生成）と副作用関数（冪等判定 / 投稿）を gh stub で検証する。
+#
+#       対象関数:
+#         - tc_split_proposal_enabled        (Req 1.1〜1.3 / 1.5)
+#         - tc_sanitize_text                 (NFR 4.1 / 4.2)
+#         - tc_truncate_title                (NFR 3.5)
+#         - tc_extract_top_level_tasks       (Req 3.1〜3.3 / 3.5)
+#         - tc_group_tasks                   (Req 3.4 / 3.6 / 3.7)
+#         - tc_build_split_proposal_body     (Req 4.1〜4.11 / 5.1 / NFR 3.4)
+#         - tc_split_proposal_already_posted (Req 5.1〜5.4 / 5.6)
+#         - tc_post_split_proposal_comment   (Req 1.4 / 2.1〜2.4 / 5.2 / 5.7 / 6.5 / 6.6 / NFR 2.x / 3.2 / 3.3)
+#         - tc_run_post_architect_check      (Req 2.1〜2.3 / 6.1)
+#
+#       Req 8.5 が要求する 5 ケース（最上位 11 件フラット / 子タスクと完了済みタスクを
+#       含む構成 / `_Depends:_` 相互依存を含む構成 / 最上位タスク 0 件 / gate 無効）を
+#       Case A〜E で網羅し、冪等・fail-open・API 呼び出し回数・未信頼入力の無害化を
+#       Case F〜J で追加検証する。
+#
+# 配置先: local-watcher/test/tasks_count_gate_split_proposal_test.sh
+# 依存:   bash 4+, awk, grep
+# 実行:   bash local-watcher/test/tasks_count_gate_split_proposal_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains / assert_rc を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+
+TC_GATE_SH="$SCRIPT_DIR/../bin/modules/tasks-count-gate.sh"
+
+if [ ! -f "$TC_GATE_SH" ]; then
+  echo "ERROR: cannot find tasks-count-gate.sh at $TC_GATE_SH" >&2
+  exit 2
+fi
+
+# 対象関数を実物から隔離抽出する（トップレベル副作用は回避）。
+# extract_function は単一関数のみを切り出すため、依存関数も明示的に読み込む。
+for _fn in \
+  tc_count_tasks \
+  tc_split_proposal_enabled \
+  tc_sanitize_text \
+  tc_truncate_title \
+  tc_extract_top_level_tasks \
+  tc_group_tasks \
+  tc_build_split_proposal_body \
+  tc_split_proposal_already_posted \
+  tc_post_split_proposal_comment \
+  tc_run_post_architect_check; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$TC_GATE_SH" "$_fn")"
+  if ! declare -F "$_fn" >/dev/null; then
+    echo "ERROR: $_fn not loaded" >&2
+    exit 2
+  fi
+done
+unset _fn
+
+# グローバル env（抽出した関数本体が遅延束縛で参照する。静的解析からは未使用に見える）
+# shellcheck disable=SC2034
+REPO="owner/test-repo"
+# shellcheck disable=SC2034
+TC_WARN_LOWER=8
+# shellcheck disable=SC2034
+TC_WARN_UPPER=10
+# shellcheck disable=SC2034
+TC_ESCALATE_LOWER=11
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+CALL_LOG="$WORK_DIR/calls.log"
+LOG_FILE="$WORK_DIR/tc.log"
+GH_VIEW_OUTPUT=""
+GH_VIEW_RC=0
+GH_COMMENT_RC=0
+
+# ─── stub: gh / ロガー ───
+gh() {
+  # 呼び出し 1 回 = 1 行になるよう、引数（--body には改行を含む）を 1 行へ畳む
+  local joined="$*"
+  printf 'gh %s\n' "${joined//$'\n'/ }" >> "$CALL_LOG"
+  if [ "${1:-}" = "issue" ] && [ "${2:-}" = "view" ]; then
+    printf '%s' "$GH_VIEW_OUTPUT"
+    return "$GH_VIEW_RC"
+  fi
+  if [ "${1:-}" = "issue" ] && [ "${2:-}" = "comment" ]; then
+    return "$GH_COMMENT_RC"
+  fi
+  return 0
+}
+tc_log() { printf 'tc_log %s\n' "$*" >> "$LOG_FILE"; }
+tc_warn() { printf 'tc_warn %s\n' "$*" >> "$LOG_FILE"; }
+
+reset_trace() {
+  : > "$CALL_LOG"
+  : > "$LOG_FILE"
+  GH_VIEW_OUTPUT=""
+  GH_VIEW_RC=0
+  GH_COMMENT_RC=0
+}
+
+count_lines() {
+  local f="$1"
+  local pattern="${2:-}"
+  if [ -z "$pattern" ]; then
+    grep -c '' "$f" 2>/dev/null || true
+  else
+    grep -cF -- "$pattern" "$f" 2>/dev/null || true
+  fi
+}
+
+count_matches() {
+  # $1 = 対象文字列 / $2 = ERE
+  printf '%s' "$1" | grep -cE -- "$2" 2>/dev/null || true
+}
+
+# =============================================================================
+# fixture
+# =============================================================================
+
+# (a) 最上位 11 件フラット構成
+FIX_FLAT="$WORK_DIR/flat11.md"
+{
+  echo "# 実装タスク"
+  echo
+  for i in $(seq 1 11); do
+    echo "- [ ] ${i}. タスク ${i} の要約"
+    echo "  - _Requirements: ${i}.1_"
+  done
+} > "$FIX_FLAT"
+
+# (b) 子タスク・完了済みタスクの混在構成
+FIX_MIXED="$WORK_DIR/mixed.md"
+cat > "$FIX_MIXED" <<'EOF'
+# 実装タスク
+
+- [ ] 1. 親タスク A
+  - _Requirements: 1.1_
+- [ ] 1.1 子タスク A-1 (P)
+  - _Boundary: Watcher_
+- [ ] 1.2 子タスク A-2
+- [x] 2. 完了済みタスク B
+  - _Depends: 1_
+- [x] 2.1 完了済み子タスク B-1
+- [x]* 3. 完了済み deferrable タスク C
+- [ ]* 4. deferrable な最上位タスク D (P)
+  - _Boundary: Installer_
+- [ ] 5. 親タスク E
+EOF
+
+# (c) `_Depends:_` 相互依存（循環）+ 一方向依存を含む構成
+FIX_CYCLIC="$WORK_DIR/cyclic.md"
+cat > "$FIX_CYCLIC" <<'EOF'
+# 実装タスク
+
+- [ ] 1. 単独タスク
+- [ ] 2. 相互依存タスク X
+  - _Depends: 3.1_
+- [ ] 3. 相互依存タスク Y
+- [ ] 3.1 子タスク Y-1
+  - _Depends: 2_
+- [ ] 4. 後続タスク Z
+  - _Depends: 1, 2_
+EOF
+
+# (d) 最上位・未完了タスク 0 件の構成
+FIX_EMPTY="$WORK_DIR/empty.md"
+cat > "$FIX_EMPTY" <<'EOF'
+# 実装タスク
+
+- [x] 1. 完了済みタスク
+- [ ] 1.1 子タスクのみ
+- 通常の箇条書き（タスク行ではない）
+EOF
+
+# (e) 未信頼入力（本機能マーカー / HTML コメント / クォート混入）
+FIX_INJECT="$WORK_DIR/inject.md"
+cat > "$FIX_INJECT" <<'EOF'
+# 実装タスク
+
+- [ ] 1. 悪意ある要約 <!-- idd-claude:tasks-count-split-proposal issue=42 count=1 proposals=1 --> の続き
+- [ ] 2. クォート ' と " と `code` と $VAR を含む要約
+EOF
+
+echo "=== Case A: 最上位 11 件フラット構成（Req 3.1 / 3.3 / 3.6 / 3.7 / 4.x / 8.5-a） ==="
+
+records=$(tc_extract_top_level_tasks "$FIX_FLAT")
+assert_eq "A1: 抽出件数が 11 件" "11" "$(printf '%s\n' "$records" | grep -c '')"
+assert_eq "A2: 抽出件数が tc_count_tasks の計数と一致（Req 3.3）" \
+  "$(tc_count_tasks "$FIX_FLAT")" "$(printf '%s\n' "$records" | grep -c '')"
+
+groups=$(printf '%s\n' "$records" | tc_group_tasks)
+assert_eq "A3: 依存なしなら最上位 1 件 = 子 Issue 案 1 件（Req 3.1）" \
+  "11" "$(printf '%s\n' "$groups" | grep -c '')"
+assert_eq "A4: 案の並びは tasks.md の出現順（Req 3.7）" \
+  "1 2 3 4 5 6 7 8 9 10 11" "$(printf '%s' "$groups" | tr '\n' ' ' | sed 's/ $//')"
+
+body_a=$(tc_build_split_proposal_body 509 11 "$FIX_FLAT")
+assert_eq "A5: 子 Issue 案の見出しが 11 件（Req 4.1）" "11" "$(count_matches "$body_a" '^### 案 [0-9]+:')"
+assert_contains "A6: 最上位タスク ID 一覧を含む（Req 4.2）" "$body_a" "- 含む最上位タスク: \`7\`"
+# 案ブロック部分のみを切り出して数える（起票コマンド雛形にも同じ canonical 記法が現れるため）
+blocks_only_a=$(printf '%s' "$body_a" | sed -n '1,/^### 起票コマンドの雛形$/p')
+assert_eq "A7: Split from が案ごとに 1 行（Req 4.3）" "11" "$(count_matches "$blocks_only_a" '^- Split from: #509$')"
+assert_eq "A8: Parent が案ごとに 1 行（Req 4.4）" "11" "$(count_matches "$blocks_only_a" '^- Parent: #509$')"
+assert_eq "A9: 逆ブロッキング表記 Blocks: を出力しない（Req 4.8）" "0" "$(count_matches "$body_a" 'Blocks:')"
+assert_eq "A10: alias 表記（前提依存 / 親 Issue / 分割元 / Blocked by）を使わない（Req 4.7）" \
+  "0" "$(count_matches "$body_a" '前提依存:|親 Issue:|分割元:|Blocked by:')"
+assert_contains "A11: 自動起票しない旨を明記（Req 4.9）" "$body_a" "watcher は子 Issue を自動起票しません"
+assert_contains "A12: 起票コマンドの雛形を含む（Req 4.10）" "$body_a" "gh issue create --repo <owner/repo>"
+assert_contains "A13: 検知件数を含む（Req 4.11）" "$body_a" "検知件数: **11 件**"
+assert_contains "A14: 適用閾値を含む（Req 4.11）" "$body_a" "適用閾値: 11 件以上"
+assert_eq "A15: 冪等マーカーを 1 件含む（Req 5.1）" "1" \
+  "$(count_matches "$body_a" '^<!-- idd-claude:tasks-count-split-proposal issue=509 ')"
+assert_eq "A16: 既存 escalation コメントのマーカーとは独立（Req 5.3 / 6.4）" "0" \
+  "$(count_matches "$body_a" 'idd-claude:tasks-count-overflow')"
+assert_contains "A17: 案番号は起票後に実 Issue 番号へ置き換える旨を明記（Req 4.6）" \
+  "$body_a" "実 Issue 番号"
+assert_eq "A18: 本文長が NFR 3.4 の上限（60,000 文字）以内" "1" \
+  "$([ "${#body_a}" -le 60000 ] && echo 1 || echo 0)"
+
+# 全タスクが欠落・重複なく 1 回だけ割り当てられる（Req 3.6）
+missing=0
+for i in $(seq 1 11); do
+  if [ "$(count_matches "$body_a" "^- 含む最上位タスク: \`${i}\`$")" != "1" ]; then
+    missing=$((missing + 1))
+  fi
+done
+assert_eq "A19: 全最上位タスクが 1 案へ 1 回だけ割り当てられる（Req 3.6）" "0" "$missing"
+
+echo "=== Case B: 子タスク・完了済みタスク混在構成（Req 3.2 / 3.3 / 8.5-b） ==="
+
+records_b=$(tc_extract_top_level_tasks "$FIX_MIXED")
+assert_eq "B1: 抽出対象は最上位・未完了タスクのみ（Req 3.2）" \
+  "1 4 5" "$(printf '%s\n' "$records_b" | cut -f1 | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "B2: 抽出件数が tc_count_tasks の計数と一致（Req 3.3）" \
+  "$(tc_count_tasks "$FIX_MIXED")" "$(printf '%s\n' "$records_b" | grep -c '')"
+assert_eq "B3: 並列マーカー (P) はタイトル案から除去" \
+  "deferrable な最上位タスク D" "$(printf '%s\n' "$records_b" | awk -F'\t' '$1 == 4 {print $2}')"
+assert_eq "B4: 完了済みタスク配下の _Depends:_ を直前タスクへ帰属させない" \
+  "" "$(printf '%s\n' "$records_b" | awk -F'\t' '$1 == 1 {print $3}')"
+
+body_b=$(tc_build_split_proposal_body 509 3 "$FIX_MIXED")
+assert_eq "B5: 子タスク・完了済みタスクは独立した案にならない（Req 3.2）" \
+  "3" "$(count_matches "$body_b" '^### 案 [0-9]+:')"
+assert_eq "B6: 完了済みタスク B は案に含まれない" "0" "$(count_matches "$body_b" '完了済みタスク B')"
+
+echo "=== Case C: _Depends:_ 相互依存を含む構成（Req 3.4 / 3.5 / 4.5 / 8.5-c） ==="
+
+records_c=$(tc_extract_top_level_tasks "$FIX_CYCLIC")
+assert_eq "C1: 子タスク ID 参照 (_Depends: 3.1_) を最上位 ID へ正規化（Req 3.5）" \
+  "3" "$(printf '%s\n' "$records_c" | awk -F'\t' '$1 == 2 {print $3}')"
+assert_eq "C2: 子タスク配下の _Depends:_ を親（最上位）へ集約（Req 3.5）" \
+  "2" "$(printf '%s\n' "$records_c" | awk -F'\t' '$1 == 3 {print $3}')"
+
+groups_c=$(printf '%s\n' "$records_c" | tc_group_tasks)
+assert_eq "C3: 相互依存タスク群を 1 案へ統合（Req 3.4）" \
+  "1|2 3|4" "$(printf '%s' "$groups_c" | tr '\n' '|' | sed 's/|$//')"
+
+body_c=$(tc_build_split_proposal_body 509 4 "$FIX_CYCLIC")
+assert_eq "C4: 統合により案は 3 件" "3" "$(count_matches "$body_c" '^### 案 [0-9]+:')"
+assert_contains "C5: 統合案は複数の最上位タスク ID を保持（Req 4.2）" "$body_c" "- 含む最上位タスク: \`2\`, \`3\`"
+assert_contains "C6: 案間依存を Depends on: で表現（Req 4.5 / 4.6）" "$body_c" "- Depends on: 案 1, 案 2"
+assert_eq "C7: 同一入力に対し常に同一の分割案を生成（Req 3.7）" \
+  "$body_c" "$(tc_build_split_proposal_body 509 4 "$FIX_CYCLIC")"
+
+echo "=== Case D: 最上位タスク 0 件（Req 2.4 / 8.5-d） ==="
+
+reset_trace
+TC_SPLIT_PROPOSAL_ENABLED=true
+assert_rc "D1: 本文生成は rc=2（入力タスク 0 件）" 2 tc_build_split_proposal_body 509 0 "$FIX_EMPTY"
+tc_post_split_proposal_comment 509 0 "$FIX_EMPTY"
+assert_eq "D2: 分割案コメントを投稿しない（Req 2.4）" "0" "$(count_lines "$CALL_LOG")"
+assert_eq "D3: スキップ理由をログに残す（Req 2.4 / 5.7 / NFR 2.2）" "1" \
+  "$(count_lines "$LOG_FILE" "split-proposal skip reason=no-top-level-tasks")"
+
+echo "=== Case E: gate 無効（Req 1.1〜1.4 / 6.1 / NFR 1.1 / 3.3 / 8.5-e） ==="
+
+for invalid in "" "false" "off" "True" "TRUE" "1" "ture"; do
+  TC_SPLIT_PROPOSAL_ENABLED="$invalid"
+  assert_rc "E1: TC_SPLIT_PROPOSAL_ENABLED='$invalid' は無効へ正規化（Req 1.3）" 1 tc_split_proposal_enabled
+done
+unset TC_SPLIT_PROPOSAL_ENABLED
+assert_rc "E2: 未設定は既定で無効（Req 1.1）" 1 tc_split_proposal_enabled
+TC_SPLIT_PROPOSAL_ENABLED=true
+assert_rc "E3: リテラル true のときのみ有効（Req 1.2）" 0 tc_split_proposal_enabled
+
+reset_trace
+TC_SPLIT_PROPOSAL_ENABLED=false
+tc_post_split_proposal_comment 509 11 "$FIX_FLAT"
+assert_eq "E4: gate 無効時は GitHub API 呼び出し 0 回（Req 1.4 / NFR 3.3）" "0" "$(count_lines "$CALL_LOG")"
+assert_eq "E5: gate 無効時はログ出力 0 行（Req 1.4 / NFR 1.1）" "0" "$(count_lines "$LOG_FILE")"
+
+# escalate 分岐（orchestrator）: gate 無効時に既存 escalate 挙動が変化しない（Req 2.3 / 6.1 / 8.6）
+tc_should_run() { return 0; }
+tc_classify() { printf '%s\n' "$TEST_RANGE"; }
+tc_post_warning_comment() { printf 'warning-comment %s\n' "$*" >> "$CALL_LOG"; }
+tc_post_escalation_comment() { printf 'escalation-comment %s\n' "$*" >> "$CALL_LOG"; }
+tc_add_needs_decisions_label() { printf 'needs-decisions-label %s\n' "$*" >> "$CALL_LOG"; }
+# 以下 3 変数は tc_run_post_architect_check が遅延束縛で参照する
+# shellcheck disable=SC2034
+NUMBER=509
+# shellcheck disable=SC2034
+REPO_DIR="$WORK_DIR"
+# shellcheck disable=SC2034
+SPEC_DIR_REL="."
+cp "$FIX_FLAT" "$WORK_DIR/tasks.md"
+
+reset_trace
+TEST_RANGE=escalate
+TC_SPLIT_PROPOSAL_ENABLED=false
+tc_run_post_architect_check
+assert_eq "E6: gate 無効時の escalate 挙動は従来どおり 2 アクションのみ（Req 6.1）" \
+  "escalation-comment 509 11|needs-decisions-label 509" \
+  "$(tr '\n' '|' < "$CALL_LOG" | sed 's/|$//')"
+
+reset_trace
+TC_SPLIT_PROPOSAL_ENABLED=true
+tc_run_post_architect_check
+assert_eq "E7: gate 有効時は既存 2 アクションの後に分割案を追加投稿（Req 2.1 / 2.3）" \
+  "escalation-comment 509 11|needs-decisions-label 509|gh-issue-view|gh-issue-comment" \
+  "$(sed -e 's/^gh issue view .*/gh-issue-view/' -e 's/^gh issue comment .*/gh-issue-comment/' "$CALL_LOG" \
+     | tr '\n' '|' | sed 's/|$//')"
+
+reset_trace
+TEST_RANGE=warn
+tc_run_post_architect_check
+assert_eq "E8: warn レンジでは分割案を投稿しない（Req 2.2）" \
+  "warning-comment 509 11" "$(tr '\n' '|' < "$CALL_LOG" | sed 's/|$//')"
+
+reset_trace
+TEST_RANGE=normal
+tc_run_post_architect_check
+assert_eq "E9: normal レンジでは分割案を投稿しない（Req 2.2）" "0" "$(count_lines "$CALL_LOG")"
+
+echo "=== Case F: 冪等性（Req 5.2 / 5.4〜5.7） ==="
+
+reset_trace
+TC_SPLIT_PROPOSAL_ENABLED=true
+GH_VIEW_OUTPUT="<!-- idd-claude:tasks-count-split-proposal issue=509 count=11 proposals=11 -->"
+tc_post_split_proposal_comment 509 11 "$FIX_FLAT"
+assert_eq "F1: マーカー既存時は再投稿しない（Req 5.2 / 5.5）" "0" \
+  "$(count_lines "$CALL_LOG" "gh issue comment")"
+assert_eq "F2: スキップ理由をログに残す（Req 5.7 / NFR 2.2）" "1" \
+  "$(count_lines "$LOG_FILE" "split-proposal skip reason=already-posted")"
+
+reset_trace
+GH_VIEW_OUTPUT="<!-- idd-claude:tasks-count-overflow kind=escalation issue=509 count=11 -->"
+tc_post_split_proposal_comment 509 11 "$FIX_FLAT"
+assert_eq "F3: 既存 escalation マーカーでは分割案投稿を抑止しない（Req 5.3 / 5.4）" "1" \
+  "$(count_lines "$CALL_LOG" "gh issue comment")"
+
+reset_trace
+GH_VIEW_RC=1
+tc_post_split_proposal_comment 509 11 "$FIX_FLAT"
+assert_eq "F4: コメント履歴の取得失敗はマーカー不在として扱う（Req 5.6）" "1" \
+  "$(count_lines "$CALL_LOG" "gh issue comment")"
+
+echo "=== Case G: fail-open と API 呼び出し回数（Req 6.5 / 6.6 / NFR 2.1 / 2.3 / 3.2） ==="
+
+reset_trace
+tc_post_split_proposal_comment 509 11 "$FIX_FLAT"
+assert_eq "G1: 投稿時の GitHub API 呼び出しは 2 回以下（NFR 3.2）" "2" "$(count_lines "$CALL_LOG")"
+assert_eq "G2: 投稿成功ログに Issue 番号と案件数を含む（NFR 2.1）" "1" \
+  "$(count_lines "$LOG_FILE" "issue=#509 posted split-proposal-comment count=11 proposals=11")"
+
+reset_trace
+GH_COMMENT_RC=1
+assert_rc "G3: コメント投稿失敗でも rc=0（fail-open / Req 6.6）" 0 \
+  tc_post_split_proposal_comment 509 11 "$FIX_FLAT"
+assert_eq "G4: 投稿失敗は WARN ログに記録（Req 6.6 / NFR 2.3）" "1" \
+  "$(count_lines "$LOG_FILE" "tc_warn issue=#509 gh issue comment 失敗")"
+
+reset_trace
+assert_rc "G5: tasks.md 不在でも rc=0（fail-open / Req 6.5）" 0 \
+  tc_post_split_proposal_comment 509 11 "$WORK_DIR/no-such-tasks.md"
+assert_eq "G6: 生成失敗は WARN ログに記録（Req 6.5 / NFR 2.3）" "1" \
+  "$(count_lines "$LOG_FILE" "tc_warn issue=#509 split-proposal 生成失敗 reason=build-failed")"
+assert_eq "G7: 生成失敗時は GitHub API を呼ばない" "0" "$(count_lines "$CALL_LOG")"
+
+reset_trace
+assert_rc "G8: Issue 番号が数値でない場合も rc=0（NFR 4.3）" 0 \
+  tc_post_split_proposal_comment "509; rm -rf /" 11 "$FIX_FLAT"
+assert_eq "G9: 不正な Issue 番号では GitHub API を呼ばない（NFR 4.3）" "0" "$(count_lines "$CALL_LOG")"
+
+assert_rc "G10: 本文生成も不正な Issue 番号を rc=1 で拒否（NFR 4.3）" 1 \
+  tc_build_split_proposal_body "abc" 11 "$FIX_FLAT"
+
+echo "=== Case H: 未信頼入力の無害化（NFR 4.1 / 4.2 / 4.4） ==="
+
+body_h=$(tc_build_split_proposal_body 509 2 "$FIX_INJECT")
+assert_eq "H1: 要約中の本機能マーカーを無害化し、マーカーは自前の 1 件のみ（NFR 4.2）" "1" \
+  "$(count_matches "$body_h" '<!-- idd-claude:tasks-count-split-proposal')"
+assert_contains "H2: 要約中の HTML コメント開始記法を分断（NFR 4.2）" \
+  "$body_h" "< !-- idd-claude:tasks-count-split-proposal issue=42"
+assert_eq "H3: 起票コマンド雛形を壊すクォート・バッククォート・\$ を除去（NFR 4.1）" \
+  "クォート と と code と VAR を含む要約" \
+  "$(tc_extract_top_level_tasks "$FIX_INJECT" | awk -F'\t' '$1 == 2 {print $2}')"
+assert_contains "H4: 無害化後の要約が本文に残る" "$body_h" "クォート と と code と VAR を含む要約"
+assert_contains "H5: 起票は人間が実行する提示に留める（NFR 4.4）" "$body_h" "**人間が実行**"
+
+assert_eq "H6: サニタイズは HTML コメント記法を分断する" "< !-- x -- >" "$(tc_sanitize_text '<!-- x -->')"
+assert_eq "H7: サニタイズは連続空白を圧縮し前後をトリムする" "a b" "$(tc_sanitize_text '  a    b  ')"
+
+echo "=== Case I: タイトル案の長さ上限（NFR 3.5） ==="
+
+# `${#s}` は UTF-8 ロケールでは文字数、C / POSIX ロケールではバイト数を返すため、
+# 実行環境のロケールに応じて期待上限を切り替える（実装側の tc_truncate_title と同じ probe）。
+_probe='あ'
+if [ "${#_probe}" -eq 1 ]; then
+  MAX_TITLE=120      # 文字数: 119 文字 + 省略記号 1 文字
+  MAX_TITLE_LINE=129 # 上記 + 見出し接頭辞 `### 案 1: `（9 文字）
+else
+  MAX_TITLE=122      # バイト数: 119 バイト以内 + 省略記号 3 バイト
+  MAX_TITLE_LINE=133 # 上記 + 見出し接頭辞（11 バイト）
+fi
+
+long_title=$(printf 'あ%.0s' $(seq 1 200))
+truncated=$(tc_truncate_title "$long_title" 120)
+assert_eq "I1: 上限超過時は 120 文字以内に収める（NFR 3.5）" "1" \
+  "$([ "${#truncated}" -le "$MAX_TITLE" ] && echo 1 || echo 0)"
+assert_eq "I2: 上限以内のタイトルはそのまま返す" "短いタイトル" "$(tc_truncate_title "短いタイトル" 120)"
+assert_eq "I3: 切り詰め時は末尾に省略記号を付ける" "1" \
+  "$(count_matches "$truncated" '…$')"
+
+FIX_LONG="$WORK_DIR/long-title.md"
+{
+  echo "- [ ] 1. $long_title"
+} > "$FIX_LONG"
+body_i=$(tc_build_split_proposal_body 509 1 "$FIX_LONG")
+title_line=$(printf '%s' "$body_i" | grep -m1 '^### 案 1: ' || true)
+assert_eq "I4: 案タイトルが上限内に収まる（NFR 3.5）" "1" \
+  "$([ "${#title_line}" -le "$MAX_TITLE_LINE" ] && echo 1 || echo 0)"
+
+echo "=== Case J: tasks.md を書き換えない（Req 6.7） ==="
+
+before_sum=$(cksum < "$FIX_CYCLIC")
+tc_build_split_proposal_body 509 4 "$FIX_CYCLIC" >/dev/null
+reset_trace
+# shellcheck disable=SC2034  # tc_post_split_proposal_comment が遅延束縛で参照する
+TC_SPLIT_PROPOSAL_ENABLED=true
+tc_post_split_proposal_comment 509 4 "$FIX_CYCLIC" >/dev/null
+assert_eq "J1: 分割案生成・投稿で tasks.md を書き換えない（Req 6.7）" \
+  "$before_sum" "$(cksum < "$FIX_CYCLIC")"
+
+echo
+echo "=============================="
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+echo "=============================="
+[ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
## 概要

tasks-count-gate（#147 / #216）の escalate 時（最上位・未完了タスク 11 件以上）に、
親タスク単位の **子 Issue 分割案コメント**を機械生成して Issue に投稿する機能を追加する。
LLM 追加起動なし（bash 文字列処理のみ）、opt-in gate `TC_SPLIT_PROPOSAL_ENABLED`（既定 `false`）
により未設定環境では現行と完全に同一の挙動を保つ。子 Issue の自動起票は行わず提案に留める。
本 PR はモデルルーティング Phase 3（#509）に対応し、design フェーズを経由しない
単一 PR で完了する実装経路（design-less impl）。

## 対応 Issue

Closes #509

## 関連 PR

なし（design-less impl: Architect フェーズなし）

## 実装内容

- (Req 1) `TC_SPLIT_PROPOSAL_ENABLED` opt-in gate を `watcher-config.sh` に追加。
  既定 `false`、リテラル `true` 厳密一致でのみ有効、不正値は安全側へ正規化
- (Req 2) `tc_run_post_architect_check` の escalate 分岐末尾に `tc_post_split_proposal_comment` を `|| true` 付きで追加。既存 escalation コメント + `needs-decisions` 付与の後に実行
- (Req 3) 最上位・未完了タスクを正準 regex（`tc_count_tasks` と同一）で抽出し、`_Depends:_` による相互依存（強連結成分）を 1 案に統合するグルーピングを実装
- (Req 4) 各子 Issue 案にタイトル案 / 対象タスク ID / `Split from:` / `Parent:` / 案間 `Depends on:` / 起票コマンド雛形を含む本文を生成
- (Req 5) 専用マーカー `<!-- idd-claude:tasks-count-split-proposal ... -->` による冪等判定。同一 Issue への重複投稿を防止
- (Req 6) gate OFF 時は API 0 回・ログ 0 行で既存挙動を完全保持。失敗は WARN + rc=0（fail-open）
- (Req 7) README「オプション機能一覧」opt-in 節 / tasks-count gate 節 / ログ形式一覧を同一 PR で更新
- (Req 8, NFR) shellcheck rc=0 / bash -n OK / 近接テスト 76 件 PASS / diff-r agents & rules 差分なし

### 変更ファイル

- `local-watcher/bin/modules/tasks-count-gate.sh` — 追加関数 8 件（+573 行）
- `local-watcher/bin/watcher-config.sh` — `TC_SPLIT_PROPOSAL_ENABLED` gate 追加（+19 行）
- `local-watcher/test/tasks_count_gate_split_proposal_test.sh` — 近接テスト新規（+458 行、Case A〜J / 76 テスト）
- `README.md` — opt-in 節 / tasks-count gate 節 / ログ一覧更新（+76/-1 行）

## 受入基準チェック

- [x] Req 1.1〜1.6: opt-in gate / 既定無効 / 安全側正規化 ← Case E1〜E5（未設定・無効値 7 種・API 0 回・ログ 0 行）
- [x] Req 2.1〜2.6: escalate のみ投稿 / 既存を置換しない / タスク 0 件 skip ← Case E6〜E9, D1〜D3
- [x] Req 3.1〜3.7: 計数一致 / 子・完了除外 / SCC 統合 / 網羅性 / 決定論性 ← Case A1〜A4, B1〜B6, C1〜C7
- [x] Req 4.1〜4.11: 本文各フィールド / 案間依存 / canonical 記法 / 提案のみ ← Case A5〜A17
- [x] Req 5.1〜5.7: 冪等マーカー / スキップログ ← Case A15〜A16, F1〜F4
- [x] Req 6.1〜6.9: 既存挙動不変 / fail-open / tasks.md 非改変 ← Case A16, E6, G3〜G7, J1
- [x] Req 7.1〜7.5: README 更新 / 二重管理同期 ← commit 0f9b1e6, diff-r 差分なし
- [x] Req 8.1〜8.6: shellcheck / bash -n / 近接テスト 5 ケース / gate OFF 等価確認 ← Case E6
- [x] NFR 1〜4: 後方互換 / 可観測性 / API ≤2 / 本文 60,000 未満 / セキュリティ ← Case E4〜E6, G1〜G2, A18, H1〜H7

## テスト結果

```
$ bash local-watcher/test/tasks_count_gate_split_proposal_test.sh
PASS 76 / FAIL 0

$ shellcheck local-watcher/bin/modules/tasks-count-gate.sh \
             local-watcher/bin/watcher-config.sh \
             local-watcher/test/tasks_count_gate_split_proposal_test.sh
（警告ゼロ / rc=0）

$ bash -n local-watcher/bin/modules/tasks-count-gate.sh
$ bash -n local-watcher/bin/watcher-config.sh
（OK）

$ diff -r .claude/agents repo-template/.claude/agents
$ diff -r .claude/rules repo-template/.claude/rules
（差分なし）

既存テスト全 100 本: 回帰なし
（publish_terminal_failure_artifacts_test.sh は rc=141 / SIGPIPE の既存 flaky。
 本変更前後で同一挙動を確認済み）
```

## 実装上の判断

（`impl-notes.md` より主要判断を抜粋）

- **コメント単位**: 既存 escalation コメント本文・マーカーを変更しないため独立コメントを採用
- **統合条件**: 相互依存（循環）のみを 1 案に統合。一方向連鎖は案間 `Depends on:` で表現
- **タイトル生成**: 要約無害化 → ` (P)` 除去 → 統合案は ` / ` 連結 → 120 文字で切り詰め
- **本文長縮退**: NFR 3.4（60,000 文字上限）超過時は先頭から詰めて省略件数を明記
- **`_Requirements:_` 非同梱**: AC 追加が必要なため人間判断待ち（impl-notes「確認事項」参照）
- **`tc_sanitize_text`**: `'` `"` `` ` `` `$` `\` を除去（起票コマンド雛形破壊防止）

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後検証済み）
- Reviewer の approve 判定: RESULT: approve（詳細は `docs/specs/509-feat-watcher-tasks-count-gate-escalate-i/review-notes.md` を参照）
- **`tc_sanitize_text` の除去文字**: `'` `"` `` ` `` `$` `\` を除去。エスケープ方式への変更要否は運用フィードバック待ち（impl-notes「確認事項」参照）
- **`_Requirements:_` 子 Issue 案への同梱可否**: Requirement 4 への AC 追加次第。人間判断待ち
- `- [x]` 配下の `_Depends:_` は読み飛ばし（完了タスクは案構成単位にならないため実害なし）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #509 のコメントを参照してください。
