### PR TITLE
chore(#516): repo-template 側 idd-claude-labels.sh を root に byte 一致させる（#54 prefix 追随）

### DIFF
--- a/docs/specs/516-chore-labels-repo-template-idd-claude-la/impl-notes.md
+++ b/docs/specs/516-chore-labels-repo-template-idd-claude-la/impl-notes.md
@@ -1,0 +1,55 @@
+# 実装ノート
+
+## 概要
+
+`repo-template/.github/scripts/idd-claude-labels.sh` を root 側
+`.github/scripts/idd-claude-labels.sh` に byte 一致させた。#54 で root に導入された
+`【Issue 用】` / `【PR 用】` description prefix と、直前の 4 行コメントブロックが
+repo-template 側に未反映だったドリフトを解消する単純同期修正。design.md / tasks.md は
+作成されていない（Architect 不要の単純同期修正のため、Issue 記載どおり）。
+
+## 変更内容
+
+- `repo-template/.github/scripts/idd-claude-labels.sh` の `LABELS=()` 配列直前に、root 側と
+  同一の 4 行コメントブロック（Issue #54 Req 2.1/2.2/2.3 の説明・description 100 文字上限・
+  name/color 不変の言及）を追加（Requirement 1 / AC 1.1）
+- 以下 9 ラベルの description 先頭に `【Issue 用】` prefix を付与: `auto-dev` /
+  `needs-decisions` / `awaiting-design-review` / `claude-claimed` / `claude-picked-up` /
+  `ready-for-review` / `claude-failed` / `skip-triage` / `hotfix`（Requirement 2 / AC 2.1, 2.2）
+- 以下 2 ラベルの description 先頭に `【PR 用】` prefix を付与: `needs-rebase` /
+  `needs-iteration`（Requirement 3 / AC 3.1, 3.2）
+- `size:small` / `size:medium` / `size:large` の 3 行、その他既存ラベル
+  （`needs-quota-wait` / `staged-for-release` / `st-failed` / `awaiting-slot` / `blocked` /
+  `needs-security-fix` / `needs-merge-gate-attention`）、オプション解析・依存チェック・
+  ラベル作成ロジック・結果集計・ヘルプ表示等は変更なし（Requirement 4 / AC 4.1〜4.4）
+- root 側 `.github/scripts/idd-claude-labels.sh` は一切変更していない（Requirement 4 / AC 4.1）
+
+## 検証結果
+
+| コマンド | 結果 |
+|---|---|
+| `diff .github/scripts/idd-claude-labels.sh repo-template/.github/scripts/idd-claude-labels.sh` | 出力なし・exit code 0（byte 一致確認、Requirement 5 / AC 5.1） |
+| `shellcheck repo-template/.github/scripts/idd-claude-labels.sh` | 警告ゼロ・exit code 0 |
+| 既存テスト | `local-watcher/test/` 配下に本スクリプト専用のテストは存在せず、影響なし |
+
+## AC Traceability
+
+| Requirement / AC | 対応内容 |
+|---|---|
+| 1.1 | root 側 4 行コメントブロックを repo-template の同一位置に同一文字列で追加 |
+| 2.1, 2.2 | 対象 9 ラベルの description に `【Issue 用】` prefix を付与し、root と完全一致 |
+| 3.1, 3.2 | 対象 2 ラベルの description に `【PR 用】` prefix を付与し、root と完全一致 |
+| 4.1 | root 側ファイルは無変更（`git diff` 未使用箇所として確認） |
+| 4.2 | `size:*` 3 行は編集対象から除外し無変更 |
+| 4.3 | LABELS 定義ブロック以外（オプション解析等）は無変更 |
+| 4.4 | 対象 11 ラベル・`size:*` 以外の既存 7 ラベルの name/color/description は無変更 |
+| 5.1 | `diff` コマンドで空出力・exit code 0 を確認 |
+| NFR 1.1 | 変更は description prefix / コメント追加のみで name・color は不変 |
+| NFR 1.2 | `--force` なし実行時の skip / 新規作成ロジック自体は無編集のため動作不変 |
+
+## 確認事項
+
+なし（root/repo-template の byte 一致を機械的に確認済みで、要件に対する解釈の曖昧さは
+発生しなかった）。
+
+STATUS: complete

--- a/docs/specs/516-chore-labels-repo-template-idd-claude-la/requirements.md
+++ b/docs/specs/516-chore-labels-repo-template-idd-claude-la/requirements.md
@@ -1,0 +1,89 @@
+# Requirements Document
+
+## Introduction
+
+`idd-claude` は `.github/scripts/idd-claude-labels.sh`（root）と
+`repo-template/.github/scripts/idd-claude-labels.sh`（consumer 配布用テンプレート）の 2 系統で
+ラベル定義スクリプトを二重管理している。#54 でラベル誤付与防止のため description に
+`【Issue 用】` / `【PR 用】` prefix を導入した際、root 側にしか反映されず repo-template 側が
+追随しないまま放置されていた（#507 の設計時に既存ドリフトとして発見・Out of Scope 化され、
+別 Issue での是正が推奨されていた）。本 Issue はその積み残しを解消し、CLAUDE.md
+「二重管理・同期の鉄則」の consumer 配布物同期に repo-template 側を追随させる。root 側を正
+（source of truth）とし、repo-template 側のみを更新する単純な同期修正であり、新規の設計判断は
+発生しない。
+
+## Requirements
+
+### Requirement 1: LABELS 定義コメントブロックの同期
+
+**Objective:** As a idd-claude 保守者, I want repo-template 側の `LABELS=()` 配列直前のコメント
+ブロックを root 側と一致させたい, so that 両ファイルを読む開発者が同じ設計意図（description
+prefix 導入経緯・GitHub description 100 文字上限・name/color 不変方針）を参照できる
+
+#### Acceptance Criteria
+
+1. When `repo-template/.github/scripts/idd-claude-labels.sh` を更新するとき, the Developer shall root 側の `LABELS=()` 配列直前にある 4 行のコメントブロック（Issue #54 Req 2.1/2.2/2.3 の説明・description 100 文字上限の言及・name/color 不変の言及を含む）を repo-template 側の同一位置に同一文字列で追加する
+
+### Requirement 2: Issue 用ラベルの description prefix 同期
+
+**Objective:** As a idd-claude 運用者, I want Issue 専用ラベルの description に統一された
+`【Issue 用】` prefix が repo-template 側にも付与されていること, so that consumer repo で
+auto-dev ワークフローを利用する運用者が、ラベルの適用先（Issue 用か PR 用か）を誤認しない
+
+#### Acceptance Criteria
+
+1. When repo-template 側の `auto-dev` / `needs-decisions` / `awaiting-design-review` / `claude-claimed` / `claude-picked-up` / `ready-for-review` / `claude-failed` / `skip-triage` / `hotfix` の各ラベル定義を更新するとき, the Developer shall 各ラベルの description 先頭に root 側と同一の `【Issue 用】` prefix を付与する
+2. The 更新後の上記 9 ラベルの description shall root 側の対応する description と完全に同一の文字列になる
+
+### Requirement 3: PR 用ラベルの description prefix 同期
+
+**Objective:** As a idd-claude 運用者, I want PR 専用ラベルの description に統一された
+`【PR 用】` prefix が repo-template 側にも付与されていること, so that consumer repo の運用者が
+Issue 用ラベルと PR 用ラベルを取り違えて付与しない
+
+#### Acceptance Criteria
+
+1. When repo-template 側の `needs-rebase` / `needs-iteration` の各ラベル定義を更新するとき, the Developer shall 各ラベルの description 先頭に root 側と同一の `【PR 用】` prefix を付与する
+2. The 更新後の上記 2 ラベルの description shall root 側の対応する description と完全に同一の文字列になる
+
+### Requirement 4: root 側ファイルおよび既存一致箇所の不変性維持
+
+**Objective:** As a idd-claude 保守者, I want 本修正が root 側ファイルおよび既に両ファイルで
+一致している箇所に一切影響を与えないこと, so that 正（source of truth）である root の内容が
+意図せず変化するリスクを避け、修正範囲を最小限に保てる
+
+#### Acceptance Criteria
+
+1. While 本 Issue の変更作業を行う間, the Developer shall root 側 `.github/scripts/idd-claude-labels.sh` に一切の変更を加えない
+2. While 本 Issue の変更作業を行う間, the Developer shall 既に両ファイルで一致している `size:small` / `size:medium` / `size:large` の 3 行の内容（name / color / description）を変更しない
+3. While 本 Issue の変更作業を行う間, the Developer shall LABELS 定義ブロック（コメント追加および対象 11 ラベルの description prefix 追加）以外の行（オプション解析・依存チェック・ラベル作成ロジック・結果集計・ヘルプ表示等）を変更しない
+4. While 本 Issue の変更作業を行う間, the Developer shall 対象 11 ラベルおよび `size:*` 3 ラベル以外の既存ラベル（`needs-quota-wait` / `staged-for-release` / `st-failed` / `awaiting-slot` / `blocked` / `needs-security-fix` / `needs-merge-gate-attention`）の name / color / description を変更しない
+
+### Requirement 5: 同期完了の検証
+
+**Objective:** As a idd-claude 運用者, I want 修正後に両ファイルの byte 一致を機械的に確認
+できること, so that ドリフト解消が客観的に検証され、再発時にも同じ手順で検出できる
+
+#### Acceptance Criteria
+
+1. When 修正完了後に `diff .github/scripts/idd-claude-labels.sh repo-template/.github/scripts/idd-claude-labels.sh` を実行するとき, the Verification Process shall 空の出力（差分なし、exit code 0）を返す
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. The repo-template 側ラベルスクリプト shall 既存の全ラベルの name および color を一切変更しない（変更を description の prefix 追加およびコメントブロック追加のみに限定する）
+2. The repo-template 側ラベルスクリプト shall 本修正の前後で、`--force` オプションなしで実行した場合の動作（既存ラベルは skip、未存在ラベルのみ新規作成）を変更しない
+
+## Out of Scope
+
+- root 側 `.github/scripts/idd-claude-labels.sh` の内容変更（正はあくまで root）
+- 実際の consumer repo・本 repo 上の GitHub ラベル（description の実データ）への反映作業（本 Issue はスクリプトファイルの同期のみが対象であり、`gh label create --force` 等でラベルを実際に更新する作業は含まない）
+- ラベルの name / color 変更、新規ラベルの追加、既存ラベルの削除
+- `size:*` 3 ラベルに関する変更（#511 で既に両ファイル一致済みであり対象外）
+- `.claude/agents` / `.claude/rules` など他の root ↔ repo-template 二重管理対象の同期（本 Issue のスコープは labels script 1 ファイルに限定）
+- README・CLAUDE.md 等ドキュメントの追加更新（本修正はスクリプト内コメント・description 文字列の同期に限定され、外部挙動・運用手順の変更を伴わないため）
+
+## Open Questions
+
+なし

--- a/docs/specs/516-chore-labels-repo-template-idd-claude-la/review-notes.md
+++ b/docs/specs/516-chore-labels-repo-template-idd-claude-la/review-notes.md
@@ -1,0 +1,78 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-23T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-516-impl-chore-labels-repo-template-idd-claude-la
+- HEAD commit: 875dded0d48de33bf89e7e2835468a2a7411d85c
+- Compared to: main..HEAD
+- 変更ファイル: `repo-template/.github/scripts/idd-claude-labels.sh` (+15/-11) と spec 成果物 2 件
+  （`requirements.md` / `impl-notes.md`）のみ
+- `design.md` / `tasks.md` は不在（design-less impl。`_Boundary:_` アノテーションが存在しない
+  ため、境界判定は requirements.md の Out of Scope 節を代替基準として評価した）
+- CLAUDE.md に `## Feature Flag Protocol` 節は存在しないため、flag 観点の確認は行わない
+  （通常の 3 カテゴリ判定のみ）
+
+## Verified Requirements
+
+- 1.1 — `repo-template/.github/scripts/idd-claude-labels.sh:60-63` に root 側と同一の 4 行
+  コメントブロック（Issue #54 Req 2.1/2.2/2.3 の説明・description 100 文字上限の言及・
+  name/color 不変の言及）が `LABELS=(`（同 :64）の直前に追加されている。root 側の同一位置
+  と文字列一致（後述 5.1 の byte 一致検証で担保）
+- 2.1 — diff 上で `auto-dev` / `needs-decisions` / `awaiting-design-review` / `claude-claimed` /
+  `claude-picked-up` / `ready-for-review` / `claude-failed` / `skip-triage` / `hotfix` の 9 行
+  すべてに `【Issue 用】 ` prefix が付与されている（`hotfix` は :80 の位置で分離されているが
+  同様に付与済み）
+- 2.2 — `diff .github/scripts/idd-claude-labels.sh repo-template/.github/scripts/idd-claude-labels.sh`
+  を Reviewer 側で再実行し、出力なし・exit code 0。上記 9 ラベルの description が root と
+  完全一致であることを機械的に確認
+- 3.1 — `needs-rebase`（:73）/ `needs-iteration`（:74）の 2 行に `【PR 用】 ` prefix が付与
+  されている
+- 3.2 — 5.1 と同じ byte 一致検証により、上記 2 ラベルの description が root と完全一致である
+  ことを確認
+- 4.1 — `git diff --numstat main..HEAD` の変更ファイルに root 側
+  `.github/scripts/idd-claude-labels.sh` は含まれない（`git diff --stat main..HEAD --
+  .github/scripts/idd-claude-labels.sh` が空出力）。root 無変更を確認
+- 4.2 — `size:small` / `size:medium` / `size:large` の 3 行は diff 上で context 行として現れ、
+  変更されていない
+- 4.3 — 変更 hunk は `LABELS=()` 直前のコメント追加と LABELS 配列内 11 行のみ（+15/-11）。
+  オプション解析・依存チェック・ラベル作成ロジック（:113 以降の `EXISTING_LABELS` 系）・
+  結果集計・ヘルプ表示は無変更
+- 4.4 — `needs-quota-wait` / `staged-for-release` / `st-failed` / `awaiting-slot` / `blocked` /
+  `needs-security-fix` / `needs-merge-gate-attention` の 7 行は diff 上で context 行として現れ、
+  name / color / description いずれも無変更
+- 5.1 — Reviewer 側で `diff .github/scripts/idd-claude-labels.sh
+  repo-template/.github/scripts/idd-claude-labels.sh` を実行 → 出力なし / exit code 0 を確認
+  （impl-notes.md の検証結果と一致）
+- NFR 1.1 — diff の全変更行が description 先頭への prefix 追加とコメント行追加のみであり、
+  `name|color` フィールドは全ラベルで不変
+- NFR 1.2 — `--force` 判定・既存ラベル skip / 新規作成の処理ブロックは diff 対象外（4.3 と同根拠）
+  であり、実行時挙動は不変
+
+## テスト観点の確認（missing test カテゴリ）
+
+CLAUDE.md「テスト・検証」節のとおり本リポジトリに unit test フレームワークは存在せず、検証は
+静的解析 + 同期 diff で行う規約。本変更は関数・module の新規追加を伴わない文字列同期であり、
+`local-watcher/test/` への近接テスト追加対象に該当しない。Reviewer 側で以下を再実行し green を
+確認した:
+
+- `diff .github/scripts/idd-claude-labels.sh repo-template/.github/scripts/idd-claude-labels.sh`
+  → 出力なし / exit 0
+- `shellcheck repo-template/.github/scripts/idd-claude-labels.sh` → 警告ゼロ / exit 0
+
+AC 5.1 が要求する検証手段（diff による byte 一致確認）が実行され結果が impl-notes.md に記録
+されているため、missing test には該当しない。
+
+## Findings
+
+なし
+
+## Summary
+
+全 numeric AC（1.1 / 2.1 / 2.2 / 3.1 / 3.2 / 4.1〜4.4 / 5.1）および NFR 1.1・1.2 のカバレッジを
+確認し、`diff` による byte 一致と `shellcheck` clean を Reviewer 側で再検証して green。変更は
+requirements.md の Out of Scope 境界（root 側無変更 / `size:*` 無変更 / labels script 1 ファイル
+限定）を逸脱していない。
+
+RESULT: approve

--- a/repo-template/.github/scripts/idd-claude-labels.sh
+++ b/repo-template/.github/scripts/idd-claude-labels.sh
@@ -57,23 +57,27 @@ if [ -n "$REPO" ]; then
 fi
 
 # Label definitions: name|color|description
+# Issue #54 Req 2.1 / 2.2 / 2.3: 誤付与防止のため description に「【PR 用】」「【Issue 用】」
+# prefix を入れて適用先を明示する。GitHub のラベル description 上限（100 文字）を超えないよう
+# 末尾の説明文は維持できる範囲で短縮しない（最長: needs-rebase = 80 文字）。
+# ラベルの name / color 自体は本要件で変更しない（既存運用との互換性維持・Req 2.5）。
 LABELS=(
-  "auto-dev|1f77b4|自動開発対象"
-  "needs-decisions|f1c40f|人間の判断が必要"
-  "awaiting-design-review|e67e22|設計 PR レビュー待ち（Architect 発動時）"
-  "claude-claimed|c39bd3|Claude Code が claim 済（Triage 実行中）"
-  "claude-picked-up|9b59b6|Claude Code 実行中"
-  "ready-for-review|2ecc71|PR 作成完了"
-  "claude-failed|e74c3c|自動実行が失敗（復旧時は ready-for-review を先に付与してから外す）"
-  "skip-triage|95a5a6|Triage をスキップ"
-  "needs-rebase|fbca04|approved PR で base が古い／conflict が発生済み（Phase A: Merge Queue Processor が付与）"
-  "needs-iteration|d4c5f9|PR レビューコメントの反復対応待ち（#26 PR Iteration Processor が処理）"
+  "auto-dev|1f77b4|【Issue 用】 自動開発対象"
+  "needs-decisions|f1c40f|【Issue 用】 人間の判断が必要"
+  "awaiting-design-review|e67e22|【Issue 用】 設計 PR レビュー待ち（Architect 発動時）"
+  "claude-claimed|c39bd3|【Issue 用】 Claude Code が claim 済（Triage 実行中）"
+  "claude-picked-up|9b59b6|【Issue 用】 Claude Code 実行中"
+  "ready-for-review|2ecc71|【Issue 用】 PR 作成完了"
+  "claude-failed|e74c3c|【Issue 用】 自動実行が失敗（復旧時は ready-for-review を先に付与してから外す）"
+  "skip-triage|95a5a6|【Issue 用】 Triage をスキップ"
+  "needs-rebase|fbca04|【PR 用】 approved PR で base が古い／conflict が発生済み（Phase A: Merge Queue Processor が付与）"
+  "needs-iteration|d4c5f9|【PR 用】 PR レビューコメントの反復対応待ち（#26 PR Iteration Processor が処理）"
   "needs-quota-wait|c5def5|【Issue 用】 Claude Max quota 超過で reset 待ち（Quota Resume Processor が自動除去）"
   "staged-for-release|b8e0d2|【Issue 用】 develop に merge 済み、main 到達待ち（multi-branch 運用専用）"
   "st-failed|d73a4a|【Issue 用】 ST failure 検知後 revert 済み（Phase B Promote Pipeline が付与）"
   "awaiting-slot|c5def5|【Issue 用】 hot file 競合予防で同サイクル dispatch を見送り中（Phase E Path Overlap Checker が付与・除去）"
   "blocked|b60205|【Issue 用】 依存 Issue 未 merge により auto-dev 進行不能"
-  "hotfix|d93f0b|hotfix 優先処理対象（Dispatcher が非 hotfix より先に投入）"
+  "hotfix|d93f0b|【Issue 用】 hotfix 優先処理対象（Dispatcher が非 hotfix より先に投入）"
   "needs-security-fix|d73a4a|【PR 用】 Security Review strict モード（#281）で severity 閾値以上の検出により付与される。手動剥がしで override 可"
   "needs-merge-gate-attention|f9d0c4|【PR 用】 claude-review が required だが adjudicator も catch-up も発火せず merge gate を満たせない停滞状態（#412）"
   "size:small|c2e0c6|【Issue 用】 Triage 判定の変更規模: 小（単一〜少数ファイルの軽微な変更）"


### PR DESCRIPTION
## 概要

`repo-template/.github/scripts/idd-claude-labels.sh` を root 側と byte 一致させる単純同期修正。
Issue #54 で root 側に導入された `【Issue 用】` / `【PR 用】` description prefix と
`LABELS=()` 直前の 4 行コメントブロックが repo-template 側に未反映のまま放置されていたドリフトを
解消する。変更ファイルは `repo-template/.github/scripts/idd-claude-labels.sh` 1 件のみ
（root 側は無変更）。design-less impl（Architect 起動なし）であり、新規の設計判断は発生しない。

## 対応 Issue

Closes #516

## 関連 PR

なし（design-less impl: Architect は起動していないため設計 PR はありません）

## 実装内容

- (Req 1 / AC 1.1) `LABELS=()` 配列直前に root 側と同一の 4 行コメントブロックを追加
- (Req 2 / AC 2.1, 2.2) 9 ラベル（`auto-dev` / `needs-decisions` / `awaiting-design-review` / `claude-claimed` / `claude-picked-up` / `ready-for-review` / `claude-failed` / `skip-triage` / `hotfix`）の description 先頭に `【Issue 用】` prefix を付与
- (Req 3 / AC 3.1, 3.2) 2 ラベル（`needs-rebase` / `needs-iteration`）の description 先頭に `【PR 用】` prefix を付与
- (Req 4) root 側ファイル・`size:*` 3 ラベル・LABELS ブロック以外の行はすべて無変更
- (NFR 1) name / color は全ラベルで不変、`--force` なし実行時の動作は変化なし

## 受入基準チェック

- [x] AC 1.1: root 側と同一の 4 行コメントブロックを同一位置に追加 ← `diff` 空出力で確認
- [x] AC 2.1: 対象 9 ラベルに `【Issue 用】` prefix を付与 ← `diff .github/scripts/idd-claude-labels.sh repo-template/.github/scripts/idd-claude-labels.sh` 空出力
- [x] AC 2.2: root と完全一致 ← 同上
- [x] AC 3.1: `needs-rebase` / `needs-iteration` に `【PR 用】` prefix を付与 ← 同上
- [x] AC 3.2: root と完全一致 ← 同上
- [x] AC 4.1〜4.4: root 側無変更、`size:*` 無変更、LABELS ブロック外無変更、他 7 ラベル無変更
- [x] AC 5.1: `diff` コマンドが空出力・exit code 0
- [x] NFR 1.1: description prefix / コメント追加のみ、name・color は不変
- [x] NFR 1.2: `--force` なし実行時の skip / 新規作成ロジック自体は無編集

## テスト結果

```
$ diff .github/scripts/idd-claude-labels.sh repo-template/.github/scripts/idd-claude-labels.sh
（出力なし / exit code 0 — byte 一致確認）

$ shellcheck repo-template/.github/scripts/idd-claude-labels.sh
（出力なし / exit code 0 — 警告ゼロ）
```

## 実装上の判断

impl-notes.md 参照。本修正は文字列同期のみであり、設計判断は発生しなかった。
Reviewer 独立レビューで同一の `diff` コマンドを再実行し、byte 一致と shellcheck クリーンを再確認済み（review-notes.md 参照）。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- base: main / baseRefName: main / OK（PR 作成後に検証）
- Reviewer 判定: `RESULT: approve`（docs/specs/516-chore-labels-repo-template-idd-claude-la/review-notes.md 参照）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #516 のコメントを参照してください。
