### PR TITLE
fix(#518): staged-for-release 併存 Issue を dispatch×multi-branch で holder から除外

### DIFF
--- a/README.md
+++ b/README.md
@@ -2231,9 +2231,22 @@ holder から除外できます。そこで Path Overlap Checker は holder ラ�
 | promote target=`main` | （不問） | 7 ラベル（full） | 維持（まだ `main` に無い in-flight 集合） |
 | 判定不能（不明 context 等） | （不問） | 7 ラベル（full） | 維持（fail-safe / 安全側） |
 
+> **併存ラベルへの post-filter による確実な除外（#518）**: 上記のラベル集合の減算は
+> `gh issue list --search` の **holder ラベルクエリから `staged-for-release` を抜く**（クエリ側
+> 減算）だけでは不十分です。`staged-for-release` と他の holder ラベル（例 `ready-for-review`）を
+> **併存**する Issue は、併存ラベル経由で OR クエリにマッチし、依然 holder として列挙されて
+> しまうためです。そこで dispatch × multi-branch では、in-flight 列挙結果に対して
+> **`staged-for-release` を付与された Issue を（他 holder ラベルの併存有無に関わらず）holder
+> 集合から落とす post-filter** を適用し、確実に除外します（#518）。この post-filter に必要な
+> ラベル情報は既存の in-flight 列挙 API 呼び出し（`--json number,labels`）から取得するため、
+> **Issue 列挙の API 回数は増えません**。ラベル取得が不能で判定できない Issue は holder に
+> 残す（安全側 / fail-safe）ため、誤って holder から外して path 衝突を見逃すことはありません。
+> この post-filter は通常 dispatch 経路と flock skip 可視化経路（#243）の**両方**に適用され、
+> どちらの経路でも同じ Issue が同じく holder から除外されます。
+
 - **single-branch（`main` only）運用ではゼロ差分**: `staged-for-release` が運用上付与されない
-  ため、`BASE_BRANCH == PROMOTION_TARGET_BRANCH` のとき full 集合を使い、本機能導入前と
-  同一の in-flight 集合 / `awaiting-slot` 判定になります（後方互換）。
+  ため、`BASE_BRANCH == PROMOTION_TARGET_BRANCH` のとき full 集合を使い（post-filter の drop
+  対象も空）、本機能導入前と同一の in-flight 集合 / `awaiting-slot` 判定になります（後方互換）。
 - **gitflow 運用ガイド**: `BASE_BRANCH=develop`（かつ `PROMOTION_TARGET_BRANCH=main`）の
   multi-branch 運用では、完了して `staged-for-release` を付与したまま open に残った Issue が、
   同一 top-level path を編集する新規 Issue を不要に `awaiting-slot` へ落とすことがなくなります。
@@ -2376,11 +2389,16 @@ path-overlap: route=flock-skip visibility skipped (別の可視化パスが進�
 ```
 
 dispatch 文脈で holder 集合から `staged-for-release` を除外した場合（multi-branch 運用）は、
-除外を判別可能な以下のログが出力されます（#221 / NFR 3.1）。single-branch 運用や除外が
+除外を判別可能な以下のログが出力されます（#221 / #518 / NFR 3.1）。single-branch 運用や除外が
 発生しない場合は出力されません（ゼロ差分）:
 
 ```
+# context レベル: 当該 dispatch で holder ラベル集合から staged-for-release を減算した事実（#221）
 path-overlap: holder-set context=dispatch excluded=staged-for-release base=<BASE_BRANCH>
+
+# issue レベル: 併存ラベル経由でクエリにマッチした staged 済み Issue を post-filter で
+#              holder から落とした事実（#518 / NFR 3。除外した Issue 単位で 1 行）
+path-overlap: holder-set excluded staged issue=#<N> label=staged-for-release
 ```
 
 ### dogfood 確認手順

--- a/docs/specs/518-fix-path-overlap-staged-for-release-hold/impl-notes.md
+++ b/docs/specs/518-fix-path-overlap-staged-for-release-hold/impl-notes.md
@@ -1,0 +1,85 @@
+# 実装ノート（#518）
+
+## 概要
+
+dispatch × multi-branch（`BASE_BRANCH != PROMOTION_TARGET_BRANCH`）文脈で、`staged-for-release`
+を付与された Issue を **他 holder ラベル（例 `ready-for-review`）併存の有無に関わらず** holder
+集合から除外する。#221 は holder ラベル集合の「クエリ側減算」のみで、併存ラベル経由でクエリに
+マッチする staged 済み Issue が holder に残る根因があった。本 Issue は列挙結果への **post-filter**
+で確実に除外する（#221 Req 1.4 を意図的に上書き）。
+
+## 変更ファイル
+
+- `local-watcher/bin/modules/path-overlap.sh`
+  - `po_resolve_staged_drop_label`（新設 / 純粋関数）: dispatch×multi-branch のみ drop 対象
+    `staged-for-release` を返し、それ以外（single-branch / promote / 判定不能）は空文字。判定条件は
+    `po_resolve_holder_labels` の multi-branch 判定と完全一致。`${LABEL_STAGED_FOR_RELEASE:-...}` 参照。
+  - `po_collect_inflight_issues`: 第 3 引数 `drop_staged_label`（`${3:-}` / 空=drop なし）追加。
+    `--json number` → `--json number,labels`（同一 API に labels 追加のみ）。列挙ループを
+    `jq -c '.[]'` のオブジェクト反復へ変更し `.number` 抽出。drop 対象ラベルを持つ Issue は
+    `po_load_edit_paths` を呼ぶ前に `continue` で除外し、NFR 3 ログを 1 行出力。
+  - `po_check_dispatch_gate` / `po__visibility_evaluate_candidate`（両経路）: `drop_label` を
+    `po_resolve_staged_drop_label "dispatch"` で解決し第 3 引数で注入（Req 3 一貫性）。
+- `local-watcher/test/po_staged_holder_dropfilter_test.sh`（新規 / 22 assertions）
+- `README.md`「holder ラベル集合の base 相対化（#221）」節およびログ出力節に #518 の精緻化を追記。
+
+## 設計判断（推奨方針からの逸脱）
+
+- 推奨方針にほぼ準拠。ラベル判定は `jq -r --arg lbl '[.labels[].name] | index($lbl) // empty'`
+  を採用（未信頼入力を `--arg` 経由の厳密一致で扱い、フィルタ文字列へ inline 展開しない / #318）。
+- `.number` 抽出時に `[ -z "$n" ] && continue` を維持し、drop なし経路の出力等価性（NFR 1）を保全。
+  数値バリデーション追加は行わず、旧挙動と byte 等価な列挙ロジックを維持した。
+- fail-safe: `drop_staged_label` が空、または labels が null / 欠落で jq が失敗する場合は
+  `2>/dev/null || echo ""` で has_staged を空にし、drop せず holder に残す（Req 4.1 安全側）。
+
+## テスト観点（Red→Green 確認済み）
+
+- 実行コマンド: `bash local-watcher/test/po_staged_holder_dropfilter_test.sh` → PASS 22 / FAIL 0
+- Red 確認: post-filter 抜きの旧 collector を再現し、staged+ready 併存 Issue が holder に残る
+  （union に `local-watcher/` を含む）ことを観測。本実装で union=`README.md` のみに除外される。
+- 既存回帰: `po_apply_awaiting_slot_test.sh`(19) / `po_sticky_comment_helpers_test.sh`(10) /
+  `repo_prefix_log_test.sh`(36) 全 pass。
+- 静的解析: `bash -n` OK / `shellcheck`（module + test）警告ゼロ。
+
+## AC Traceability（1 要件 1 行）
+
+| AC | 担保テスト |
+|---|---|
+| 1.1 | `po_resolve_staged_drop_label` Case 1 + collector Case A（staged 併存除外→union=README.md） |
+| 1.2 | collector Case A（holders[local-watcher/] 未計上 / holders[README.md]=41） |
+| 1.3 | Case A で union から脱落 → 呼び出し側 overlap=0 経路（`po_check_dispatch_gate` 既存挙動）で担保 |
+| 2.1 | `po_resolve_staged_drop_label` Case 2/3（single-branch → 空 = holder 維持） |
+| 2.2 | `po_resolve_staged_drop_label` Case 4（promote → 空 = holder 維持） |
+| 2.3 | collector Case B（drop なし = 従来どおり staged 併存 Issue を holder 計上 / ゼロ差分） |
+| 3.1 / 3.2 | 両呼び出し元が `po_resolve_staged_drop_label "dispatch"` で同一 drop ラベルを解決・注入（コード配線 + Case A の除外規則） |
+| 4.1 | collector Case D（labels 欠落 Issue は drop されず holder 維持） |
+| 4.2 | `po_resolve_staged_drop_label` Case 5/6（不明 context / 省略 → 空 = holder 維持） |
+| NFR 1.1 | collector Case B（drop なし union 等価）+ Red 確認（旧挙動一致） |
+| NFR 1.2 | collector Case E（staged 不在 Issue は drop_label 指定でも全 holder 維持） |
+| NFR 2.1 / 2.3 | collector Case A（`gh issue list` 1 回 / `--json number,labels` で追加 API なし） |
+| NFR 2.2 | `po_load_edit_paths` は drop されなかった Issue 各 1 回（既存構造不変） |
+| NFR 3.1 | collector Case A（`holder-set excluded staged issue=#40 label=staged-for-release` ログ出力） |
+
+## 確認事項
+
+- **requirements.md Open Questions（遷移プロセッサ）**: gitflow + promote 無効構成では、
+  impl PR が develop merge 後も `ready-for-review` が Issue に残置し続ける（除去処理が
+  promote-pipeline 側にしかない）。本 Issue は holder 除外で実害（新規 Issue の awaiting-slot
+  恒久滞留）を解消するが、`ready-for-release`→`staged-for-release` の自動遷移や `ready-for-review`
+  残置の解消は **Out of Scope**（別 Issue 候補）。ラベルライフサイクル上の残置問題は本 Issue
+  完了後も残る旨を記録する。運用者は手動で `staged-for-release` を付与する既存運用を前提とする。
+- **#221 Req 1.4 の上書き**: 本実装は #221 Req 1.4（併存時 holder 維持）を意図的に上書きする。
+  #221 の当該挙動を検証する既存テスト fixture は存在しなかった（`po_collect_inflight_issues`
+  を直接検証するテストは本 Issue で新設した `po_staged_holder_dropfilter_test.sh` が初）ため、
+  既存 fixture の破壊的更新は発生していない。
+- **repo-template 同期**: `path-overlap.sh` は `install.sh` 経由で `$HOME/bin/modules/` へ配布
+  される構造で `repo-template/` 配下に複製が無いため、repo-template 同期は不要（確認済み）。
+  `.claude/{agents,rules}` は未変更で byte 一致を確認済み。
+
+## 検証サマリ
+
+- `bash -n local-watcher/bin/modules/path-overlap.sh` — OK
+- `shellcheck local-watcher/bin/modules/path-overlap.sh local-watcher/test/po_staged_holder_dropfilter_test.sh` — 警告ゼロ
+- テスト: 新規 22 pass / 既存 po_* 系 65 pass、全 green
+
+STATUS: complete

--- a/docs/specs/518-fix-path-overlap-staged-for-release-hold/requirements.md
+++ b/docs/specs/518-fix-path-overlap-staged-for-release-hold/requirements.md
@@ -1,0 +1,86 @@
+# Requirements Document
+
+## Introduction
+
+Phase E Path Overlap Checker（#18）の dispatch-time gate では、#221 で「dispatch × multi-branch（`BASE_BRANCH != PROMOTION_TARGET_BRANCH`）では develop 統合済みを示す `staged-for-release` を holder 集合から除外する」契約を導入した。しかし実装は holder ラベル集合の**クエリ側減算のみ**（`staged-for-release` を抜いた 6 ラベルの `label:X OR ...` クエリを発行）で、列挙結果から staged 済み Issue を落とす後段フィルタが無い。そのため `staged-for-release` と他の holder ラベル（例: `ready-for-review`）を**併存**する Issue は、併存ラベル経由でクエリにマッチし、依然 holder として列挙・計上される。
+
+さらに gitflow かつ promote pipeline 無効の構成では、`ready-for-review` を除去する処理が promote-pipeline 側にしか存在しないため、impl PR が develop へ merge された後も `ready-for-review` が Issue に残置し続ける。運用者が手で `staged-for-release` を付与しても、上記の併存問題により当該 Issue が holder 集合から外れない。実害として、gitflow（`BASE_BRANCH=develop` / `PATH_OVERLAP_CHECK=true` / promote 無効）構成で develop merge 済みの複数 Issue（`ready-for-review` + `staged-for-release` 併存）が、同一 top-level path を編集する新規 Issue を毎 tick `awaiting-slot` へ落とし、次リリースまで数日〜恒久的に dispatch をブロックする事象が発生した。
+
+本要件は、dispatch × multi-branch 文脈において「`staged-for-release` を**付与されている** Issue は、他 holder ラベルの併存有無に関わらず holder 集合から**除外**する」ことを定義する。これは #221 Requirement 1.4（「Issue が `staged-for-release` と他 in-flight ラベルを併せ持つとき holder 集合に**維持**する」）を**意図的に上書き**する変更である。上書きの根拠は、gitflow + promote 無効では `ready-for-review` 残置が構造的に発生するため併存を holder 維持条件にすると本問題が解消せず、かつ `staged-for-release` の存在こそが develop 統合済みの信頼できるシグナルであることによる。single-branch 構成および promote target=main の文脈では従来どおり `staged-for-release` を holder に維持し、ゼロ差分を保つ。
+
+## Requirements
+
+### Requirement 1: staged-for-release 併存 Issue の holder 除外（dispatch × multi-branch）
+
+**Objective:** As a watcher 運用者, I want dispatch × multi-branch で `staged-for-release` を付与された Issue を他ラベル併存の有無に関わらず holder 集合から除外したい, so that develop 統合済みの Issue が新規 Issue の dispatch を恒久的に阻害しなくなる
+
+補足: 本 Requirement は #221 Requirement 1.4（併存時は holder 維持）を意図的に上書きする。#221 Req 1.4 の挙動を検証する既存テスト fixture は本 Issue により更新される想定であり、それ以外の path-overlap fixture は不変（NFR 1 参照）。
+
+#### Acceptance Criteria
+
+1. When Path Overlap Checker が dispatch base ブランチと promote target ブランチが異なる（multi-branch）文脈で in-flight holder を収集するとき, the Path Overlap Checker shall `staged-for-release` を付与された Issue を、他の holder ラベルの併存有無に関わらず holder 集合から除外する。
+2. When Issue が `staged-for-release` と `ready-for-review` を併存し open のまま multi-branch dispatch 文脈で評価されるとき, the Path Overlap Checker shall 当該 Issue を holder 集合に計上しない。
+3. While `staged-for-release` を付与された Issue が open のまま残っているとき, the dispatcher shall 同一 top-level path を編集する新規 Issue を当該 Issue を理由に awaiting-slot へ落とさない。
+
+### Requirement 2: single-branch / promote 文脈での holder 維持（後方互換）
+
+**Objective:** As a watcher 運用者, I want single-branch 運用と promote target=main の文脈では `staged-for-release` を従来どおり holder に維持したい, so that 本変更が既存の single-branch 運用と promote 判定に差分を与えない
+
+#### Acceptance Criteria
+
+1. When single-branch 構成（dispatch base ブランチと promote target ブランチが同一、main only / 未設定）で dispatch が行われるとき, the Path Overlap Checker shall `staged-for-release` を付与された Issue を holder 集合に維持する。
+2. When path-overlap holder の収集が promote target=main の文脈で行われるとき, the Path Overlap Checker shall `staged-for-release` を付与された Issue を holder 集合に維持する。
+3. When single-branch 構成で dispatch が行われるとき, the Path Overlap Checker shall 本変更導入前と同一の holder 集合および awaiting-slot 判定結果を生成する。
+
+### Requirement 3: dispatch 通常経路と flock-skip 可視化経路の一貫性
+
+**Objective:** As a watcher 運用者, I want dispatch 通常経路と flock-skip 可視化経路とで holder 除外結果を一致させたい, so that どちらの経路でも同じ Issue が同じく holder から除外され awaiting-slot 判定が矛盾しない
+
+#### Acceptance Criteria
+
+1. When flock-skip 可視化経路が multi-branch 文脈で候補を評価するとき, the Path Overlap Checker shall 通常 dispatch 経路と同一の `staged-for-release` 併存 Issue 除外規則を適用する。
+2. The Path Overlap Checker shall 通常 dispatch 経路と flock-skip 可視化経路とで、`staged-for-release` を付与された Issue の holder 計上有無を同一に決定する。
+
+### Requirement 4: コンテキスト / ラベル判定不能時の安全側挙動
+
+**Objective:** As a watcher 運用者, I want ラベル取得やコンテキスト判定が不能なときに holder を維持する安全側へ倒したい, so that 誤って holder から外すことで path 衝突を見逃すリスクを避けられる
+
+#### Acceptance Criteria
+
+1. If Issue の holder 該当ラベル（`staged-for-release` の有無を含む）を取得できず判定不能であるとき, the Path Overlap Checker shall 当該 Issue を holder 集合に維持する。
+2. If 呼び出しコンテキスト（dispatch base / promote target）が判定不能であるとき, the Path Overlap Checker shall `staged-for-release` を付与された Issue を holder 集合に維持する。
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性（ゼロ差分）
+
+1. When `PATH_OVERLAP_CHECK` が off / 未設定 / 不正値であるとき, the Path Overlap Checker shall 本変更導入前と同一の挙動（early return / no-op）を保つ。
+2. The Path Overlap Checker shall `staged-for-release` を付与されていない Issue の holder 計上挙動（`claude-claimed` / `claude-picked-up` / `awaiting-design-review` / `ready-for-review` / `needs-iteration` / `needs-rebase` 単独および併存を含む）を本変更導入前と同一に保つ。
+
+### NFR 2: API 呼び出し回数の不変性
+
+1. The Path Overlap Checker shall in-flight Issue の列挙を 1 サイクルあたり 1 回に保ち、追加の Issue 列挙 API 呼び出しを発生させない。
+2. The Path Overlap Checker shall 各候補 Issue あたりの edit_paths 読み出し API 呼び出し回数を 1 回に保つ。
+3. The Path Overlap Checker shall holder 除外判定に必要なラベル情報を既存の in-flight 列挙 API 呼び出しの結果から取得し、ラベル取得のための追加 API 呼び出しを発生させない。
+
+### NFR 3: 可観測性
+
+1. When multi-branch 文脈で `staged-for-release` を付与された Issue を holder 集合から除外したとき, the Path Overlap Checker shall 当該除外がログから判別可能な形でログ出力する。
+
+## Out of Scope
+
+- promote pipeline 本体の挙動変更
+- gitflow での `ready-for-review` → `staged-for-release` 自動遷移の新設（別 Issue 候補）
+- impl PR merge 検出時に `ready-for-review` → `staged-for-release` へ遷移させる軽量プロセッサの新設（本 Issue の holder 除外だけで実害は解消するため。Open Questions 参照）
+- 新しい env var / フラグの追加（既存の `BASE_BRANCH` / `PROMOTION_TARGET_BRANCH` の 2 変数のみで multi-branch を判定する #221 の設計を踏襲する）
+- `staged-for-release` を誰がどのタイミングで付与するかの運用フローの新設（既存運用を前提とする）
+- #221 Requirement 1.4 の挙動を検証する既存テスト fixture 以外の path-overlap テスト fixture の破壊的変更
+
+## Open Questions
+
+- promote pipeline 無効の gitflow 構成向けに「impl PR merge 検出時に `ready-for-review` → `staged-for-release` へ遷移させる軽量プロセッサ」を提供するか。本 Issue のデフォルト方針は「holder 除外だけで実害（新規 Issue の awaiting-slot 恒久滞留）は解消するため、遷移プロセッサは本 Issue スコープ外（必要なら別 Issue）」とする。ただしラベルのライフサイクルとして、develop merge 後も `ready-for-review` が意味を失ったまま残置する問題は本 Issue 完了後も残る旨を記録する。
+
+## 関連
+
+- Depends on: #221
+- Related: #316 #100 #18 #15

--- a/docs/specs/518-fix-path-overlap-staged-for-release-hold/review-notes.md
+++ b/docs/specs/518-fix-path-overlap-staged-for-release-hold/review-notes.md
@@ -1,0 +1,47 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4.8 timestamp=2026-07-27T01:47:05Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-518-impl-fix-path-overlap-staged-for-release-hold
+- HEAD commit: 715e4fe71cbc788fcd6e329bb72da602030d7eec
+- Compared to: main..HEAD
+- 変更ファイル: `local-watcher/bin/modules/path-overlap.sh` / `local-watcher/test/po_staged_holder_dropfilter_test.sh`（新規）/ `README.md` / spec 成果物（requirements.md, impl-notes.md）
+- 本 Issue は design-less impl（`tasks.md` / `design.md` 不在）。`_Boundary:_` アノテーションは
+  存在しないため、境界は requirements.md の scope（Path Overlap Checker = `path-overlap.sh`）で判定した。
+- CLAUDE.md に `## Feature Flag Protocol` 節（`**採否**:` 行）は存在しない（rules テーブルの
+  参照行のみ）。よって flag 観点は適用せず、通常の 3 カテゴリ判定のみを実施。
+
+## Verified Requirements
+
+- 1.1 — `po_resolve_staged_drop_label`（dispatch×multi-branch のみ `staged-for-release` を返す純粋関数）+ `po_collect_inflight_issues` の post-filter（`drop_staged_label` を持つ Issue を `continue` 除外）。テスト Case 1 + collector Case A（union=README.md のみ）
+- 1.2 — collector Case A: staged+ready 併存 Issue 40 が holders[local-watcher/] に非計上、holders[README.md]=41 のみ
+- 1.3 — dispatch gate 経路への配線（`po_check_dispatch_gate` L896-903 が drop ラベルを collector に注入）。除外により当該 Issue が union から脱落し、既存 overlap 判定で candidate が awaiting-slot に落ちない（Case A の union 除外がその前提を担保）
+- 2.1 — single-branch（BASE=PROMOTION_TARGET）で drop ラベルが空 → filter 無効化 = holder 維持。Case 2/3（空文字返却）
+- 2.2 — promote context では multi-branch でも空文字。Case 4
+- 2.3 — drop なし経路の出力等価（NFR 1 ゼロ差分）。Case B（union に両 path 残置 / 除外ログなし）
+- 3.1 — flock-skip 可視化経路 `po__visibility_evaluate_candidate` L991-997 が通常経路と同一の `po_resolve_staged_drop_label "dispatch"` + collector を呼ぶ配線。除外規則の実体は共有関数（テスト済み Case A）に一元化
+- 3.2 — 両呼び出し元が同一引数 `po_resolve_staged_drop_label "dispatch"` を用い drop 計上有無を同一決定（コード配線 diff で確認）
+- 4.1 — labels 取得不能 Issue は drop せず holder 維持（fail-safe）。Case D（labels キー欠落 Issue 42 が holders[docs/] に残留）
+- 4.2 — context 判定不能（不明値 / 省略）で空文字 = holder 維持。Case 5/6
+- NFR 1.1 — `PATH_OVERLAP_CHECK` gate 早期 return は本差分で不変（drop 解決は gate 有効後にのみ発生）
+- NFR 1.2 — staged 未付与 Issue の holder 計上不変。Case E（staged 不在は drop_label 指定でも全 holder 維持）
+- NFR 2.1 / 2.3 — `--json number` → `--json number,labels` の同一 API 拡張でラベル取得。Case A で `gh issue list` 呼び出しが 1 回のみを assert
+- NFR 2.2 — `po_load_edit_paths` は非 drop Issue 各 1 回（既存ループ構造不変）
+- NFR 3.1 — 除外を issue 単位でログ出力（`holder-set excluded staged issue=#N label=...`）。Case A で issue=#40 / label=staged-for-release を assert
+
+## Findings
+
+なし
+
+## Summary
+
+現行確定 requirements.md の全 AC（Req 1〜4）および NFR を、`path-overlap.sh` の post-filter 追加と
+新規 22 assertion のテストで観測可能にカバー。新規テスト 22 pass / 既存 po 回帰（19 + 10）green、
+`bash -n` / `shellcheck` 警告ゼロを reviewer 側でも再実行し確認。変更は Path Overlap Checker と
+README 同期・spec 成果物に限定され境界逸脱なし。requirements.md Open Questions に記録された
+`ready-for-review` 残置解消 / 遷移プロセッサは明示的に Out of Scope（別 Issue 候補）であり、当該
+impl PR の reject 理由には含めない（設計レベルの還流は別経路の責務）。
+
+RESULT: approve

--- a/local-watcher/bin/modules/path-overlap.sh
+++ b/local-watcher/bin/modules/path-overlap.sh
@@ -264,6 +264,41 @@ po_resolve_holder_labels() {
   return 0
 }
 
+# ─── #518: Staged-for-release Holder Drop Label Resolver (Req 1.1 / 3.1 / 3.2 / 4.2 / NFR 1.1) ───
+# dispatch × multi-branch のときだけ「holder 集合から drop すべきラベル」
+# （= staged-for-release）を返す純粋関数。それ以外（single-branch / promote / 判定不能）は
+# 空文字を返し、「drop しない」= holder 維持（安全側）を意味する。
+#
+# 背景（#221 との関係）: #221 の `po_resolve_holder_labels` は holder ラベル集合から
+# staged-for-release を抜く「クエリ側減算」のみを行う。しかし staged-for-release と他の
+# holder ラベル（例 `ready-for-review`）を併存する Issue は、併存ラベル経由で OR クエリに
+# マッチし、依然 holder として列挙されてしまう。本関数は `po_collect_inflight_issues` の
+# 列挙結果に対する post-filter の drop 対象ラベルを供給し、併存有無に関わらず staged 済み
+# Issue を holder から確実に外す（#518）。
+#
+# 判定条件は `po_resolve_holder_labels` の multi-branch 判定
+# （context=dispatch かつ BASE_BRANCH != PROMOTION_TARGET_BRANCH）と**完全に一致**させること。
+# ハードコード重複を避けるため `${LABEL_STAGED_FOR_RELEASE:-staged-for-release}` を参照する。
+#
+# Args:
+#   $1 = context（"dispatch" | "promote"）
+# Stdout: dispatch×multi-branch のとき staged-for-release ラベル名、それ以外は空文字
+# Return: 0 always（判定不能でも空文字 = drop しない安全側 / Req 4.2）
+po_resolve_staged_drop_label() {
+  local context="${1:-}"
+
+  # dispatch かつ multi-branch（BASE_BRANCH != PROMOTION_TARGET_BRANCH）のみ drop 対象を返す。
+  # 判定条件は po_resolve_holder_labels の multi-branch 判定と完全一致（真理値表 design.md D3）。
+  if [ "$context" = "dispatch" ] && [ "${BASE_BRANCH:-main}" != "${PROMOTION_TARGET_BRANCH:-main}" ]; then
+    printf '%s' "${LABEL_STAGED_FOR_RELEASE:-staged-for-release}"
+    return 0
+  fi
+
+  # single-branch / promote / 判定不能 → 空文字（drop しない = holder 維持 / fail-safe / Req 4.2）
+  printf '%s' ''
+  return 0
+}
+
 # ─── Phase E: Label OR-clause Builder (#221 Req 1.2 / 4.2 / NFR 1.1) ───
 # holder ラベル CSV を `gh issue list --search` 用の OR clause
 # `label:"X" OR label:"Y" OR ...` へ組み立てる。空要素・前後空白は除去し、
@@ -330,9 +365,18 @@ po_build_label_or_clause() {
 # 除外（Req 4.2）: st-failed, awaiting-slot（集合非依存で固定維持）
 # 候補自身を除外（Req 4.3）、同 repo のみ（Req 4.4: --repo "$REPO" 固定）
 #
+# #518 補足: 第 3 引数 drop_staged_label（空文字 = drop しない）を追加。dispatch×multi-branch
+#   では呼び出し側が `staged-for-release` を渡し、列挙結果から当該ラベルを持つ Issue を
+#   holder 集合から落とす（クエリ側減算では併存ラベル経由で残ってしまう Issue を確実に除外）。
+#   `--json number` を `--json number,labels` に拡張して同一 API 呼び出しでラベルを取得する
+#   ため、in-flight 列挙の API 回数は増えない（NFR 2.3）。第 3 引数省略時は drop なし = 完全な
+#   後方互換（single-branch / 既存 2 引数呼び出しは出力等価 / NFR 1）。
+#
 # Args:
 #   $1 = candidate issue number
 #   $2 = holder labels CSV（省略時 default = 現行 7 ラベル集合 / 後方互換 #221 NFR 1.1）
+#   $3 = drop_staged_label（省略時 "" = drop しない / #518。非空なら当該ラベルを持つ Issue を
+#        holder から除外する）
 # Stdout: JSON object `{"union": [...], "holders": {path: [issue#, ...]}}`
 # Return: 0 = 列挙 OK / 1 = gh API 失敗（caller は fail-open で empty 扱い + warn）
 po_collect_inflight_issues() {
@@ -340,6 +384,8 @@ po_collect_inflight_issues() {
   # #221 task 2: holder ラベル集合を第 2 引数で受ける。default は現行 7 ラベル集合に
   # 固定（引数を渡さない既存呼び出し = single-branch 運用は現行クエリと完全一致 / NFR 1.1）。
   local holder_labels="${2:-claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release}"
+  # #518: dispatch×multi-branch で holder から落とす staged ラベル（空文字 = drop しない）。
+  local drop_staged_label="${3:-}"
 
   # 与えられた CSV を `label:"X" OR label:"Y" OR ...` 形式へ動的に組み立てる。
   # `gh issue list --label A --label B` は AND になるため `--search 'label:A OR ...'`
@@ -354,23 +400,43 @@ po_collect_inflight_issues() {
 
   local search_query
   search_query="is:open is:issue (${label_clause}) -label:\"st-failed\" -label:\"awaiting-slot\""
+  # #518: labels も同時取得（追加 API を発生させない / NFR 2.3）。
   local issues_json
   if ! issues_json=$(gh issue list --repo "$REPO" \
       --search "$search_query" \
-      --json number \
+      --json number,labels \
       --limit 50 2>/dev/null); then
     return 1
   fi
 
   # 候補自身を除外（Req 4.3）、各 Issue について po_load_edit_paths を呼んで
   # union（unique 済 path 配列）と holders map（path → [issue#, ...]）を併走更新する。
+  # #518: 各 Issue はオブジェクト単位（jq -c '.[]'）で反復し、`.number` を抽出する。
   local accum
   accum='{"union": [], "holders": {}}'
-  local n
-  while IFS= read -r n; do
+  local issue_obj n
+  while IFS= read -r issue_obj; do
+    [ -z "$issue_obj" ] && continue
+    n=$(printf '%s' "$issue_obj" | jq -r '.number' 2>/dev/null || echo "")
     [ -z "$n" ] && continue
     if [ "$n" = "$candidate" ]; then
       continue
+    fi
+    # #518 post-filter（Req 1.1 / 1.2）: dispatch×multi-branch で staged-for-release を
+    # 付与された Issue は、他 holder ラベルの併存有無に関わらず holder 集合から除外する。
+    # ラベル判定は jq --arg（厳密一致）で行い、外部入力をフィルタ文字列へ inline 展開しない。
+    # fail-safe（Req 4.1）: drop_staged_label が空、または labels 取得不能で判定不能なら
+    # drop しない（= holder に残す安全側。誤って外して path 衝突を見逃すリスクを避ける）。
+    if [ -n "$drop_staged_label" ]; then
+      local has_staged
+      has_staged=$(printf '%s' "$issue_obj" \
+        | jq -r --arg lbl "$drop_staged_label" \
+            '[.labels[].name] | index($lbl) // empty' 2>/dev/null || echo "")
+      if [ -n "$has_staged" ]; then
+        # NFR 3: 除外を single issue 単位で判別可能にログ出力（drop 経路のみ）。
+        po_log "holder-set excluded staged issue=#${n} label=${drop_staged_label}"
+        continue
+      fi
     fi
     local paths
     paths=$(po_load_edit_paths "$n")
@@ -388,7 +454,7 @@ po_collect_inflight_issues() {
           .holders[$p] = ((.holders[$p] // []) + [$holder] | unique)
         )
     ')
-  done < <(echo "$issues_json" | jq -r '.[].number')
+  done < <(echo "$issues_json" | jq -c '.[]')
 
   echo "$accum"
   return 0
@@ -824,11 +890,17 @@ po_check_dispatch_gate() {
     po_log "holder-set context=dispatch excluded=${LABEL_STAGED_FOR_RELEASE:-staged-for-release} base=${BASE_BRANCH:-main}"
   fi
 
+  # #518: dispatch×multi-branch のときだけ holder 列挙結果から staged-for-release を
+  # 併存ラベルの有無に関わらず落とすための drop ラベルを解決する（single-branch / 判定不能
+  # では空文字 = drop なし）。
+  local drop_staged_label
+  drop_staged_label=$(po_resolve_staged_drop_label "dispatch")
+
   # in-flight union + holders map を取得（Req 4.1〜4.4 / 5.3 / 8.1）。
-  # 解決済み holder 集合を注入する（#221 Req 1.1 / 1.3）。
+  # 解決済み holder 集合と drop ラベルを注入する（#221 Req 1.1 / 1.3 / #518 Req 1.1）。
   # 失敗時は fail-open で claim 続行
   local inflight_obj
-  if ! inflight_obj=$(po_collect_inflight_issues "$candidate" "$holder_labels"); then
+  if ! inflight_obj=$(po_collect_inflight_issues "$candidate" "$holder_labels" "$drop_staged_label"); then
     po_warn "issue=#${candidate} in-flight 列挙に失敗、本サイクルは overlap 判定を skip して claim 続行"
     return 0
   fi
@@ -914,10 +986,15 @@ po__visibility_evaluate_candidate() {
   local holder_labels
   holder_labels=$(po_resolve_holder_labels "dispatch")
 
+  # #518 Req 3: 通常 dispatch 経路と同一の staged-for-release 除外規則を適用するため、
+  # dispatch×multi-branch のときだけ drop ラベルを解決する（両経路で除外結果を一致させる）。
+  local drop_staged_label
+  drop_staged_label=$(po_resolve_staged_drop_label "dispatch")
+
   # in-flight union + holders map を read-only で取得（Req 2.3 / 7.1）。失敗時は
   # 当該候補のみ skip して warn 判定へ返す（fail-open / NFR 3.2）。
   local inflight_obj
-  if ! inflight_obj=$(po_collect_inflight_issues "$candidate" "$holder_labels"); then
+  if ! inflight_obj=$(po_collect_inflight_issues "$candidate" "$holder_labels" "$drop_staged_label"); then
     return 1
   fi
   local inflight_paths inflight_holders

--- a/local-watcher/test/po_staged_holder_dropfilter_test.sh
+++ b/local-watcher/test/po_staged_holder_dropfilter_test.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+#
+# 用途: local-watcher/bin/modules/path-overlap.sh の #518 変更を fixture で検証する
+#       スモークテスト。
+#
+#       #221 は dispatch×multi-branch で staged-for-release を holder ラベル集合から
+#       「クエリ側減算」で除外するが、staged-for-release と他 holder ラベル（例
+#       ready-for-review）を併存する Issue は併存ラベル経由でクエリにマッチし依然 holder に
+#       残る。#518 は列挙結果への post-filter で当該 Issue を確実に holder から落とす。
+#
+#       対象関数:
+#         - po_resolve_staged_drop_label（#518 新設 / 純粋関数）
+#         - po_collect_inflight_issues（#518 で第 3 引数 drop_staged_label + post-filter 追加）
+#
+#       検証する AC（docs/specs/518-fix-path-overlap-staged-for-release-hold/requirements.md）:
+#         - Req 1.1 / 1.2: dispatch×multi-branch で staged 併存 Issue を holder から除外
+#         - Req 2.1 / 2.2 / 2.3 / NFR 1: single-branch / promote / drop なしでは holder 維持（ゼロ差分）
+#         - Req 4.1: labels 判定不能な Issue は drop せず holder 維持（fail-safe）
+#         - Req 4.2: コンテキスト判定不能なら drop ラベルは空（holder 維持）
+#         - NFR 3: 除外を single issue 単位で判別可能にログ出力
+#
+#       既存 po_apply_awaiting_slot_test.sh と同じ per-test の awk extract_function +
+#       gh / po_load_edit_paths / po_log stub イディオムを踏襲する。
+#
+# 配置先: local-watcher/test/po_staged_holder_dropfilter_test.sh
+# 依存:   bash 4+, awk, jq
+# 実行:   bash local-watcher/test/po_staged_holder_dropfilter_test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# extract_function / assert_eq / assert_contains を共有ライブラリから source（#474）。
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+PATH_OVERLAP_SH="$SCRIPT_DIR/../bin/modules/path-overlap.sh"
+
+if [ ! -f "$PATH_OVERLAP_SH" ]; then
+  echo "ERROR: cannot find path-overlap.sh at $PATH_OVERLAP_SH" >&2
+  exit 2
+fi
+
+# 対象関数 + 実依存 po_build_label_or_clause を実物で読み込む（extract_function は単一関数を
+# 隔離抽出するため、依存ヘルパーは明示的に読み込む）。gh / po_load_edit_paths / po_log は
+# 後段で stub する。
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PATH_OVERLAP_SH" "po_resolve_staged_drop_label")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PATH_OVERLAP_SH" "po_collect_inflight_issues")"
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$PATH_OVERLAP_SH" "po_build_label_or_clause")"
+
+if ! declare -F po_resolve_staged_drop_label >/dev/null; then
+  echo "ERROR: po_resolve_staged_drop_label not loaded" >&2
+  exit 2
+fi
+if ! declare -F po_collect_inflight_issues >/dev/null; then
+  echo "ERROR: po_collect_inflight_issues not loaded" >&2
+  exit 2
+fi
+if ! declare -F po_build_label_or_clause >/dev/null; then
+  echo "ERROR: po_build_label_or_clause not loaded" >&2
+  exit 2
+fi
+
+# グローバル env（遅延束縛で抽出関数本体から参照される）
+# shellcheck disable=SC2034  # po_collect_inflight_issues が --repo "$REPO" で参照
+REPO="owner/test-repo"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ─── stub 群 ───
+# gh issue list の返す JSON は GH_ISSUE_LIST_JSON で制御。呼び出しは GH_CALL_LOG に記録。
+# po_load_edit_paths は issue 番号ごとに固定の edit_paths を返す。
+# po_log は LOG_LOG に記録して drop ログを観測する。
+
+reset_stub_state() {
+  GH_ISSUE_LIST_JSON="${1:-[]}"
+  GH_CALL_LOG="$(mktemp)"
+  LOG_LOG="$(mktemp)"
+}
+
+cleanup_stub_state() {
+  rm -f "$GH_CALL_LOG" "$LOG_LOG"
+}
+
+# shellcheck disable=SC2317  # 対象関数から間接的に呼ばれる stub
+gh() {
+  local sub="${1:-}" sub2="${2:-}"
+  case "$sub" in
+    issue)
+      case "$sub2" in
+        list)
+          echo "gh issue list $*" >>"$GH_CALL_LOG"
+          if [ "${GH_LIST_RC:-0}" -ne 0 ]; then
+            return "${GH_LIST_RC}"
+          fi
+          printf '%s' "${GH_ISSUE_LIST_JSON}"
+          return 0
+          ;;
+        *)
+          echo "gh issue $* (unhandled)" >>"$GH_CALL_LOG"
+          return 0
+          ;;
+      esac
+      ;;
+    *)
+      echo "gh $* (unhandled)" >>"$GH_CALL_LOG"
+      return 0
+      ;;
+  esac
+}
+
+# shellcheck disable=SC2317  # 対象関数から間接的に呼ばれる stub
+po_load_edit_paths() {
+  case "$1" in
+    40) echo '["local-watcher/"]' ;;
+    41) echo '["README.md"]' ;;
+    42) echo '["docs/"]' ;;
+    99) echo '["candidate-only/"]' ;;
+    *) echo '[]' ;;
+  esac
+}
+
+# shellcheck disable=SC2317  # 対象関数から間接的に呼ばれる stub
+po_log() { echo "$*" >>"$LOG_LOG"; }
+
+# union 配列を sort 済み CSV で取り出すヘルパー
+union_csv() {
+  printf '%s' "$1" | jq -r '.union | sort | join(",")' 2>/dev/null || echo "PARSE_ERR"
+}
+# 指定 path の holders を sort 済み CSV で取り出すヘルパー
+holders_csv() {
+  printf '%s' "$1" | jq -r --arg p "$2" '(.holders[$p] // []) | sort | join(",")' 2>/dev/null || echo "PARSE_ERR"
+}
+
+echo "--- po_resolve_staged_drop_label（純粋関数 / Req 1.1 / 3.1 / 4.2 / NFR 1.1） ---"
+
+# Case 1: dispatch×multi-branch（BASE_BRANCH=develop / PROMOTION_TARGET_BRANCH=main）→ staged-for-release
+actual=$(BASE_BRANCH="develop" PROMOTION_TARGET_BRANCH="main" po_resolve_staged_drop_label "dispatch")
+assert_eq "Req 1.1: dispatch×multi-branch は staged-for-release を drop 対象に返す" \
+  "staged-for-release" "$actual"
+
+# Case 2: single-branch（両方 main）→ 空文字（drop しない / NFR 1.1）
+actual=$(BASE_BRANCH="main" PROMOTION_TARGET_BRANCH="main" po_resolve_staged_drop_label "dispatch")
+assert_eq "NFR 1.1: single-branch（main/main）は空文字（drop しない）" "" "$actual"
+
+# Case 3: single-branch（両方未設定 → :-main で main/main）→ 空文字
+actual=$(unset BASE_BRANCH PROMOTION_TARGET_BRANCH; po_resolve_staged_drop_label "dispatch")
+assert_eq "NFR 1.1: branch 未設定（default main/main）は空文字" "" "$actual"
+
+# Case 4: promote context（multi-branch でも）→ 空文字（Req 2 / holder 維持）
+actual=$(BASE_BRANCH="develop" PROMOTION_TARGET_BRANCH="main" po_resolve_staged_drop_label "promote")
+assert_eq "Req 2: promote context は multi-branch でも空文字（holder 維持）" "" "$actual"
+
+# Case 5: 不明 context → 空文字（Req 4.2 / fail-safe）
+actual=$(BASE_BRANCH="develop" PROMOTION_TARGET_BRANCH="main" po_resolve_staged_drop_label "garbage")
+assert_eq "Req 4.2: 不明 context は空文字（fail-safe / holder 維持）" "" "$actual"
+
+# Case 6: context 引数省略 → 空文字（Req 4.2）
+actual=$(BASE_BRANCH="develop" PROMOTION_TARGET_BRANCH="main" po_resolve_staged_drop_label)
+assert_eq "Req 4.2: context 省略は空文字（fail-safe）" "" "$actual"
+
+# Case 7: LABEL_STAGED_FOR_RELEASE override を尊重する
+actual=$(BASE_BRANCH="develop" PROMOTION_TARGET_BRANCH="main" LABEL_STAGED_FOR_RELEASE="sfr-custom" po_resolve_staged_drop_label "dispatch")
+assert_eq "override: LABEL_STAGED_FOR_RELEASE の override を尊重する" "sfr-custom" "$actual"
+
+echo ""
+echo "--- po_collect_inflight_issues の drop 挙動（副作用関数 / Req 1.1 / 1.2 / 4.1 / NFR 1 / NFR 3） ---"
+
+# 共通 fixture: issue 40（staged + ready 併存, path=local-watcher/）,
+#               issue 41（claude-claimed のみ, path=README.md）
+LIST_STAGED_COEXIST='[
+  {"number":40,"labels":[{"name":"staged-for-release"},{"name":"ready-for-review"}]},
+  {"number":41,"labels":[{"name":"claude-claimed"}]}
+]'
+
+# ── Case A: drop_label 指定 → staged 併存 Issue 40 が union / holders から除外される（Req 1.1 / 1.2） ──
+reset_stub_state "$LIST_STAGED_COEXIST"
+out=$(po_collect_inflight_issues 99 "claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase" "staged-for-release")
+assert_eq "Req 1.1: staged 併存 Issue 除外後の union は README.md のみ" \
+  "README.md" "$(union_csv "$out")"
+assert_eq "Req 1.2: 除外された Issue 40 は holders[local-watcher/] に計上されない" \
+  "" "$(holders_csv "$out" "local-watcher/")"
+assert_eq "Req 1.2: 残った Issue 41 は holders[README.md] に計上される" \
+  "41" "$(holders_csv "$out" "README.md")"
+# NFR 3: 除外ログが single issue 単位で出る
+log_out="$(cat "$LOG_LOG")"
+assert_contains "NFR 3: 除外ログに issue=#40 が含まれる" "$log_out" "issue=#40"
+assert_contains "NFR 3: 除外ログに label=staged-for-release が含まれる" "$log_out" "label=staged-for-release"
+# NFR 2.3: gh issue list は 1 回のみ（追加 API を発生させない）
+list_count=$( { grep -c "gh issue list" "$GH_CALL_LOG" 2>/dev/null || true; } )
+assert_eq "NFR 2.3: gh issue list は 1 回のみ" "1" "$list_count"
+cleanup_stub_state
+
+# ── Case B: drop_label 空（第 3 引数省略）→ staged 併存 Issue 40 が従来どおり holder 計上（NFR 1） ──
+reset_stub_state "$LIST_STAGED_COEXIST"
+out=$(po_collect_inflight_issues 99 "claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release")
+assert_eq "NFR 1: drop なしでは union に local-watcher/ と README.md の両方が残る" \
+  "README.md,local-watcher/" "$(union_csv "$out")"
+assert_eq "NFR 1: drop なしでは Issue 40 が holders[local-watcher/] に計上される" \
+  "40" "$(holders_csv "$out" "local-watcher/")"
+# drop なし経路では除外ログを出さない（single-branch ゼロ差分）
+log_out="$(cat "$LOG_LOG")"
+assert_eq "NFR 1: drop なし経路では除外ログを出さない" "" "$log_out"
+cleanup_stub_state
+
+# ── Case C: 候補自身が引き続き除外される（Req 4.3 相当 / 既存挙動維持） ──
+LIST_WITH_CANDIDATE='[
+  {"number":99,"labels":[{"name":"claude-claimed"}]},
+  {"number":41,"labels":[{"name":"claude-claimed"}]}
+]'
+reset_stub_state "$LIST_WITH_CANDIDATE"
+out=$(po_collect_inflight_issues 99 "claude-claimed" "staged-for-release")
+assert_eq "候補自身 99 は除外され union は README.md のみ（candidate-only/ を含まない）" \
+  "README.md" "$(union_csv "$out")"
+cleanup_stub_state
+
+# ── Case D: fail-safe — labels 判定不能（labels キー欠落）Issue は drop されず holder に残る（Req 4.1） ──
+LIST_LABELS_MISSING='[
+  {"number":42},
+  {"number":41,"labels":[{"name":"claude-claimed"}]}
+]'
+reset_stub_state "$LIST_LABELS_MISSING"
+out=$(po_collect_inflight_issues 99 "claude-claimed" "staged-for-release")
+assert_eq "Req 4.1: labels 欠落の Issue 42 は drop されず holders[docs/] に残る" \
+  "42" "$(holders_csv "$out" "docs/")"
+assert_eq "Req 4.1: union には docs/ と README.md の両方が残る" \
+  "README.md,docs/" "$(union_csv "$out")"
+# 判定不能で drop していないため除外ログは出さない
+log_out="$(cat "$LOG_LOG")"
+assert_eq "Req 4.1: 判定不能では除外ログを出さない" "" "$log_out"
+cleanup_stub_state
+
+# ── Case E: drop_label 指定でも staged を持たない Issue は holder 維持（NFR 1.2） ──
+LIST_NO_STAGED='[
+  {"number":40,"labels":[{"name":"ready-for-review"}]},
+  {"number":41,"labels":[{"name":"claude-claimed"}]}
+]'
+reset_stub_state "$LIST_NO_STAGED"
+out=$(po_collect_inflight_issues 99 "ready-for-review,claude-claimed" "staged-for-release")
+assert_eq "NFR 1.2: staged を持たない Issue は drop_label 指定でも全て holder に残る" \
+  "README.md,local-watcher/" "$(union_csv "$out")"
+log_out="$(cat "$LOG_LOG")"
+assert_eq "NFR 1.2: staged 不在では除外ログを出さない" "" "$log_out"
+cleanup_stub_state
+
+echo ""
+echo "==========================================="
+echo "PASS: $PASS_COUNT, FAIL: $FAIL_COUNT"
+echo "==========================================="
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Path Overlap Checker（`path-overlap.sh`）の dispatch × multi-branch 文脈において、`staged-for-release`
を付与された Issue が他の holder ラベル（例: `ready-for-review`）と**併存する場合でも holder 集合から除外**されない
バグを修正する。

gitflow + promote pipeline 無効の構成では `ready-for-review` の除去処理が promote-pipeline 側にしか
存在しないため、develop merge 後も `ready-for-release` が残置し続ける。この残置と `staged-for-release`
の併存が原因で、同一 top-level path を編集する新規 Issue が毎 tick `awaiting-slot` へ落ち、数日〜恒久的に
dispatch がブロックされる事象が発生していた。

`po_collect_inflight_issues` に post-filter を追加し、`staged-for-release` 付きの Issue をクエリ結果から
除外する純粋関数 `po_resolve_staged_drop_label` を新設することで修正する。single-branch / promote 文脈では
従来どおり holder を維持し、後方互換性を保つ。

## 対応 Issue

Closes #518

## 関連 PR

なし（design-less impl）

## 実装内容

- (Req 1) `po_resolve_staged_drop_label` 新設: dispatch×multi-branch のみ `staged-for-release` を返す純粋関数。`BASE_BRANCH != PROMOTION_TARGET_BRANCH` 判定は既存 `po_resolve_holder_labels` と同一条件。
- (Req 1.2 / Req 3) `po_collect_inflight_issues`: 第 3 引数 `drop_staged_label` を追加。`--json number` → `--json number,labels` 拡張（同一 API 呼び出し 1 回、NFR 2.1/2.3）。ループ内で drop ラベルを持つ Issue を `continue` で除外し、NFR 3 ログ出力。
- (Req 3) `po_check_dispatch_gate` / `po__visibility_evaluate_candidate` の両経路: `po_resolve_staged_drop_label "dispatch"` で同一の drop ラベルを解決・注入し、通常経路と flock-skip 可視化経路の一貫性を保証。
- (Req 4) fail-safe: labels 取得不能 / context 判定不能の場合は空文字返却 → drop なし = holder 維持（安全側）。
- `README.md`: 「holder ラベル集合の base 相対化（#221）」節および関連ログ出力節に #518 精緻化を追記。
- `local-watcher/test/po_staged_holder_dropfilter_test.sh`（新規 / 22 assertions）追加。

## 受入基準チェック

- [x] Req 1.1: dispatch×multi-branch で staged Issue を併存有無に関わらず除外 ← `po_resolve_staged_drop_label` Case 1 + collector Case A
- [x] Req 1.2: staged+ready 併存 Issue が holder に非計上 ← collector Case A（holders[local-watcher/] 未計上）
- [x] Req 1.3: 当該 Issue を理由に awaiting-slot に落ちない ← Case A で union 脱落
- [x] Req 2.1: single-branch では staged を holder 維持 ← Case 2/3（空文字返却）
- [x] Req 2.2: promote context でも staged を holder 維持 ← Case 4（空文字返却）
- [x] Req 2.3: single-branch でゼロ差分 ← collector Case B
- [x] Req 3.1 / 3.2: 両経路で同一除外規則 ← 両呼び出し元が同一 `po_resolve_staged_drop_label "dispatch"` を使用
- [x] Req 4.1: labels 取得不能時は holder 維持 ← collector Case D
- [x] Req 4.2: context 判定不能時は holder 維持 ← Case 5/6
- [x] NFR 1.1: PATH_OVERLAP_CHECK off は early return 不変
- [x] NFR 1.2: staged 未付与 Issue の holder 計上不変 ← Case E
- [x] NFR 2.1 / 2.3: API 呼び出し 1 回 / ラベル追加 API なし ← Case A で assert
- [x] NFR 3.1: 除外ログ出力 ← Case A（`holder-set excluded staged issue=#40 label=staged-for-release`）

## テスト結果

```
新規テスト: bash local-watcher/test/po_staged_holder_dropfilter_test.sh
→ PASS 22 / FAIL 0

既存回帰テスト:
  po_apply_awaiting_slot_test.sh      : 19 pass
  po_sticky_comment_helpers_test.sh   : 10 pass
  repo_prefix_log_test.sh             : 36 pass
全 green

静的解析:
  bash -n local-watcher/bin/modules/path-overlap.sh  : OK
  shellcheck path-overlap.sh / po_staged_holder_dropfilter_test.sh : 警告ゼロ
```

## 実装上の判断

- #221 Req 1.4（`staged-for-release` 併存時は holder 維持）を意図的に上書き。根拠: gitflow + promote 無効では `ready-for-review` 残置が構造的に発生するため、併存を holder 維持条件にしても実害が解消しない。`staged-for-release` の存在が develop 統合済みの信頼できるシグナルである。
- `--json number,labels` への同一 API 拡張（追加 API 呼び出しゼロ、NFR 2.1/2.3 準拠）。
- 未信頼入力の jq 扱い: `--arg` 経由の厳密一致で inline 展開を回避（#318 規約準拠）。
- `repo-template/` 配下に `path-overlap.sh` 複製がないため repo-template 同期は不要（確認済み）。

詳細は `docs/specs/518-fix-path-overlap-staged-for-release-hold/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- **requirements.md Open Questions（遷移プロセッサ）**: gitflow + promote 無効構成での `ready-for-review` 残置は本 PR 完了後も残る（本変更は holder 除外で実害を解消するが、ラベルライフサイクル上の残置自体は解消しない）。別 Issue として対応予定。
- **#221 Req 1.4 の上書き**: 意図的な上書き。既存 fixture への破壊的変更は発生していない（`po_collect_inflight_issues` を直接検証するテストは本 PR で新設した `po_staged_holder_dropfilter_test.sh` が初）。
- Reviewer notes: `docs/specs/518-fix-path-overlap-staged-for-release-hold/review-notes.md` 参照（RESULT: approve）
- base: main / baseRefName: main / OK（PR 作成後に検証済み）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #518 のコメントを参照してください。
