### PR TITLE
fix(#520): 無保持残存 lock file をセッション生存と誤判定し孤児 pickup を永久回収しない問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -4971,12 +4971,18 @@ Failed Recovery が Issue 単位の通算 attempt budget を持つのに対し�
    `flock -n -x` を試行し、いずれの slot も保持されていない（保持されている slot が 1 つでも
    あれば「アクティブの可能性あり」へ倒す）
 3. **watcher セッション不在**: slot ロックを保持していた pid を `fuser` / `lsof` で取得し、
-   `kill -0 <pid>` で現存確認。pid 取得不能 / OS 差で観測手段が無い場合は「セッション存在の
-   可能性あり」へ倒す（保守的 fallback）
+   `kill -0 <pid>` で現存確認。観測手段（`fuser` / `lsof`）が **利用可能で保持者を検出しない**
+   場合は「セッションなし」と判定します（flock 方式の lock file は保持プロセスが死んでも
+   ディスクに残るため、この状態はまさに回収対象の孤児です / #520）。**safe-side fallback は
+   観測手段（`fuser` / `lsof`）自体が不在のときに限定** し、その場合のみ「セッション存在の
+   可能性あり」へ倒します
 
-**判定根拠取得失敗時は「アクティブの可能性あり」へ倒す** 保守的 fallback を全関数で徹底し、
-誤検出による進行中作業の喪失を構造的に防ぎます（Req 3.4）。判定根拠（age / lock / session）は
-`stale-pickup:` prefix の 1 行ログで watcher ログへ記録されます（Req 3.5 / NFR 4.1, 4.2）。
+**観測手段が不在のときのみ「アクティブの可能性あり」へ倒す** safe-side fallback を徹底し、
+誤検出による進行中作業の喪失を構造的に防ぎます（#379 Req 3.4 の適用範囲を #520 で限定）。
+判定根拠（age / lock / session）は `stale-pickup:` prefix の 1 行ログで watcher ログへ記録され、
+セッション判定理由（`holder-alive` / `no-holder` / `tool-absent` / `no-lockfile`）は既存の
+`sess=N` フィールドを保ったまま `sess_reason=<token>` として同ログに追記されます
+（Req 3.5 / NFR 4.1, 4.2 / #520 Req 4.2〜4.4）。
 
 ### 復旧アクション
 

--- a/docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/impl-notes.md
+++ b/docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/impl-notes.md
@@ -1,0 +1,80 @@
+# 実装ノート（#520 / Stale Pickup Reaper セッション判定の誤 safe-side 修正）
+
+## 概要
+
+`sr_check_session`（`local-watcher/bin/modules/stale-pickup-reaper.sh`）のセッション存在
+判定を修正した。従来は「観測手段（fuser/lsof）が利用可能でありながら保持者を 1 件も返さない」
+状態を根拠取得失敗として safe-side（`sess=1`）に倒していたため、flock 方式の残存 lock file が
+1 度でも残ると reaper が当該 repo で永久に機能しなかった（feedman#223 / #234）。
+
+本修正で当該状態を「保持者が既に死んでいる = 孤児」寄り（`sess=0`）に扱い、safe-side
+fallback は「観測手段（fuser/lsof）自体が不在」のときに限定した（#379 Req 3.4 の適用範囲修正）。
+
+## 実装方式（判定マトリクス）
+
+`sr_check_session` の分岐（`stale-pickup-reaper.sh:sr_check_session`）:
+
+- lock file 不在 → `return 0`（reason=`no-lockfile`）
+- fuser/lsof 双方不在 → `return 1`（reason=`tool-absent` / safe-side 維持）
+- ツール利用可能で全 lock file を走査:
+  - 保持者問い合わせが空 → 早期 return せず次 lock file へ継続（**修正核心**。旧 `return 1` を撤去）
+  - 生存 pid を 1 件でも検出 → `return 1`（reason=`holder-alive`）
+  - 取得 pid が全て非生存 → 継続
+  - 走査完了で生存保持者なし → `return 0`（reason=`no-holder`）
+
+判定理由は新規グローバル `SR_SESSION_REASON` に surface し、`sr_is_active` が既存 `sess=N` の
+直後に `sess_reason=<token>` を **別フィールド**として 1 行ログに追記する（既存 `age`/`lock`/`sess`
+のフィールド名・形式は不変 / NFR 3.3）。`sess=N` を機械パースする箇所は本テストの
+`grep -qE 'age=[0-9]+ lock=[0-9]+ sess=[0-9]+'` のみで、末尾追記により非破壊であることを確認済み。
+
+## AC トレーサビリティ（1 要件 1 行）
+
+| AC | 担保テスト（`local-watcher/test/sr_activity_check_test.sh`） |
+|---|---|
+| Req 1.1 | 10d（空 fuser → rc=0）/ 10f（累積で無保持を継続） |
+| Req 1.2 | 10c（非生存 pid → rc=0 / pid_max により当環境 skip、Section 11 で AND 側担保）+ 10d |
+| Req 1.3 | 10a（lock file 不在 → rc=0 / reason=no-lockfile） |
+| Req 2.1 | 10b（生存 pid → rc=1 / reason=holder-alive） |
+| Req 2.2 | 10f（無保持 + 生存保持者の複数 lock file → rc=1） |
+| Req 3.1 | 10e（binary 実在時 skip）+ 10g（PATH 空で決定論的に rc=1 / tool-absent） |
+| Req 3.2 | 10g（tool-absent 経路のみ safe-side）/ Section 10d が no-holder を safe-side 除外 |
+| Req 4.1 | Section 11（`age=N lock=N sess=N` 形式維持）+ 10h（sess=N 保持） |
+| Req 4.2 | 10b + 10h（sess_reason=holder-alive をログ追記） |
+| Req 4.3 | 10d + 10h（sess_reason=no-holder をログ追記） |
+| Req 4.4 | 10g + 10h（sess_reason=tool-absent をログ追記） |
+| Req 5.1 | Section 11 全 0 → inactive（3 観点 AND）/ 既存 `sr_recovery_action_test.sh` Section 13 |
+| Req 5.2 | Section 10d/10f が「無保持 lock file の存在のみで固定しない」を担保 |
+| Req 6.1 | 10d（無保持残存 lock file fixture → sess=0） |
+| Req 6.2 | 10b（実プロセス保持中 → sess=1） |
+| Req 6.3 | 10d（Section 10d 期待値を rc=1→rc=0 へ反転 / テスト内コメントで #520 明示） |
+| NFR 1.1 | Section 11 の 8 通り AND（生存保持者・fresh・lock 保持で keep=誤回収ゼロ） |
+| NFR 2 | fuser/lsof 双方が同一下流ロジック（空→継続 / pid→kill -0）を通る構造で同一判定 |
+| NFR 3.1〜3.3 | marker_age/slot_lock/AND 契約・env/label/prefix/フィールド名を不変（本修正は session のみ） |
+| NFR 4.1 | `bash -n` / `shellcheck` クリア（下記） |
+| NFR 4.2 | README「アクティブセッション判定」節を safe-side 限定の語義へ更新 |
+
+## 検証結果（サマリ）
+
+- `bash -n local-watcher/bin/modules/stale-pickup-reaper.sh` → OK
+- `bash -n local-watcher/test/sr_activity_check_test.sh` → OK
+- `shellcheck local-watcher/bin/modules/stale-pickup-reaper.sh` → 警告ゼロ（.shellcheckrc baseline 尊重）
+- `sr_activity_check_test.sh` → PASS=40 FAIL=0
+- `sr_recovery_action_test.sh` → PASS=40 FAIL=0
+- `sr_wiring_test.sh` → PASS=61 FAIL=0
+- `sr_marker_state_test.sh` → PASS=64 FAIL=0
+- `diff -r .claude/agents repo-template/.claude/agents` → 空（未変更）
+- `diff -r .claude/rules repo-template/.claude/rules` → 空（未変更）
+
+## 環境依存の skip（既存挙動 / 本修正前と同一）
+
+- 10c: `pid_max=4194304 > 99999` のため大値 pid の不在保証不可で skip。全 pid 非生存経路は
+  Section 11 の AND 判定で担保。
+- 10e: fuser/lsof binary が当環境に実在するため関数 stub 経路を構成できず skip（既存仕様）。
+  tool-absent 経路は 10g（PATH 空サブシェル）で全環境決定論的に担保するよう追加した。
+
+## 確認事項
+
+- なし。requirements.md（唯一の正準ソース）と矛盾なく実装できた。design.md / tasks.md は
+  本 spec dir に存在せず（バグ修正のため Architect 不介在）、単一実装パスで完了した。
+
+STATUS: complete

--- a/docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/requirements.md
+++ b/docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/requirements.md
@@ -1,0 +1,125 @@
+# Requirements Document
+
+## Introduction
+
+Stale Pickup Reaper（#379）は、watcher セッションの異常終了で `claude-picked-up` /
+`claude-claimed` ラベルが取り残された孤児 Issue を、3 観点（marker 経過時間 / slot ロック非保持 /
+セッション不在）の AND 判定で「非アクティブ」と確定した場合にのみ `auto-dev` へ自動復帰させる。
+しかし、セッション不在判定（本書では `sess` 値と呼ぶ）に構造的な誤りがあり、`STALE_PICKUP_REAPER_ENABLED=true`
+を有効化しても孤児が回収されない事象が feedman 運用で 2 回発生した（feedman#223 / feedman#234）。
+
+原因は、slot lock file の保持プロセスを問い合わせる手段（`fuser` / `lsof` 等）が **利用可能でありながら
+保持プロセスを 1 件も返さない**（＝保持者が既に死んでいる）状態を、根拠取得失敗として safe-side
+（セッションの可能性あり = `sess=1`）に倒していた点にある。flock 方式の lock file は保持プロセスが死んでも
+ファイル自体はディスクに残るため、「file 存在 + 保持者なし」はまさに検出したい「孤児」状態そのものである。
+これを生存扱いにするため、一度でも lock file が残ると reaper は当該 repo で永久に機能しなくなる。
+
+本修正は、#379 の Req 3.4（根拠取得失敗時の safe-side fallback）の意図を「保持プロセス問い合わせ手段が
+**不在**のときのみ safe-side」に限定・修正し、「手段は利用可能だが保持者が検出されない」ケースを
+「セッションなし（`sess=0`）」と正しく判定させる。生存中セッションの誤回収ゼロは引き続き最優先で維持する。
+
+## Requirements
+
+### Requirement 1: 無保持の残存 lock file をセッションなしと判定する
+
+**Objective:** As a idd-claude 運用者, I want 保持プロセスが存在しない残存 lock file を「セッションなし」と判定させる, so that 一度残存した lock file が原因で孤児 pickup が永久に回収されなくなる状態を解消できる
+
+#### Acceptance Criteria
+
+1. When 対象 repo の slot lock file が存在し、保持プロセス問い合わせ手段（`fuser` / `lsof` 等）が利用可能で、当該 lock file を保持しているプロセスが 1 件も検出されない, the Stale Pickup Reaper shall セッション存在判定を `sess=0`（セッションなし）とする
+2. When slot lock file が存在し、保持プロセスの pid を取得したが取得した pid がすべて非生存（生存確認に失敗）である, the Stale Pickup Reaper shall セッション存在判定を `sess=0`（セッションなし）とする
+3. When 対象 repo の slot lock file が 1 つも存在しない, the Stale Pickup Reaper shall セッション存在判定を `sess=0`（セッションなし）とする
+
+### Requirement 2: 生存セッションの保護（誤回収ゼロ維持）
+
+**Objective:** As a idd-claude 運用者, I want 実際に処理中のセッションが保持する lock file を「セッションあり」と判定させ続ける, so that 進行中作業の pickup ラベルが誤って剥がされる二重処理・branch 競合を防げる
+
+#### Acceptance Criteria
+
+1. When slot lock file が存在し、当該 lock file を保持している生存プロセスが 1 件以上検出される, the Stale Pickup Reaper shall セッション存在判定を `sess=1`（セッションの可能性あり）とする
+2. While 複数の slot lock file が存在する, when いずれか 1 つでも生存する保持プロセスが検出される, the Stale Pickup Reaper shall セッション存在判定を `sess=1` とし、他 slot が無保持であっても `sess=0` へ倒さない
+
+### Requirement 3: 問い合わせ手段不在時の safe-side fallback の限定
+
+**Objective:** As a idd-claude 運用者, I want 保持プロセスを観測する手段自体が使えない環境でのみ安全側に倒させる, so that #379 Req 3.4 の保守的 fallback を維持しつつ、その適用範囲を過剰に広げない
+
+#### Acceptance Criteria
+
+1. If slot lock file は存在するが保持プロセスを問い合わせる手段（`fuser` / `lsof` 等）がいずれも利用できない, the Stale Pickup Reaper shall セッション存在判定を `sess=1`（セッションの可能性あり）として safe-side に倒す
+2. The Stale Pickup Reaper shall #379 Req 3.4（根拠取得失敗時の safe-side fallback）の適用範囲を「保持プロセス問い合わせ手段が不在のとき」に限定し、「手段は利用可能だが保持プロセスが検出されないとき」を safe-side 扱いから除外する
+
+### Requirement 4: セッション判定理由のログ判別可能性
+
+**Objective:** As a idd-claude 運用者, I want `sess` 値がどの根拠で決まったかをログから区別できるようにする, so that 「保持者あり」「保持者なし」「ツール不在」のどれで判定が確定したかを事後調査で切り分けられる
+
+#### Acceptance Criteria
+
+1. The Stale Pickup Reaper shall 判定根拠ログにおいて既存の `age` / `lock` / `sess` の各フィールド形式を維持する
+2. When 生存する保持プロセスを検出して `sess=1` と判定した, the Stale Pickup Reaper shall その判定理由が「保持 pid あり」であるとログから判別できる形で記録する
+3. When 保持プロセスが検出されず `sess=0` と判定した, the Stale Pickup Reaper shall その判定理由が「保持者なし」であるとログから判別できる形で記録する
+4. When 問い合わせ手段の不在により `sess=1` と判定した, the Stale Pickup Reaper shall その判定理由が「ツール不在」であるとログから判別できる形で記録する
+
+### Requirement 5: 孤児 pickup の自動回収（到達ゴール）
+
+**Objective:** As a idd-claude 運用者, I want 閾値を超過した無保持の孤児 Issue が自動回収されるようにする, so that GitHub API rate limit 等でラベル除去に失敗した Issue を人間の手動復旧なしで復帰できる
+
+#### Acceptance Criteria
+
+1. When 孤児 Issue に対し「marker 経過時間が閾値超」「対応 slot ロック非保持」「セッション存在判定 `sess=0`」の 3 観点がすべて成立する, the Stale Pickup Reaper shall 当該 Issue を非アクティブと確定し復旧アクション（pickup 系ラベル除去 → `auto-dev` 復帰）へ進む
+2. While 無保持の残存 lock file がディスク上に残っている, the Stale Pickup Reaper shall 当該 lock file の存在のみを理由に閾値超過の孤児 Issue を回収対象外へ固定しない
+
+### Requirement 6: 回帰防止テスト
+
+**Objective:** As a idd-claude メンテナ, I want 誤判定の再現条件と正常系の双方をテストで固定する, so that 本修正の効果を検証しつつ将来の退行を防止できる
+
+#### Acceptance Criteria
+
+1. The Stale Pickup Reaper のテスト shall 無保持の残存 lock file（保持プロセス問い合わせ手段が利用可能かつ保持者なし）を再現する fixture を備え、セッション存在判定が `sess=0` になることを検証する
+2. The Stale Pickup Reaper のテスト shall 実プロセスが lock file を保持中の正常系 fixture を備え、セッション存在判定が `sess=1` になることを検証する
+3. The Stale Pickup Reaper のテスト shall 既存 Section 10d（空の保持者問い合わせ結果に対して従来 `sess=1`（rc=1）を固定していたケース）の期待値を `sess=0`（rc=0）へ反転し、当該反転が本修正による意図的な期待値変更であることをテスト内コメントで明示する
+
+## Non-Functional Requirements
+
+### NFR 1: 誤回収ゼロの維持（安全性）
+
+1. The Stale Pickup Reaper shall 生存中の watcher / claude セッションが保持する pickup 系ラベルを本修正の前後で 1 件も誤って除去しない（誤回収件数 = 0 を維持する）
+
+### NFR 2: OS 間の判定同一性
+
+1. The Stale Pickup Reaper shall Linux（`fuser` 経路）と macOS（`lsof` 経路）とで、同一の lock file 保持状態に対し同一のセッション存在判定結果（`sess` 値）を返す
+
+### NFR 3: 後方互換性
+
+1. The Stale Pickup Reaper shall 既存の 3 観点 AND 判定契約（marker 経過時間 / slot ロック非保持 / セッション不在が全て「非アクティブ」のときのみ非アクティブ確定）を変更しない
+2. The Stale Pickup Reaper shall marker 経過時間判定と slot ロック保持判定の観測挙動を変更せず、本修正の対象をセッション存在判定に限定する
+3. The Stale Pickup Reaper shall 既存 env var 名 / ラベル名 / ログ prefix（`stale-pickup:`）/ 判定フィールド名（`age` / `lock` / `sess`）を変更しない
+
+### NFR 4: 静的解析とドキュメント同期
+
+1. The Stale Pickup Reaper 配布物 shall `shellcheck` を警告ゼロ、`bash -n` をエラーなしでクリアする
+2. The Stale Pickup Reaper 配布物 shall セッション判定の safe-side 適用範囲の限定（「ツール不在時のみ safe-side」）を README の該当記述と整合させる
+
+## Traceability
+
+- 元機能: #379（`docs/specs/379-feat-watcher-claude-picked-up-issue-reap/`）。本 Issue は #379 Req 3.4（根拠取得失敗時の safe-side fallback）の適用範囲を「問い合わせ手段の不在時」に限定・修正する位置づけ。
+- 対象挙動: #379 Req 3.1 観点 3（セッション存在判定）/ Req 3.4（safe-side fallback）。
+- 既存テスト: `local-watcher/test/sr_activity_check_test.sh` Section 10（Requirement 6 AC3 が Section 10d の期待値を反転する）。
+- 実運用トリガ: feedman#223（2026-07-27）/ feedman#234（2026-07-29）の孤児化 2 事例。
+
+## Out of Scope
+
+- resumable return 時の `claude-picked-up` 除去リトライ強化（別 Issue へ分割可）
+- GitHub API rate limit 対策そのもの
+- marker 経過時間判定・slot ロック保持判定のロジック変更（本修正はセッション存在判定のみを対象）
+- 3 観点 AND 判定の観点追加 / 削除 / 重み変更
+- watcher セッションのプロセス監視・自動再起動・ヘルスチェック機構
+- 修正すべきコード行の指定・内部関数構成・関数シグネチャの決定（Architect / Developer の責務）
+- 判定根拠ログの全面フォーマット再設計（既存 `age` / `lock` / `sess` 形式を保つ範囲での判定理由付加に限定）
+
+## Open Questions
+
+- なし（Issue 本文が唯一の正準ソース。Issue コメントには bot の起動通知のみで人間の追加決定事項はない）
+
+## 関連
+
+- Related: #379

--- a/docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/review-notes.md
+++ b/docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/review-notes.md
@@ -1,0 +1,46 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-29T03:02:08Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-520-impl-fix-stale-pickup-reaper-lock-file-pickup
+- HEAD commit: 178d25cf7e2eebe51191541b15c523a37f9ee551
+- Compared to: main..HEAD
+
+## Verified Requirements
+
+- 1.1 — `sr_check_session`: 空 `pids` 時に旧 `return 1` を撤去し `continue`→`no-holder`→`return 0`（`stale-pickup-reaper.sh:516-521,537-540`）。テスト 10d（空 fuser 出力 → rc=0）
+- 1.2 — 取得 pid が全て非生存時に kill -0 ループ通過後 `no-holder`→`return 0`（`stale-pickup-reaper.sh:524-540`。#520 前から保存された挙動）。テスト 10c（99999 不在 pid → rc=0 / pid_max 依存 skip は既存挙動）
+- 1.3 — lock file 不在で `no-lockfile`→`return 0`（`stale-pickup-reaper.sh:472-483`）。テスト 10a（rc=0 + reason=no-lockfile）
+- 2.1 — 生存 pid 検出で `holder-alive`→`return 1`（`stale-pickup-reaper.sh:529-532`）。テスト 10b（自プロセス pid → rc=1 + holder-alive）
+- 2.2 — 複数 lock file を累積走査し他 slot 無保持でも生存保持者検出で `return 1`（`stale-pickup-reaper.sh:502-535`）。テスト 10f（slot-1 無保持 + slot-2 生存 → rc=1）
+- 3.1 — fuser/lsof 双方不在時のみ `tool-absent`→`return 1`（`stale-pickup-reaper.sh:491-496`）。テスト 10g（PATH 空で決定論的に rc=1 + tool-absent）+ 10e（binary 実在時 skip）
+- 3.2 — `no-holder`（手段あり保持者なし / rc=0）と `tool-absent`（手段不在 / rc=1）を別トークンで区別（`stale-pickup-reaper.sh:459-463`）。テスト 10d（no-holder → rc=0）+ 10g（tool-absent → rc=1）
+- 4.1 — `age=$age lock=$lock sess=$sess` フィールド形式を維持し末尾に別フィールド追記（`stale-pickup-reaper.sh:580,583`）。テスト Section 11（`age=N lock=N sess=N` 形式維持）
+- 4.2 — holder-alive を `sess_reason` としてログ追記。テスト 10b + 10h（`sess_reason=holder-alive`）
+- 4.3 — no-holder を `sess_reason` としてログ追記。テスト 10d + 10h（`sess_reason=no-holder`）
+- 4.4 — tool-absent を `sess_reason` としてログ追記。テスト 10g + 10h（`sess_reason=tool-absent`）
+- 5.1 — 3 観点 AND 判定（`sr_is_active`）は不変で全 0 時 inactive 確定（`stale-pickup-reaper.sh:579-584`）。テスト Section 11（全 0 → inactive）+ `sr_recovery_action_test` Section 13
+- 5.2 — 無保持 lock file を no-holder(sess=0) 化し回収固定を解消。テスト 10d/10f
+- 6.1 — 無保持残存 lock file fixture → sess=0。テスト 10d
+- 6.2 — 実プロセス保持中 fixture → sess=1。テスト 10b
+- 6.3 — Section 10d の期待値を rc=1→rc=0 へ反転し #520 意図をコメント明示（`sr_activity_check_test.sh:292-303`。旧期待値もコメント保存）
+- NFR 3.1〜3.3 — env var / label / prefix(`stale-pickup:`) / `age`/`lock`/`sess` フィールド名を不変（diff で確認）。`sess=N` を機械パースする外部コードは bin/ 内に存在せず（grep 確認）末尾追記が非破壊
+- NFR 4.1 — `bash -n` エラーなし / `shellcheck` 警告ゼロ（reviewer 再実行で確認）
+- NFR 4.2 — README「アクティブセッション判定」節を safe-side 限定の語義へ更新（`README.md:4971-4985`）
+
+## Findings
+
+なし
+
+## Summary
+
+`sr_check_session` の safe-side fallback を「観測手段（fuser/lsof）不在時のみ」に限定し、
+「手段はあるが保持者なし」を no-holder(sess=0) と判定する修正。requirements.md の全 numeric AC
+（Req 1〜6 / NFR 1〜4）に対応する実装とテストを確認。reviewer 再実行で `sr_activity_check_test`
+PASS=40/FAIL=0、関連 3 テストも全 PASS、`shellcheck`/`bash -n` クリーン。design-less bug fix で
+tasks.md 不在のため `_Boundary:_` 制約は無く、変更は対象 module + 対応テスト + README doc 同期に
+限定され boundary 逸脱なし。
+
+RESULT: approve

--- a/local-watcher/bin/modules/stale-pickup-reaper.sh
+++ b/local-watcher/bin/modules/stale-pickup-reaper.sh
@@ -341,6 +341,14 @@ sr_fetch_candidates() {
 #                           1=inactive (revert へ進む)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+# sr_check_session が surface するセッション判定理由トークンを保持するグローバル
+# （#520 / Req 4.2〜4.4）。値: no-lockfile / tool-absent / holder-alive / no-holder。
+# sr_check_session の各呼び出しで再代入され、sr_is_active が既存 `sess=N` の直後に
+# `sess_reason=<token>` を別フィールドとして 1 行ログへ追記する（既存 age/lock/sess の
+# フィールド名・形式は不変 / NFR 3.3）。orchestrator 起動ごとに bash プロセスごと
+# 再初期化されるため明示 unset は不要。set -u 安全のため自己代入で初期化する。
+SR_SESSION_REASON="${SR_SESSION_REASON:-}"
+
 # marker.first_seen_at から現在までの経過分数を閾値判定する純粋関数（Req 3.1 観点 1 /
 # Req 4.2 / Req 4.4 / NFR 4.1）。
 #
@@ -428,22 +436,40 @@ sr_check_slot_lock() {
 }
 
 # Lock file 保持 pid の生存確認で「watcher / claude セッション存在」を判定する
-# （Req 3.1 観点 3 / Req 3.4）。
+# （#379 Req 3.1 観点 3 / #520 で safe-side fallback の適用範囲を限定）。
 #
 # Args: $1 = marker_json (将来拡張用 / 現状未使用)
 # Returns:
-#   0 = no session detected (lock file 不在 / 全 pid が非生存)
-#   1 = session may be alive (1 件でも pid 生存 / fuser & lsof 不在で判定不能含む safe-side)
+#   0 = no session detected
+#         (lock file 不在 / 保持者問い合わせが空 / 取得 pid が全て非生存 / Req 1.1〜1.3)
+#   1 = session may be alive
+#         (1 件でも pid 生存 / fuser & lsof 双方不在で観測手段なしの safe-side / Req 2.x, 3.x)
 #
-# 副作用なし（pid 取得・生存確認のみ）。Linux は `fuser`、macOS は `lsof -t` で
-# lock file 保持 pid を取得し、`kill -0 <pid>` で生存確認する。fuser / lsof どちらも
-# 不在の環境では Req 3.4 の safe-side として rc=1 を返す。
+# 副作用: 判定理由トークンを $SR_SESSION_REASON に surface する（#520 / Req 4.2〜4.4）。
+# それ以外の外部副作用なし（pid 取得・生存確認のみ / read-only）。Linux は `fuser`、
+# macOS は `lsof -t` で lock file 保持 pid を取得し `kill -0 <pid>` で生存確認する（NFR 2）。
+#
+# #520 の修正核心: flock 方式の lock file は保持プロセスが死んでもディスクに残るため、
+# 「観測手段は利用可能だが保持者を 1 件も返さない」状態は『保持者が既に死んでいる = 孤児』
+# そのものである。旧実装はこれを safe-side（rc=1）に倒していたため、一度 lock file が残ると
+# reaper が当該 repo で永久に機能しなくなっていた（feedman#223 / #234）。本修正では当該状態を
+# 「セッションなし」寄り（早期 return せず走査継続）に扱い、safe-side fallback は「観測手段
+# （fuser/lsof）自体が不在」のときに限定する（Req 3.1 / Req 3.2 / #379 Req 3.4 の適用範囲修正）。
+#
+# 判定理由トークン（$SR_SESSION_REASON）:
+#   - no-lockfile  : lock file が 1 つも存在しない（rc=0 / Req 1.3）
+#   - tool-absent  : fuser/lsof 双方不在で観測手段なし（rc=1 / safe-side / Req 3.1）
+#   - holder-alive : 生存する保持 pid を検出（rc=1 / Req 2.1, 2.2）
+#   - no-holder    : 観測手段はあるが生存保持者を 1 件も検出せず（rc=0 / Req 1.1, 1.2）
 sr_check_session() {
   # 将来拡張用に引数を受け取るが本実装では未参照（SC2034 を `:` 参照で意図的に抑止）
   local _marker_json="${1:-}"
   : "$_marker_json"
 
-  # lock file が一切無いケースは「保持 pid 自体が存在しない」= no session
+  # 判定理由の既定値。lock file 不在ケースの理由でもある（Req 1.3 / Req 4.x）。
+  SR_SESSION_REASON="no-lockfile"
+
+  # lock file が一切無いケースは「保持 pid 自体が存在しない」= no session（Req 1.3）
   local lockfile
   local any_lockfile=0
   for lockfile in "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-"*.lock; do
@@ -452,20 +478,26 @@ sr_check_session() {
     break
   done
   if [ "$any_lockfile" = "0" ]; then
+    SR_SESSION_REASON="no-lockfile"
     return 0
   fi
 
-  # pid 取得手段の選定: Linux fuser → macOS lsof の順に試行。両方不在は safe-side。
+  # pid 取得手段の選定: Linux fuser → macOS lsof の順に試行。両方不在のときのみ safe-side。
   local pid_tool=""
   if command -v fuser >/dev/null 2>&1; then
     pid_tool="fuser"
   elif command -v lsof >/dev/null 2>&1; then
     pid_tool="lsof"
   else
-    return 1  # fuser / lsof 双方不在 → safe-side（Req 3.4）
+    # 観測手段（fuser/lsof）自体が不在 → safe-side（Req 3.1 / Req 3.2）。
+    # 「手段はあるが保持者が検出されない（下の no-holder）」とは明確に区別する（#520）。
+    SR_SESSION_REASON="tool-absent"
+    return 1
   fi
 
-  # 各 lock file から pid を取得し生存確認
+  # 各 lock file から pid を取得し生存確認する。全 lock file を走査し、生存保持者を
+  # 1 件でも検出すれば「セッションあり」（Req 2.1 / Req 2.2）。空の保持者問い合わせ結果は
+  # 「保持者なし = 孤児寄り」として早期 return せず次の lock file 検査へ進む（#520 修正核心）。
   local pids pid
   for lockfile in "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-"*.lock; do
     [ -f "$lockfile" ] || continue
@@ -482,11 +514,11 @@ sr_check_session() {
     esac
 
     if [ -z "$pids" ]; then
-      # この lock file からは pid を取得できなかった → safe-side で「保持の可能性あり」
-      # （他 lock file で生存 pid を見つけても結論変わらないので即 return しない / 累積判定）
-      # ただし lock file が存在する以上、pid 取得自体ができないのは Req 3.4 の対象として
-      # safe-side 寄りに倒す。次の lock file 検査を続けるが、ここで return 1 しても良い。
-      return 1
+      # 観測手段は利用可能だが当該 lock file の保持者が 0 件 = 保持プロセスが既に死んでいる
+      # （flock 方式の lock file はプロセス死亡後もディスクに残る）。これはまさに検出したい
+      # 「孤児」状態そのものなので safe-side に倒さず、次の lock file 検査へ進む（#520 /
+      # Req 1.1）。他 lock file に生存保持者があれば下で holder-alive を返す（累積判定）。
+      continue
     fi
 
     for pid in $pids; do
@@ -495,12 +527,16 @@ sr_check_session() {
         ''|*[!0-9]*) continue ;;
       esac
       if kill -0 "$pid" 2>/dev/null; then
-        return 1  # 1 件でも生存 pid あり = session may be alive
+        # 1 件でも生存 pid あり = session may be alive（Req 2.1 / Req 2.2）
+        SR_SESSION_REASON="holder-alive"
+        return 1
       fi
     done
   done
 
-  # すべての pid が非生存（または lock file 自体が 0 件）→ no session detected
+  # 全 lock file を走査し終え、生存保持者が 1 件も無い（保持者なし or 取得 pid が全て非生存）
+  # → no session detected（Req 1.1 / Req 1.2）
+  SR_SESSION_REASON="no-holder"
   return 0
 }
 
@@ -514,14 +550,16 @@ sr_check_session() {
 # AND 判定: age == 0 AND lock == 0 AND sess == 0 のときのみ「非アクティブ確定」（return 1）。
 # それ以外（いずれか 1 観点でも「アクティブの可能性あり」を示す）は keep（return 0）。
 #
-# 判定根拠は `sr_log` で 1 行記録（Req 3.5 / NFR 4.1 / NFR 4.2）:
-#   非アクティブ確定時: `issue=#N inactive (age>threshold, no slot lock, no session) age=$age lock=$lock sess=$sess`
-#   keep 時:            `issue=#N keep age=$age lock=$lock sess=$sess`
+# 判定根拠は `sr_log` で 1 行記録（Req 3.5 / NFR 4.1 / NFR 4.2 / #520 Req 4.2〜4.4）:
+#   非アクティブ確定時: `issue=#N inactive (age>threshold, no slot lock, no session) age=$age lock=$lock sess=$sess sess_reason=$sess_reason`
+#   keep 時:            `issue=#N keep age=$age lock=$lock sess=$sess sess_reason=$sess_reason`
+# 既存 `age` / `lock` / `sess=N` のフィールド名・形式は不変で、判定理由 `sess_reason` を
+# 末尾に別フィールドとして追記する（NFR 3.3 / 既存 sess=N パーサを壊さない）。
 #
 # Args: $1 = marker_json (string)
 sr_is_active() {
   local marker_json="$1"
-  local age lock sess
+  local age lock sess sess_reason
   local issue_id
 
   # issue 番号を marker JSON から抽出（ログ識別用 / 未含有時は `?` で fallback）
@@ -531,14 +569,18 @@ sr_is_active() {
   sr_check_marker_age "$marker_json" || age=$?
   lock=0
   sr_check_slot_lock "$marker_json" || lock=$?
+  # sess の判定理由は sr_check_session が $SR_SESSION_REASON に surface する（#520）。
+  # 呼び出し前に空へ倒し、未設定（stub 等）でも `unknown` に安全に fallback させる。
+  SR_SESSION_REASON=""
   sess=0
   sr_check_session "$marker_json" || sess=$?
+  sess_reason="${SR_SESSION_REASON:-unknown}"
 
   if [ "$age" = "0" ] && [ "$lock" = "0" ] && [ "$sess" = "0" ]; then
-    sr_log "issue=#$issue_id inactive (age>threshold, no slot lock, no session) age=$age lock=$lock sess=$sess"
+    sr_log "issue=#$issue_id inactive (age>threshold, no slot lock, no session) age=$age lock=$lock sess=$sess sess_reason=$sess_reason"
     return 1  # inactive 確定 → revert へ
   fi
-  sr_log "issue=#$issue_id keep age=$age lock=$lock sess=$sess"
+  sr_log "issue=#$issue_id keep age=$age lock=$lock sess=$sess sess_reason=$sess_reason"
   return 0    # active or unknown → keep
 }
 

--- a/local-watcher/test/sr_activity_check_test.sh
+++ b/local-watcher/test/sr_activity_check_test.sh
@@ -224,12 +224,23 @@ else
 fi
 
 # ============================================================
-# Section 10: sr_check_session — kill -0 による pid 生存確認（task 4 / Req 3.1 観点 3 / Req 3.4）
+# Section 10: sr_check_session — kill -0 による pid 生存確認
+#   （task 4 / Req 3.1 観点 3 + #520 Req 1.x / 2.x / 3.x / 4.x）
 #
 # 検証経路:
-#   - lock file 不在 → rc=0 (no session detected)
-#   - lock file 存在 + 自プロセス（`$$`）pid が保持中 → rc=1 (session may be alive)
-#   - lock file 存在 + 大値 pid（99999 等）の死活確認 → rc=0 (no session)
+#   - 10a: lock file 不在 → rc=0 (no session / reason=no-lockfile)
+#   - 10b: lock file 存在 + 自プロセス（`$$`）pid が保持中 → rc=1 (reason=holder-alive)
+#   - 10c: lock file 存在 + 大値 pid（99999 等）の死活確認 → rc=0 (no session)
+#   - 10d: 【#520 反転】観測手段は利用可能だが保持者なし（空 fuser 出力）
+#          → rc=0 (no session / reason=no-holder)。旧実装は safe-side rc=1 に倒していた
+#   - 10e: fuser/lsof 双方不在（binary 実在時は skip）→ rc=1 (safe-side / 維持)
+#   - 10f: 複数 lock file の累積判定（無保持 + 生存保持者）→ rc=1（Req 2.2）
+#   - 10g: PATH 空でツール不在を決定論的に再現 → rc=1 / reason=tool-absent（Req 3.1 / 4.4）
+#   - 10h: sr_is_active が sess_reason=<token> を 1 行ログへ追記（Req 4.2〜4.4 / NFR 3.3）
+#
+# #520 修正核心: flock 方式の lock file はプロセス死亡後もディスクに残るため、「観測手段は
+# 利用可能だが保持者を 1 件も返さない」= 孤児状態を rc=0（セッションなし）と判定する。
+# safe-side fallback は「観測手段（fuser/lsof）自体が不在」のときに限定する。
 #
 # 注意: fuser / lsof の挙動を直接呼ぶと OS 差異が出るため、本 section では
 # fuser / lsof を **bash 関数として stub 化** し、関数経路で pid を返す形に統一する。
@@ -241,6 +252,8 @@ echo "--- Section 10: sr_check_session（task 4 / Req 3.1 観点 3 / Req 3.4） 
 SLOT_LOCK_DIR=$(mktemp -d)
 REPO_SLUG="owner-test-repo"
 assert_rc "Req 3.1 観点 3: lock file 不在で rc=0 (no session detected)" 0 sr_check_session '{}'
+# #520 Req 1.3 / Req 4.x: lock file 不在の判定理由が surface 値で判別できる
+assert_eq "Req 1.3: lock file 不在の判定理由が no-lockfile" "no-lockfile" "$SR_SESSION_REASON"
 
 # ── 10b: lock file 存在 + fuser stub が生存 pid を返す → rc=1 (session may be alive) ──
 touch "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-1.lock"
@@ -251,7 +264,10 @@ fuser() {
   echo "$$"
 }
 # 関数 stub を優先的に使うため command -v fuser は true を返す（builtin 経路）
-assert_rc "Req 3.1 観点 3: 自プロセス pid（生存）で rc=1 (session may be alive)" 1 sr_check_session '{}'
+# Req 6.2: 実プロセス（必ず生存する自プロセス pid）が lock file を保持中の正常系
+assert_rc "Req 2.1 / 6.2: 自プロセス pid（生存）で rc=1 (session may be alive)" 1 sr_check_session '{}'
+# #520 Req 4.2: 生存保持者検出時の判定理由が holder-alive として surface される
+assert_eq "Req 4.2: 生存保持者検出時の判定理由が holder-alive" "holder-alive" "$SR_SESSION_REASON"
 
 # ── 10c: fuser stub が大値 pid（不在）を返す → rc=0 (no session) ──
 # 99999 のような大値 pid は通常存在しない（厳密には環境依存だが Linux 既定 pid_max ≦ 32768 環境で確実に不在）
@@ -273,12 +289,20 @@ else
   assert_rc "Req 3.1 観点 3: 99999 (不在 pid) で rc=0 (no session)" 0 sr_check_session '{}'
 fi
 
-# ── 10d: fuser stub が空文字を返す（pid 取得失敗） → rc=1 (safe-side / Req 3.4) ──
+# ── 10d: fuser stub が空文字を返す（保持者なし） → rc=0 (no session / #520 Req 6.3 反転) ──
+# 【#520 による意図的な期待値反転】観測手段（fuser/lsof）が利用可能でありながら保持者を
+# 1 件も返さない状態は「保持プロセスが既に死んでいる = 孤児」そのものである。flock 方式の
+# lock file はプロセス死亡後もディスクに残るため、旧実装が本ケースを safe-side（rc=1）に
+# 倒していたことで、一度 lock file が残ると reaper が永久に機能しなくなるバグがあった
+# （feedman#223 / #234）。本修正で rc=0 (no session / sess=0) へ反転する（Req 1.1 / Req 6.3）。
+# 旧期待値: `assert_rc "Req 3.4: ... 空 fuser 出力 ... rc=1 (safe-side)" 1 ...`
 # shellcheck disable=SC2317
 fuser() {
   echo ""
 }
-assert_rc "Req 3.4: pid 取得失敗（空 fuser 出力）で rc=1 (safe-side)" 1 sr_check_session '{}'
+assert_rc "Req 1.1（#520 反転）: 空 fuser 出力（保持者なし）で rc=0 (no session)" 0 sr_check_session '{}'
+# #520 Req 4.3: 保持者なしの判定理由が no-holder として surface される
+assert_eq "Req 4.3: 保持者なしの判定理由が no-holder" "no-holder" "$SR_SESSION_REASON"
 
 # ── 10e: fuser / lsof どちらも不在 → rc=1 (safe-side / Req 3.4) ──
 # fuser / lsof を unset し、command -v が両方 fail する状態を作る
@@ -290,8 +314,110 @@ if command -v fuser >/dev/null 2>&1; then
 elif command -v lsof >/dev/null 2>&1; then
   echo "SKIP: 10e を skip（lsof binary が実在し関数 stub 不在 → bin に到達する）"
 else
-  assert_rc "Req 3.4: fuser/lsof 双方不在で rc=1 (safe-side)" 1 sr_check_session '{}'
+  assert_rc "Req 3.1（#520 維持）: fuser/lsof 双方不在で rc=1 (safe-side)" 1 sr_check_session '{}'
 fi
+
+# ── 10f: 複数 lock file の累積判定（1 無保持 + 1 生存保持者）→ rc=1（Req 2.2） ──
+# 1 つ目の lock file は保持者なし（空）、2 つ目は生存 pid を返す stub。空の保持者結果で
+# 早期 return せず走査を継続し、生存保持者を検出して rc=1 になることを検証（#520 累積判定）。
+SLOT_LOCK_DIR=$(mktemp -d)
+REPO_SLUG="owner-test-repo"
+touch "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-1.lock"
+touch "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-2.lock"
+# shellcheck disable=SC2317
+fuser() {
+  case "$1" in
+    *slot-1.lock) echo "" ;;      # 無保持（保持者なし）→ 早期 return せず継続すべき
+    *slot-2.lock) echo "$$" ;;    # 生存保持者（自プロセス pid）
+    *) echo "" ;;
+  esac
+}
+assert_rc "Req 2.2: 無保持 + 生存保持者の複数 lock file で rc=1 (session may be alive)" 1 sr_check_session '{}'
+assert_eq "Req 2.2 / 4.2: 累積判定で生存保持者検出時の理由が holder-alive" "holder-alive" "$SR_SESSION_REASON"
+unset -f fuser 2>/dev/null || true
+rm -rf "$SLOT_LOCK_DIR"
+
+# ── 10g: fuser/lsof 双方不在で rc=1 + reason=tool-absent を決定論的に検証（Req 3.1 / 4.4） ──
+# 環境に fuser/lsof binary が実在してもツール不在を決定論的に再現するため、サブシェルで
+# PATH を空にし関数 stub も unset して command -v を両方 fail させる（10e は binary 実在時
+# skip されるため、本ケースで tool-absent 経路を全環境で必ず観測する）。
+SLOT_LOCK_DIR=$(mktemp -d)
+REPO_SLUG="owner-test-repo"
+touch "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-1.lock"
+unset -f fuser lsof 2>/dev/null || true
+ta_out=$(
+  PATH=""
+  _rc=0
+  sr_check_session '{}' >/dev/null 2>&1 || _rc=$?
+  printf '%s|%s' "$_rc" "${SR_SESSION_REASON:-}"
+)
+ta_rc="${ta_out%%|*}"
+ta_reason="${ta_out#*|}"
+assert_eq "Req 3.1: fuser/lsof 双方不在で rc=1 (safe-side 維持 / 反転しない)" "1" "$ta_rc"
+assert_eq "Req 4.4: ツール不在の判定理由が tool-absent" "tool-absent" "$ta_reason"
+rm -rf "$SLOT_LOCK_DIR"
+
+# ── 10h: sr_is_active が sess_reason を 1 行ログに追記する（Req 4.2〜4.4 / NFR 3.3 後方互換） ──
+# real sr_check_session を用い marker_age / slot_lock を stub して固定。sess の判定理由が
+# sr_is_active のログに sess_reason=<token> として追記され、既存 sess=N フィールドが
+# 維持されることを検証する（各 subshell 内に stub を閉じ込め本物の関数を汚さない）。
+SLOT_LOCK_DIR=$(mktemp -d)
+REPO_SLUG="owner-test-repo"
+touch "$SLOT_LOCK_DIR/${REPO_SLUG}-slot-1.lock"
+
+# (no-holder) fuser 空 → sess=0 reason=no-holder → inactive ログ
+log_noholder=$(
+  # shellcheck disable=SC2317
+  sr_check_marker_age() { return 0; }
+  # shellcheck disable=SC2317
+  sr_check_slot_lock() { return 0; }
+  # shellcheck disable=SC2317
+  fuser() { echo ""; }
+  cap=""
+  # shellcheck disable=SC2317
+  sr_log() { cap="${cap}$*
+"; }
+  sr_is_active '{"issue":77}' >/dev/null 2>&1 || true
+  printf '%s' "$cap"
+)
+assert_contains "Req 4.3: sr_is_active ログに sess_reason=no-holder を追記" "$log_noholder" "sess_reason=no-holder"
+assert_contains "NFR 3.3: no-holder ログで既存 sess=0 フィールドを維持（後方互換）" "$log_noholder" "sess=0"
+
+# (holder-alive) fuser 生存 pid → sess=1 reason=holder-alive → keep ログ
+log_alive=$(
+  # shellcheck disable=SC2317
+  sr_check_marker_age() { return 0; }
+  # shellcheck disable=SC2317
+  sr_check_slot_lock() { return 0; }
+  # shellcheck disable=SC2317
+  fuser() { echo "$$"; }
+  cap=""
+  # shellcheck disable=SC2317
+  sr_log() { cap="${cap}$*
+"; }
+  sr_is_active '{"issue":78}' >/dev/null 2>&1 || true
+  printf '%s' "$cap"
+)
+assert_contains "Req 4.2: sr_is_active ログに sess_reason=holder-alive を追記" "$log_alive" "sess_reason=holder-alive"
+assert_contains "NFR 3.3: holder-alive ログで既存 sess=1 フィールドを維持（後方互換）" "$log_alive" "sess=1"
+
+# (tool-absent) PATH 空でツール不在 → sess=1 reason=tool-absent → keep ログ
+unset -f fuser lsof 2>/dev/null || true
+log_toolabsent=$(
+  PATH=""
+  # shellcheck disable=SC2317
+  sr_check_marker_age() { return 0; }
+  # shellcheck disable=SC2317
+  sr_check_slot_lock() { return 0; }
+  cap=""
+  # shellcheck disable=SC2317
+  sr_log() { cap="${cap}$*
+"; }
+  sr_is_active '{"issue":79}' >/dev/null 2>&1 || true
+  printf '%s' "$cap"
+)
+assert_contains "Req 4.4: sr_is_active ログに sess_reason=tool-absent を追記" "$log_toolabsent" "sess_reason=tool-absent"
+rm -rf "$SLOT_LOCK_DIR"
 
 # 後片付け
 unset -f fuser 2>/dev/null || true


### PR DESCRIPTION
## 概要

Stale Pickup Reaper（#379）のセッション存在判定（`sr_check_session`）に構造的な誤りがあり、
`STALE_PICKUP_REAPER_ENABLED=true` を有効化しても孤児 pickup が永久に回収されない事象が
feedman#223 / feedman#234 で 2 回発生した。

原因は「保持プロセス問い合わせ手段（fuser/lsof）が利用可能でありながら保持者を 1 件も
返さない」状態を根拠取得失敗として safe-side（`sess=1` / セッションの可能性あり）に
倒していた点にある。flock 方式の lock file はプロセスが死んでもファイルが残るため、
「file 存在 + 保持者なし」はまさに検出したい「孤児」状態そのものであり、これを生存扱いに
することで reaper が永久に機能しなくなっていた。

本 PR は safe-side fallback の適用範囲を「保持プロセス問い合わせ手段が不在のときのみ」に
限定し、「手段はあるが保持者なし」を `no-holder`（`sess=0`）として正しく孤児判定するよう修正する。

## 対応 Issue

Closes #520

## 関連 PR

なし（design-less bug fix。Architect 不介在のため設計 PR なし）

## 実装内容

- (Req 1.1 / Req 5.2) `sr_check_session` の保持者問い合わせが空の場合の旧 `return 1`（safe-side）を撤去し、次の lock file への `continue` → 走査完了後 `no-holder`→`return 0` へ変更（修正核心）
- (Req 3.1 / Req 3.2) safe-side fallback（`tool-absent`→`return 1`）を fuser/lsof 双方が不在の場合にのみ適用するよう限定
- (Req 4.2〜4.4) 判定理由を新規グローバル `SR_SESSION_REASON` に surface し、`sr_is_active` が既存 `sess=N` の直後に `sess_reason=<token>` を別フィールドとしてログ追記（既存 `age`/`lock`/`sess` のフィールド名・形式は不変）
- (NFR 4.2) README「アクティブセッション判定」節を safe-side 限定の語義（ツール不在時のみ）へ更新
- (Req 6.1〜6.3) `sr_activity_check_test.sh` に新テスト 10d/10f/10g/10h を追加し、Section 10d の期待値を rc=1→rc=0 へ反転（`#520` コメント明示）

## 受入基準チェック

- [x] Req 1.1: When 保持プロセス問い合わせ手段が利用可能で保持者なし → `sess=0` ← テスト 10d（空 fuser 出力 → rc=0）
- [x] Req 1.2: When 取得 pid が全て非生存 → `sess=0` ← テスト 10c + Section 11
- [x] Req 1.3: When lock file 不在 → `sess=0` ← テスト 10a（rc=0 / reason=no-lockfile）
- [x] Req 2.1: When 生存保持プロセス検出 → `sess=1` ← テスト 10b（自プロセス pid → rc=1 / holder-alive）
- [x] Req 2.2: While 複数 lock file、1 件でも生存保持者 → `sess=1` ← テスト 10f（slot-1 無保持 + slot-2 生存 → rc=1）
- [x] Req 3.1: If ツール不在 → `sess=1`（safe-side） ← テスト 10g（PATH 空で決定論的 rc=1 / tool-absent）
- [x] Req 3.2: safe-side 適用範囲をツール不在時に限定 ← テスト 10d が no-holder を safe-side 除外
- [x] Req 4.1〜4.4: ログフィールド形式維持 + 判定理由判別 ← テスト Section 11 / 10b / 10d / 10g / 10h
- [x] Req 5.1: 3 観点 AND 全 0 → 非アクティブ確定 ← Section 11 / `sr_recovery_action_test` Section 13
- [x] Req 5.2: 無保持 lock file を回収対象外固定から解消 ← テスト 10d / 10f
- [x] Req 6.1〜6.3: 回帰防止テスト（無保持残存 / 実プロセス保持 / 期待値反転） ← テスト 10d / 10b / Section 10d コメント
- [x] NFR 1.1: 誤回収ゼロ維持 ← Section 11 の 8 通り AND
- [x] NFR 3.1〜3.3: 後方互換性（env/label/prefix/フィールド名不変）← diff で確認
- [x] NFR 4.1: shellcheck 警告ゼロ / bash -n エラーなし
- [x] NFR 4.2: README 更新

## テスト結果

```
sr_activity_check_test.sh: PASS=40 FAIL=0
sr_recovery_action_test.sh: PASS=40 FAIL=0
sr_wiring_test.sh: PASS=61 FAIL=0
sr_marker_state_test.sh: PASS=64 FAIL=0
bash -n stale-pickup-reaper.sh: OK
shellcheck stale-pickup-reaper.sh: 警告ゼロ
diff -r .claude/agents repo-template/.claude/agents: 空（同期済み）
diff -r .claude/rules repo-template/.claude/rules: 空（同期済み）
```

## 実装上の判断

- 旧 `return 1`（保持者問い合わせ空 → 即 safe-side）の撤去が修正核心。空を「根拠取得失敗」と
  みなしていた解釈を「保持者が存在しない」に正す。
- 判定理由は `SR_SESSION_REASON` グローバルで surface し、ログへの末尾追記は非破壊（NFR 3.3）。
- Req 1.2（全 pid 非生存）は `kill -0` ループ後の継続で担保。テスト 10c は `pid_max` 依存で
  skip するが、Section 11 の AND 判定ルートで回帰保護されている。
- README 更新（NFR 4.2）は safe-side の語義を「ツール不在時のみ」に限定する 1 節の書き換え。

詳細は `docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/impl-notes.md` を参照。

## 確認事項 / レビュワーへの依頼

- design-less impl: 単一 PR で完了のため Closes を採用
- Reviewer（独立レビュー）: RESULT: approve（`docs/specs/520-fix-stale-pickup-reaper-lock-file-pickup/review-notes.md` 参照）
- 10c は実行環境の `pid_max`（4194304 > 99999）依存で skip。全 pid 非生存経路は Section 11 の AND 判定で担保済み（既存仕様）
- `sess_reason` は既存ログをパースする外部コードへの非破壊追記（bin/ 内に `sess=N` 機械パース箇所は grep で不在確認済み）
- base: main / baseRefName: main / OK（PR 作成後検証）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #520 のコメントを参照してください。
