### PR TITLE
feat(#521): GitHub API 消費の削減と rate limit 耐性強化（スナップショット共有・バケット可視化・縮退・リトライ・REST 負荷分散）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1568,6 +1568,7 @@ idd-claude は基本フロー（Triage → 実装 → PR 作成）以外の機�
 | **Security Review Processor**（Claude Code 公式 `/security-review` skill を `claude` CLI headless 経由で open PR の diff に適用し、検出結果を PR コメント投稿 + `security-notes.md` 成果物として残す。既定は **advisory 固定**でマージブロックを行わない / strict モードは `SECURITY_REVIEW_MODE=strict` で別途有効化（#281）） | `SECURITY_REVIEW_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `1` / typo）はすべて OFF | **前提**: `claude` CLI が watcher 実行環境に**インストール・認証済み**であること（既存必須ツール）。推奨: `SECURITY_REVIEW_MODEL`（既定 `claude-opus-4-8`）、`SECURITY_REVIEW_MAX_PRS`（既定 `5`）、`SECURITY_REVIEW_HEAD_PATTERN`（既定 `^claude/issue-`）、`SECURITY_REVIEW_EXEC_TIMEOUT`（既定 `600`） | [Security Review Processor (#279)](#security-review-processor-279) | #279, #281 |
 | **Failed Recovery Processor**（`claude-failed` ラベル付き Issue + auto-merge 待ち PR の CI error を fresh Claude session で自動解析・修正する Processor。Issue 単位の **通算 4 回** attempt budget と同原因再発 + 無進捗の **no-progress ガード**で quota 燃焼と多重ループを必ず終端させる。**Reviewer 内部 2/2 試行・pr-iteration 3R との独立カウンタ**（D-19b）。state は `$HOME/.issue-watcher/failed-recovery/<repo-slug>/<issue>.json` に atomic write。**`FAILED_RECOVERY_ENABLED=true` AND `FULL_AUTO_ENABLED=true`** の AND 二重 opt-in 配下。gate OFF 時は gh API 呼び出しゼロで本機能導入前と完全に等価（既存 `claude-failed` 手動運用と等価）。終端時は `claude-failed` ラベル据え置きで手動レビューへエスカレーション） | `FAILED_RECOVERY_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `TRUE` / `1` / `on` / `yes` / typo）はすべて OFF に正規化。さらに `FULL_AUTO_ENABLED=true` との AND 評価で双方 ON のときのみ起動 | **前提**: `FULL_AUTO_ENABLED=true`（#348 kill switch との AND 評価）。**前提**: `claude` CLI が watcher 実行環境に**インストール・認証済み**であること。推奨: `FAILED_RECOVERY_MAX_ATTEMPTS`（既定 `4` / 通算 attempt 上限）、`FAILED_RECOVERY_MAX_TURNS`（既定 `20` / claude session turn 上限）、`FAILED_RECOVERY_DEV_MODEL`（既定 `claude-opus-4-8`）、`FAILED_RECOVERY_MAX_PRS`（既定 `3` / 1 サイクル走査件数）、`FAILED_RECOVERY_GIT_TIMEOUT`（既定 `60` 秒）、`FAILED_RECOVERY_STATE_DIR`（既定 `$HOME/.issue-watcher/failed-recovery/<repo-slug>` / 通常変更不要） | [Failed Recovery Processor (#359)](#failed-recovery-processor-359) | #359 |
 | **Stale Pickup Reaper**（watcher セッションがクラッシュ / OOM / マシン再起動などで異常終了した結果、`claude-picked-up` / `claude-claimed` ラベルが Issue に残り続けて dispatcher が「処理中」とみなして候補から永久除外する停止状態を自動回復させる Processor。3 観点 AND 判定（marker 経過時間が閾値超 + 該当 slot ロック非保持 + watcher セッション不在）で **非アクティブ確定** のときのみ pickup ラベルを除去し `auto-dev` 状態へ戻す。impl branch は触らず温存し、次サイクルで dispatcher が impl-resume として再 pickup する。state は `$HOME/.issue-watcher/stale-pickup/<repo-slug>/<issue>.json` に atomic write。**`STALE_PICKUP_REAPER_ENABLED=true` 単独 opt-in**（`FULL_AUTO_ENABLED` 配下に **入らない** / 二重 opt-in 不要 / ラベル除去のみで claude 起動・コード変更・push を行わないため）。`claude-failed` ラベル付き Issue は対象外（Failed Recovery Processor #359 の領分） / `needs-decisions` / `awaiting-design-review` / `needs-quota-wait` / `blocked` / `hold` / `staged-for-release` 等の人間判断待ち・正当な待機状態ラベル付き Issue は対象外。gate OFF 時は gh API 呼び出しゼロで本機能導入前と完全に等価） | `STALE_PICKUP_REAPER_ENABLED` | `false` | `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `TRUE` / `1` / `on` / `yes` / typo）はすべて OFF に正規化 | 推奨: `STALE_PICKUP_REAPER_THRESHOLD_MINUTES`（既定 `45` / pickup ラベル滞留閾値・分単位 / 非整数 / `<=0` は既定 45 にフォールバック）、`STALE_PICKUP_REAPER_MAX_ISSUES`（既定 `20` / 1 サイクル走査件数上限）、`STALE_PICKUP_REAPER_GH_TIMEOUT`（既定 `60` / gh 呼び出しごとの timeout 秒）、`STALE_PICKUP_REAPER_STATE_DIR`（既定 `$HOME/.issue-watcher/stale-pickup/<repo-slug>` / 通常変更不要） | [Stale Pickup Reaper (#379)](#stale-pickup-reaper-379) | #379 |
+| **GitHub API Rate Guard**（1 サイクル内の **GitHub API rate limit**（core / graphql / search バケット）消費削減・枯渇耐性の 5 機能: (1) 一覧取得のサイクル内スナップショット共有、(2) バケット別残量の可視化、(3) 残量閾値割れ時の WARN と非必須プロセッサ縮退、(4) 状態遷移系ラベル操作の rate-limit 限定リトライ、(5) per-branch PR 存在確認の REST（core バケット）逃がし。**すべて機能別に独立 opt-in / 既定 OFF**。gate 全 OFF（既定）では新規 API 呼び出しゼロで本機能導入前と byte 等価。取得・残量取得・REST の失敗はすべて従来経路へ fail-safe フォールバック。**Claude Max quota**（`rate_limit_event` / [Quota-Aware Watcher #66](#quota-aware-watcher-66)）とは別物のため log prefix を `gh-rate-limit:`、env prefix を `GH_API_` に分離） | `GH_API_SNAPSHOT_ENABLED` / `GH_API_BUCKET_LOG_ENABLED` / `GH_API_DEGRADE_ENABLED` / `GH_API_STATE_RETRY_ENABLED` / `GH_API_REST_OFFLOAD_ENABLED`（機能別 5 gate） | `false` | 各 gate `=true` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `True` / `1` / typo）はすべて OFF に正規化（安全側 no-op）。数値 env（limit / threshold / attempts / sleep / timeout）は非整数 / ≤0（threshold は <0）を既定へ正規化 | 推奨: 下記詳細セクションの env 一覧・縮退優先順を参照 | [GitHub API Rate Guard (#521)](#github-api-rate-guard-521) | #521 |
 | **needs-decisions Auto-Continue**（Triage / PM が出力した `decisions[].classification` タグに基づき、`needs-decisions` 状態の Issue のうち `safe` 分類（PM 第一推奨あり + 機密 / コンプラ / 不可逆 / 外部影響のいずれにも該当しない）のみを **PM の第一推奨**で自動続行させる Processor。判定順序は **kill switch → mode → classification → recommendation** の 4 段で、auto-continue 時は `claude-claimed` のみ除去（`needs-decisions` ラベル不付与）+ Issue コメント 1 件（採用 recommendation + mode + classification + 監査用 fingerprint）投稿で次サイクル再 pickup に戻す。**`human-only` 分類はモードによらず絶対停止**（NFR 4.2 hard safety boundary）/ 分類欠落 / 混在 / jq 失敗 / Triage JSON 不在もすべて `human-only` 扱いで halt。**`NEEDS_DECISIONS_MODE != all-human` AND `FULL_AUTO_ENABLED=true`** の AND 二重 opt-in 配下。gate OFF 時 / 既定 `all-human` 時は gh API 呼び出しゼロで本機能導入前と完全に等価。既存 `needs-decisions` 付与経路（Partial Status Gate #148 / Spec Completeness #219 / Tasks Count #131 等）の挙動は touch しない（新規 pickup 経路を作らない / NFR 1.3）。pilot 運用先 = altpocket-server） | `NEEDS_DECISIONS_MODE` | `all-human` | `all-human` / `classified` / `all-auto` の 3 値厳密一致のみ有効。それ以外（未設定 / 空文字 / `Classified` / `auto` / 大文字小文字違い / 前後空白付き / typo）はすべて安全側 `all-human` に正規化（=`needs-decisions` 自動続行は発火しない）。さらに `FULL_AUTO_ENABLED=true` との AND 評価で双方 ON のときのみ起動 | **前提**: `FULL_AUTO_ENABLED=true`（[#348 kill switch](#full-auto-kill-switch) との AND 評価）。**前提**: Triage / PM agent が `decisions[].classification` を出力していること（`triage-prompt.tmpl` / `.claude/agents/product-manager.md` で文書化済）。`classified` = `safe` のみ自動続行（推奨）/ `all-auto` = 全 `safe` を自動続行（危険 / 明示 opt-in） | [needs-decisions Auto-Continue (#362)](#needs-decisions-auto-continue-362) | #362, #348 |
 | **Security Review strict モード**（#279 advisory 経路を温存したまま、severity 閾値以上の検出時に `needs-security-fix` + `needs-iteration` をペア付与して PR Iteration Processor #26 の自動反復動線に乗せる） | `SECURITY_REVIEW_MODE` | `advisory` | `=strict` 厳密一致のみ有効。それ以外（未設定 / 空文字 / `Strict` / `STRICT` / 前後空白付き / typo）は WARN 1 行 + `advisory` fallback。`SECURITY_REVIEW_STRICT` は deprecated alias で WARN のみ（mode 解決には影響しない） | **前提**: `SECURITY_REVIEW_ENABLED=true`（本機能の起動 gate）。**前提**: `bash .github/scripts/idd-claude-labels.sh --force` で `needs-security-fix` ラベルを作成済みであること。推奨: `SECURITY_REVIEW_BLOCK_LABEL`（既定 `needs-security-fix`、付与ラベル名 override） | [strict モード（#281）](#strict-モード281) | #281 |
 | **Security Review strict severity 閾値**（strict モードでマージ阻害ラベルを付与する severity 下限。critical > high > medium > low > info の ordinal） | `SECURITY_REVIEW_BLOCK_SEVERITY` | `high` | 許容値は lowercase 厳密一致の `critical` / `high` / `medium` / `low` / `info` の 5 値。それ以外（大文字混在 / typo / 前後空白付き）は WARN 1 行 + `high` fallback | **前提**: `SECURITY_REVIEW_MODE=strict`（advisory 経路では参照されない） | [strict モード（#281）](#strict-モード281) | #281 |
@@ -5082,6 +5083,104 @@ git pull origin main
 ```
 
 を再実行してください（`$HOME/bin/modules/stale-pickup-reaper.sh` も同時に再配置されます）。
+
+---
+
+## GitHub API Rate Guard (#521)
+
+watcher は 1 回の cron tick（サイクル）で複数のプロセッサ（Merge Queue / PR Iteration /
+PR Reviewer / Design Review Release / Dispatcher 等）を順に実行し、各プロセッサが独立に
+PR 一覧 / Issue 一覧を GitHub API から取得します。同一サイクル内で同じ一覧取得が重複すると
+**GitHub API rate limit**（GraphQL は 5,000 point/h をアカウント内の全ツールで共有）を急速に
+消費し、枯渇時にはプロセッサが失敗して特に resumable return 時の状態遷移系ラベル操作
+（`claude-picked-up` 除去等）が失敗すると Issue が孤児化します。
+
+本機能は (1) 一覧取得のサイクル内スナップショット共有、(2) バケット別残量の可視化、
+(3) 残量閾値割れ時の WARN と縮退、(4) 状態遷移系ラベル操作の限定リトライ、(5) hot path の
+一部の REST（core バケット）への負荷分散、の 5 点を **すべて機能別に独立 opt-in / 既定 OFF** で
+導入します。**gate を 1 つも有効化しない限り、新規 API 呼び出しはゼロで、一覧取得挙動・
+プロセッサ実行順・ラベル遷移・ログ出力は本機能導入前と完全に等価**です（既定安全側 / NFR 1.1）。
+不正値・typo は安全側（無効 / 既定値）へ正規化されます。
+
+> **用語分離（重要）**: 本機能が対象とするのは **GitHub API rate limit**（core / graphql /
+> search バケット）であり、Claude Max サブスクリプションの 5 時間 quota
+> （`rate_limit_event`。[Quota-Aware Watcher (#66)](#quota-aware-watcher-66) が対象）とは
+> **別物**です。混同を避けるため、本機能のログ prefix は `gh-rate-limit:`、env prefix は
+> `GH_API_`、module prefix は `grl_` に統一しています。
+
+### opt-in 手順
+
+有効化したい機能の gate env を cron / launchd エントリ（または per-repo env ファイル
+`$HOME/.issue-watcher/<REPO_SLUG>.env`）で `=true` に設定します。各機能は独立に有効化できます:
+
+```bash
+# 例: スナップショット共有 + バケット可視化 + 縮退を有効化
+REPO=owner/repo REPO_DIR=$HOME/work/repo \
+  GH_API_SNAPSHOT_ENABLED=true \
+  GH_API_BUCKET_LOG_ENABLED=true \
+  GH_API_DEGRADE_ENABLED=true \
+  $HOME/bin/issue-watcher.sh
+```
+
+`local-watcher/bin/modules/api-rate-guard.sh` は `install.sh` 再実行で
+`$HOME/bin/modules/` へ配置されます（consumer repo への配布は不要 = local-watcher 専用）。
+
+### 導入する env var 一覧と既定値
+
+| env | 既定 | 正規化 | 対応機能 |
+|---|---|---|---|
+| `GH_API_SNAPSHOT_ENABLED` | `false` | `=true` 厳密一致のみ ON、他は OFF | (1) スナップショット共有 |
+| `GH_API_SNAPSHOT_PR_LIMIT` | `100` | 非整数 / ≤0 → 100 | (1) PR 超集合取得の `--limit` |
+| `GH_API_SNAPSHOT_ISSUE_LIMIT` | `100` | 非整数 / ≤0 → 100 | (1) Issue 超集合取得の `--limit` |
+| `GH_API_SNAPSHOT_DIR` | `$HOME/.issue-watcher/api-snapshot/<REPO_SLUG>` | — | (1) スナップショット JSON 配置先 |
+| `GH_API_SNAPSHOT_GH_TIMEOUT` | `60` | 非整数 / ≤0 → 60 | (1) 超集合取得の gh timeout 秒 |
+| `GH_API_BUCKET_LOG_ENABLED` | `false` | `=true` のみ ON | (2) バケット可視化 |
+| `GH_API_DEGRADE_ENABLED` | `false` | `=true` のみ ON | (3) 縮退 |
+| `GH_API_DEGRADE_GRAPHQL_THRESHOLD` | `500` | 非整数 / <0 → 500（保守的既定） | (3) graphql 残量の縮退閾値 |
+| `GH_API_STATE_RETRY_ENABLED` | `false` | `=true` のみ ON | (4) 限定リトライ |
+| `GH_API_STATE_RETRY_MAX_ATTEMPTS` | `3` | 非整数 / ≤0 → 3（有限） | (4) 再試行回数上限 |
+| `GH_API_STATE_RETRY_SLEEP` | `2` | 非整数 / <0 → 2 | (4) 試行間 backoff 秒 |
+| `GH_API_REST_OFFLOAD_ENABLED` | `false` | `=true` のみ ON | (5) REST 逃がし |
+
+### バケット可視化ログの読み方
+
+`GH_API_BUCKET_LOG_ENABLED=true` のとき、各サイクル終端に以下の固定書式 1 行が `LOG_DIR`
+配下へ出力されます（`/rate_limit` 参照は rate limit を消費しません）:
+
+```text
+[2026-07-29 12:00:00] [owner/repo] gh-rate-limit: core=4990/5000 graphql=4800/5000 search=28/30
+```
+
+- 書式は `gh-rate-limit: core=<残量>/<上限> graphql=<残量>/<上限> search=<残量>/<上限>`。
+  `grep 'gh-rate-limit:'` で事後検索できます。
+- **graphql バケット**（5,000/h をアカウント内の全ツールで共有）が枯渇の主動機のため、
+  縮退判定の主対象です。残量が急減していれば枯渇の予兆です。
+- 取得に失敗した場合は `gh-rate-limit: WARN: ...` を出力してサイクルは継続します。
+
+### 縮退の優先順位（essential vs non-essential）
+
+`GH_API_DEGRADE_ENABLED=true` のとき、graphql 残量が `GH_API_DEGRADE_GRAPHQL_THRESHOLD`
+（既定 500）を下回ると、**非必須（non-essential）プロセッサを当該サイクルで skip** し、
+`gh-rate-limit: WARN: skip processor=<name> reason=degrade bucket=graphql remaining=<r> threshold=<t>`
+を出力します。**必須（essential）プロセッサは残量にかかわらず skip されません**（dispatch と
+状態遷移の完遂性を守る / NFR 2.2）:
+
+| 分類 | プロセッサ | 縮退時 |
+|---|---|---|
+| **essential**（常に実行） | quota-resume / merge-queue(-recheck) / auto-rebase / auto-merge(-design/-disarm/-merged) / promote-pipeline / stale-pickup-reaper / design-review-release / Dispatcher | 実行 |
+| non-essential（縮退時 skip） | pr-reviewer / claude-review-catchup / claude-review-merge-gate-visibility / pr-design-reviewer / security-review / pr-iteration / failed-recovery | skip |
+
+非必須プロセッサ（レビュー系・可視化系・claude 起動を伴う反復/回復）は次サイクルで再試行
+されるため、縮退で skip しても安全です。
+
+### fail-safe / 後方互換
+
+- スナップショット取得・バケット残量取得・REST 逃がしのいずれの失敗も、従来の個別取得 /
+  従来 GraphQL 経路へフォールバックしサイクルを継続します（warn ログを 1 行残す）。
+- 状態遷移系ラベル操作のリトライは有限回（`GH_API_STATE_RETRY_MAX_ATTEMPTS`）で打ち切り、
+  上限到達でも `claude-picked-up` を残置したまま次 tick で再評価されます（孤児化しない）。
+- 既存 env var 名 / ラベル名 / exit code / cron 登録文字列 / ログ出力先は本機能で変更しません。
+  新規ラベルも導入しません。
 
 ---
 

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/impl-notes.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/impl-notes.md
@@ -1,0 +1,80 @@
+# 実装ノート（#521 watcher の GitHub API 消費削減・rate limit 耐性強化）
+
+## 実装した機能の要約
+
+新規 module `local-watcher/bin/modules/api-rate-guard.sh`（prefix `grl_` / 関数定義のみ）に
+5 機能を集約。全 gate 既定 OFF・不正値は安全側正規化。ロガー `grl_log/_warn/_error`
+（prefix `gh-rate-limit:`）は `core_utils.sh`。env は `watcher-config.sh`。
+
+| 機能 | 主関数 | env | 配線 / 差し替え | テスト |
+|---|---|---|---|---|
+| (1) snapshot 共有 | `grl_snapshot_init` / `_active` / `_prs` / `_issues` / `grl_pr_snapshot_or_live` / `grl_issue_snapshot_or_live` | `GH_API_SNAPSHOT_ENABLED` ほか 4 | `issue-watcher.sh:412`（quota-resume 直前）+ PR 9 / Issue 4 module | `api_rate_guard_snapshot_test.sh` / `_pr_equiv_test.sh` / `_review_equiv_test.sh` / `_issue_equiv_test.sh` |
+| (2) バケット可視化 | `grl_buckets_refresh` / `grl_buckets_log` | `GH_API_BUCKET_LOG_ENABLED` | refresh=`:418` / log=`:905`（`echo 完了` 直前） | `api_rate_guard_degrade_test.sh` |
+| (3) 縮退 | `grl_degrade_should_run` | `GH_API_DEGRADE_ENABLED` / `_GRAPHQL_THRESHOLD` | 非必須 7 call site を gate | `api_rate_guard_degrade_test.sh` |
+| (4) 限定リトライ | `grl_retry_label_op` | `GH_API_STATE_RETRY_ENABLED` / `_MAX_ATTEMPTS` / `_SLEEP` | 再 pickup 復帰 3 箇所（impl-pipeline ×2 / slot-worker ×1） | `api_rate_guard_retry_test.sh` |
+| (5) REST 逃がし | `grl_rest_prs_for_head` / `grl_gh_pr_list_head` | `GH_API_REST_OFFLOAD_ENABLED` | per-branch 存在確認 3 箇所（resume ×1 / stage-checkpoint ×2） | `api_rate_guard_rest_test.sh` |
+
+## AC トレーサビリティ（1 要件群 1 行）
+
+| 要件 | 担保テスト / 検証 |
+|---|---|
+| 1.1–1.3（opt-in / 既定 no-op / 不正値正規化 / NFR1.1） | snapshot/degrade/retry/rest 各 test の gate off / typo ケース + Task10 config 正規化 smoke + gate-off no-op smoke（gh 非呼び出し確認） |
+| 1.4–1.6（既存 env/ラベル/exit code 不変・新規ラベル無） | 新規 `GH_API_*` 名のみ追加。既存識別子・ラベル非変更（コードレビュー / 108 test suite 回帰） |
+| 2.1, 2.2（サイクル冒頭 1 回取得 / NFR3.1） | `api_rate_guard_snapshot_test.sh`（PR/Issue list 各 1 回） |
+| 2.3（個別取得と等価判定） | `_pr_equiv` / `_review_equiv` / `_issue_equiv`（client jq が server search を再現） |
+| 2.4（鮮度クリティカルは個別） | `_pr_equiv`（Dispatcher 非参加をソース走査で確認） |
+| 2.5, 2.6（取得失敗 fallback + warn / NFR2.1） | `api_rate_guard_snapshot_test.sh`（PR/Issue fetch fail → active=off + warn） |
+| 3.1–3.4（終端 1 行ログ / 非消費 / 固定書式 / 失敗継続） | `api_rate_guard_degrade_test.sh`（gh api rate_limit parse / 書式 / 取得失敗継続） |
+| 4.1–4.6（閾値 WARN / 非必須 skip / essential 不 skip / 閾値 env / skip ログ / 無効時不 skip） | `api_rate_guard_degrade_test.sh`（閾値割れ skip / gate off run / 安全側 fallback）+ 分類表 |
+| 5.1–5.6（rate-limit 限定リトライ / 有限 / 孤児化しない / 安全側 / 試行ログ） | `api_rate_guard_retry_test.sh`（N 回試行 / 非 rate-limit 1 回 / 上限打ち切り / gate off 単発） |
+| 6.1–6.4（REST 逃がし / 等価判定 / 失敗 fallback / 無効時 GraphQL） | `api_rate_guard_rest_test.sh`（REST→JSON 正規化 MERGED 変換 / 失敗 fallback / gate off 従来経路） |
+| 7.1–7.3（README opt-in 手順 / env 表 / ログ読み方・縮退優先順） | README「GitHub API Rate Guard (#521)」節 |
+| NFR5.1（未信頼入力） | jq は `--arg` / `--argjson`、REST は `-f` で query param、branch はクォート維持 |
+| NFR6.1, 6.2（shellcheck 0 / fixture テスト） | Task10 verify（shellcheck + bash -n PASS）/ 全 test は gh stub で live API なし |
+
+## design との差異・着手時に判明したドリフト（確認事項）
+
+1. **Issue 超集合 union に `updatedAt` を追加**: design の Issue union は
+   `number,title,body,url,labels,author` だが、参加 processor の stale-pickup-reaper
+   （Inventory #13）は `updatedAt` を必須参照する。真の超集合にするため
+   `grl_snapshot_issue_fields` に `updatedAt` を追加した（design union の抜けを補完）。
+2. **Issue consumer 3 件は wrapper ではなく branch パターンで実装**: design は Issue 参加
+   4 module を `grl_issue_snapshot_or_live` 経由と規定するが、quota-aware / dependency-resolver /
+   path-overlap の現行コマンドは `--label` / `is:open`-in-search 形で、wrapper の統一形
+   （`--state open --search`）と **byte 一致しない**。かつ既存テスト（#346 の `--label auto-dev`
+   アサート、#518 の labels 欠落 fixture）が旧コマンド形/挙動を前提とする。NFR 1.1（gate off
+   byte 等価）を最優先し、`grl_snapshot_active` 分岐で **active 時のみ snapshot+client 絞り込み /
+   gate off は原コマンドを逐語温存** する branch パターンを採用した。stale-pickup-reaper は
+   コマンド形が wrapper と一致するため wrapper 経由（`grl_issue_snapshot_or_live` は reaper が使用）。
+3. **REST offload 対象は 3 箇所（design 記載の 4 箇所ではない）**: design は
+   `slot-worker-resume.sh:318,1017` の 2 箇所を挙げるが、`:318` は design-PR probe（`--search
+   ... in:head` の prefix 検索）で単一 branch の `--head <branch> --state all` ではないため
+   REST `pulls?head=owner:branch`（厳密 branch 指定）へ逃がせない。差し替えは resume:1017 /
+   stage-checkpoint:192 / :694 の 3 箇所。gate off fallback は superset `--json` + `--limit 20`
+   で結果等価（呼び出し側は自 field を jq 抽出し `.[0]`/state 選択のため存在判定は不変）。
+4. **degrade skip ログは `grl_warn` 経由**: Req 4.1 が WARN を要求するため
+   `gh-rate-limit: WARN: skip processor=... reason=degrade bucket=graphql remaining=... threshold=...`
+   の 1 行で出力（design の literal は "WARN:" を省いていたが、grep 対象 token は全て含む）。
+
+上記 1–4 はいずれも実装を正しくするための解釈であり、spec 本文の書き換えは行っていない。
+Architect / reviewer の確認が必要な場合は本 PR で判断されたい。それ以外の確認事項: なし。
+
+## 実行した検証コマンドとその結果
+
+- `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/watcher-config.sh local-watcher/bin/modules/*.sh && bash -n local-watcher/bin/issue-watcher.sh` → PASS（新規警告 0）
+- 全 test suite（`local-watcher/test/*_test.sh` 108 本）→ 108 passed / 0 failed
+- config 正規化 smoke: 不正値（`TRUE` / `-5` / `abc` / `0` / `on`）→ すべて安全側既定へ正規化を確認
+- module load + gate-off no-op smoke: 全 gate off で `grl_*` が gh を 1 度も呼ばず（NFR 1.1）、
+  snapshot=inactive / buckets STATUS=disabled / degrade=常に run を確認
+- 実エントリポイント dry-run: config parse + 全 module load 成功（`git pull origin` で停止 =
+  live GitHub 不在のため想定内。新規 module の syntax/wiring クラッシュなし）
+- 新規公開 IF 追加で失敗した既存テストは fixture 追従で全 green 化（Issue #410）:
+  auto-merge* ×3 / dr_unblock_sweep / po_staged / sr_marker_state / sr_wiring /
+  stage_a_verify_round1_defer
+
+## 派生タスク候補（次 Issue）
+
+- config 起動サマリ行（`base-branch=... full-auto=...`）へ `gh-api-guard=` 状態の追記（可観測性向上）
+- graphql 以外（core / search）バケットの縮退閾値対応（現状は graphql 単一閾値 / design Non-Goal）
+
+STATUS: complete

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/review-notes.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/review-notes.md
@@ -1,0 +1,77 @@
+# Review Notes
+
+<!-- idd-claude:review round=1 model=claude-opus-4-8 timestamp=2026-07-29T00:00:00Z -->
+
+## Reviewed Scope
+
+- Branch: claude/issue-521-impl-feat-watcher-github-api-rate-limit
+- HEAD commit: 097ab7b90d15300c63e34a12fcaa70a63603cc62
+- Compared to: main..HEAD
+
+Feature Flag Protocol: CLAUDE.md に `## Feature Flag Protocol` 節（`**採否**:` 行）が存在しない
+ため opt-out 扱いとし、通常の 3 カテゴリ判定（AC 未カバー / missing test / boundary 逸脱）のみを
+適用した。全 108 テスト green / `shellcheck`（issue-watcher.sh + watcher-config.sh + modules/*.sh）
+新規警告 0 / `bash -n` OK を reviewer 自身で再実行確認済み。
+
+## Verified Requirements
+
+- 1.1 — 各 grl_* 関数が `GH_API_*_ENABLED != "true"` で早期 no-op。`api_rate_guard_snapshot_test.sh`
+  ケース1（gate off で gh 非呼び出し / active=off）、degrade/retry/rest 各 test の gate off ケース
+- 1.2 — `watcher-config.sh` 新規 12 env の既定を全て false / 安全側数値に固定
+- 1.3 — config `case` 正規化 + `api_rate_guard_snapshot_test.sh` ケース2（`TRUE` typo → inactive）
+- 1.4 — 追加は `GH_API_*` 名のみ。既存 env 名（REPO/REPO_DIR/LOG_DIR 等）非変更（diff 確認）
+- 1.5 — 既存ラベル / exit code / cron 文字列 / LOG_DIR 出力先の変更なし（diff 確認）
+- 1.6 — 新規ラベル導入なし（idd-claude-labels.sh は diff 対象外）
+- 2.1 — `issue-watcher.sh:409` に `grl_snapshot_init` 配線 + `api_rate_guard_snapshot_test.sh`
+  「PR/Issue list 各 1 回」アサート
+- 2.2 — `grl_pr/issue_snapshot_or_live` が active 時に file を返し再取得しない（snapshot_test ケース6）
+- 2.3 — `api_rate_guard_pr_equiv_test.sh` / `_review_equiv_test.sh` / `_issue_equiv_test.sh`
+  （client jq が server `--search` を等価再現。live 経路は byte 等価）
+- 2.4 — Dispatcher 候補クエリ（issue-watcher.sh:715/724）/ `check_existing_impl_pr`（gh api graphql）/
+  design-PR probe（slot-worker-resume.sh:318 の `--search ... in:head`）は差し替えず個別取得を維持。
+  `api_rate_guard_pr_equiv_test.sh` ケース5 で Dispatcher 非参加を検証
+- 2.5 — `grl_snapshot_init` 取得失敗で active=off へ fallback（snapshot_test ケース4/5）
+- 2.6 — fallback 時に `grl_warn` 出力（snapshot_test ケース4 で `gh-rate-limit: WARN` 確認）
+- 3.1 — `grl_buckets_log` を cycle 終端（issue-watcher.sh:902）へ配線 + `api_rate_guard_degrade_test.sh`
+- 3.2 — `gh api rate_limit`（非消費経路）で取得。degrade_test が経路を assert
+- 3.3 — 固定書式 `gh-rate-limit: core=r/l graphql=r/l search=r/l`（degrade_test ケース2）
+- 3.4 — 取得失敗は warn + 継続（degrade_test ケース3）
+- 4.1 — `grl_degrade_should_run` が閾値割れで WARN（degrade_test ケース4）
+- 4.2 — 非必須 7 call site を `grl_degrade_should_run && { ... }` で gate（issue-watcher.sh diff）
+- 4.3 — essential（dispatch / merge / 状態遷移 / reaper / release / Dispatcher）は gate せず常時実行（diff 確認）
+- 4.4 — `GH_API_DEGRADE_GRAPHQL_THRESHOLD` 既定 500（保守的）/ env 調整可
+- 4.5 — skip ログに processor 名・bucket・残量・閾値（degrade_test が 4 トークン assert）
+- 4.6 — gate off は常に rc=0（degrade_test「gate off: 残量僅少でも skip しない」）
+- 5.1 — resumable-return 3 箇所（impl-pipeline.sh ×2 / slot-worker.sh ×1）を `grl_retry_label_op` 経由へ差替
+- 5.2 — rate-limit 文言検出時のみ再試行 / 非 rate-limit は 1 回（`api_rate_guard_retry_test.sh` ケース3/4）
+- 5.3 — `GH_API_STATE_RETRY_MAX_ATTEMPTS` 既定 3（有限）/ retry_test で上限 3 回打ち切り
+- 5.4 — 上限到達でも label 残置 + rc 非0 で次 tick 再評価（retry_test ケース3）
+- 5.5 — wrapper は既存 gh 引数の rc を変えず回数のみ増やす。差替先は PICKED/CLAIMED 除去のみで FAILED 非付与（diff 確認）
+- 5.6 — 再試行ログに issue/op/attempt（retry_test が `retry issue=#42 op=-claude-picked-up attempt=1/3` を assert）
+- 6.1 — `grl_rest_prs_for_head` が offload on で `gh api repos/.../pulls?head=` 経由（`api_rate_guard_rest_test.sh` ケース2）
+- 6.2 — open→OPEN / closed+merged_at→MERGED / closed→CLOSED 正規化（rest_test ケース2）
+- 6.3 — REST 失敗時 `gh pr list --head` へ fallback + warn（rest_test ケース3）
+- 6.4 — gate off は従来 GraphQL 経路（rest_test ケース1）
+- 7.1 — README「GitHub API Rate Guard (#521)」節に opt-in 手順・既定安全側方針を追記
+- 7.2 — README に新規 env 12 個の一覧と既定値表を追記（design env 表と一致）
+- 7.3 — README にバケット可視化ログの読み方 + essential/non-essential 縮退優先順表 + 用語分離を追記
+
+## Findings
+
+なし
+
+## Summary
+
+Req 1〜7 の全 numeric AC について、観測可能な実装と live-API 非依存の fixture テストが差分内に
+確認できた。全 gate 既定 OFF で新規 API 呼び出しゼロ・live 経路 byte 等価を保つ後方互換設計で、
+`_Boundary:_` 逸脱なし（変更ファイルは全て design File Structure Plan / 各 task boundary 内）。
+108 テスト green・shellcheck 新規警告 0・bash -n OK を再実行確認済み。
+
+（設計レベルの補足 / 当該 impl PR の reject 理由には含めない）: REST offload の差替は 3 箇所で、
+design File Structure Plan が挙げた slot-worker-resume.sh:318 は per-branch の `--head` 呼び出し
+ではなく prefix `--search ... in:head` probe のため対象外とした旨が impl-notes に記録されている。
+これは Req 6.1 の適用対象（per-branch exact head の存在確認）を正しく満たしており AC 未カバーに
+該当しない。design.md の該当記述と実装の食い違いは設計 iteration / 別 Issue で還流すべき軽微な
+ドリフトであり、本 impl PR の reject 事由ではない。
+
+RESULT: approve

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -47,7 +47,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Requirements: 3.1, 3.2, 3.3, 3.4_
   - _Depends: 1_
 
-- [ ] 6. 残量閾値割れ時の WARN と縮退
+- [x] 6. 残量閾値割れ時の WARN と縮退
   - `api-rate-guard.sh` に `grl_degrade_should_run <processor名>` を実装（`GH_API_DEGRADE_ENABLED=true` かつ graphql 残量 < `GH_API_DEGRADE_GRAPHQL_THRESHOLD` で WARN + 非必須は rc=1 skip・essential 名は常に rc=0。gate off は常に rc=0 = 従来挙動 / Req 4.6）
   - skip 時に `gh-rate-limit: skip processor=<name> reason=degrade bucket=graphql remaining=<r> threshold=<t>` を出力（Req 4.5 / WARN に bucket・残量・閾値含む）
   - `watcher-config.sh` に `GH_API_DEGRADE_ENABLED`（既定 false）と `GH_API_DEGRADE_GRAPHQL_THRESHOLD`（既定 500 / 保守的 / 非整数・<0 を既定へ）を追加（Req 4.4）

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -73,7 +73,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Requirements: 6.1, 6.2, 6.3, 6.4_
   - _Depends: 1_
 
-- [ ] 9. README 整合
+- [x] 9. README 整合
   - README「オプション機能一覧」へ 5 機能の opt-in 手順・有効化時の挙動・既定安全側方針を追記（Req 7.1）
   - 新規 env 12 個の一覧と既定値の表を追記（Req 7.2 / design env 表と一致）
   - バケット可視化ログ（`gh-rate-limit:` 書式）の読み方と縮退の優先順位（essential vs non-essential 分類）を追記（Req 7.3）。GitHub API rate limit と Claude Max quota の用語分離を明記

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -80,7 +80,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Requirements: 7.1, 7.2, 7.3_
   - _Depends: 1, 5, 6, 7, 8_
 
-- [ ] 10. 全体整合の検証（統合・no-op 回帰）
+- [x] 10. 全体整合の検証（統合・no-op 回帰）
   - gate 全 off（既定）で main loop の一覧取得回数・プロセッサ実行順・ログ出力が導入前と一致することを統合テストで確認（Req 1.1 no-op / NFR 1.1）
   - `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/watcher-config.sh local-watcher/bin/modules/*.sh` 新規警告 0・`bash -n` OK を確認（NFR 6.1）
   - dry-run（対象なし・全 gate off）で `処理対象の Issue なし` 正常終了、`GH_API_BUCKET_LOG_ENABLED=true` で終端 1 行ログ出力を smoke 確認

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -4,7 +4,7 @@
 可視化 → 縮退 → リトライ → REST 逃がし → README → 全体検証」。全 gate 既定 off のため、各タスク
 commit 時点で未設定環境の挙動は不変（NFR 1.1）。
 
-- [ ] 1. snapshot 基盤 module・config・cycle 配線
+- [x] 1. snapshot 基盤 module・config・cycle 配線
   - `local-watcher/bin/modules/api-rate-guard.sh` を新規作成（prefix `grl_` / 関数定義のみ・トップレベル副作用なし / ファイル冒頭ヘッダに用途・prefix・依存を明記）
   - `grl_snapshot_init` / `grl_snapshot_active` / `grl_snapshot_prs` / `grl_snapshot_issues` / `grl_pr_snapshot_or_live` / `grl_issue_snapshot_or_live` を実装（超集合フィールド union は design 参照。`mktemp`→`mv` の atomic 書込・`GRL_SNAPSHOT_STATUS` グローバルで active 管理）
   - 取得失敗時は `grl_warn` 出力 + active=off で fallback（Req 2.5, 2.6 / NFR 2.1）。gate off / 未設定 / 不正値は no-op（Req 1.1, 1.2, 1.3）

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -31,7 +31,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Boundary: pr-iteration, pr-reviewer, pr-design-reviewer, security-review_
   - _Depends: 1_
 
-- [ ] 4. Issue snapshot 参加 processor の差し替え (P)
+- [x] 4. Issue snapshot 参加 processor の差し替え (P)
   - Inventory #11〜#14 の 4 module（`dependency-resolver.sh` / `path-overlap.sh` / `stale-pickup-reaper.sh` / `quota-aware.sh`）の `gh issue list` を `grl_issue_snapshot_or_live` 経由へ差し替え、client jq を現行 `--search` で再現（Req 2.3）
   - 参加条件「対象集合 ⊆ (open ∧ auto-dev)」を各 module のコメントに明記。gate off 時は live 経路で byte 等価
   - 各 module の fixture テストに snapshot 参照時の等価集合ケースを追加（reaper の `label:claude-picked-up` 絞り込み等 / live API なし）

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -39,7 +39,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Boundary: dependency-resolver, path-overlap, stale-pickup-reaper, quota-aware_
   - _Depends: 1_
 
-- [ ] 5. バケット別残量の可視化
+- [x] 5. バケット別残量の可視化
   - `api-rate-guard.sh` に `grl_buckets_refresh`（`gh api rate_limit` → core/graphql/search の remaining/limit をグローバルへ / 非消費経路 / 失敗は warn + 継続）と `grl_buckets_log`（cycle 終端に固定書式 1 行 `gh-rate-limit: core=<r>/<l> graphql=<r>/<l> search=<r>/<l>` を `LOG_DIR` へ）を実装（Req 3.1, 3.2, 3.3, 3.4）
   - `watcher-config.sh` に `GH_API_BUCKET_LOG_ENABLED`（既定 false / `true` のみ ON）を追加
   - `issue-watcher.sh` の cycle 終端（`echo 完了` 直前）へ `grl_buckets_log || true` を、repo 最新化直後へ `grl_buckets_refresh || true`（degrade 用 / 後続 task 6 が参照）を配線

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -65,7 +65,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 5.6_
   - _Depends: 1_
 
-- [ ] 8. GraphQL から REST への負荷分散
+- [x] 8. GraphQL から REST への負荷分散
   - `api-rate-guard.sh` に `grl_rest_prs_for_head <branch> <state>` を実装（`GH_API_REST_OFFLOAD_ENABLED=true` 時に `gh api "repos/$REPO/pulls" -f head="$owner:$branch" -f state="$state"` で REST core 経由取得し、`gh pr list --head` 互換 JSON へ正規化: `state` は open→OPEN / closed+merged_at→MERGED / closed→CLOSED、`headRefName`=head.ref、`url`=html_url。失敗・gate off は `gh pr list --head` へ fallback / Req 6.1, 6.2, 6.3, 6.4）
   - `watcher-config.sh` に `GH_API_REST_OFFLOAD_ENABLED`（既定 false）を追加
   - per-branch PR 存在確認（`slot-worker-resume.sh:318,1017` / `stage-checkpoint.sh:192,694`）を `grl_rest_prs_for_head` 経由へ差し替え（呼び出し側が参照する number/state/headRefName/url フィールドの互換を保つ）

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -56,7 +56,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5, 4.6_
   - _Depends: 1, 5_
 
-- [ ] 7. 状態遷移系ラベル操作の限定リトライ
+- [x] 7. 状態遷移系ラベル操作の限定リトライ
   - `api-rate-guard.sh` に `grl_retry_label_op <issue番号> <gh issue edit 引数...>` を実装（`GH_API_STATE_RETRY_ENABLED=true` 時のみ、rate-limit 文言検出時に `GH_API_STATE_RETRY_MAX_ATTEMPTS` まで `GH_API_STATE_RETRY_SLEEP` 秒 backoff 再試行。非 rate-limit 失敗は再試行せず即返す。gate off は 1 回実行 = 従来挙動）
   - 試行ごとに `gh-rate-limit: retry issue=#<N> op=<label操作> attempt=<i>/<max>` を出力（Req 5.6）。上限到達でも `claude-picked-up` を残置し次 tick 再評価（孤児化しない / holder ラベル誤除去を発生させない / Req 5.4, 5.5）
   - `watcher-config.sh` に `GH_API_STATE_RETRY_ENABLED`（既定 false）/ `GH_API_STATE_RETRY_MAX_ATTEMPTS`（既定 3 / 有限）/ `GH_API_STATE_RETRY_SLEEP`（既定 2）を追加

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -14,7 +14,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - `local-watcher/test/api_rate_guard_snapshot_test.sh` を追加（`extract_function` + fixture。超集合取得・accessor・active 判定・取得失敗時 fallback・gate off no-op を live API なしで検証 / NFR 6.2）
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 2.1, 2.2, 2.5, 2.6_
 
-- [ ] 2. PR snapshot 差し替え: merge / auto-merge 系 (P)
+- [x] 2. PR snapshot 差し替え: merge / auto-merge 系 (P)
   - Inventory #1〜#6 の 5 module（`merge-queue.sh`（recheck 含む）/ `auto-rebase.sh` / `auto-merge.sh` / `auto-merge-design.sh` / `auto-merge-disarm.sh`）の `gh pr list` を `grl_pr_snapshot_or_live` 経由へ差し替え
   - snapshot 参照時、各 module の client jq を現行 `--search` 全条件で再現（design「等価性ルール」表。例: merge-queue へ `-label:needs-rebase` / `-label:failed` の `index==null` select 追加、auto-rebase の `label:needs-rebase` 包含）— gate off の live 経路は byte 等価に保つ（Req 2.3）
   - 鮮度クリティカル（Dispatcher 候補 / check_existing_impl_pr）は差し替えず個別取得を維持（Req 2.4）

--- a/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
+++ b/docs/specs/521-feat-watcher-github-api-rate-limit/tasks.md
@@ -23,7 +23,7 @@ commit 時点で未設定環境の挙動は不変（NFR 1.1）。
   - _Boundary: merge-queue, auto-rebase, auto-merge, auto-merge-design, auto-merge-disarm_
   - _Depends: 1_
 
-- [ ] 3. PR snapshot 差し替え: review 系 (P)
+- [x] 3. PR snapshot 差し替え: review 系 (P)
   - Inventory #7〜#10 の 4 module（`pr-iteration.sh` / `pr-reviewer.sh` / `pr-design-reviewer.sh` / `security-review.sh`）の `gh pr list` を `grl_pr_snapshot_or_live` 経由へ差し替え、client jq を現行 `--search` 全条件（`-draft:true` = `isDraft==false` 等）で再現（Req 2.3）
   - gate off の live 経路は byte 等価に保つ
   - 各 module の fixture テストに snapshot 参照時の等価集合ケースを追加（`-draft:true` 相当の client 絞り込み / live API なし）

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -411,6 +411,12 @@ git pull --ff-only origin "$BASE_BRANCH"
 # 参加 processor は従来の個別取得へフォールバックする（Req 2.5, 2.6 / NFR 2.1）。
 grl_snapshot_init || grl_warn "grl_snapshot_init が想定外のエラーで終了しました（各 processor は個別取得へフォールバック）"
 
+# GitHub API Rate Guard: サイクル冒頭のバケット残量取得（#521 / Req 3 可視化 / Req 4 縮退）。
+# BUCKET_LOG / DEGRADE のいずれも無効なら新規 API 呼び出しゼロで即 return（NFR 1.1）。取得失敗も
+# rc=0（fail-safe）で当サイクルのバケット参照を無効化し、後続 processor を阻害しない（Req 3.4）。
+# ここで取得した graphql 残量を後続の grl_degrade_should_run（task 6）が参照する。
+grl_buckets_refresh || true
+
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # メインループ: Processor / Gate 実行順序（モジュール分割完了マニフェスト / #455 Phase 1・#468 gate）
 #
@@ -890,6 +896,11 @@ if [ "$DISPATCHER_RC" -ne 0 ]; then
   # サイクル中断（既存の ERROR 終了規約 = exit 1 と整合）
   exit "$DISPATCHER_RC"
 fi
+
+# GitHub API Rate Guard: サイクル終端のバケット残量ログ（#521 / Req 3.1, 3.3）。
+# GH_API_BUCKET_LOG_ENABLED=true のときのみ `gh-rate-limit: core=.. graphql=.. search=..` を
+# 1 行出力する。gate off は no-op で本機能導入前と等価（NFR 1.1）。取得失敗は warn + 継続。
+grl_buckets_log || true
 
 echo "[$(date '+%F %T')] 完了"
 exit 0

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -504,7 +504,9 @@ process_promote_pipeline \
 # PR Reviewer Processor (#261) を PR Iteration の直前に実行。レビュー結果で付与した
 # needs-iteration ラベルを同一 flock 内で直後の process_pr_iteration が引き継げる
 # （PR_REVIEWER_ENABLED!=true なら即 return 0 で本機能導入前と等価、NFR 1.1）。
-process_pr_reviewer || pr_warn "process_pr_reviewer が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+# #521 Req 4.2: non-essential（レビュー系）。graphql 残量閾値割れ時は縮退で skip（essential は
+# gate せず常時実行 / Req 4.3）。gate off / 残量未取得は常に実行（NFR 1.1, 2.2）。
+grl_degrade_should_run "pr-reviewer" && { process_pr_reviewer || pr_warn "process_pr_reviewer が想定外のエラーで終了しました（後続 Issue 処理は継続）"; }
 
 # Issue #374 claude-review Catch-up Processor を PR Reviewer の直後に実行。
 # per-task ループ運用で `publish_claude_review_status` が PR 作成より前の時間軸で発火して
@@ -512,7 +514,7 @@ process_pr_reviewer || pr_warn "process_pr_reviewer が想定外のエラーで�
 # AND 二重 opt-in（PR_REVIEWER_STATUS_CHECK_ENABLED=true AND FULL_AUTO_ENABLED=true）が
 # 成立した場合のみ動作。OFF（既定）なら即 return 0 で本機能導入前と等価（NFR 1.1）。
 # `PR_REVIEWER_ENABLED` の値には依存しない（claude-review 単独有効化を維持）。
-process_claude_review_status_catchup || pr_warn "process_claude_review_status_catchup が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+grl_degrade_should_run "claude-review-catchup" && { process_claude_review_status_catchup || pr_warn "process_claude_review_status_catchup が想定外のエラーで終了しました（後続 Issue 処理は継続）"; }
 
 # Issue #412 Merge Gate Visibility Processor を catch-up の直後に実行。
 # `claude-review` を required status に採用した repo で、adjudicator も Reviewer catch-up も
@@ -520,7 +522,7 @@ process_claude_review_status_catchup || pr_warn "process_claude_review_status_ca
 # 観測ログ）。`claude-review` が required でない repo では即 return 0（gh api 1 回のみ /
 # NFR 1.1 ほぼ no-op）。adjudicator や catch-up が後発で publish に成功した場合は次サイクル
 # 冒頭で当該 PR がケース 1 / ケース 2 として解消され、label が冪等に除去される（Req 4.3）。
-process_claude_review_merge_gate_visibility || pr_warn "process_claude_review_merge_gate_visibility が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+grl_degrade_should_run "claude-review-merge-gate-visibility" && { process_claude_review_merge_gate_visibility || pr_warn "process_claude_review_merge_gate_visibility が想定外のエラーで終了しました（後続 Issue 処理は継続）"; }
 
 # Issue #407: Design PR Reviewer Processor。設計 PR (`claude/issue-<N>-design-<slug>`) 専用の
 # 独立 Claude レビュアを起動し、claude-review status と needs-iteration ラベルを確定する。
@@ -531,24 +533,24 @@ process_claude_review_merge_gate_visibility || pr_warn "process_claude_review_me
 # 本 design 経路に入ることで、設計 PR が万一 impl 経路から claude-review を書かれても
 # 本 processor が後発で確定する（design.md「claude-review publisher contention」節）。
 # impl 経路（pr-reviewer.sh / adjudicator.sh / catch-up）は不変（Req 7.2, 7.3）。
-process_pr_design_reviewer || pdr_warn "process_pr_design_reviewer が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+grl_degrade_should_run "pr-design-reviewer" && { process_pr_design_reviewer || pdr_warn "process_pr_design_reviewer が想定外のエラーで終了しました（後続 Issue 処理は継続）"; }
 
 # Security Review Processor (#279) を PR Reviewer の直後・PR Iteration の直前に実行。
 # advisory 固定動作（ラベル操作なし）のため PR Reviewer の needs-iteration 付与とは
 # 競合しない。PR タイムライン上で「外部 AI レビュー → セキュリティレビュー → iteration
 # 反復」の時系列が運用者に提示される（SECURITY_REVIEW_ENABLED!=true なら即 return 0 で
 # 本機能導入前と等価、NFR 1.1）。
-process_security_review || sec_warn "process_security_review が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+grl_degrade_should_run "security-review" && { process_security_review || sec_warn "process_security_review が想定外のエラーで終了しました（後続 Issue 処理は継続）"; }
 
 # Phase A 直後に PR Iteration Processor を実行（AC 8.1 / 8.2: 同一 flock 内で直列実行）
-process_pr_iteration || pi_warn "process_pr_iteration が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+grl_degrade_should_run "pr-iteration" && { process_pr_iteration || pi_warn "process_pr_iteration が想定外のエラーで終了しました（後続 Issue 処理は継続）"; }
 
 # Failed Recovery Processor (#359) を PR Iteration の直後・Design Review Release の直前に実行。
 # `claude-failed` Issue + auto-merge 待ち PR の CI error を fresh Claude session で
 # 自動修正する。FAILED_RECOVERY_ENABLED=true AND FULL_AUTO_ENABLED=true の二重 opt-in
 # が成立する場合のみ起動し、それ以外（既定）は即 return 0 で本機能導入前と等価（NFR 1.1, 1.3）。
 # 通算 4 回上限（FAILED_RECOVERY_MAX_ATTEMPTS）と no-progress ガードで quota 燃焼を防ぐ。
-process_failed_recovery || fr_warn "process_failed_recovery が想定外のエラーで終了しました（後続 Issue 処理は継続）"
+grl_degrade_should_run "failed-recovery" && { process_failed_recovery || fr_warn "process_failed_recovery が想定外のエラーで終了しました（後続 Issue 処理は継続）"; }
 
 # Stale Pickup Reaper (#379) を Failed Recovery の直後・Design Review Release の直前に実行。
 # claude-picked-up / claude-claimed ラベルが残り continuance しないセッション喪失 Issue を

--- a/local-watcher/bin/issue-watcher.sh
+++ b/local-watcher/bin/issue-watcher.sh
@@ -256,7 +256,7 @@ IDD_MODULE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/mo
 # 3 プロセッサ（promote-pipeline / pr-iteration / stage-a-verify）を並べ、末尾に
 # #238 の scaffolding-health.sh と #239 の per-run evidence サマリ（run-summary.sh）、
 # #325 の token usage 計測（token-usage.sh）を置く。
-REQUIRED_MODULES=( "core_utils.sh" "env-loader.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "auto-merge.sh" "auto-merge-design.sh" "auto-merge-disarm.sh" "path-overlap.sh" "model-router.sh" "promote-pipeline.sh" "pr-iteration-comments.sh" "pr-iteration-state.sh" "pr-iteration-oos.sh" "pr-iteration-exec.sh" "pr-iteration.sh" "pr-reviewer-exec.sh" "pr-reviewer-publish.sh" "pr-reviewer.sh" "adjudicator.sh" "pr-design-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "token-usage.sh" "security-review.sh" "guard-hook.sh" "context-map.sh" "failed-recovery-attempt.sh" "failed-recovery-invoke.sh" "failed-recovery.sh" "stale-pickup-reaper.sh" "needs-decisions-auto.sh" "dep-cycle-detect.sh" "slack-notify.sh" "auto-merge-merged.sh" "design-review-release.sh" "tasks-count-gate.sh" "debugger-gate.sh" "stage-checkpoint.sh" "per-task-loop-diffrange.sh" "per-task-loop-exec.sh" "per-task-loop-prompt.sh" "per-task-loop.sh" "impl-pipeline-prompt.sh" "impl-pipeline-review.sh" "impl-pipeline.sh" "dependency-resolver.sh" "slot-worker-resume.sh" "slot-worker.sh" )
+REQUIRED_MODULES=( "core_utils.sh" "env-loader.sh" "api-rate-guard.sh" "quota-aware.sh" "merge-queue.sh" "auto-rebase.sh" "auto-merge.sh" "auto-merge-design.sh" "auto-merge-disarm.sh" "path-overlap.sh" "model-router.sh" "promote-pipeline.sh" "pr-iteration-comments.sh" "pr-iteration-state.sh" "pr-iteration-oos.sh" "pr-iteration-exec.sh" "pr-iteration.sh" "pr-reviewer-exec.sh" "pr-reviewer-publish.sh" "pr-reviewer.sh" "adjudicator.sh" "pr-design-reviewer.sh" "stage-a-verify.sh" "scaffolding-health.sh" "run-summary.sh" "token-usage.sh" "security-review.sh" "guard-hook.sh" "context-map.sh" "failed-recovery-attempt.sh" "failed-recovery-invoke.sh" "failed-recovery.sh" "stale-pickup-reaper.sh" "needs-decisions-auto.sh" "dep-cycle-detect.sh" "slack-notify.sh" "auto-merge-merged.sh" "design-review-release.sh" "tasks-count-gate.sh" "debugger-gate.sh" "stage-checkpoint.sh" "per-task-loop-diffrange.sh" "per-task-loop-exec.sh" "per-task-loop-prompt.sh" "per-task-loop.sh" "impl-pipeline-prompt.sh" "impl-pipeline-review.sh" "impl-pipeline.sh" "dependency-resolver.sh" "slot-worker-resume.sh" "slot-worker.sh" )
 for _idd_mod in "${REQUIRED_MODULES[@]}"; do
   _idd_mod_path="$IDD_MODULE_DIR/$_idd_mod"
   if [ ! -f "$_idd_mod_path" ]; then
@@ -402,6 +402,14 @@ unset _dirty_status
 
 git checkout "$BASE_BRANCH"
 git pull --ff-only origin "$BASE_BRANCH"
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# GitHub API Rate Guard: サイクル冒頭のスナップショット取得（#521 / Req 2.1, 2.2）
+# repo 最新化直後・全 processor 実行前に PR/Issue 超集合を各 1 回取得し file 共有する。
+# GH_API_SNAPSHOT_ENABLED=true 厳密一致のときのみ発火し、それ以外（既定）は即 return 0 で
+# 本機能導入前と完全に等価（NFR 1.1）。取得失敗も rc=0（fail-safe）で active=off とし、
+# 参加 processor は従来の個別取得へフォールバックする（Req 2.5, 2.6 / NFR 2.1）。
+grl_snapshot_init || grl_warn "grl_snapshot_init が想定外のエラーで終了しました（各 processor は個別取得へフォールバック）"
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # メインループ: Processor / Gate 実行順序（モジュール分割完了マニフェスト / #455 Phase 1・#468 gate）

--- a/local-watcher/bin/modules/api-rate-guard.sh
+++ b/local-watcher/bin/modules/api-rate-guard.sh
@@ -49,7 +49,9 @@ grl_snapshot_pr_fields() {
   echo "number,title,headRefName,headRefOid,baseRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,labels,url,headRepositoryOwner,autoMergeRequest"
 }
 grl_snapshot_issue_fields() {
-  echo "number,title,body,url,labels,author"
+  # design Issue union（number,title,body,url,labels,author）に加え、stale-pickup-reaper
+  # （Inventory #13 参加）が必須とする updatedAt を含めて真の超集合にする（#521 確認事項参照）。
+  echo "number,title,body,url,labels,author,updatedAt"
 }
 
 # snapshot ディレクトリの絶対パス（config 既定は $HOME/.issue-watcher/api-snapshot/$REPO_SLUG）。
@@ -171,25 +173,23 @@ grl_pr_snapshot_or_live() {
 
 # 参加 processor 用ラッパ（Issue）。active なら超集合を返し caller が client jq で絞る。
 # 非 active なら live 引数で従来 gh issue list を実行。
-# $1=timeout $2=search $3=jsonfields $4=limit → stdout Issue JSON
+# $1=timeout（空なら timeout ラッパを付けない = 元々 timeout 無しの consumer 用）
+# $2=search（空なら --search を付けない）$3=jsonfields $4=limit → stdout Issue JSON
+# 元々 timeout / --search を付けていなかった consumer（quota-aware / path-overlap /
+# dependency-resolver）に対しても gate off の live 経路を等価に保つため、空値時は当該
+# フラグ / timeout ラッパを省略する。
 grl_issue_snapshot_or_live() {
   local timeout_s="$1" search="$2" fields="$3" limit="$4"
   if grl_snapshot_active; then
     grl_snapshot_issues
     return 0
   fi
-  if [ -n "$search" ]; then
-    timeout "$timeout_s" gh issue list \
-      --repo "$REPO" \
-      --state open \
-      --search "$search" \
-      --json "$fields" \
-      --limit "$limit" 2>/dev/null
+  local -a cmd=(gh issue list --repo "$REPO" --state open)
+  [ -n "$search" ] && cmd+=(--search "$search")
+  cmd+=(--json "$fields" --limit "$limit")
+  if [ -n "$timeout_s" ]; then
+    timeout "$timeout_s" "${cmd[@]}" 2>/dev/null
   else
-    timeout "$timeout_s" gh issue list \
-      --repo "$REPO" \
-      --state open \
-      --json "$fields" \
-      --limit "$limit" 2>/dev/null
+    "${cmd[@]}" 2>/dev/null
   fi
 }

--- a/local-watcher/bin/modules/api-rate-guard.sh
+++ b/local-watcher/bin/modules/api-rate-guard.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# api-rate-guard.sh — GitHub API rate limit の削減・耐性強化モジュール（#521）
+#
+# 用途:
+#   watcher の 1 cron tick（サイクル）における GitHub API rate limit（core / graphql /
+#   search バケット）の消費削減と枯渇耐性を集約する単一モジュール。5 機能を束ねる:
+#     Req2 snapshot : grl_snapshot_init / _active / _prs / _issues /
+#                     grl_pr_snapshot_or_live / grl_issue_snapshot_or_live
+#                     （サイクル冒頭で PR/Issue 超集合を各 1 回取得し file 共有）
+#     Req3 bucket   : grl_buckets_log（cycle 終端に core/graphql/search を 1 行ログ）
+#     Req4 degrade  : grl_buckets_refresh / grl_degrade_should_run（残量閾値割れで非必須 skip）
+#     Req5 retry    : grl_retry_label_op（状態遷移系ラベル操作の rate-limit 限定リトライ）
+#     Req6 REST     : grl_rest_prs_for_head（per-branch PR 存在確認を REST core へ逃がす）
+#
+# prefix:
+#   grl_（GitHub Rate Limit）。Claude Max quota（rate_limit_event / quota-aware.sh の
+#   `qa_` / #66・#104）とは別物のため、ログ prefix は `gh-rate-limit:`、env prefix は
+#   `GH_API_` に統一して用語混同を避ける。
+#
+# 配置先:
+#   $HOME/bin/modules/api-rate-guard.sh（install.sh が local-watcher/bin/modules/ から配置）
+#
+# 依存:
+#   - 本モジュールは issue-watcher.sh 本体から `source` される前提（単体起動しない）。
+#     `set -euo pipefail` は本体側で宣言済みのため、本モジュールは関数定義のみを持ち
+#     トップレベル副作用（代入・実行）を持たない（module loader 規約 / CLAUDE.md §1）。
+#   - ロガー grl_log / grl_warn / grl_error は core_utils.sh に定義（本体より前に source）。
+#   - グローバル変数（$REPO / $REPO_SLUG / $LABEL_TRIGGER / $GH_API_*）は
+#     watcher-config.sh が本体 source 前に定義・正規化済み。
+#   - モジュールグローバル: GRL_SNAPSHOT_STATUS（active/inactive）/ GRL_BUCKET_* を
+#     grl_snapshot_init / grl_buckets_refresh が代入する（単一 writer = flock 済み main）。
+#   - 外部 CLI: gh / jq / date / mktemp / mv / cat / timeout。
+#   - すべての新挙動は対応 gate（GH_API_*_ENABLED）が `true` 厳密一致のときのみ発火し、
+#     それ以外（未設定 / 不正値 / 取得失敗）は従来の個別取得・従来 mutation・従来 GraphQL へ
+#     透過フォールバックする（fail-safe / NFR 2.1）。
+#
+# セットアップ参照先:
+#   README.md「オプション機能一覧」/ docs/specs/521-feat-watcher-github-api-rate-limit/
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Req 2: サイクル内スナップショット共有
+# ─────────────────────────────────────────────────────────────────────────────
+
+# 超集合の --json フィールド union（design「等価性ルール」節）。参加 processor は
+# 超集合を client jq で自 processor の server search 条件へ絞り込む。
+# PR: 全 open PR 全件（--search なし）を 1 回取得。
+# Issue: open ∧ auto-dev（picked/claimed/needs-quota-wait は auto-dev を保持する部分集合）。
+grl_snapshot_pr_fields() {
+  echo "number,title,headRefName,headRefOid,baseRefName,isDraft,mergeable,mergeStateStatus,reviewDecision,labels,url,headRepositoryOwner,autoMergeRequest"
+}
+grl_snapshot_issue_fields() {
+  echo "number,title,body,url,labels,author"
+}
+
+# snapshot ディレクトリの絶対パス（config 既定は $HOME/.issue-watcher/api-snapshot/$REPO_SLUG）。
+grl_snapshot_dir() {
+  echo "${GH_API_SNAPSHOT_DIR:-$HOME/.issue-watcher/api-snapshot/$REPO_SLUG}"
+}
+
+# $1=書き込み先パス / $2=内容。同一ディレクトリ内 mktemp→mv で atomic 書き込み。
+# rc: 0=成功 / 1=失敗（呼び出し元で active=off へフォールバック）。
+grl_atomic_write() {
+  local dest="$1" content="$2"
+  local tmp
+  tmp="$(mktemp "${dest}.XXXXXX" 2>/dev/null)" || return 1
+  if ! printf '%s' "$content" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  if ! mv -f "$tmp" "$dest" 2>/dev/null; then
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  return 0
+}
+
+# サイクル冒頭で PR/Issue 超集合を各 1 回取得し file へ atomic 書き込みする。
+# 成功で GRL_SNAPSHOT_STATUS=active、gate off / 取得失敗は inactive（従来の個別取得へ
+# フォールバックさせる / Req 2.5, 2.6 / NFR 2.1）。
+# rc: 常に 0（失敗も 0 = fail-safe でサイクルを中断しない）。
+grl_snapshot_init() {
+  # gate off / 未設定 / 不正値は no-op（active=off のまま / Req 1.1, 1.2, 1.3）
+  if [ "${GH_API_SNAPSHOT_ENABLED:-false}" != "true" ]; then
+    GRL_SNAPSHOT_STATUS="inactive"
+    return 0
+  fi
+  local dir
+  dir="$(grl_snapshot_dir)"
+  if ! mkdir -p "$dir" 2>/dev/null; then
+    grl_warn "snapshot ディレクトリ作成に失敗（個別取得へフォールバック / Req 2.5）: $dir"
+    GRL_SNAPSHOT_STATUS="inactive"
+    return 0
+  fi
+  local timeout_s="${GH_API_SNAPSHOT_GH_TIMEOUT:-60}"
+  local prs_json="" issues_json=""
+  # PR 超集合: 全 open PR（--search なし）。各参加 processor は client jq で絞る。
+  if ! prs_json=$(timeout "$timeout_s" gh pr list \
+      --repo "$REPO" \
+      --state open \
+      --json "$(grl_snapshot_pr_fields)" \
+      --limit "${GH_API_SNAPSHOT_PR_LIMIT:-100}" 2>/dev/null); then
+    grl_warn "PR 超集合の取得に失敗（個別取得へフォールバック / Req 2.5, 2.6）"
+    GRL_SNAPSHOT_STATUS="inactive"
+    return 0
+  fi
+  # Issue 超集合: open ∧ auto-dev（LABEL_TRIGGER）。参加 Issue processor の対象集合は
+  # (open ∧ auto-dev) の部分集合（design List Fetch Inventory #11〜#14）。
+  if ! issues_json=$(timeout "$timeout_s" gh issue list \
+      --repo "$REPO" \
+      --state open \
+      --label "$LABEL_TRIGGER" \
+      --json "$(grl_snapshot_issue_fields)" \
+      --limit "${GH_API_SNAPSHOT_ISSUE_LIMIT:-100}" 2>/dev/null); then
+    grl_warn "Issue 超集合の取得に失敗（個別取得へフォールバック / Req 2.5, 2.6）"
+    GRL_SNAPSHOT_STATUS="inactive"
+    return 0
+  fi
+  if ! grl_atomic_write "$dir/prs.json" "$prs_json" \
+    || ! grl_atomic_write "$dir/issues.json" "$issues_json"; then
+    grl_warn "snapshot ファイル書き込みに失敗（個別取得へフォールバック / Req 2.5）"
+    GRL_SNAPSHOT_STATUS="inactive"
+    return 0
+  fi
+  GRL_SNAPSHOT_STATUS="active"
+  local pr_n issue_n
+  pr_n=$(printf '%s' "$prs_json" | jq 'length' 2>/dev/null || echo "?")
+  issue_n=$(printf '%s' "$issues_json" | jq 'length' 2>/dev/null || echo "?")
+  grl_log "snapshot 取得完了 PR=${pr_n} Issue=${issue_n} dir=$dir"
+  return 0
+}
+
+# 当サイクルの snapshot が有効か。
+# rc: 0=有効（gate on かつ取得成功）/ 1=無効（gate off or 取得失敗）。
+grl_snapshot_active() {
+  [ "${GH_API_SNAPSHOT_ENABLED:-false}" = "true" ] \
+    && [ "${GRL_SNAPSHOT_STATUS:-inactive}" = "active" ]
+}
+
+# PR / Issue 超集合 JSON 配列を stdout へ返す（active 時のみ意味を持つ）。
+grl_snapshot_prs() {
+  cat "$(grl_snapshot_dir)/prs.json" 2>/dev/null
+}
+grl_snapshot_issues() {
+  cat "$(grl_snapshot_dir)/issues.json" 2>/dev/null
+}
+
+# 参加 processor 用ラッパ（PR）。active なら超集合を返し caller が client jq で絞る。
+# 非 active（gate off / 取得失敗）なら live 引数で従来 gh pr list を実行（byte 等価）。
+# $1=timeout $2=search（空なら --search を付けない）$3=jsonfields $4=limit → stdout PR JSON
+grl_pr_snapshot_or_live() {
+  local timeout_s="$1" search="$2" fields="$3" limit="$4"
+  if grl_snapshot_active; then
+    grl_snapshot_prs
+    return 0
+  fi
+  if [ -n "$search" ]; then
+    timeout "$timeout_s" gh pr list \
+      --repo "$REPO" \
+      --state open \
+      --search "$search" \
+      --json "$fields" \
+      --limit "$limit" 2>/dev/null
+  else
+    timeout "$timeout_s" gh pr list \
+      --repo "$REPO" \
+      --state open \
+      --json "$fields" \
+      --limit "$limit" 2>/dev/null
+  fi
+}
+
+# 参加 processor 用ラッパ（Issue）。active なら超集合を返し caller が client jq で絞る。
+# 非 active なら live 引数で従来 gh issue list を実行。
+# $1=timeout $2=search $3=jsonfields $4=limit → stdout Issue JSON
+grl_issue_snapshot_or_live() {
+  local timeout_s="$1" search="$2" fields="$3" limit="$4"
+  if grl_snapshot_active; then
+    grl_snapshot_issues
+    return 0
+  fi
+  if [ -n "$search" ]; then
+    timeout "$timeout_s" gh issue list \
+      --repo "$REPO" \
+      --state open \
+      --search "$search" \
+      --json "$fields" \
+      --limit "$limit" 2>/dev/null
+  else
+    timeout "$timeout_s" gh issue list \
+      --repo "$REPO" \
+      --state open \
+      --json "$fields" \
+      --limit "$limit" 2>/dev/null
+  fi
+}

--- a/local-watcher/bin/modules/api-rate-guard.sh
+++ b/local-watcher/bin/modules/api-rate-guard.sh
@@ -337,3 +337,73 @@ grl_retry_label_op() {
     attempt=$((attempt + 1))
   done
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Req 6: GraphQL から REST への負荷分散（per-branch PR 存在確認の hot path 逃がし）
+# ─────────────────────────────────────────────────────────────────────────────
+
+# 従来経路（GraphQL search 経由の `gh pr list --head`）で per-branch PR を取得する fallback。
+# 呼び出し側が参照する union フィールド（number/state/headRefName/headRefOid/url）を返す。
+# $3 が非空なら timeout でラップする（元々 timeout 付きだった consumer 用）。
+grl_gh_pr_list_head() {
+  local branch="$1" state="$2" timeout_s="${3:-}"
+  if [ -n "$timeout_s" ]; then
+    timeout "$timeout_s" gh pr list --repo "$REPO" --head "$branch" --state "$state" \
+      --json number,state,headRefName,headRefOid,url --limit 20 2>/dev/null
+  else
+    gh pr list --repo "$REPO" --head "$branch" --state "$state" \
+      --json number,state,headRefName,headRefOid,url --limit 20 2>/dev/null
+  fi
+}
+
+# per-branch PR 存在確認を GraphQL search（`gh pr list --head`）から REST core
+# （`gh api repos/{owner}/{repo}/pulls?head=`）へ逃がすラッパ。offload on 時は REST で取得し
+# `gh pr list --head` 互換 JSON（number / state / headRefName / headRefOid / url）へ正規化して
+# 返す（state は open→OPEN / closed+merged_at→MERGED / closed→CLOSED / Req 6.2 等価判定）。
+# offload off / REST 失敗 / 正規化失敗は `gh pr list --head` へ fallback（Req 6.3, 6.4）。
+# 呼び出し側は number/state/headRefName/headRefOid/url を jq で抽出する既存契約を維持できる。
+# Args: $1=branch / $2=state（open|closed|all。既定 all）/ $3=timeout 秒（任意 / 空なら timeout なし）
+# Stdout: PR 配列 JSON（gh pr list --head 互換）
+grl_rest_prs_for_head() {
+  local branch="$1" state="${2:-all}" timeout_s="${3:-}"
+  # gate off → 従来経路（gh pr list --head）へ委譲（Req 6.4）。
+  if [ "${GH_API_REST_OFFLOAD_ENABLED:-false}" != "true" ]; then
+    grl_gh_pr_list_head "$branch" "$state" "$timeout_s"
+    return $?
+  fi
+  local owner="${REPO%%/*}"
+  local rest_state
+  case "$state" in
+    open)   rest_state="open" ;;
+    closed) rest_state="closed" ;;
+    *)      rest_state="all" ;;
+  esac
+  # REST core 経由取得（未信頼 branch は -f 経由で query param に渡し URL へ inline 展開しない / NFR 5.1）。
+  local rest_json ok=1
+  if [ -n "$timeout_s" ]; then
+    rest_json=$(timeout "$timeout_s" gh api "repos/$REPO/pulls" -f head="$owner:$branch" -f state="$rest_state" 2>/dev/null) && ok=0 || ok=$?
+  else
+    rest_json=$(gh api "repos/$REPO/pulls" -f head="$owner:$branch" -f state="$rest_state" 2>/dev/null) && ok=0 || ok=$?
+  fi
+  if [ "$ok" -ne 0 ]; then
+    grl_warn "REST offload 取得に失敗（gh pr list --head へ fallback / branch=$branch / Req 6.3）"
+    grl_gh_pr_list_head "$branch" "$state" "$timeout_s"
+    return $?
+  fi
+  # REST → gh pr list 互換 JSON へ正規化（Req 6.2 等価判定）。
+  local norm
+  if norm=$(printf '%s' "$rest_json" | jq -c '[.[] | {
+        number: .number,
+        state: (if .state == "open" then "OPEN"
+                elif .merged_at != null then "MERGED"
+                else "CLOSED" end),
+        headRefName: .head.ref,
+        headRefOid: .head.sha,
+        url: .html_url
+      }]' 2>/dev/null); then
+    printf '%s' "$norm"
+    return 0
+  fi
+  grl_warn "REST offload レスポンスの正規化に失敗（gh pr list --head へ fallback / branch=$branch / Req 6.3）"
+  grl_gh_pr_list_head "$branch" "$state" "$timeout_s"
+}

--- a/local-watcher/bin/modules/api-rate-guard.sh
+++ b/local-watcher/bin/modules/api-rate-guard.sh
@@ -250,3 +250,34 @@ grl_buckets_log() {
   grl_log "core=${GRL_BUCKET_CORE_REMAINING}/${GRL_BUCKET_CORE_LIMIT} graphql=${GRL_BUCKET_GRAPHQL_REMAINING}/${GRL_BUCKET_GRAPHQL_LIMIT} search=${GRL_BUCKET_SEARCH_REMAINING}/${GRL_BUCKET_SEARCH_LIMIT}"
   return 0
 }
+
+# 非必須プロセッサ call site の縮退 gate。graphql バケット残量が閾値を下回ったら skip
+# （rc=1）+ WARN（bucket・残量・閾値を含む / Req 4.1, 4.2, 4.5 / NFR 4.2）。
+# gate off / 残量未取得 / 残量が非整数のときは常に実行（rc=0 / 安全側 / Req 4.6 / NFR 2.2）。
+# essential プロセッサは呼び出し側で本 gate を通さないため常に実行される（Req 4.3）。
+# Args: $1 = プロセッサ名（skip ログに記録）
+# rc: 0=実行してよい / 1=当サイクルは skip
+grl_degrade_should_run() {
+  local name="$1"
+  # gate off は常に実行（従来挙動 / Req 4.6）
+  if [ "${GH_API_DEGRADE_ENABLED:-false}" != "true" ]; then
+    return 0
+  fi
+  # 残量が取得できていない（bucket 取得失敗等）→ 安全側で実行（必須処理を守る / NFR 2.2）
+  if [ "${GRL_BUCKET_STATUS:-}" != "ok" ]; then
+    return 0
+  fi
+  local remaining="${GRL_BUCKET_GRAPHQL_REMAINING:-}"
+  local threshold="${GH_API_DEGRADE_GRAPHQL_THRESHOLD:-500}"
+  # 残量が非整数（"?" 等）→ 判定不能なので安全側で実行
+  case "$remaining" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  if [ "$remaining" -lt "$threshold" ]; then
+    # 閾値割れ → WARN + skip。skip ログに processor 名・bucket・残量・閾値を含める
+    # （Req 4.1 WARN / Req 4.5 skip 根拠 / NFR 4.2）。
+    grl_warn "skip processor=$name reason=degrade bucket=graphql remaining=$remaining threshold=$threshold"
+    return 1
+  fi
+  return 0
+}

--- a/local-watcher/bin/modules/api-rate-guard.sh
+++ b/local-watcher/bin/modules/api-rate-guard.sh
@@ -193,3 +193,60 @@ grl_issue_snapshot_or_live() {
     "${cmd[@]}" 2>/dev/null
   fi
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Req 3 / 4: バケット別 rate limit の可視化・縮退用残量取得
+# ─────────────────────────────────────────────────────────────────────────────
+
+# `gh api rate_limit`（プライマリ rate limit を消費しない参照経路 / Req 3.2）で core /
+# graphql / search バケットの remaining・limit をモジュールグローバルへ取り込む。
+# BUCKET_LOG / DEGRADE のいずれも無効なら新規 API 呼び出しゼロで即 return（NFR 1.1）。
+# 取得 / パース失敗は warn + GRL_BUCKET_STATUS=unavailable で継続（Req 3.4 / NFR 2.1）。
+# rc: 常に 0（fail-safe）。
+grl_buckets_refresh() {
+  if [ "${GH_API_BUCKET_LOG_ENABLED:-false}" != "true" ] \
+    && [ "${GH_API_DEGRADE_ENABLED:-false}" != "true" ]; then
+    GRL_BUCKET_STATUS="disabled"
+    return 0
+  fi
+  local json
+  if ! json=$(gh api rate_limit 2>/dev/null); then
+    grl_warn "rate_limit の取得に失敗（バケット可視化 / 縮退は当サイクル無効化して継続 / Req 3.4, NFR 2.1）"
+    GRL_BUCKET_STATUS="unavailable"
+    return 0
+  fi
+  local parsed
+  parsed=$(printf '%s' "$json" | jq -r '
+    [ (.resources.core.remaining // "?"), (.resources.core.limit // "?"),
+      (.resources.graphql.remaining // "?"), (.resources.graphql.limit // "?"),
+      (.resources.search.remaining // "?"), (.resources.search.limit // "?") ]
+    | @tsv' 2>/dev/null)
+  if [ -z "$parsed" ]; then
+    grl_warn "rate_limit のパースに失敗（バケット可視化 / 縮退は当サイクル無効化して継続 / Req 3.4）"
+    GRL_BUCKET_STATUS="unavailable"
+    return 0
+  fi
+  IFS=$'\t' read -r GRL_BUCKET_CORE_REMAINING GRL_BUCKET_CORE_LIMIT \
+    GRL_BUCKET_GRAPHQL_REMAINING GRL_BUCKET_GRAPHQL_LIMIT \
+    GRL_BUCKET_SEARCH_REMAINING GRL_BUCKET_SEARCH_LIMIT <<< "$parsed"
+  GRL_BUCKET_STATUS="ok"
+  return 0
+}
+
+# cycle 終端に core / graphql / search の残量・上限を 1 行の固定書式でログ出力する（Req 3.1,
+# 3.3）。grep 可能な固定書式: `gh-rate-limit: core=<r>/<l> graphql=<r>/<l> search=<r>/<l>`。
+# gate off は no-op、残量取得失敗は warn + 継続（Req 3.4）。
+# rc: 常に 0。
+grl_buckets_log() {
+  if [ "${GH_API_BUCKET_LOG_ENABLED:-false}" != "true" ]; then
+    return 0
+  fi
+  # cycle 終端の残量を反映するため再取得する（rate_limit は非消費 / Req 3.2）。
+  grl_buckets_refresh
+  if [ "${GRL_BUCKET_STATUS:-}" != "ok" ]; then
+    grl_warn "バケット残量を取得できず可視化ログを出力できません（Req 3.4）"
+    return 0
+  fi
+  grl_log "core=${GRL_BUCKET_CORE_REMAINING}/${GRL_BUCKET_CORE_LIMIT} graphql=${GRL_BUCKET_GRAPHQL_REMAINING}/${GRL_BUCKET_GRAPHQL_LIMIT} search=${GRL_BUCKET_SEARCH_REMAINING}/${GRL_BUCKET_SEARCH_LIMIT}"
+  return 0
+}

--- a/local-watcher/bin/modules/api-rate-guard.sh
+++ b/local-watcher/bin/modules/api-rate-guard.sh
@@ -281,3 +281,59 @@ grl_degrade_should_run() {
   fi
   return 0
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Req 5: 状態遷移系ラベル操作の限定リトライ
+# ─────────────────────────────────────────────────────────────────────────────
+
+# resumable-return 系の `gh issue edit`（LABEL_PICKED 除去等）を rate-limit 起因失敗時のみ
+# 有限回リトライするラッパ。gate off は 1 回だけ実行（従来挙動 / gh 出力抑止 / rc をそのまま
+# 返す = byte 等価 / NFR 1.1）。gate on 時、rate-limit 文言を検出したときのみ
+# GH_API_STATE_RETRY_MAX_ATTEMPTS まで GH_API_STATE_RETRY_SLEEP 秒 backoff 再試行する。
+# 非 rate-limit 失敗は再試行せず即返す（不要な二次消費回避 / Req 5.2）。上限到達でも Issue は
+# LABEL_PICKED を残置したまま最終 rc を返し次 tick で再評価される（孤児化しない / Req 5.4）。
+# holder からのラベル誤除去等は発生させない（既存 gh 引数の rc を変えず回数のみ増やす / Req 5.5）。
+# Args: $1=issue 番号 / $@(2..)=gh issue edit の引数（--repo ... --remove-label ... 等）
+# rc: 最終 gh の rc（成功 0）
+grl_retry_label_op() {
+  local issue="$1"
+  shift
+  # gate off → 1 回だけ実行（従来挙動 / gh の stdout/stderr は従来同様抑止 / Req 5 gate off）
+  if [ "${GH_API_STATE_RETRY_ENABLED:-false}" != "true" ]; then
+    gh issue edit "$issue" "$@" >/dev/null 2>&1
+    return $?
+  fi
+  # op 記述（--remove-label / --add-label 値から compact に組み立て、ログの grep 性を高める）
+  local op="" prev="" a
+  for a in "$@"; do
+    case "$prev" in
+      --remove-label) op="${op:+$op,}-${a}" ;;
+      --add-label)    op="${op:+$op,}+${a}" ;;
+    esac
+    prev="$a"
+  done
+  [ -z "$op" ] && op="label-edit"
+  local max="${GH_API_STATE_RETRY_MAX_ATTEMPTS:-3}"
+  local sleep_s="${GH_API_STATE_RETRY_SLEEP:-2}"
+  local attempt=1 rc=0 err=""
+  while :; do
+    err=$(gh issue edit "$issue" "$@" 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+      return 0
+    fi
+    # rate-limit 起因でなければ即返す（二次消費回避 / Req 5.2）
+    if ! printf '%s' "$err" | grep -qiE 'rate.?limit|RATE_LIMITED|HTTP 429|too many requests'; then
+      return "$rc"
+    fi
+    if [ "$attempt" -ge "$max" ]; then
+      # 上限到達 → 最終 rc を返す（label 残置で次 tick 再評価 / 孤児化しない / Req 5.4）
+      grl_warn "retry issue=#$issue op=$op attempt=$attempt/$max 上限到達（label 残置で次 tick 再評価）"
+      return "$rc"
+    fi
+    # 再試行ログ（Req 5.6: issue 番号・操作種別・試行回数）
+    grl_log "retry issue=#$issue op=$op attempt=$attempt/$max"
+    sleep "$sleep_s" 2>/dev/null || true
+    attempt=$((attempt + 1))
+  done
+}

--- a/local-watcher/bin/modules/auto-merge-design.sh
+++ b/local-watcher/bin/modules/auto-merge-design.sh
@@ -272,12 +272,11 @@ process_auto_merge_design() {
   # ラベル必須条件は付与しない（Issue #354 設計判断）。
   local repo_owner="${REPO%%/*}"
   local prs_json
-  if ! prs_json=$(timeout "$AUTO_MERGE_DESIGN_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "-label:\"$LABEL_FAILED\" -label:\"$LABEL_NEEDS_DECISIONS\" -label:\"$LABEL_NEEDS_ITERATION\" -draft:true" \
-      --json number,headRefName,headRefOid,baseRefName,mergeable,labels,url,isDraft,headRepositoryOwner,autoMergeRequest \
-      --limit 50 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$AUTO_MERGE_DESIGN_GIT_TIMEOUT" \
+      "-label:\"$LABEL_FAILED\" -label:\"$LABEL_NEEDS_DECISIONS\" -label:\"$LABEL_NEEDS_ITERATION\" -draft:true" \
+      "number,headRefName,headRefOid,baseRefName,mergeable,labels,url,isDraft,headRepositoryOwner,autoMergeRequest" \
+      50); then
     amd_warn "対象 PR 一覧の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     return 0
   fi
@@ -285,11 +284,20 @@ process_auto_merge_design() {
   # Req 2.6 / 6.7 / 8.3: head pattern によるクライアント側フィルタ（impl PR / 人間が
   # 手書きした PR を除外）+ fork 除外。impl PR は `^claude/issue-.*-design` パターン
   # 不一致により自然分離される（二重防御）。
+  # #521 Req 2.3: snapshot 参照時に server search の `-label:failed` /
+  #   `-label:needs-decisions` / `-label:needs-iteration`（除外）を client jq で再現。
+  #   live 経路では冪等。
   prs_json=$(echo "$prs_json" | jq \
     --arg pattern "$AUTO_MERGE_DESIGN_HEAD_PATTERN" \
     --arg owner "$repo_owner" \
+    --arg failed "$LABEL_FAILED" \
+    --arg needs_decisions "$LABEL_NEEDS_DECISIONS" \
+    --arg needs_iteration "$LABEL_NEEDS_ITERATION" \
     '[.[]
       | select(.isDraft == false)
+      | select((.labels // [] | map(.name) | index($failed)) == null)
+      | select((.labels // [] | map(.name) | index($needs_decisions)) == null)
+      | select((.labels // [] | map(.name) | index($needs_iteration)) == null)
       | select(.headRefName | test($pattern))
       | select((.headRepositoryOwner.login // "") == $owner)
     ]')

--- a/local-watcher/bin/modules/auto-merge-disarm.sh
+++ b/local-watcher/bin/modules/auto-merge-disarm.sh
@@ -227,11 +227,13 @@ process_auto_merge_disarm() {
   #      表現しづらく、autoMergeRequest は server-side filter 不可のため client 側で扱う）。
   local repo_owner="${REPO%%/*}"
   local prs_json
-  if ! prs_json=$(timeout "$AUTO_MERGE_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --json number,headRefName,labels,autoMergeRequest,url,state,isDraft,headRepositoryOwner \
-      --limit 100 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得。本 processor の live 経路は --search なし
+  # （全 open PR）で、PR 超集合（全 open PR）と同一集合のため client jq の追加は不要
+  # （空 search を渡すとラッパは live 時に --search を付けず byte 等価な gh pr list を実行）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$AUTO_MERGE_GIT_TIMEOUT" \
+      "" \
+      "number,headRefName,labels,autoMergeRequest,url,state,isDraft,headRepositoryOwner" \
+      100); then
     amx_warn "対象 PR 一覧の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     return 0
   fi

--- a/local-watcher/bin/modules/auto-merge.sh
+++ b/local-watcher/bin/modules/auto-merge.sh
@@ -257,22 +257,29 @@ process_auto_merge() {
   # GraphQL の autoMergeRequest フィールドを引いて Req 4.5 の冪等判定に使う。
   local repo_owner="${REPO%%/*}"
   local prs_json
-  if ! prs_json=$(timeout "$AUTO_MERGE_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "label:\"$LABEL_READY\" -label:\"$LABEL_FAILED\" -label:\"$LABEL_NEEDS_DECISIONS\" -draft:true" \
-      --json number,headRefName,headRefOid,baseRefName,mergeable,labels,url,isDraft,headRepositoryOwner,autoMergeRequest \
-      --limit 50 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$AUTO_MERGE_GIT_TIMEOUT" \
+      "label:\"$LABEL_READY\" -label:\"$LABEL_FAILED\" -label:\"$LABEL_NEEDS_DECISIONS\" -draft:true" \
+      "number,headRefName,headRefOid,baseRefName,mergeable,labels,url,isDraft,headRepositoryOwner,autoMergeRequest" \
+      50); then
     am_warn "対象 PR 一覧の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     return 0
   fi
 
   # Req 6.3: head pattern によるクライアント側フィルタ（人間が手書きした PR を除外）+ fork 除外。
+  # #521 Req 2.3: snapshot 参照時に server search の `label:ready-for-review`（包含）/
+  #   `-label:failed` / `-label:needs-decisions`（除外）を client jq で再現。live 経路では冪等。
   prs_json=$(echo "$prs_json" | jq \
     --arg pattern "$AUTO_MERGE_HEAD_PATTERN" \
     --arg owner "$repo_owner" \
+    --arg ready "$LABEL_READY" \
+    --arg failed "$LABEL_FAILED" \
+    --arg needs_decisions "$LABEL_NEEDS_DECISIONS" \
     '[.[]
       | select(.isDraft == false)
+      | select((.labels // [] | map(.name) | index($ready)) != null)
+      | select((.labels // [] | map(.name) | index($failed)) == null)
+      | select((.labels // [] | map(.name) | index($needs_decisions)) == null)
       | select(.headRefName | test($pattern))
       | select((.headRepositoryOwner.login // "") == $owner)
     ]')

--- a/local-watcher/bin/modules/auto-rebase.sh
+++ b/local-watcher/bin/modules/auto-rebase.sh
@@ -59,12 +59,11 @@ ar_fetch_candidates() {
   local repo_owner="${REPO%%/*}"
   local prs_json
   # Server-side filter（Phase A Re-check と同パターン）。
-  if ! prs_json=$(timeout "$AUTO_REBASE_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "review:approved label:\"$LABEL_NEEDS_REBASE\" -label:\"$LABEL_FAILED\" -draft:true" \
-      --json number,headRefName,baseRefName,labels,url,isDraft,reviewDecision,headRepositoryOwner,title,headRefOid \
-      --limit 100 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$AUTO_REBASE_GIT_TIMEOUT" \
+      "review:approved label:\"$LABEL_NEEDS_REBASE\" -label:\"$LABEL_FAILED\" -draft:true" \
+      "number,headRefName,baseRefName,labels,url,isDraft,reviewDecision,headRepositoryOwner,title,headRefOid" \
+      100); then
     ar_warn "対象 PR 一覧の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     echo "[]"
     return 1
@@ -74,12 +73,18 @@ ar_fetch_candidates() {
   #   - isDraft / reviewDecision の再確認
   #   - head ref prefix (MERGE_QUEUE_HEAD_PATTERN): 人間の手書き PR を巻き込まない
   #   - head repo owner == base repo owner: fork PR を除外
+  # #521 Req 2.3: snapshot 参照時に server search の `label:needs-rebase`（包含）/
+  #   `-label:failed`（除外）を client jq で再現（等価性ルール表）。live 経路では冪等。
   echo "$prs_json" | jq \
     --arg pattern "$MERGE_QUEUE_HEAD_PATTERN" \
     --arg owner "$repo_owner" \
+    --arg needs_rebase "$LABEL_NEEDS_REBASE" \
+    --arg failed "$LABEL_FAILED" \
     '[.[]
       | select(.isDraft == false)
       | select(.reviewDecision == "APPROVED")
+      | select((.labels // [] | map(.name) | index($needs_rebase)) != null)
+      | select((.labels // [] | map(.name) | index($failed)) == null)
       | select(.headRefName | test($pattern))
       | select((.headRepositoryOwner.login // "") == $owner)
     ]'

--- a/local-watcher/bin/modules/core_utils.sh
+++ b/local-watcher/bin/modules/core_utils.sh
@@ -203,6 +203,23 @@ pdr_error() {
   echo "[$(date '+%F %T')] [$REPO] pr-design-reviewer: ERROR: $*" >&2
 }
 
+# api-rate-guard 専用ロガー（識別用 prefix と timestamp 形式を Issue Watcher と揃える）
+# Issue #521: 既存 `qa_log` / `pr_log` と同形式の
+# `[YYYY-MM-DD HH:MM:SS] [$REPO] gh-rate-limit:` prefix を用いる。`grl_warn` / `grl_error`
+# は `>&2` に出力。GitHub API rate limit（core/graphql/search バケット）を扱う本機能は
+# Claude Max quota（quota-aware.sh の `qa_` / rate_limit_event）とは別物のため、ログ prefix
+# を `gh-rate-limit:` に分離して用語混同を避ける（design Overview の用語分離）。関数本体は
+# modules/api-rate-guard.sh 配置。REQUIRED_MODULES には api-rate-guard.sh が登録済み。
+grl_log() {
+  echo "[$(date '+%F %T')] [$REPO] gh-rate-limit: $*"
+}
+grl_warn() {
+  echo "[$(date '+%F %T')] [$REPO] gh-rate-limit: WARN: $*" >&2
+}
+grl_error() {
+  echo "[$(date '+%F %T')] [$REPO] gh-rate-limit: ERROR: $*" >&2
+}
+
 # Reviewer / Pipeline 専用ロガー（既存 mq_log / pi_log と同形式 / #468 で issue-watcher.sh 本体から移設）
 # 他の processor ロガーと異なり `[$REPO]` prefix を持たない点は、移設前の本体定義を byte 等価で
 # 温存したもの（#455 共通規約: ログ文言を 1 文字も変えない）。消費側は impl-pipeline.sh /

--- a/local-watcher/bin/modules/dependency-resolver.sh
+++ b/local-watcher/bin/modules/dependency-resolver.sh
@@ -794,8 +794,26 @@ dr_unblock_sweep() {
   # `_dispatcher_run` のメイン候補クエリ（search_filter）と整合する `-label:"..."`
   # 除外を `--search` に追加する。
   # FIFO 順（Issue 番号昇順）を取りやすくするため `sort:created-asc` を採用。
+  # #521 Req 2.3: サイクル内 Issue snapshot 共有。対象集合（open ∧ auto-dev ∧ blocked）は
+  # (open ∧ auto-dev) の部分集合。snapshot active 時のみ超集合を client 絞り込み
+  # （blocked 包含 + failed/needs-decisions 除外）し FIFO 相当（Issue 番号昇順 ≒ created-asc /
+  # Issue 番号は作成順に単調増加）で整列する。それ以外（gate off / 非 active）は従来の
+  # gh issue list（--label auto-dev --label blocked + sort:created-asc）を byte 等価に実行する
+  # （NFR 1.1）。
   local issues_json
-  if ! issues_json=$(gh issue list \
+  if grl_snapshot_active; then
+    if ! issues_json=$(grl_snapshot_issues | jq -c \
+          --arg blocked "$LABEL_BLOCKED" --arg failed "$LABEL_FAILED" --arg nd "$LABEL_NEEDS_DECISIONS" \
+          '[.[]
+             | (.labels // [] | map(.name)) as $n
+             | select(($n | index($blocked)) != null)
+             | select(($n | index($failed)) == null)
+             | select(($n | index($nd)) == null)
+          ] | sort_by(.number)' 2>/dev/null); then
+      dr_warn "dr_unblock_sweep: snapshot 絞り込み失敗 / スイープ skip"
+      return 0
+    fi
+  elif ! issues_json=$(gh issue list \
         --repo "$REPO" \
         --label "$LABEL_TRIGGER" \
         --label "$LABEL_BLOCKED" \

--- a/local-watcher/bin/modules/impl-pipeline.sh
+++ b/local-watcher/bin/modules/impl-pipeline.sh
@@ -78,9 +78,12 @@ _assert_base_branch_resolved() {
 # 戻り値: 0 = ラベル除去成功 / 1 = gh 失敗（fail-open。呼び出し側は return 3 を維持し、
 #         ラベル残置の旨を警告ログに残す。手動除去で復旧可能）
 stage_a_verify_round1_defer() {
-  if gh issue edit "$NUMBER" --repo "$REPO" \
+  # #521 Req 5: 再 pickup 復帰系の label 除去（PICKED を外し FAILED は付けない）を
+  # grl_retry_label_op 経由にし、rate-limit 起因失敗を有限回リトライして孤児化を防ぐ。
+  # gate off（既定）は 1 回実行 = 従来挙動（gh 出力抑止は wrapper 内で行う / NFR 1.1）。
+  if grl_retry_label_op "$NUMBER" --repo "$REPO" \
       --remove-label "$LABEL_PICKED" \
-      --remove-label "$LABEL_CLAIMED" >/dev/null 2>&1; then
+      --remove-label "$LABEL_CLAIMED"; then
     echo "[$(date '+%F %T')] stage-a-verify: round=1 差し戻し: claude-picked-up 除去 → bare auto-dev candidate へ復帰（次 tick 再 pickup / issue=#$NUMBER）" >> "$LOG"
     return 0
   fi
@@ -270,9 +273,12 @@ run_impl_pipeline() {
           # 同一 tick 即時再開について (Req 1.1): dispatcher は tick 冒頭に候補スナップショットを
           # 取得するため、tick 途中の本ラベル除去は当該 tick のキューに影響しない（同一 tick 内
           # 即時再 claim は構造的に起きず、再開は後続 tick から）。
-          if gh issue edit "$NUMBER" --repo "$REPO" \
+          # #521 Req 5: 再 pickup 復帰系の label 除去（PICKED を外し FAILED は付けない）を
+          # grl_retry_label_op 経由にし rate-limit 起因失敗を有限回リトライ（孤児化防止）。
+          # gate off（既定）は 1 回実行 = 従来挙動（NFR 1.1）。
+          if grl_retry_label_op "$NUMBER" --repo "$REPO" \
               --remove-label "$LABEL_PICKED" \
-              --remove-label "$LABEL_CLAIMED" >/dev/null 2>&1; then
+              --remove-label "$LABEL_CLAIMED"; then
             pt_log "issue=#${NUMBER} claude-picked-up を除去し bare auto-dev candidate へ復帰 → 後続 tick で impl-resume 再開" | tee -a "$LOG"
           else
             # pt_warn は stderr 出力のため、$LOG への grep 可能な記録は別途 tee で残す（NFR 2.1）

--- a/local-watcher/bin/modules/merge-queue.sh
+++ b/local-watcher/bin/modules/merge-queue.sh
@@ -202,12 +202,12 @@ process_merge_queue() {
   # GitHub search 構文で server side フィルタ（API call 削減・NFR 1.2）
   local repo_owner="${REPO%%/*}"
   local prs_json
-  if ! prs_json=$(timeout "$MERGE_QUEUE_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "review:approved -label:\"$LABEL_NEEDS_REBASE\" -label:\"$LABEL_FAILED\" -draft:true" \
-      --json number,headRefName,baseRefName,mergeable,mergeStateStatus,labels,url,isDraft,reviewDecision,headRepositoryOwner \
-      --limit 50 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate on 時は超集合 file を共有参照、
+  # gate off / 取得失敗時は従来の gh pr list を byte 等価に実行）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$MERGE_QUEUE_GIT_TIMEOUT" \
+      "review:approved -label:\"$LABEL_NEEDS_REBASE\" -label:\"$LABEL_FAILED\" -draft:true" \
+      "number,headRefName,baseRefName,mergeable,mergeStateStatus,labels,url,isDraft,reviewDecision,headRepositoryOwner" \
+      50); then
     mq_warn "approved PR の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     return 0
   fi
@@ -216,12 +216,19 @@ process_merge_queue() {
   #   - isDraft / reviewDecision の再確認（server filter の保険）
   #   - head ref prefix (MERGE_QUEUE_HEAD_PATTERN): 人間の手書き PR を巻き込まない
   #   - head repo owner == base repo owner: fork PR を除外
+  # #521 Req 2.3: snapshot（全 open PR 超集合）参照時に server search の
+  #   `-label:needs-rebase` / `-label:failed` を client jq で再現（等価性ルール表）。
+  #   live 経路では server が既に除外済みのため冪等（byte 等価を保つ）。
   prs_json=$(echo "$prs_json" | jq \
     --arg pattern "$MERGE_QUEUE_HEAD_PATTERN" \
     --arg owner "$repo_owner" \
+    --arg needs_rebase "$LABEL_NEEDS_REBASE" \
+    --arg failed "$LABEL_FAILED" \
     '[.[]
       | select(.isDraft == false)
       | select(.reviewDecision == "APPROVED")
+      | select((.labels // [] | map(.name) | index($needs_rebase)) == null)
+      | select((.labels // [] | map(.name) | index($failed)) == null)
       | select(.headRefName | test($pattern))
       | select((.headRepositoryOwner.login // "") == $owner)
     ]')
@@ -349,12 +356,11 @@ process_merge_queue_recheck() {
   # AC 4.3 / 4.4: server-side フィルタで API call を最小化、Phase A と同一 timeout を適用。
   local repo_owner="${REPO%%/*}"
   local prs_json
-  if ! prs_json=$(timeout "$MERGE_QUEUE_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "review:approved label:\"$LABEL_NEEDS_REBASE\" -label:\"$LABEL_FAILED\" -draft:true" \
-      --json number,headRefName,baseRefName,mergeable,labels,url,isDraft,reviewDecision,headRepositoryOwner \
-      --limit 100 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$MERGE_QUEUE_GIT_TIMEOUT" \
+      "review:approved label:\"$LABEL_NEEDS_REBASE\" -label:\"$LABEL_FAILED\" -draft:true" \
+      "number,headRefName,baseRefName,mergeable,labels,url,isDraft,reviewDecision,headRepositoryOwner" \
+      100); then
     # AC 4.5: タイムアウト / エラー時は WARN を出して以降スキップ（後続処理は継続）
     mqr_warn "対象 PR 一覧の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     return 0
@@ -364,12 +370,18 @@ process_merge_queue_recheck() {
   #   - isDraft / reviewDecision の再確認
   #   - head ref prefix (MERGE_QUEUE_HEAD_PATTERN): 人間の手書き PR を巻き込まない
   #   - head repo owner == base repo owner: fork PR を除外
+  # #521 Req 2.3: snapshot 参照時に server search の `label:needs-rebase`（包含）/
+  #   `-label:failed`（除外）を client jq で再現（等価性ルール表）。live 経路では冪等。
   prs_json=$(echo "$prs_json" | jq \
     --arg pattern "$MERGE_QUEUE_HEAD_PATTERN" \
     --arg owner "$repo_owner" \
+    --arg needs_rebase "$LABEL_NEEDS_REBASE" \
+    --arg failed "$LABEL_FAILED" \
     '[.[]
       | select(.isDraft == false)
       | select(.reviewDecision == "APPROVED")
+      | select((.labels // [] | map(.name) | index($needs_rebase)) != null)
+      | select((.labels // [] | map(.name) | index($failed)) == null)
       | select(.headRefName | test($pattern))
       | select((.headRepositoryOwner.login // "") == $owner)
     ]')

--- a/local-watcher/bin/modules/path-overlap.sh
+++ b/local-watcher/bin/modules/path-overlap.sh
@@ -392,17 +392,40 @@ po_collect_inflight_issues() {
   # 形式を使う（既存 Phase B / Phase D が同形式を採用済）。
   # fail-safe（#221 Req 4.2）: CSV が空 / 不正で有効ラベルが 1 つも得られない場合は
   # full 7 ラベル集合へ fallback する（holder から誤って外さない安全側）。
+  local holder_csv="$holder_labels"
   local label_clause
-  label_clause=$(po_build_label_or_clause "$holder_labels")
+  label_clause=$(po_build_label_or_clause "$holder_csv")
   if [ -z "$label_clause" ]; then
-    label_clause=$(po_build_label_or_clause "claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release")
+    holder_csv="claude-claimed,claude-picked-up,awaiting-design-review,ready-for-review,needs-iteration,needs-rebase,staged-for-release"
+    label_clause=$(po_build_label_or_clause "$holder_csv")
   fi
 
   local search_query
   search_query="is:open is:issue (${label_clause}) -label:\"st-failed\" -label:\"awaiting-slot\""
   # #518: labels も同時取得（追加 API を発生させない / NFR 2.3）。
+  # #521 Req 2.3: サイクル内 Issue snapshot 共有。holder（in-flight ラベル群）は
+  # (open ∧ auto-dev) の部分集合（design Inventory #12）。snapshot active 時のみ超集合を
+  # holder ラベル OR + st-failed/awaiting-slot 除外で client 絞り込みする（holder 集合は
+  # effective CSV を JSON 配列化して jq --argjson で厳密一致判定 / NFR 5.1: フィルタ文字列へ
+  # inline 展開しない）。それ以外（gate off / 非 active）は従来の gh issue list --search を
+  # byte 等価に実行する（NFR 1.1）。取得失敗時は従来どおり return 1（caller が fail-open + warn）。
   local issues_json
-  if ! issues_json=$(gh issue list --repo "$REPO" \
+  if grl_snapshot_active; then
+    local holders_json
+    holders_json=$(printf '%s' "$holder_csv" | jq -R -c \
+      'split(",") | map(gsub("^[[:space:]]+|[[:space:]]+$";"")) | map(select(length>0))' \
+      2>/dev/null || echo '[]')
+    if ! issues_json=$(grl_snapshot_issues | jq -c \
+        --argjson holders "$holders_json" \
+        '[.[]
+           | (.labels // [] | map(.name)) as $n
+           | select($holders | any(. as $h | ($n | index($h)) != null))
+           | select(($n | index("st-failed")) == null)
+           | select(($n | index("awaiting-slot")) == null)
+        ]' 2>/dev/null); then
+      return 1
+    fi
+  elif ! issues_json=$(gh issue list --repo "$REPO" \
       --search "$search_query" \
       --json number,labels \
       --limit 50 2>/dev/null); then

--- a/local-watcher/bin/modules/pr-design-reviewer.sh
+++ b/local-watcher/bin/modules/pr-design-reviewer.sh
@@ -159,12 +159,13 @@ pdr_fetch_design_prs() {
   local repo_owner="${REPO%%/*}"
   local timeout_s="${PR_REVIEWER_GIT_TIMEOUT:-120}"
   local prs_json
-  if ! prs_json=$(timeout "$timeout_s" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "-draft:true" \
-      --json number,headRefName,headRefOid,baseRefName,isDraft,url,headRepositoryOwner \
-      --limit 50 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  # server search は `-draft:true` のみで、後続 client jq の `isDraft==false` が完全再現する
+  # ため追加の client jq は不要（超集合参照時も同一集合 / gate off の live 経路は byte 等価）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$timeout_s" \
+      "-draft:true" \
+      "number,headRefName,headRefOid,baseRefName,isDraft,url,headRepositoryOwner" \
+      50); then
     pdr_warn "設計 PR 候補の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     echo "[]"
     return 0

--- a/local-watcher/bin/modules/pr-iteration.sh
+++ b/local-watcher/bin/modules/pr-iteration.sh
@@ -79,12 +79,11 @@ pi_fetch_candidate_prs() {
   local repo_owner="${REPO%%/*}"
   local prs_json
   # AC 1.1 / 1.4 / 1.5 / 8.4: needs-iteration 付き、claude-failed / needs-rebase 無し、非 draft
-  if ! prs_json=$(timeout "$PR_ITERATION_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "label:\"$LABEL_NEEDS_ITERATION\" -label:\"$LABEL_FAILED\" -label:\"$LABEL_NEEDS_REBASE\" -draft:true" \
-      --json number,headRefName,baseRefName,isDraft,url,labels,headRepositoryOwner,body \
-      --limit 50 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$PR_ITERATION_GIT_TIMEOUT" \
+      "label:\"$LABEL_NEEDS_ITERATION\" -label:\"$LABEL_FAILED\" -label:\"$LABEL_NEEDS_REBASE\" -draft:true" \
+      "number,headRefName,baseRefName,isDraft,url,labels,headRepositoryOwner,body" \
+      50); then
     pi_warn "needs-iteration PR の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     echo "[]"
     return 0
@@ -94,13 +93,22 @@ pi_fetch_candidate_prs() {
   # #35 AC 4.4 / 5.1: design pattern は PR_ITERATION_DESIGN_ENABLED=true のときのみ OR 条件に
   # 含める。#112 以降デフォルトは true。明示的に false を渡した場合のみ impl pattern だけで
   # 絞り込み、設計 PR は candidate 段階で除外される（= 設計 PR 拡張 #35 導入前と同一の挙動）。
+  # #521 Req 2.3: snapshot 参照時に server search の `label:needs-iteration`（包含）/
+  #   `-label:failed` / `-label:needs-rebase`（除外）/ `-draft:true`（isDraft==false）を
+  #   client jq で再現（等価性ルール表）。live 経路では冪等（byte 等価を保つ）。
   echo "$prs_json" | jq \
     --arg impl_pattern "$PR_ITERATION_HEAD_PATTERN" \
     --arg design_pattern "$PR_ITERATION_DESIGN_HEAD_PATTERN" \
     --arg design_enabled "$PR_ITERATION_DESIGN_ENABLED" \
     --arg owner "$repo_owner" \
+    --arg needs_iteration "$LABEL_NEEDS_ITERATION" \
+    --arg failed "$LABEL_FAILED" \
+    --arg needs_rebase "$LABEL_NEEDS_REBASE" \
     '[.[]
       | select(.isDraft == false)
+      | select((.labels // [] | map(.name) | index($needs_iteration)) != null)
+      | select((.labels // [] | map(.name) | index($failed)) == null)
+      | select((.labels // [] | map(.name) | index($needs_rebase)) == null)
       | select((.headRepositoryOwner.login // "") == $owner)
       | select(
           (.headRefName | test($impl_pattern))

--- a/local-watcher/bin/modules/pr-reviewer.sh
+++ b/local-watcher/bin/modules/pr-reviewer.sh
@@ -240,12 +240,13 @@ pr_already_processed() {
 pr_fetch_candidate_prs() {
   local repo_owner="${REPO%%/*}"
   local prs_json
-  if ! prs_json=$(timeout "$PR_REVIEWER_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "-draft:true" \
-      --json number,headRefName,headRefOid,baseRefName,isDraft,url,headRepositoryOwner \
-      --limit 50 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  # server search は `-draft:true` のみで、client jq の `isDraft==false` が完全再現するため
+  # 追加の client jq は不要（超集合参照時も同一集合を返す / gate off の live 経路は byte 等価）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$PR_REVIEWER_GIT_TIMEOUT" \
+      "-draft:true" \
+      "number,headRefName,headRefOid,baseRefName,isDraft,url,headRepositoryOwner" \
+      50); then
     pr_warn "候補 PR の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     echo "[]"
     return 0

--- a/local-watcher/bin/modules/quota-aware.sh
+++ b/local-watcher/bin/modules/quota-aware.sh
@@ -678,8 +678,21 @@ process_quota_resume() {
   fi
   qa_log "Resume Processor 開始 (grace=${QUOTA_RESUME_GRACE_SEC}s)"
 
+  # #521 Req 2.3: サイクル内 Issue snapshot 共有。対象集合（open ∧ needs-quota-wait）は
+  # (open ∧ auto-dev) の部分集合（needs-quota-wait 中も auto-dev を保持）のため Issue 超集合に
+  # 含まれる。snapshot active 時のみ超集合を needs-quota-wait で client 絞り込みし、それ以外
+  # （gate off / 非 active）は従来の gh issue list（--label needs-quota-wait）を byte 等価に実行
+  # する（NFR 1.1）。
   local issues_json
-  if ! issues_json=$(gh issue list --repo "$REPO" \
+  if grl_snapshot_active; then
+    if ! issues_json=$(grl_snapshot_issues | jq -c \
+          --arg needs_quota "$LABEL_NEEDS_QUOTA_WAIT" \
+          '[.[] | select((.labels // [] | map(.name) | index($needs_quota)) != null)]' \
+          2>/dev/null); then
+      qa_warn "needs-quota-wait Issue の snapshot 絞り込みに失敗（後続 Processor 継続）"
+      return 0
+    fi
+  elif ! issues_json=$(gh issue list --repo "$REPO" \
         --label "$LABEL_NEEDS_QUOTA_WAIT" --state open \
         --json number --limit 50 2>/dev/null); then
     qa_warn "needs-quota-wait Issue 取得に失敗（後続 Processor 継続）"

--- a/local-watcher/bin/modules/security-review.sh
+++ b/local-watcher/bin/modules/security-review.sh
@@ -330,12 +330,13 @@ sec_apply_block_labels() {
 sec_fetch_candidate_prs() {
   local repo_owner="${REPO%%/*}"
   local prs_json
-  if ! prs_json=$(timeout "$SECURITY_REVIEW_GIT_TIMEOUT" gh pr list \
-      --repo "$REPO" \
-      --state open \
-      --search "-draft:true" \
-      --json number,headRefName,headRefOid,baseRefName,isDraft,url,headRepositoryOwner \
-      --limit 50 2>/dev/null); then
+  # #521 Req 2.3: サイクル内 PR snapshot 経由取得（gate off / 取得失敗時は従来 gh pr list）。
+  # server search は `-draft:true` のみで、後続 client jq の `isDraft==false` が完全再現する
+  # ため追加の client jq は不要（超集合参照時も同一集合 / gate off の live 経路は byte 等価）。
+  if ! prs_json=$(grl_pr_snapshot_or_live "$SECURITY_REVIEW_GIT_TIMEOUT" \
+      "-draft:true" \
+      "number,headRefName,headRefOid,baseRefName,isDraft,url,headRepositoryOwner" \
+      50); then
     sec_warn "候補 PR の取得に失敗しました（gh pr list タイムアウトまたはエラー）"
     echo "[]"
     return 0

--- a/local-watcher/bin/modules/slot-worker-resume.sh
+++ b/local-watcher/bin/modules/slot-worker-resume.sh
@@ -1012,10 +1012,11 @@ publish_claude_review_status() {
   esac
 
   # PR 番号 / head sha を取得（BRANCH 経由）
+  # #521 Req 6: per-branch PR 存在確認を grl_rest_prs_for_head 経由にし、offload on 時は REST
+  # （core バケット）へ逃がす。offload off / REST 失敗時は従来 gh pr list --head へ fallback
+  # （number/state/headRefName/headRefOid/url の互換 JSON を返すため下流 jq 抽出は不変 / NFR 1.1）。
   local pr_json pr_number sha pr_url
-  if ! pr_json=$(timeout "${PR_REVIEWER_GIT_TIMEOUT:-120}" \
-      gh pr list --repo "$REPO" --head "$BRANCH" --state all \
-        --json number,headRefOid,url --limit 1 2>/dev/null); then
+  if ! pr_json=$(grl_rest_prs_for_head "$BRANCH" "all" "${PR_REVIEWER_GIT_TIMEOUT:-120}"); then
     pr_warn "claude-review status publish: gh pr list 失敗 (branch=${BRANCH} issue=#${NUMBER:-?})"
     return 1
   fi

--- a/local-watcher/bin/modules/slot-worker.sh
+++ b/local-watcher/bin/modules/slot-worker.sh
@@ -383,8 +383,11 @@ _slot_run_issue() {
     # 除去して auto-dev へ戻し、dispatcher の in-flight 判定が誤らないようにする（次 tick の
     # 再 pickup は人間が足場を修復した後に full 判定で自然に進行する / `_slot_mark_failed` の
     # label 操作を参考にするが `claude-failed` は付けない / fail-open）。
-    gh issue edit "$NUMBER" --repo "$REPO" \
-      --remove-label "$LABEL_CLAIMED" --remove-label "$LABEL_PICKED" >/dev/null 2>&1 || true
+    # #521 Req 5: 再 pickup 復帰系の label 除去（claim 系を外し FAILED は付けない）を
+    # grl_retry_label_op 経由にし rate-limit 起因失敗を有限回リトライ（孤児化防止）。
+    # gate off（既定）は 1 回実行 = 従来挙動（NFR 1.1）。
+    grl_retry_label_op "$NUMBER" --repo "$REPO" \
+      --remove-label "$LABEL_CLAIMED" --remove-label "$LABEL_PICKED" || true
     slot_log "scaffolding-health: HALT により agent stage を起動せず人間判断待ち（claim 系ラベル除去 / Issue #${NUMBER}）"
     return 0
   fi

--- a/local-watcher/bin/modules/stage-checkpoint.sh
+++ b/local-watcher/bin/modules/stage-checkpoint.sh
@@ -189,8 +189,10 @@ stage_checkpoint_read_review_result() {
 stage_checkpoint_find_impl_pr() {
   local include_closed="${1:-false}"
   local prs
-  prs=$(gh pr list --repo "$REPO" --head "$BRANCH" --state all \
-        --json number,state --limit 5 2>/dev/null) || return 2
+  # #521 Req 6: per-branch PR 存在確認を grl_rest_prs_for_head 経由にし offload on 時は REST へ
+  # 逃がす。off / 失敗時は従来 gh pr list --head へ fallback（number/state 等の互換 JSON を返す
+  # ため下流 jq 抽出は不変 / NFR 1.1）。取得失敗は従来どおり return 2（gh API エラー）。
+  prs=$(grl_rest_prs_for_head "$BRANCH" "all") || return 2
 
   # OPEN / MERGED を優先採用（OPEN > MERGED の順）。CLOSED の件数も観測ログのために抽出する。
   local open_pr merged_pr closed_pr closed_count
@@ -690,9 +692,10 @@ _spec_create_docs_pr() {
   local docs_branch="claude/issue-${NUMBER}-docs-${SLUG}"
 
   # 冪等ガード: 既存の docs 補完 PR があれば作成しない（NFR 2.1 / 2.2）。
+  # #521 Req 6: per-branch PR 存在確認を grl_rest_prs_for_head 経由にし offload on 時は REST へ
+  # 逃がす（off / 失敗時は従来 gh pr list --head へ fallback。number を含む互換 JSON / NFR 1.1）。
   local existing_docs_pr
-  existing_docs_pr=$(gh pr list --repo "$REPO" --head "$docs_branch" --state all \
-                     --json number --limit 1 2>/dev/null \
+  existing_docs_pr=$(grl_rest_prs_for_head "$docs_branch" "all" \
                      | jq -r '.[0].number // empty' 2>/dev/null || true)
   if [ -n "$existing_docs_pr" ]; then
     sc_log "spec-completeness: action=docs-pr result=skip-existing pr=#${existing_docs_pr} branch=${docs_branch} issue=#${NUMBER}" >> "$LOG"

--- a/local-watcher/bin/modules/stale-pickup-reaper.sh
+++ b/local-watcher/bin/modules/stale-pickup-reaper.sh
@@ -253,18 +253,44 @@ sr_save_marker() {
 #
 # Stdout: JSON 配列文字列（候補なし / 取得失敗時は `[]`）
 # Returns: 0（常に。fail-continue）
+
+# #521 Req 2.3: Issue snapshot 超集合（全 open ∧ auto-dev）を server search と等価な集合へ
+# client jq で絞り込むヘルパー。include ラベル 1 つ（picked / claimed）を包含し、exclude ラベル
+# 配列（exclude_filter の `-label:...` 群）を除外する。live 経路では server が既に絞るため冪等。
+# Args: $1=対象 JSON 配列 / $2=include ラベル名 / $3=exclude ラベル JSON 配列
+# Stdout: 絞り込み後 JSON 配列（jq 失敗時は入力をそのまま返す fail-safe）
+sr_snapshot_client_filter() {
+  local json="$1" inc="$2" exc="$3"
+  printf '%s' "$json" | jq -c \
+    --arg inc "$inc" \
+    --argjson exc "$exc" \
+    '[.[]
+       | (.labels // [] | map(.name)) as $n
+       | select(($n | index($inc)) != null)
+       | select(($exc | any(. as $e | ($n | index($e)) != null)) | not)
+    ]' 2>/dev/null || printf '%s' "$json"
+}
+
 sr_fetch_candidates() {
   local exclude_filter
   exclude_filter="-label:\"$LABEL_FAILED\" -label:\"$LABEL_NEEDS_DECISIONS\" -label:\"$LABEL_AWAITING_DESIGN\" -label:\"$LABEL_NEEDS_QUOTA_WAIT\" -label:\"$LABEL_BLOCKED\" -label:\"$LABEL_STAGED_FOR_RELEASE\" -label:\"hold\""
+  # #521 Req 2.3: snapshot 参照時に exclude_filter を client jq で再現するための除外ラベル
+  # JSON 配列（server search の `-label:...` 群と 1:1 対応）。picked/claimed は auto-dev を
+  # 保持する部分集合のため Issue 超集合（open ∧ auto-dev / updatedAt 含む）に含まれる。
+  local exclude_json
+  exclude_json=$(jq -n -c \
+    --arg a "$LABEL_FAILED" --arg b "$LABEL_NEEDS_DECISIONS" --arg c "$LABEL_AWAITING_DESIGN" \
+    --arg d "$LABEL_NEEDS_QUOTA_WAIT" --arg e "$LABEL_BLOCKED" --arg f "$LABEL_STAGED_FOR_RELEASE" \
+    '[$a,$b,$c,$d,$e,$f,"hold"]' 2>/dev/null || echo '[]')
 
   # クエリ 1: claude-picked-up 候補
+  # #521 Req 2.3: サイクル内 Issue snapshot 経由取得（gate off / 取得失敗時は従来 gh issue list を
+  # byte 等価に実行。--state open --search の形は現行と一致）。
   local picked_json
-  if ! picked_json=$(timeout "$STALE_PICKUP_REAPER_GH_TIMEOUT" gh issue list \
-      --repo "$REPO" \
-      --state open \
-      --search "label:\"$LABEL_PICKED\" $exclude_filter" \
-      --json number,labels,title,url,updatedAt \
-      --limit "$STALE_PICKUP_REAPER_MAX_ISSUES" 2>/dev/null); then
+  if ! picked_json=$(grl_issue_snapshot_or_live "$STALE_PICKUP_REAPER_GH_TIMEOUT" \
+      "label:\"$LABEL_PICKED\" $exclude_filter" \
+      "number,labels,title,url,updatedAt" \
+      "$STALE_PICKUP_REAPER_MAX_ISSUES"); then
     sr_warn "sr_fetch_candidates: gh issue list 失敗（label:$LABEL_PICKED / timeout または API エラー）"
     echo "[]"
     return 0
@@ -277,15 +303,19 @@ sr_fetch_candidates() {
     sr_warn "sr_fetch_candidates: gh issue list が JSON 配列を返さなかった（label:$LABEL_PICKED）"
     picked_json="[]"
   fi
+  # snapshot active 時のみ超集合を label:picked-up 包含 + exclude_filter 除外で絞り込む。
+  # gate off / snapshot 非 active では従来 gh の server search が既に絞った結果をそのまま使う
+  # （client 再絞り込みを掛けず byte 等価 / NFR 1.1）。
+  if grl_snapshot_active; then
+    picked_json=$(sr_snapshot_client_filter "$picked_json" "$LABEL_PICKED" "$exclude_json")
+  fi
 
   # クエリ 2: claude-claimed 候補
   local claimed_json
-  if ! claimed_json=$(timeout "$STALE_PICKUP_REAPER_GH_TIMEOUT" gh issue list \
-      --repo "$REPO" \
-      --state open \
-      --search "label:\"$LABEL_CLAIMED\" $exclude_filter" \
-      --json number,labels,title,url,updatedAt \
-      --limit "$STALE_PICKUP_REAPER_MAX_ISSUES" 2>/dev/null); then
+  if ! claimed_json=$(grl_issue_snapshot_or_live "$STALE_PICKUP_REAPER_GH_TIMEOUT" \
+      "label:\"$LABEL_CLAIMED\" $exclude_filter" \
+      "number,labels,title,url,updatedAt" \
+      "$STALE_PICKUP_REAPER_MAX_ISSUES"); then
     sr_warn "sr_fetch_candidates: gh issue list 失敗（label:$LABEL_CLAIMED / timeout または API エラー）"
     echo "[]"
     return 0
@@ -296,6 +326,9 @@ sr_fetch_candidates() {
   if ! printf '%s' "$claimed_json" | jq -e 'type == "array"' >/dev/null 2>&1; then
     sr_warn "sr_fetch_candidates: gh issue list が JSON 配列を返さなかった（label:$LABEL_CLAIMED）"
     claimed_json="[]"
+  fi
+  if grl_snapshot_active; then
+    claimed_json=$(sr_snapshot_client_filter "$claimed_json" "$LABEL_CLAIMED" "$exclude_json")
   fi
 
   # 2 結果を結合 + dedup + truncate（jq で完結 / NFR 3.1: --argjson 経由）

--- a/local-watcher/bin/watcher-config.sh
+++ b/local-watcher/bin/watcher-config.sh
@@ -1497,6 +1497,23 @@ GH_API_DEGRADE_GRAPHQL_THRESHOLD="${GH_API_DEGRADE_GRAPHQL_THRESHOLD:-500}"
 case "$GH_API_DEGRADE_GRAPHQL_THRESHOLD" in
   ''|*[!0-9]*) GH_API_DEGRADE_GRAPHQL_THRESHOLD="500" ;;
 esac
+# Req 5: 状態遷移系ラベル操作の限定リトライ。`=true` 厳密一致のみ ON。
+GH_API_STATE_RETRY_ENABLED="${GH_API_STATE_RETRY_ENABLED:-false}"
+case "$GH_API_STATE_RETRY_ENABLED" in
+  true) : ;;
+  *)    GH_API_STATE_RETRY_ENABLED="false" ;;
+esac
+# 再試行回数上限（有限 / 安全側既定 3 / 非整数・≤0 は既定へ / NFR 2.3）。
+GH_API_STATE_RETRY_MAX_ATTEMPTS="${GH_API_STATE_RETRY_MAX_ATTEMPTS:-3}"
+case "$GH_API_STATE_RETRY_MAX_ATTEMPTS" in
+  ''|*[!0-9]*) GH_API_STATE_RETRY_MAX_ATTEMPTS="3" ;;
+  *) if [ "$GH_API_STATE_RETRY_MAX_ATTEMPTS" -le 0 ]; then GH_API_STATE_RETRY_MAX_ATTEMPTS="3"; fi ;;
+esac
+# 試行間 backoff 秒（既定 2 / 非整数・<0 は既定へ）。
+GH_API_STATE_RETRY_SLEEP="${GH_API_STATE_RETRY_SLEEP:-2}"
+case "$GH_API_STATE_RETRY_SLEEP" in
+  ''|*[!0-9]*) GH_API_STATE_RETRY_SLEEP="2" ;;
+esac
 
 # ─── デフォルト有効化フラグの値正規化 (#112 Req 2.10 / #412 で本フラグを追加) ───
 # 下記 10 種の env var はすべて「`=false` を明示した場合のみ無効、それ以外

--- a/local-watcher/bin/watcher-config.sh
+++ b/local-watcher/bin/watcher-config.sh
@@ -1479,6 +1479,12 @@ case "$GH_API_SNAPSHOT_GH_TIMEOUT" in
   ''|*[!0-9]*) GH_API_SNAPSHOT_GH_TIMEOUT="60" ;;
   *) if [ "$GH_API_SNAPSHOT_GH_TIMEOUT" -le 0 ]; then GH_API_SNAPSHOT_GH_TIMEOUT="60"; fi ;;
 esac
+# Req 3: バケット別 rate limit の可視化（cycle 終端 1 行ログ）。`=true` 厳密一致のみ ON。
+GH_API_BUCKET_LOG_ENABLED="${GH_API_BUCKET_LOG_ENABLED:-false}"
+case "$GH_API_BUCKET_LOG_ENABLED" in
+  true) : ;;
+  *)    GH_API_BUCKET_LOG_ENABLED="false" ;;
+esac
 
 # ─── デフォルト有効化フラグの値正規化 (#112 Req 2.10 / #412 で本フラグを追加) ───
 # 下記 10 種の env var はすべて「`=false` を明示した場合のみ無効、それ以外

--- a/local-watcher/bin/watcher-config.sh
+++ b/local-watcher/bin/watcher-config.sh
@@ -1485,6 +1485,18 @@ case "$GH_API_BUCKET_LOG_ENABLED" in
   true) : ;;
   *)    GH_API_BUCKET_LOG_ENABLED="false" ;;
 esac
+# Req 4: 残量閾値割れ時の WARN と非必須プロセッサ縮退。`=true` 厳密一致のみ ON。
+GH_API_DEGRADE_ENABLED="${GH_API_DEGRADE_ENABLED:-false}"
+case "$GH_API_DEGRADE_ENABLED" in
+  true) : ;;
+  *)    GH_API_DEGRADE_ENABLED="false" ;;
+esac
+# graphql バケット残量の縮退閾値（保守的既定 500 / 必須処理を完遂できる余力を残す）。
+# 非整数 / <0 は既定 500 へ正規化（0 は許容 = 実質縮退無効化したい運用向け / Req 4.4）。
+GH_API_DEGRADE_GRAPHQL_THRESHOLD="${GH_API_DEGRADE_GRAPHQL_THRESHOLD:-500}"
+case "$GH_API_DEGRADE_GRAPHQL_THRESHOLD" in
+  ''|*[!0-9]*) GH_API_DEGRADE_GRAPHQL_THRESHOLD="500" ;;
+esac
 
 # ─── デフォルト有効化フラグの値正規化 (#112 Req 2.10 / #412 で本フラグを追加) ───
 # 下記 10 種の env var はすべて「`=false` を明示した場合のみ無効、それ以外

--- a/local-watcher/bin/watcher-config.sh
+++ b/local-watcher/bin/watcher-config.sh
@@ -1443,6 +1443,43 @@ IMPL_RESUME_PRESERVE_COMMITS="${IMPL_RESUME_PRESERVE_COMMITS:-true}"
 # （Req 2.9, 5.2）。
 IMPL_RESUME_PROGRESS_TRACKING="${IMPL_RESUME_PROGRESS_TRACKING:-true}"
 
+# ─── GitHub API Rate Guard 設定 (#521) ───
+# watcher の 1 サイクル内 GitHub API rate limit（core / graphql / search バケット）消費削減・
+# 枯渇耐性のための 5 機能を制御する env 群。関数本体は modules/api-rate-guard.sh（prefix
+# grl_）、ロガー grl_log / grl_warn / grl_error は core_utils.sh。すべて opt-in（既定 false /
+# `=true` 厳密一致のみ ON）で、未設定・不正値・typo はすべて安全側（無効）へ正規化し、未設定
+# 環境は本機能導入前と完全に等価な no-op を保つ（Req 1.1〜1.3, NFR 1.1）。Claude Max quota
+# （rate_limit_event / quota-aware.sh の領分）とは別物のため env prefix を GH_API_ に分離。
+# 既定 OFF の opt-in 制のため、後段「デフォルト有効化フラグの値正規化」ループには含めない。
+#
+# Req 2: サイクル内スナップショット共有。`=true` 厳密一致のみ ON（Req 1.2, 1.3）。
+GH_API_SNAPSHOT_ENABLED="${GH_API_SNAPSHOT_ENABLED:-false}"
+case "$GH_API_SNAPSHOT_ENABLED" in
+  true) : ;;
+  *)    GH_API_SNAPSHOT_ENABLED="false" ;;
+esac
+# PR 超集合取得の --limit（非整数 / ≤0 は既定 100 へ正規化）。
+GH_API_SNAPSHOT_PR_LIMIT="${GH_API_SNAPSHOT_PR_LIMIT:-100}"
+case "$GH_API_SNAPSHOT_PR_LIMIT" in
+  ''|*[!0-9]*) GH_API_SNAPSHOT_PR_LIMIT="100" ;;
+  *) if [ "$GH_API_SNAPSHOT_PR_LIMIT" -le 0 ]; then GH_API_SNAPSHOT_PR_LIMIT="100"; fi ;;
+esac
+# Issue 超集合取得の --limit（非整数 / ≤0 は既定 100 へ正規化）。
+GH_API_SNAPSHOT_ISSUE_LIMIT="${GH_API_SNAPSHOT_ISSUE_LIMIT:-100}"
+case "$GH_API_SNAPSHOT_ISSUE_LIMIT" in
+  ''|*[!0-9]*) GH_API_SNAPSHOT_ISSUE_LIMIT="100" ;;
+  *) if [ "$GH_API_SNAPSHOT_ISSUE_LIMIT" -le 0 ]; then GH_API_SNAPSHOT_ISSUE_LIMIT="100"; fi ;;
+esac
+# スナップショット JSON ファイル（prs.json / issues.json）の配置先。$HOME/.issue-watcher/
+# 配下（user-owned・単一 writer・flock 保護）で symlink TOCTOU を回避（CLAUDE.md §6）。
+GH_API_SNAPSHOT_DIR="${GH_API_SNAPSHOT_DIR:-$HOME/.issue-watcher/api-snapshot/$REPO_SLUG}"
+# 超集合取得の gh timeout 秒（非整数 / ≤0 は既定 60 へ正規化）。
+GH_API_SNAPSHOT_GH_TIMEOUT="${GH_API_SNAPSHOT_GH_TIMEOUT:-60}"
+case "$GH_API_SNAPSHOT_GH_TIMEOUT" in
+  ''|*[!0-9]*) GH_API_SNAPSHOT_GH_TIMEOUT="60" ;;
+  *) if [ "$GH_API_SNAPSHOT_GH_TIMEOUT" -le 0 ]; then GH_API_SNAPSHOT_GH_TIMEOUT="60"; fi ;;
+esac
+
 # ─── デフォルト有効化フラグの値正規化 (#112 Req 2.10 / #412 で本フラグを追加) ───
 # 下記 10 種の env var はすべて「`=false` を明示した場合のみ無効、それ以外
 # （未設定 / 空文字 / `0` / `False` / `Yes` / typo 等）はすべてデフォルト有効」

--- a/local-watcher/bin/watcher-config.sh
+++ b/local-watcher/bin/watcher-config.sh
@@ -1514,6 +1514,13 @@ GH_API_STATE_RETRY_SLEEP="${GH_API_STATE_RETRY_SLEEP:-2}"
 case "$GH_API_STATE_RETRY_SLEEP" in
   ''|*[!0-9]*) GH_API_STATE_RETRY_SLEEP="2" ;;
 esac
+# Req 6: per-branch PR 存在確認を GraphQL search から REST（core バケット）へ逃がす負荷分散。
+# `=true` 厳密一致のみ ON。
+GH_API_REST_OFFLOAD_ENABLED="${GH_API_REST_OFFLOAD_ENABLED:-false}"
+case "$GH_API_REST_OFFLOAD_ENABLED" in
+  true) : ;;
+  *)    GH_API_REST_OFFLOAD_ENABLED="false" ;;
+esac
 
 # ─── デフォルト有効化フラグの値正規化 (#112 Req 2.10 / #412 で本フラグを追加) ───
 # 下記 10 種の env var はすべて「`=false` を明示した場合のみ無効、それ以外

--- a/local-watcher/test/api_rate_guard_degrade_test.sh
+++ b/local-watcher/test/api_rate_guard_degrade_test.sh
@@ -109,6 +109,45 @@ rm -f "$warn_file"
 logfail_out="$(grl_buckets_log 2>&1 || true)"
 assert_contains "取得失敗: buckets_log は warn で継続" "$logfail_out" "gh-rate-limit: WARN"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. grl_degrade_should_run（Req 4）: 閾値割れで非必須 skip / essential は呼び出し側で
+#    gate しないため本関数は processor 名を問わず同一判定（skip 判定は残量のみに依存）。
+# ─────────────────────────────────────────────────────────────────────────────
+# gate off → 常に rc=0（従来挙動 / Req 4.6）
+GH_API_DEGRADE_ENABLED="false"
+GRL_BUCKET_STATUS="ok"
+GRL_BUCKET_GRAPHQL_REMAINING="10"
+GH_API_DEGRADE_GRAPHQL_THRESHOLD="500"
+assert_rc "degrade gate off: 残量僅少でも rc=0（skip しない）" 0 grl_degrade_should_run "pr-reviewer"
+
+# gate on + 残量 >= 閾値 → rc=0（実行）
+GH_API_DEGRADE_ENABLED="true"
+GRL_BUCKET_GRAPHQL_REMAINING="600"
+assert_rc "degrade on + 残量>=閾値: rc=0（実行）" 0 grl_degrade_should_run "pr-reviewer"
+
+# gate on + 残量 < 閾値 → rc=1（skip）+ WARN に bucket/残量/閾値
+GH_API_DEGRADE_ENABLED="true"
+GRL_BUCKET_GRAPHQL_REMAINING="100"
+GH_API_DEGRADE_GRAPHQL_THRESHOLD="500"
+assert_rc "degrade on + 残量<閾値: rc=1（skip）" 1 grl_degrade_should_run "pr-reviewer"
+skip_out="$(grl_degrade_should_run "pr-reviewer" 2>&1 1>/dev/null || true)"
+assert_contains "skip ログに processor 名" "$skip_out" "skip processor=pr-reviewer"
+assert_contains "skip ログに reason=degrade" "$skip_out" "reason=degrade"
+assert_contains "skip ログに bucket=graphql" "$skip_out" "bucket=graphql"
+assert_contains "skip ログに remaining/threshold" "$skip_out" "remaining=100 threshold=500"
+
+# gate on + 残量未取得（status != ok）→ 安全側 rc=0（必須処理を守る / NFR 2.2）
+GH_API_DEGRADE_ENABLED="true"
+GRL_BUCKET_STATUS="unavailable"
+GRL_BUCKET_GRAPHQL_REMAINING="0"
+assert_rc "degrade on + 残量未取得: 安全側 rc=0（実行）" 0 grl_degrade_should_run "pr-reviewer"
+
+# gate on + 残量非整数（"?"）→ 安全側 rc=0
+GH_API_DEGRADE_ENABLED="true"
+GRL_BUCKET_STATUS="ok"
+GRL_BUCKET_GRAPHQL_REMAINING="?"
+assert_rc "degrade on + 残量非整数: 安全側 rc=0（実行）" 0 grl_degrade_should_run "pr-reviewer"
+
 # ── サマリ ──
 echo "----------------------------------------"
 echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"

--- a/local-watcher/test/api_rate_guard_degrade_test.sh
+++ b/local-watcher/test/api_rate_guard_degrade_test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #521 task 5/6 で追加した api-rate-guard.sh のバケット可視化（grl_buckets_refresh /
+#       grl_buckets_log）と縮退（grl_degrade_should_run）を fixture + gh stub で検証する
+#       スモークテスト（live GitHub API なし / NFR 6.2）。
+#
+#       検証観点（docs/specs/521-feat-watcher-github-api-rate-limit/requirements.md）:
+#         - Req 3.1 / 3.3: cycle 終端に固定書式 1 行 `gh-rate-limit: core=r/l graphql=r/l search=r/l`
+#         - Req 3.2: rate_limit 参照は `gh api rate_limit`（非消費経路）
+#         - Req 3.4: 取得失敗は warn + 継続（後続を中断しない）
+#         - Req 1.1 / NFR 1.1: BUCKET_LOG / DEGRADE 双方 off で gh 非呼び出し（no-op）
+#         - Req 4.1 / 4.2 / 4.5: graphql 残量 < 閾値で WARN + 非必須 skip（skip ログに bucket/残量/閾値）
+#         - Req 4.3 / 4.6 / NFR 2.2: essential は常に run / gate off は常に run
+#
+# 配置先: local-watcher/test/api_rate_guard_degrade_test.sh
+# 依存:   bash 4+, awk, jq, grep
+# 実行:   bash local-watcher/test/api_rate_guard_degrade_test.sh
+
+# shellcheck disable=SC2034,SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+GRL_MOD="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+CORE_MOD="$SCRIPT_DIR/../bin/modules/core_utils.sh"
+
+for f in "$GRL_MOD" "$CORE_MOD"; do
+  if [ ! -f "$f" ]; then echo "ERROR: cannot find $f" >&2; exit 2; fi
+done
+if ! command -v jq >/dev/null 2>&1; then echo "ERROR: jq required" >&2; exit 2; fi
+
+for fn in grl_log grl_warn grl_error; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$CORE_MOD" "$fn")"
+done
+for fn in grl_buckets_refresh grl_buckets_log grl_degrade_should_run; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD" "$fn")"
+done
+for fn in grl_buckets_refresh grl_buckets_log; do
+  if ! declare -F "$fn" >/dev/null; then echo "ERROR: $fn not loaded" >&2; exit 2; fi
+done
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+REPO="owner/test-repo"
+
+# gh stub: `gh api rate_limit` に fixture JSON を返す。呼び出しを GH_CALL_LOG に記録。
+GH_CALL_LOG="$(mktemp)"
+trap 'rm -f "$GH_CALL_LOG" 2>/dev/null || true' EXIT
+RATE_LIMIT_JSON='{"resources":{"core":{"limit":5000,"remaining":4990},"graphql":{"limit":5000,"remaining":4800},"search":{"limit":30,"remaining":28}}}'
+gh() {
+  echo "gh $*" >> "$GH_CALL_LOG"
+  if [ "${1:-}" = "api" ] && [ "${2:-}" = "rate_limit" ]; then
+    if [ "${GH_STUB_MODE:-ok}" = "fail" ]; then return 1; fi
+    printf '%s' "$RATE_LIMIT_JSON"
+    return 0
+  fi
+  return 0
+}
+reset_calls() { : > "$GH_CALL_LOG"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. gate off（BUCKET_LOG / DEGRADE 双方 off）→ gh 非呼び出し（NFR 1.1）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_BUCKET_LOG_ENABLED="false"
+GH_API_DEGRADE_ENABLED="false"
+GRL_BUCKET_STATUS=""
+reset_calls
+grl_buckets_refresh
+assert_eq "gate off: STATUS=disabled" "disabled" "$GRL_BUCKET_STATUS"
+assert_eq "gate off: gh api rate_limit 非呼び出し" "" "$(cat "$GH_CALL_LOG")"
+out="$(grl_buckets_log 2>&1)"
+assert_eq "gate off: buckets_log は no-op（出力なし）" "" "$out"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. BUCKET_LOG on + 取得成功 → parse + 固定書式ログ（Req 3.1, 3.2, 3.3）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_BUCKET_LOG_ENABLED="true"
+GH_STUB_MODE="ok"
+GRL_BUCKET_STATUS=""
+reset_calls
+grl_buckets_refresh
+assert_eq "refresh: STATUS=ok" "ok" "$GRL_BUCKET_STATUS"
+assert_eq "refresh: core remaining" "4990" "$GRL_BUCKET_CORE_REMAINING"
+assert_eq "refresh: graphql remaining" "4800" "$GRL_BUCKET_GRAPHQL_REMAINING"
+assert_eq "refresh: search limit" "30" "$GRL_BUCKET_SEARCH_LIMIT"
+assert_contains "refresh: 非消費経路 gh api rate_limit" "$(cat "$GH_CALL_LOG")" "gh api rate_limit"
+
+log_out="$(grl_buckets_log 2>&1)"
+assert_contains "buckets_log: 固定書式 prefix" "$log_out" "gh-rate-limit: core=4990/5000 graphql=4800/5000 search=28/30"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. 取得失敗 → warn + STATUS=unavailable + 継続（Req 3.4 / NFR 2.1）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_BUCKET_LOG_ENABLED="true"
+GH_STUB_MODE="fail"
+GRL_BUCKET_STATUS=""
+# subshell 化するとグローバル代入が失われるため、current shell で実行して stderr を file 捕捉。
+warn_file="$(mktemp)"
+grl_buckets_refresh 2>"$warn_file" || true
+assert_eq "取得失敗: STATUS=unavailable" "unavailable" "$GRL_BUCKET_STATUS"
+assert_contains "取得失敗: warn 出力" "$(cat "$warn_file")" "gh-rate-limit: WARN"
+rm -f "$warn_file"
+# buckets_log も warn で継続（クラッシュしない）
+logfail_out="$(grl_buckets_log 2>&1 || true)"
+assert_contains "取得失敗: buckets_log は warn で継続" "$logfail_out" "gh-rate-limit: WARN"
+
+# ── サマリ ──
+echo "----------------------------------------"
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then exit 1; fi
+echo "api_rate_guard_degrade_test: all passed"

--- a/local-watcher/test/api_rate_guard_issue_equiv_test.sh
+++ b/local-watcher/test/api_rate_guard_issue_equiv_test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #521 task 4 で Issue snapshot 参加へ差し替えた 4 module
+#       （dependency-resolver / path-overlap / stale-pickup-reaper / quota-aware）の
+#       「snapshot 参照 client jq が server search と等価集合を返す」ことを fixture で検証する
+#       スモークテスト（live GitHub API なし / NFR 6.2）。
+#
+#       検証観点（docs/specs/521-feat-watcher-github-api-rate-limit/requirements.md）:
+#         - Req 2.3: stale-pickup-reaper の実 sr_snapshot_client_filter / sr_fetch_candidates が
+#                    超集合から label:picked/claimed 包含 + exclude_filter 除外の等価集合を返す。
+#         - Req 2.3: quota-aware / dependency-resolver / path-overlap の client jq（module 内と
+#                    同一表現）が超集合から等価集合を返す。各 module が grl_issue_snapshot_or_live
+#                    経由化されていることをソース走査で確認。
+#
+# 配置先: local-watcher/test/api_rate_guard_issue_equiv_test.sh
+# 依存:   bash 4+, awk, jq, grep
+# 実行:   bash local-watcher/test/api_rate_guard_issue_equiv_test.sh
+
+# 抽出関数・stub 変数の多用で SC2034、ソース走査 grep の jq リテラルで SC2016 を file-wide 抑止。
+# shellcheck disable=SC2034,SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+MOD_DIR="$SCRIPT_DIR/../bin/modules"
+SR_MOD="$MOD_DIR/stale-pickup-reaper.sh"
+QA_MOD="$MOD_DIR/quota-aware.sh"
+DR_MOD="$MOD_DIR/dependency-resolver.sh"
+PO_MOD="$MOD_DIR/path-overlap.sh"
+GRL_MOD="$MOD_DIR/api-rate-guard.sh"
+
+for f in "$SR_MOD" "$QA_MOD" "$DR_MOD" "$PO_MOD" "$GRL_MOD"; do
+  if [ ! -f "$f" ]; then echo "ERROR: cannot find $f" >&2; exit 2; fi
+done
+if ! command -v jq >/dev/null 2>&1; then echo "ERROR: jq required" >&2; exit 2; fi
+
+for fn in sr_log sr_warn sr_error sr_snapshot_client_filter sr_fetch_candidates; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$SR_MOD" "$fn")"
+done
+for fn in sr_snapshot_client_filter sr_fetch_candidates; do
+  if ! declare -F "$fn" >/dev/null; then echo "ERROR: $fn not loaded" >&2; exit 2; fi
+done
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ── グローバル env ──
+REPO="owner/test-repo"
+LABEL_PICKED="claude-picked-up"
+LABEL_CLAIMED="claude-claimed"
+LABEL_FAILED="claude-failed"
+LABEL_NEEDS_DECISIONS="needs-decisions"
+LABEL_AWAITING_DESIGN="awaiting-design-review"
+LABEL_NEEDS_QUOTA_WAIT="needs-quota-wait"
+LABEL_BLOCKED="blocked"
+LABEL_STAGED_FOR_RELEASE="staged-for-release"
+STALE_PICKUP_REAPER_GH_TIMEOUT="60"
+STALE_PICKUP_REAPER_MAX_ISSUES="50"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. sr_snapshot_client_filter（実コード）: include 包含 + exclude 除外（Req 2.3）
+# ─────────────────────────────────────────────────────────────────────────────
+EXC_JSON='["claude-failed","needs-decisions","awaiting-design-review","needs-quota-wait","blocked","staged-for-release","hold"]'
+SET='[
+  {"number":10,"labels":[{"name":"claude-picked-up"}]},
+  {"number":11,"labels":[{"name":"claude-picked-up"},{"name":"claude-failed"}]},
+  {"number":12,"labels":[{"name":"claude-picked-up"},{"name":"hold"}]},
+  {"number":13,"labels":[{"name":"ready-for-review"}]}
+]'
+out="$(sr_snapshot_client_filter "$SET" "claude-picked-up" "$EXC_JSON")"
+nums="$(echo "$out" | jq -c '[.[].number]')"
+assert_eq "reaper filter: picked 包含 + failed/hold 除外 + 非 picked 除外" "[10]" "$nums"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. sr_fetch_candidates（実コード / end-to-end）: 超集合 → picked+claimed 結合等価集合
+# ─────────────────────────────────────────────────────────────────────────────
+ISSUE_SUPERSET='[
+  {"number":10,"labels":[{"name":"claude-picked-up"}],"title":"a","url":"u10","updatedAt":"2026-01-01T00:00:00Z"},
+  {"number":11,"labels":[{"name":"claude-picked-up"},{"name":"claude-failed"}],"title":"b","url":"u11","updatedAt":"2026-01-01T00:00:00Z"},
+  {"number":12,"labels":[{"name":"claude-claimed"}],"title":"c","url":"u12","updatedAt":"2026-01-01T00:00:00Z"},
+  {"number":13,"labels":[{"name":"claude-claimed"},{"name":"needs-quota-wait"}],"title":"d","url":"u13","updatedAt":"2026-01-01T00:00:00Z"},
+  {"number":14,"labels":[{"name":"ready-for-review"}],"title":"e","url":"u14","updatedAt":"2026-01-01T00:00:00Z"},
+  {"number":15,"labels":[{"name":"claude-picked-up"},{"name":"blocked"}],"title":"f","url":"u15","updatedAt":"2026-01-01T00:00:00Z"}
+]'
+# active 相当: wrapper が超集合を返し、grl_snapshot_active=true で client 絞り込みが走る
+grl_issue_snapshot_or_live() { printf '%s' "$ISSUE_SUPERSET"; }
+grl_snapshot_active() { return 0; }
+merged="$(sr_fetch_candidates)"
+nums="$(echo "$merged" | jq -c '[.[].number] | sort')"
+assert_eq "reaper end-to-end: picked(10)+claimed(12) のみ（failed/needs-quota-wait/blocked/非対象 除外）" "[10,12]" "$nums"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. quota-aware client jq（module と同一表現）: needs-quota-wait 包含（Req 2.3）
+# ─────────────────────────────────────────────────────────────────────────────
+QA_SET='[
+  {"number":20,"labels":[{"name":"needs-quota-wait"}]},
+  {"number":21,"labels":[{"name":"auto-dev"}]},
+  {"number":22,"labels":[{"name":"needs-quota-wait"},{"name":"auto-dev"}]}
+]'
+qa_out="$(printf '%s' "$QA_SET" | jq -c \
+  --arg needs_quota "needs-quota-wait" \
+  '[.[] | select((.labels // [] | map(.name) | index($needs_quota)) != null)]')"
+assert_eq "quota-aware filter: needs-quota-wait 包含のみ" "[20,22]" "$(echo "$qa_out" | jq -c '[.[].number]')"
+# module が該当 select を持つ
+assert_rc "quota-aware: needs_quota include select 存在" 0 grep -q 'index($needs_quota)) != null' "$QA_MOD"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. dependency-resolver client jq（module と同一表現）: blocked 包含 + 除外 + number 整列
+# ─────────────────────────────────────────────────────────────────────────────
+DR_SET='[
+  {"number":33,"body":"x","labels":[{"name":"auto-dev"},{"name":"blocked"}]},
+  {"number":30,"body":"y","labels":[{"name":"auto-dev"},{"name":"blocked"}]},
+  {"number":31,"body":"z","labels":[{"name":"auto-dev"},{"name":"blocked"},{"name":"claude-failed"}]},
+  {"number":32,"body":"w","labels":[{"name":"auto-dev"}]}
+]'
+dr_out="$(printf '%s' "$DR_SET" | jq -c \
+  --arg blocked "blocked" --arg failed "claude-failed" --arg nd "needs-decisions" \
+  '[.[] | (.labels // [] | map(.name)) as $n
+     | select(($n | index($blocked)) != null)
+     | select(($n | index($failed)) == null)
+     | select(($n | index($nd)) == null)
+  ] | sort_by(.number)')"
+assert_eq "dependency-resolver filter: blocked 包含/failed 除外/非 blocked 除外 + number 昇順" "[30,33]" "$(echo "$dr_out" | jq -c '[.[].number]')"
+assert_rc "dependency-resolver: blocked include + sort_by(.number) 存在" 0 grep -q 'sort_by(.number)' "$DR_MOD"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. path-overlap client jq（module と同一表現）: holder OR + st-failed/awaiting-slot 除外
+# ─────────────────────────────────────────────────────────────────────────────
+PO_SET='[
+  {"number":40,"labels":[{"name":"claude-claimed"}]},
+  {"number":41,"labels":[{"name":"needs-iteration"}]},
+  {"number":42,"labels":[{"name":"claude-picked-up"},{"name":"st-failed"}]},
+  {"number":43,"labels":[{"name":"ready-for-review"},{"name":"awaiting-slot"}]},
+  {"number":44,"labels":[{"name":"auto-dev"}]}
+]'
+HOLDERS='["claude-claimed","claude-picked-up","awaiting-design-review","ready-for-review","needs-iteration","needs-rebase","staged-for-release"]'
+po_out="$(printf '%s' "$PO_SET" | jq -c \
+  --argjson holders "$HOLDERS" \
+  '[.[] | (.labels // [] | map(.name)) as $n
+     | select($holders | any(. as $h | ($n | index($h)) != null))
+     | select(($n | index("st-failed")) == null)
+     | select(($n | index("awaiting-slot")) == null)
+  ]')"
+assert_eq "path-overlap filter: holder OR 包含 / st-failed・awaiting-slot・非 holder 除外" "[40,41]" "$(echo "$po_out" | jq -c '[.[].number]')"
+assert_rc "path-overlap: holder OR any() select 存在" 0 grep -q 'any(. as \$h' "$PO_MOD"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. 各 module が snapshot に参加 / 超集合 union に updatedAt を含む
+#    reaper は wrapper grl_issue_snapshot_or_live 経由（server search 形が一致し byte 等価）、
+#    quota/dep/path は grl_snapshot_active 分岐で snapshot 参照（gate off は原コマンドを温存し
+#    byte 等価 / NFR 1.1）。いずれも snapshot active 時のみ client 絞り込みが走る。
+# ─────────────────────────────────────────────────────────────────────────────
+assert_rc "stale-pickup-reaper.sh: grl_issue_snapshot_or_live 経由（wrapper）" 0 \
+  grep -q 'grl_issue_snapshot_or_live' "$SR_MOD"
+for m in "$QA_MOD" "$DR_MOD" "$PO_MOD"; do
+  assert_rc "$(basename "$m"): grl_snapshot_active 分岐で snapshot 参照" 0 \
+    grep -q 'grl_snapshot_active' "$m"
+  assert_rc "$(basename "$m"): active 時 grl_snapshot_issues を参照" 0 \
+    grep -q 'grl_snapshot_issues' "$m"
+done
+assert_rc "Issue 超集合 union に updatedAt を含む（reaper 参加のため）" 0 \
+  grep -q 'number,title,body,url,labels,author,updatedAt' "$GRL_MOD"
+
+# ── サマリ ──
+echo "----------------------------------------"
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then exit 1; fi
+echo "api_rate_guard_issue_equiv_test: all passed"

--- a/local-watcher/test/api_rate_guard_pr_equiv_test.sh
+++ b/local-watcher/test/api_rate_guard_pr_equiv_test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #521 task 2 で PR snapshot 参加へ差し替えた merge/auto-merge 系 module の
+#       「snapshot 参照 client jq が server search と等価集合を返す」ことを fixture で検証する
+#       スモークテスト（live GitHub API なし / NFR 6.2）。
+#
+#       検証観点（docs/specs/521-feat-watcher-github-api-rate-limit/requirements.md）:
+#         - Req 2.3: 超集合（全 open PR）を client jq で絞り込んだ結果が、従来の server
+#                    `--search` と等価集合になる。代表として auto-rebase の
+#                    `label:needs-rebase` 包含 + `-label:failed` 除外 + draft/fork 除外を
+#                    実 ar_fetch_candidates で行う。
+#         - Req 2.3: merge-queue / auto-merge / auto-merge-design の inline client jq が
+#                    server search の label 条件（index==null / index!=null）を含むことを
+#                    ソース走査で確認（drift 検出）。
+#         - Req 2.4: 鮮度クリティカルな Dispatcher 候補クエリは snapshot 経由へ差し替えず
+#                    個別取得を維持することをソース走査で確認。
+#
+# 配置先: local-watcher/test/api_rate_guard_pr_equiv_test.sh
+# 依存:   bash 4+, awk, jq, grep
+# 実行:   bash local-watcher/test/api_rate_guard_pr_equiv_test.sh
+
+# 抽出関数および stub から indirect 参照される変数を多用するため SC2034 を抑止（file-wide）。
+# module ソース走査の grep パターンは `$needs_rebase` 等の jq 変数リテラルを意図的に単一
+# クォートで保持するため SC2016（single-quote 非展開）も file-wide で抑止する。
+# shellcheck disable=SC2034,SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+MOD_DIR="$SCRIPT_DIR/../bin/modules"
+AR_MOD="$MOD_DIR/auto-rebase.sh"
+MQ_MOD="$MOD_DIR/merge-queue.sh"
+AM_MOD="$MOD_DIR/auto-merge.sh"
+AMD_MOD="$MOD_DIR/auto-merge-design.sh"
+WATCHER_SH="$SCRIPT_DIR/../bin/issue-watcher.sh"
+
+for f in "$AR_MOD" "$MQ_MOD" "$AM_MOD" "$AMD_MOD" "$WATCHER_SH"; do
+  if [ ! -f "$f" ]; then echo "ERROR: cannot find $f" >&2; exit 2; fi
+done
+if ! command -v jq >/dev/null 2>&1; then echo "ERROR: jq required" >&2; exit 2; fi
+
+# ar ロガー + ar_fetch_candidates を実コードから抽出
+for fn in ar_log ar_warn ar_error ar_fetch_candidates; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$AR_MOD" "$fn")"
+done
+if ! declare -F ar_fetch_candidates >/dev/null; then
+  echo "ERROR: ar_fetch_candidates not loaded" >&2; exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ── グローバル env ──
+REPO="owner/test-repo"
+AUTO_REBASE_GIT_TIMEOUT="60"
+MERGE_QUEUE_HEAD_PATTERN="^claude/"
+LABEL_NEEDS_REBASE="needs-rebase"
+LABEL_FAILED="claude-failed"
+
+# ── stub: grl_pr_snapshot_or_live を active 相当（超集合を返す）に固定 ──
+# 全 open PR 超集合（draft / fork / 非 approved / needs-rebase 無し / failed 併存 を含む）。
+PR_SUPERSET='[
+  {"number":1,"headRefName":"claude/issue-1-impl","baseRefName":"main","labels":[{"name":"needs-rebase"}],"url":"u1","isDraft":false,"reviewDecision":"APPROVED","headRepositoryOwner":{"login":"owner"},"title":"t1","headRefOid":"a1"},
+  {"number":2,"headRefName":"claude/issue-2-impl","baseRefName":"main","labels":[],"url":"u2","isDraft":false,"reviewDecision":"APPROVED","headRepositoryOwner":{"login":"owner"},"title":"t2","headRefOid":"a2"},
+  {"number":3,"headRefName":"claude/issue-3-impl","baseRefName":"main","labels":[{"name":"needs-rebase"},{"name":"claude-failed"}],"url":"u3","isDraft":false,"reviewDecision":"APPROVED","headRepositoryOwner":{"login":"owner"},"title":"t3","headRefOid":"a3"},
+  {"number":4,"headRefName":"claude/issue-4-impl","baseRefName":"main","labels":[{"name":"needs-rebase"}],"url":"u4","isDraft":true,"reviewDecision":"APPROVED","headRepositoryOwner":{"login":"owner"},"title":"t4","headRefOid":"a4"},
+  {"number":5,"headRefName":"claude/issue-5-impl","baseRefName":"main","labels":[{"name":"needs-rebase"}],"url":"u5","isDraft":false,"reviewDecision":null,"headRepositoryOwner":{"login":"owner"},"title":"t5","headRefOid":"a5"},
+  {"number":6,"headRefName":"claude/issue-6-impl","baseRefName":"main","labels":[{"name":"needs-rebase"}],"url":"u6","isDraft":false,"reviewDecision":"APPROVED","headRepositoryOwner":{"login":"forkuser"},"title":"t6","headRefOid":"a6"}
+]'
+grl_pr_snapshot_or_live() { echo "$PR_SUPERSET"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. auto-rebase: 超集合 → client jq が server search と等価集合を返す（Req 2.3）
+#    期待: PR#1 のみ（approved + needs-rebase 包含 + failed 除外 + 非 draft + owner 一致）。
+# ─────────────────────────────────────────────────────────────────────────────
+out="$(ar_fetch_candidates)"
+nums="$(echo "$out" | jq -c '[.[].number]')"
+assert_eq "auto-rebase 等価集合: needs-rebase 包含/failed 除外/draft 除外/fork 除外" "[1]" "$nums"
+
+# 個別根拠の可視化
+assert_eq "auto-rebase: 総数 1" "1" "$(echo "$out" | jq 'length')"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. merge-queue の inline client jq に label 除外条件が含まれる（Req 2.3 / drift 検出）
+# ─────────────────────────────────────────────────────────────────────────────
+assert_rc "merge-queue: needs-rebase 除外 select 存在" 0 \
+  grep -q 'index($needs_rebase)) == null' "$MQ_MOD"
+assert_rc "merge-queue: failed 除外 select 存在" 0 \
+  grep -q 'index($failed)) == null' "$MQ_MOD"
+# recheck 側は needs-rebase 包含
+assert_rc "merge-queue-recheck: needs-rebase 包含 select 存在" 0 \
+  grep -q 'index($needs_rebase)) != null' "$MQ_MOD"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. auto-merge / auto-merge-design の inline client jq に label 条件が含まれる（Req 2.3）
+# ─────────────────────────────────────────────────────────────────────────────
+assert_rc "auto-merge: ready 包含 select 存在" 0 \
+  grep -q 'index($ready)) != null' "$AM_MOD"
+assert_rc "auto-merge: needs-decisions 除外 select 存在" 0 \
+  grep -q 'index($needs_decisions)) == null' "$AM_MOD"
+assert_rc "auto-merge-design: needs-iteration 除外 select 存在" 0 \
+  grep -q 'index($needs_iteration)) == null' "$AMD_MOD"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. 各 module が grl_pr_snapshot_or_live 経由へ差し替え済み（snapshot 参加 / Req 2.3）
+# ─────────────────────────────────────────────────────────────────────────────
+for m in "$MQ_MOD" "$AM_MOD" "$AMD_MOD" "$AR_MOD" "$MOD_DIR/auto-merge-disarm.sh"; do
+  assert_rc "$(basename "$m"): grl_pr_snapshot_or_live 経由" 0 \
+    grep -q 'grl_pr_snapshot_or_live' "$m"
+done
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Req 2.4: Dispatcher 候補クエリは snapshot 経由へ差し替えず個別取得を維持
+#    （issue-watcher.sh 本体の Dispatcher が grl_issue_snapshot_or_live を使わない）。
+# ─────────────────────────────────────────────────────────────────────────────
+assert_eq "Dispatcher 候補クエリは snapshot 非参加（grl 未使用）" "0" \
+  "$(grep -c 'grl_issue_snapshot_or_live' "$WATCHER_SH" || true)"
+
+# ── サマリ ──
+echo "----------------------------------------"
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then exit 1; fi
+echo "api_rate_guard_pr_equiv_test: all passed"

--- a/local-watcher/test/api_rate_guard_rest_test.sh
+++ b/local-watcher/test/api_rate_guard_rest_test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #521 task 8 で追加した grl_rest_prs_for_head（GraphQL→REST 負荷分散）を
+#       fixture + gh stub で検証するスモークテスト（live GitHub API なし / NFR 6.2）。
+#
+#       検証観点（docs/specs/521-feat-watcher-github-api-rate-limit/requirements.md）:
+#         - Req 6.1 / 6.2: offload on 時に REST core 経由取得し gh pr list --head 互換 JSON へ
+#                          正規化（open→OPEN / closed+merged_at→MERGED / closed→CLOSED /
+#                          headRefName=head.ref / headRefOid=head.sha / url=html_url）
+#         - Req 6.3: REST 失敗時は従来 gh pr list --head へ fallback + warn
+#         - Req 6.4 / NFR 1.1: gate off 時は従来 gh pr list --head 経路
+#
+# 配置先: local-watcher/test/api_rate_guard_rest_test.sh
+# 依存:   bash 4+, awk, jq, grep
+# 実行:   bash local-watcher/test/api_rate_guard_rest_test.sh
+
+# shellcheck disable=SC2034,SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+GRL_MOD="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+CORE_MOD="$SCRIPT_DIR/../bin/modules/core_utils.sh"
+
+for f in "$GRL_MOD" "$CORE_MOD"; do
+  if [ ! -f "$f" ]; then echo "ERROR: cannot find $f" >&2; exit 2; fi
+done
+if ! command -v jq >/dev/null 2>&1; then echo "ERROR: jq required" >&2; exit 2; fi
+
+for fn in grl_log grl_warn grl_error; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$CORE_MOD" "$fn")"
+done
+for fn in grl_gh_pr_list_head grl_rest_prs_for_head; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD" "$fn")"
+done
+if ! declare -F grl_rest_prs_for_head >/dev/null; then
+  echo "ERROR: grl_rest_prs_for_head not loaded" >&2; exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+REPO="owner/test-repo"
+
+# fixtures
+REST_JSON='[
+  {"number":1,"state":"open","merged_at":null,"head":{"ref":"claude/issue-1-impl","sha":"aaa"},"html_url":"https://h/1"},
+  {"number":2,"state":"closed","merged_at":"2026-01-01T00:00:00Z","head":{"ref":"claude/issue-2-impl","sha":"bbb"},"html_url":"https://h/2"},
+  {"number":3,"state":"closed","merged_at":null,"head":{"ref":"claude/issue-3-impl","sha":"ccc"},"html_url":"https://h/3"}
+]'
+FALLBACK_JSON='[{"number":99,"state":"OPEN","headRefName":"claude/issue-99-impl","headRefOid":"zzz","url":"https://h/99"}]'
+
+GH_CALL_LOG="$(mktemp)"
+trap 'rm -f "$GH_CALL_LOG" 2>/dev/null || true' EXIT
+gh() {
+  echo "gh $*" >> "$GH_CALL_LOG"
+  case "${1:-}" in
+    api)
+      if [ "${GH_STUB_MODE:-ok}" = "rest-fail" ]; then return 1; fi
+      printf '%s' "$REST_JSON"; return 0
+      ;;
+    pr)
+      if [ "${2:-}" = "list" ]; then printf '%s' "$FALLBACK_JSON"; return 0; fi
+      ;;
+  esac
+  return 0
+}
+timeout() { shift; "$@"; }
+reset_calls() { : > "$GH_CALL_LOG"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. gate off（offload off）→ 従来 gh pr list --head 経路（Req 6.4 / NFR 1.1）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_REST_OFFLOAD_ENABLED="false"
+reset_calls
+out="$(grl_rest_prs_for_head "claude/issue-99-impl" "all")"
+assert_eq "gate off: 従来 gh pr list --head の結果を返す" "$FALLBACK_JSON" "$out"
+assert_contains "gate off: gh pr list を呼ぶ" "$(cat "$GH_CALL_LOG")" "gh pr list"
+assert_eq "gate off: gh api rate offload を呼ばない" "0" "$(grep -c 'gh api' "$GH_CALL_LOG" || true)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. offload on + REST 成功 → 正規化（OPEN/MERGED/CLOSED 変換 / Req 6.1, 6.2）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_REST_OFFLOAD_ENABLED="true"
+GH_STUB_MODE="ok"
+reset_calls
+out="$(grl_rest_prs_for_head "claude/issue-1-impl" "all")"
+assert_contains "offload on: REST(gh api pulls) を呼ぶ" "$(cat "$GH_CALL_LOG")" "gh api repos/owner/test-repo/pulls"
+assert_eq "offload on: PR1 open→OPEN" "OPEN" "$(echo "$out" | jq -r '.[0].state')"
+assert_eq "offload on: PR2 closed+merged_at→MERGED" "MERGED" "$(echo "$out" | jq -r '.[1].state')"
+assert_eq "offload on: PR3 closed→CLOSED" "CLOSED" "$(echo "$out" | jq -r '.[2].state')"
+assert_eq "offload on: headRefName=head.ref" "claude/issue-2-impl" "$(echo "$out" | jq -r '.[1].headRefName')"
+assert_eq "offload on: headRefOid=head.sha" "bbb" "$(echo "$out" | jq -r '.[1].headRefOid')"
+assert_eq "offload on: url=html_url" "https://h/3" "$(echo "$out" | jq -r '.[2].url')"
+assert_eq "offload on: 数=3" "3" "$(echo "$out" | jq 'length')"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. offload on + REST 失敗 → 従来 gh pr list --head へ fallback + warn（Req 6.3）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_REST_OFFLOAD_ENABLED="true"
+GH_STUB_MODE="rest-fail"
+reset_calls
+out="$(grl_rest_prs_for_head "claude/issue-99-impl" "all" 2>/dev/null)"
+assert_eq "REST 失敗: gh pr list --head へ fallback" "$FALLBACK_JSON" "$out"
+warn_out="$(grl_rest_prs_for_head "claude/issue-99-impl" "all" 2>&1 1>/dev/null)"
+assert_contains "REST 失敗: warn 出力" "$warn_out" "gh-rate-limit: WARN"
+assert_contains "REST 失敗: fallback 経路で gh pr list を呼ぶ" "$(cat "$GH_CALL_LOG")" "gh pr list"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. offload on + timeout 指定（元々 timeout 付き consumer）→ timeout 経由でも正規化される
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_REST_OFFLOAD_ENABLED="true"
+GH_STUB_MODE="ok"
+reset_calls
+out="$(grl_rest_prs_for_head "claude/issue-1-impl" "all" "120")"
+assert_eq "timeout 指定 offload on: 正規化される（PR1 OPEN）" "OPEN" "$(echo "$out" | jq -r '.[0].state')"
+
+# ── サマリ ──
+echo "----------------------------------------"
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then exit 1; fi
+echo "api_rate_guard_rest_test: all passed"

--- a/local-watcher/test/api_rate_guard_retry_test.sh
+++ b/local-watcher/test/api_rate_guard_retry_test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #521 task 7 で追加した grl_retry_label_op（状態遷移系ラベル操作の限定リトライ）を
+#       fixture + gh stub で検証するスモークテスト（live GitHub API なし / NFR 6.2）。
+#
+#       検証観点（docs/specs/521-feat-watcher-github-api-rate-limit/requirements.md）:
+#         - Req 5.1 / 5.2: rate-limit 起因失敗のみ上限まで再試行、非 rate-limit は 1 回で即返す
+#         - Req 5.3 / NFR 2.3: 再試行は有限回（上限で打ち切り）
+#         - Req 5.4: 上限到達でも rc を返し（label 残置 = 次 tick 再評価 / 孤児化しない）
+#         - Req 5.6: 再試行ログに issue 番号・操作種別・試行回数
+#         - Req 1.1 / NFR 1.1: gate off は 1 回だけ実行（従来挙動）
+#
+# 配置先: local-watcher/test/api_rate_guard_retry_test.sh
+# 依存:   bash 4+, awk, grep
+# 実行:   bash local-watcher/test/api_rate_guard_retry_test.sh
+
+# shellcheck disable=SC2034,SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+GRL_MOD="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+CORE_MOD="$SCRIPT_DIR/../bin/modules/core_utils.sh"
+
+for f in "$GRL_MOD" "$CORE_MOD"; do
+  if [ ! -f "$f" ]; then echo "ERROR: cannot find $f" >&2; exit 2; fi
+done
+
+for fn in grl_log grl_warn grl_error; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$CORE_MOD" "$fn")"
+done
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$GRL_MOD" "grl_retry_label_op")"
+if ! declare -F grl_retry_label_op >/dev/null; then
+  echo "ERROR: grl_retry_label_op not loaded" >&2; exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+REPO="owner/test-repo"
+GH_API_STATE_RETRY_MAX_ATTEMPTS="3"
+GH_API_STATE_RETRY_SLEEP="0"
+
+# gh stub: issue edit 呼び出しを file カウンタで数える。GH_STUB_MODE で挙動切替。
+GH_CALLS_FILE="$(mktemp)"
+trap 'rm -f "$GH_CALLS_FILE" 2>/dev/null || true' EXIT
+gh() {
+  if [ "${1:-}" = "issue" ] && [ "${2:-}" = "edit" ]; then
+    local n; n=$(cat "$GH_CALLS_FILE" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "$GH_CALLS_FILE"
+    case "${GH_STUB_MODE:-ok}" in
+      ok)        return 0 ;;
+      ratelimit) echo "API rate limit exceeded for user" >&2; return 1 ;;
+      other)     echo "unprocessable: some other error" >&2; return 1 ;;
+      rl-then-ok)
+        if [ "$n" -ge 2 ]; then return 0; else echo "You have exceeded a secondary rate limit" >&2; return 1; fi ;;
+    esac
+  fi
+  return 0
+}
+# sleep を no-op に（実 sleep を避ける）
+sleep() { :; }
+reset_calls() { echo 0 > "$GH_CALLS_FILE"; }
+calls() { cat "$GH_CALLS_FILE"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. gate off → 1 回だけ実行（従来挙動 / NFR 1.1）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_STATE_RETRY_ENABLED="false"
+GH_STUB_MODE="ratelimit"
+reset_calls
+rc=0; grl_retry_label_op 42 --repo "$REPO" --remove-label "claude-picked-up" || rc=$?
+assert_eq "gate off: gh 1 回のみ（rate-limit でもリトライしない）" "1" "$(calls)"
+assert_eq "gate off: gh の rc をそのまま返す（1）" "1" "$rc"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. gate on + 初回成功 → 1 回、rc=0
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_STATE_RETRY_ENABLED="true"
+GH_STUB_MODE="ok"
+reset_calls
+rc=0; grl_retry_label_op 42 --repo "$REPO" --remove-label "claude-picked-up" >/dev/null 2>&1 || rc=$?
+assert_eq "gate on 初回成功: gh 1 回" "1" "$(calls)"
+assert_eq "gate on 初回成功: rc=0" "0" "$rc"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. gate on + rate-limit 継続 → 上限 3 回で打ち切り、rc 非0、上限到達 warn（Req 5.2, 5.3, 5.4）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_STATE_RETRY_ENABLED="true"
+GH_STUB_MODE="ratelimit"
+reset_calls
+out_file="$(mktemp)"
+rc=0; grl_retry_label_op 42 --repo "$REPO" --remove-label "claude-picked-up" >"$out_file" 2>&1 || rc=$?
+assert_eq "rate-limit 継続: gh は上限 3 回（有限打ち切り / NFR 2.3）" "3" "$(calls)"
+assert_eq "rate-limit 継続: 最終 rc 非0（label 残置で次 tick / Req 5.4）" "1" "$rc"
+assert_contains "再試行ログに issue/op/attempt（Req 5.6）" "$(cat "$out_file")" "retry issue=#42 op=-claude-picked-up attempt=1/3"
+assert_contains "再試行ログ attempt=2/3" "$(cat "$out_file")" "attempt=2/3"
+assert_contains "上限到達 warn" "$(cat "$out_file")" "attempt=3/3 上限到達"
+rm -f "$out_file"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. gate on + 非 rate-limit 失敗 → 1 回で即返す（二次消費回避 / Req 5.2）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_STATE_RETRY_ENABLED="true"
+GH_STUB_MODE="other"
+reset_calls
+rc=0; grl_retry_label_op 42 --repo "$REPO" --remove-label "claude-picked-up" >/dev/null 2>&1 || rc=$?
+assert_eq "非 rate-limit 失敗: gh 1 回のみ（リトライしない）" "1" "$(calls)"
+assert_eq "非 rate-limit 失敗: rc 非0" "1" "$rc"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. gate on + rate-limit 後に成功 → 2 回、rc=0
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_STATE_RETRY_ENABLED="true"
+GH_STUB_MODE="rl-then-ok"
+reset_calls
+rc=0; grl_retry_label_op 42 --repo "$REPO" --remove-label "claude-picked-up" >/dev/null 2>&1 || rc=$?
+assert_eq "rate-limit→成功: gh 2 回" "2" "$(calls)"
+assert_eq "rate-limit→成功: rc=0" "0" "$rc"
+
+# ── サマリ ──
+echo "----------------------------------------"
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then exit 1; fi
+echo "api_rate_guard_retry_test: all passed"

--- a/local-watcher/test/api_rate_guard_review_equiv_test.sh
+++ b/local-watcher/test/api_rate_guard_review_equiv_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #521 task 3 で PR snapshot 参加へ差し替えた review 系 module
+#       （pr-iteration / pr-reviewer / pr-design-reviewer / security-review）の
+#       「snapshot 参照 client jq が server search と等価集合を返す」ことを fixture で検証する
+#       スモークテスト（live GitHub API なし / NFR 6.2）。
+#
+#       検証観点（docs/specs/521-feat-watcher-github-api-rate-limit/requirements.md）:
+#         - Req 2.3: pr-iteration の超集合 client jq が server search
+#                    （label:needs-iteration 包含 / -label:failed / -label:needs-rebase 除外 /
+#                    -draft:true）と等価集合を返すことを実 pi_fetch_candidate_prs で確認。
+#         - Req 2.3: pr-reviewer / pr-design-reviewer / security-review は server search が
+#                    `-draft:true` のみで client jq の isDraft==false が完全再現するため
+#                    追加 client jq 不要。grl_pr_snapshot_or_live 経由化 + isDraft==false 存在を
+#                    ソース走査で確認（drift 検出）。
+#
+# 配置先: local-watcher/test/api_rate_guard_review_equiv_test.sh
+# 依存:   bash 4+, awk, jq, grep
+# 実行:   bash local-watcher/test/api_rate_guard_review_equiv_test.sh
+
+# 抽出関数・stub 変数の多用で SC2034 を、ソース走査 grep の単一クォート jq リテラルで SC2016 を
+# file-wide 抑止する。
+# shellcheck disable=SC2034,SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+MOD_DIR="$SCRIPT_DIR/../bin/modules"
+PI_MOD="$MOD_DIR/pr-iteration.sh"
+PR_MOD="$MOD_DIR/pr-reviewer.sh"
+PDR_MOD="$MOD_DIR/pr-design-reviewer.sh"
+SEC_MOD="$MOD_DIR/security-review.sh"
+
+for f in "$PI_MOD" "$PR_MOD" "$PDR_MOD" "$SEC_MOD"; do
+  if [ ! -f "$f" ]; then echo "ERROR: cannot find $f" >&2; exit 2; fi
+done
+if ! command -v jq >/dev/null 2>&1; then echo "ERROR: jq required" >&2; exit 2; fi
+
+for fn in pi_log pi_warn pi_error pi_fetch_candidate_prs; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$PI_MOD" "$fn")"
+done
+if ! declare -F pi_fetch_candidate_prs >/dev/null; then
+  echo "ERROR: pi_fetch_candidate_prs not loaded" >&2; exit 2
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ── グローバル env ──
+REPO="owner/test-repo"
+PR_ITERATION_GIT_TIMEOUT="60"
+PR_ITERATION_HEAD_PATTERN="^claude/issue-[0-9]+-impl-"
+PR_ITERATION_DESIGN_HEAD_PATTERN="^claude/issue-[0-9]+-design-"
+PR_ITERATION_DESIGN_ENABLED="true"
+LABEL_NEEDS_ITERATION="needs-iteration"
+LABEL_FAILED="claude-failed"
+LABEL_NEEDS_REBASE="needs-rebase"
+
+# 全 open PR 超集合（needs-iteration 無し / failed 併存 / needs-rebase 併存 / draft / fork /
+# design PR を含む）。
+PR_SUPERSET='[
+  {"number":1,"headRefName":"claude/issue-1-impl-a","baseRefName":"main","isDraft":false,"url":"u1","labels":[{"name":"needs-iteration"}],"headRepositoryOwner":{"login":"owner"},"body":"b1"},
+  {"number":2,"headRefName":"claude/issue-2-impl-a","baseRefName":"main","isDraft":false,"url":"u2","labels":[],"headRepositoryOwner":{"login":"owner"},"body":"b2"},
+  {"number":3,"headRefName":"claude/issue-3-impl-a","baseRefName":"main","isDraft":false,"url":"u3","labels":[{"name":"needs-iteration"},{"name":"claude-failed"}],"headRepositoryOwner":{"login":"owner"},"body":"b3"},
+  {"number":4,"headRefName":"claude/issue-4-impl-a","baseRefName":"main","isDraft":false,"url":"u4","labels":[{"name":"needs-iteration"},{"name":"needs-rebase"}],"headRepositoryOwner":{"login":"owner"},"body":"b4"},
+  {"number":5,"headRefName":"claude/issue-5-impl-a","baseRefName":"main","isDraft":true,"url":"u5","labels":[{"name":"needs-iteration"}],"headRepositoryOwner":{"login":"owner"},"body":"b5"},
+  {"number":6,"headRefName":"claude/issue-6-impl-a","baseRefName":"main","isDraft":false,"url":"u6","labels":[{"name":"needs-iteration"}],"headRepositoryOwner":{"login":"forkuser"},"body":"b6"},
+  {"number":7,"headRefName":"claude/issue-7-design-a","baseRefName":"main","isDraft":false,"url":"u7","labels":[{"name":"needs-iteration"}],"headRepositoryOwner":{"login":"owner"},"body":"b7"}
+]'
+grl_pr_snapshot_or_live() { echo "$PR_SUPERSET"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. pr-iteration: 超集合 → client jq が server search と等価集合（Req 2.3）
+#    期待: PR#1（impl+needs-iteration）と #7（design+needs-iteration、design_enabled=true）。
+# ─────────────────────────────────────────────────────────────────────────────
+out="$(pi_fetch_candidate_prs)"
+nums="$(echo "$out" | jq -c '[.[].number]')"
+assert_eq "pr-iteration 等価集合: needs-iteration 包含/failed・needs-rebase・draft・fork 除外" "[1,7]" "$nums"
+
+# design_enabled=false のとき design PR (#7) が候補から外れる（既存挙動維持の確認）
+PR_ITERATION_DESIGN_ENABLED="false"
+out="$(pi_fetch_candidate_prs)"
+nums="$(echo "$out" | jq -c '[.[].number]')"
+assert_eq "pr-iteration: design_enabled=false で design PR 除外" "[1]" "$nums"
+PR_ITERATION_DESIGN_ENABLED="true"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. draft-only 3 module: grl_pr_snapshot_or_live 経由化 + isDraft==false 存在（Req 2.3）
+# ─────────────────────────────────────────────────────────────────────────────
+for pair in "pr-reviewer:$PR_MOD" "pr-design-reviewer:$PDR_MOD" "security-review:$SEC_MOD"; do
+  name="${pair%%:*}"; mod="${pair##*:}"
+  assert_rc "$name: grl_pr_snapshot_or_live 経由" 0 grep -q 'grl_pr_snapshot_or_live' "$mod"
+  assert_rc "$name: client jq に isDraft==false 存在（-draft:true 再現）" 0 \
+    grep -q 'select(.isDraft == false)' "$mod"
+  # 旧 raw fetch（timeout ... gh pr list）が残っていない
+  assert_eq "$name: raw 'timeout ... gh pr list' 消失" "0" \
+    "$(grep -c 'timeout .* gh pr list' "$mod" || true)"
+done
+
+# pr-iteration も grl 経由化を確認
+assert_rc "pr-iteration: grl_pr_snapshot_or_live 経由" 0 grep -q 'grl_pr_snapshot_or_live' "$PI_MOD"
+
+# ── サマリ ──
+echo "----------------------------------------"
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then exit 1; fi
+echo "api_rate_guard_review_equiv_test: all passed"

--- a/local-watcher/test/api_rate_guard_snapshot_test.sh
+++ b/local-watcher/test/api_rate_guard_snapshot_test.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# 用途: Issue #521 task 1 で新規追加した local-watcher/bin/modules/api-rate-guard.sh の
+#       スナップショット共有基盤（Req 2）を fixture + gh stub で検証するスモークテスト。
+#       live GitHub API を呼ばず、timeout / gh を stub して判定を観測する（NFR 6.2）。
+#
+#       対象関数:
+#         - grl_snapshot_init           (Req 2.1, 2.2, 2.5, 2.6 / gate off no-op / fetch 失敗 fallback)
+#         - grl_snapshot_active         (active/inactive 判定)
+#         - grl_snapshot_prs / _issues  (超集合 file accessor)
+#         - grl_pr_snapshot_or_live     (Req 2.3 active=超集合 / 非 active=live 委譲)
+#         - grl_issue_snapshot_or_live  (同上 Issue 版)
+#
+#       検証する AC（docs/specs/521-feat-watcher-github-api-rate-limit/requirements.md）:
+#         - Req 1.1 / 1.2 / 1.3: gate off / 未設定 / 不正値 → 新挙動なし（active=off / gh 非呼び出し）
+#         - Req 2.1 / 2.2: gate on で PR/Issue 超集合を各 1 回取得し file 共有
+#         - Req 2.5 / 2.6: 取得失敗は warn + active=off で個別取得へフォールバック
+#         - Req 2.3: 非 active 時にラッパが live 引数へ byte 等価に委譲
+#
+# 配置先: local-watcher/test/api_rate_guard_snapshot_test.sh
+# 依存:   bash 4+, awk, jq, mktemp
+# 実行:   bash local-watcher/test/api_rate_guard_snapshot_test.sh
+
+# 抽出関数および stub から indirect 参照される変数を多用するため、shellcheck からは
+# 未使用に見える。本ファイル全体で SC2034（unused variable）を抑止する。
+# shellcheck disable=SC2034
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/test-helpers.sh"
+GRL_MOD="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+CORE_MOD="$SCRIPT_DIR/../bin/modules/core_utils.sh"
+
+for f in "$GRL_MOD" "$CORE_MOD"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: cannot find $f" >&2
+    exit 2
+  fi
+done
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not found in PATH" >&2
+  exit 2
+fi
+
+# grl ロガーは core_utils.sh 定義、snapshot 系は api-rate-guard.sh 定義。
+for fn in grl_log grl_warn grl_error; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$CORE_MOD" "$fn")"
+done
+for fn in grl_snapshot_pr_fields grl_snapshot_issue_fields grl_snapshot_dir \
+          grl_atomic_write grl_snapshot_init grl_snapshot_active \
+          grl_snapshot_prs grl_snapshot_issues \
+          grl_pr_snapshot_or_live grl_issue_snapshot_or_live; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD" "$fn")"
+done
+
+for fn in grl_snapshot_init grl_snapshot_active grl_pr_snapshot_or_live grl_issue_snapshot_or_live; do
+  if ! declare -F "$fn" >/dev/null; then
+    echo "ERROR: $fn not loaded" >&2
+    exit 2
+  fi
+done
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ── グローバル env（遅延束縛で抽出関数本体から参照される） ──
+REPO="owner/test-repo"
+REPO_SLUG="owner-test-repo"
+LABEL_TRIGGER="auto-dev"
+GRL_SNAPSHOT_STATUS="inactive"
+
+# 一時 snapshot ディレクトリ
+GH_API_SNAPSHOT_DIR="$(mktemp -d)"
+trap 'rm -rf "$GH_API_SNAPSHOT_DIR" 2>/dev/null || true' EXIT
+GH_API_SNAPSHOT_PR_LIMIT="100"
+GH_API_SNAPSHOT_ISSUE_LIMIT="100"
+GH_API_SNAPSHOT_GH_TIMEOUT="60"
+
+# ── stub: timeout は bash 関数 gh を実行するため duration を捨てて "$@" を実行 ──
+GH_CALL_LOG="$(mktemp)"
+trap 'rm -rf "$GH_API_SNAPSHOT_DIR" "$GH_CALL_LOG" 2>/dev/null || true' EXIT
+timeout() { shift; "$@"; }
+
+# gh stub。GH_STUB_MODE で挙動を切り替える。呼び出し引数を GH_CALL_LOG に追記。
+PR_SUPERSET='[{"number":1,"title":"a","isDraft":false},{"number":2,"title":"b","isDraft":true}]'
+ISSUE_SUPERSET='[{"number":10,"labels":[{"name":"auto-dev"}]},{"number":11,"labels":[{"name":"auto-dev"},{"name":"claude-picked-up"}]}]'
+gh() {
+  echo "gh $*" >> "$GH_CALL_LOG"
+  local kind="$2"  # $1=pr|issue, $2=list
+  case "$1" in
+    pr)
+      if [ "${GH_STUB_MODE:-ok}" = "pr-fail" ]; then return 1; fi
+      echo "$PR_SUPERSET"
+      ;;
+    issue)
+      if [ "${GH_STUB_MODE:-ok}" = "issue-fail" ]; then return 1; fi
+      echo "$ISSUE_SUPERSET"
+      ;;
+  esac
+  : "$kind"
+}
+
+reset_calls() { : > "$GH_CALL_LOG"; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. gate off（既定 false）→ no-op（active=off / gh 非呼び出し）（Req 1.1, 1.2）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_SNAPSHOT_ENABLED="false"
+GRL_SNAPSHOT_STATUS="inactive"
+reset_calls
+grl_snapshot_init
+assert_eq "gate off: status=inactive" "inactive" "$GRL_SNAPSHOT_STATUS"
+assert_rc "gate off: grl_snapshot_active rc=1" 1 grl_snapshot_active
+assert_eq "gate off: gh 非呼び出し" "" "$(cat "$GH_CALL_LOG")"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. 不正値（typo）→ 安全側 off（Req 1.3）
+#    ※ config 正規化は watcher-config.sh 側だが、init 自体も `!= true` で安全側に倒す
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_SNAPSHOT_ENABLED="TRUE"   # 大文字は true 厳密一致でない
+GRL_SNAPSHOT_STATUS="inactive"
+reset_calls
+grl_snapshot_init
+assert_eq "typo(TRUE): status=inactive" "inactive" "$GRL_SNAPSHOT_STATUS"
+assert_rc "typo(TRUE): active rc=1" 1 grl_snapshot_active
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. gate on + 取得成功 → active / file 書き込み（Req 2.1, 2.2）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_SNAPSHOT_ENABLED="true"
+GH_STUB_MODE="ok"
+GRL_SNAPSHOT_STATUS="inactive"
+reset_calls
+grl_snapshot_init
+assert_eq "gate on: status=active" "active" "$GRL_SNAPSHOT_STATUS"
+assert_rc "gate on: active rc=0" 0 grl_snapshot_active
+assert_eq "gate on: prs.json 内容" "$PR_SUPERSET" "$(cat "$GH_API_SNAPSHOT_DIR/prs.json")"
+assert_eq "gate on: issues.json 内容" "$ISSUE_SUPERSET" "$(cat "$GH_API_SNAPSHOT_DIR/issues.json")"
+# PR / Issue 各 1 回のみ取得（NFR 3.1）
+assert_eq "gate on: PR list 1 回" "1" "$(grep -c 'gh pr list' "$GH_CALL_LOG")"
+assert_eq "gate on: Issue list 1 回" "1" "$(grep -c 'gh issue list' "$GH_CALL_LOG")"
+# accessor
+assert_eq "grl_snapshot_prs=超集合" "$PR_SUPERSET" "$(grl_snapshot_prs)"
+assert_eq "grl_snapshot_issues=超集合" "$ISSUE_SUPERSET" "$(grl_snapshot_issues)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. gate on + PR 取得失敗 → warn + active=off（Req 2.5, 2.6 / NFR 2.1）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_SNAPSHOT_ENABLED="true"
+GH_STUB_MODE="pr-fail"
+GRL_SNAPSHOT_STATUS="inactive"
+reset_calls
+warn_out="$(grl_snapshot_init 2>&1 1>/dev/null || true)"
+assert_eq "PR fetch fail: status=inactive" "inactive" "$GRL_SNAPSHOT_STATUS"
+assert_contains "PR fetch fail: warn 出力" "$warn_out" "gh-rate-limit: WARN"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. gate on + Issue 取得失敗 → warn + active=off（Req 2.5, 2.6）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_STUB_MODE="issue-fail"
+GRL_SNAPSHOT_STATUS="inactive"
+grl_snapshot_init >/dev/null 2>&1 || true
+assert_eq "Issue fetch fail: status=inactive" "inactive" "$GRL_SNAPSHOT_STATUS"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. ラッパ: active 時は超集合を返す（live 引数を無視 / Req 2.3）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_SNAPSHOT_ENABLED="true"
+GH_STUB_MODE="ok"
+GRL_SNAPSHOT_STATUS="inactive"
+grl_snapshot_init >/dev/null 2>&1
+reset_calls
+out="$(grl_pr_snapshot_or_live 60 "review:approved -draft:true" "number,title" 50)"
+assert_eq "wrapper active(PR): 超集合返却" "$PR_SUPERSET" "$out"
+assert_eq "wrapper active(PR): live gh 非呼び出し" "" "$(cat "$GH_CALL_LOG")"
+out="$(grl_issue_snapshot_or_live 60 "label:auto-dev" "number,labels" 50)"
+assert_eq "wrapper active(Issue): 超集合返却" "$ISSUE_SUPERSET" "$out"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. ラッパ: 非 active（gate off）時は live 引数で従来 gh を実行（byte 等価 / Req 2.3）
+# ─────────────────────────────────────────────────────────────────────────────
+GH_API_SNAPSHOT_ENABLED="false"
+GRL_SNAPSHOT_STATUS="inactive"
+reset_calls
+out="$(grl_pr_snapshot_or_live 60 "review:approved -draft:true" "number,title" 50)"
+assert_eq "wrapper live(PR): 超集合を stub gh から返却" "$PR_SUPERSET" "$out"
+assert_contains "wrapper live(PR): --search を含む" "$(cat "$GH_CALL_LOG")" '--search review:approved -draft:true'
+assert_contains "wrapper live(PR): --json を含む" "$(cat "$GH_CALL_LOG")" '--json number,title'
+assert_contains "wrapper live(PR): --limit を含む" "$(cat "$GH_CALL_LOG")" '--limit 50'
+
+# 空 search → --search を付けない（auto-merge-disarm 互換 / byte 等価）
+reset_calls
+out="$(grl_pr_snapshot_or_live 60 "" "number,title" 100)"
+calls="$(cat "$GH_CALL_LOG")"
+assert_eq "wrapper live(PR, 空 search): --search なし" "0" "$(printf '%s' "$calls" | grep -c -- '--search' || true)"
+assert_contains "wrapper live(PR, 空 search): --state open" "$calls" '--state open'
+
+# Issue live 委譲
+reset_calls
+out="$(grl_issue_snapshot_or_live 60 "label:\"needs-quota-wait\"" "number,labels" 50)"
+assert_contains "wrapper live(Issue): --search を含む" "$(cat "$GH_CALL_LOG")" 'gh issue list'
+
+# ── サマリ ──
+echo "----------------------------------------"
+echo "PASS: $PASS_COUNT / FAIL: $FAIL_COUNT"
+if [ "$FAIL_COUNT" -ne 0 ]; then
+  exit 1
+fi
+echo "api_rate_guard_snapshot_test: all passed"

--- a/local-watcher/test/auto-merge-design_test.sh
+++ b/local-watcher/test/auto-merge-design_test.sh
@@ -78,6 +78,15 @@ eval "$(extract_function "$AMD_MOD" "amd_enable_auto_merge_for_pr")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$AMD_MOD" "process_auto_merge_design")"
 
+# Issue #521: process_auto_merge_design は PR 一覧取得を grl_pr_snapshot_or_live 経由に
+# 差し替えた。GH_API_SNAPSHOT_ENABLED 未設定（既定 false）では wrapper が従来の gh pr list
+# へ委譲するため（snapshot inactive）、下記 stub gh/timeout がそのまま観測される（byte 等価）。
+GRL_MOD="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+for fn in grl_snapshot_dir grl_snapshot_active grl_snapshot_prs grl_pr_snapshot_or_live; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD" "$fn")"
+done
+
 # full_auto_enabled は issue-watcher.sh 本体に定義されている（#348）
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$WATCHER_SH" "full_auto_enabled")"

--- a/local-watcher/test/auto-merge-disarm_test.sh
+++ b/local-watcher/test/auto-merge-disarm_test.sh
@@ -61,6 +61,15 @@ for fn in amx_log amx_warn amx_error amx_resolve_gate_enabled amx_should_disarm_
   eval "$(extract_function "$AMX_MOD" "$fn")"
 done
 
+# Issue #521: process_auto_merge_disarm は PR 一覧取得を grl_pr_snapshot_or_live 経由に
+# 差し替えた。GH_API_SNAPSHOT_ENABLED 未設定（既定 false）では wrapper が従来の gh pr list
+# へ委譲するため（snapshot inactive）、下記 stub gh/timeout がそのまま観測される（byte 等価）。
+GRL_MOD="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+for fn in grl_snapshot_dir grl_snapshot_active grl_snapshot_prs grl_pr_snapshot_or_live; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD" "$fn")"
+done
+
 # full_auto_enabled は issue-watcher.sh 本体に定義されている（#348）
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$WATCHER_SH" "full_auto_enabled")"

--- a/local-watcher/test/auto-merge_test.sh
+++ b/local-watcher/test/auto-merge_test.sh
@@ -72,6 +72,15 @@ eval "$(extract_function "$AM_MOD" "am_enable_auto_merge_for_pr")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$AM_MOD" "process_auto_merge")"
 
+# Issue #521: process_auto_merge は PR 一覧取得を grl_pr_snapshot_or_live 経由に差し替えた。
+# GH_API_SNAPSHOT_ENABLED 未設定（既定 false）では wrapper が従来の gh pr list へ委譲する
+# ため（snapshot inactive）、下記 stub gh/timeout がそのまま観測される（byte 等価）。
+GRL_MOD="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+for fn in grl_snapshot_dir grl_snapshot_active grl_snapshot_prs grl_pr_snapshot_or_live; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD" "$fn")"
+done
+
 # full_auto_enabled は issue-watcher.sh 本体に定義されている（#348）
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$WATCHER_SH" "full_auto_enabled")"

--- a/local-watcher/test/dr_unblock_sweep_test.sh
+++ b/local-watcher/test/dr_unblock_sweep_test.sh
@@ -77,6 +77,15 @@ eval "$(extract_function "$DR_SH" "dr_unblock_sweep")"
 eval "$(extract_function "$DR_SH" "dr_extract_deps")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$DR_SH" "dr_format_unresolved_comment")"
+# Issue #521: dr_unblock_sweep は Issue 一覧取得を grl_issue_snapshot_or_live 経由へ差し替えた。
+# GH_API_SNAPSHOT_ENABLED 未設定（既定 false）では wrapper が従来の gh issue list へ委譲する
+# （snapshot inactive）ため、下記 gh stub がそのまま観測される（byte 等価）。
+GRL_MOD_T="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+for _grl_fn in grl_snapshot_dir grl_snapshot_active grl_snapshot_issues grl_issue_snapshot_or_live; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD_T" "$_grl_fn")"
+done
+unset _grl_fn
 # Issue #348: dr_unblock_sweep 内で full_auto_enabled を呼ぶため、ヘルパー抽出規約
 # （CLAUDE.md 機能追加ガイドライン §7）に従って当該抽出リストへ追随させる。
 # shellcheck disable=SC1090,SC2086

--- a/local-watcher/test/po_staged_holder_dropfilter_test.sh
+++ b/local-watcher/test/po_staged_holder_dropfilter_test.sh
@@ -48,6 +48,15 @@ eval "$(extract_function "$PATH_OVERLAP_SH" "po_resolve_staged_drop_label")"
 eval "$(extract_function "$PATH_OVERLAP_SH" "po_collect_inflight_issues")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$PATH_OVERLAP_SH" "po_build_label_or_clause")"
+# Issue #521: po_collect_inflight_issues は Issue 一覧取得を grl_issue_snapshot_or_live 経由へ
+# 差し替えた。GH_API_SNAPSHOT_ENABLED 未設定（既定 false）では wrapper が従来の gh issue list へ
+# 委譲する（snapshot inactive）ため、下記 gh stub がそのまま観測される（byte 等価）。
+GRL_MOD_T="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+for _grl_fn in grl_snapshot_dir grl_snapshot_active grl_snapshot_issues grl_issue_snapshot_or_live; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD_T" "$_grl_fn")"
+done
+unset _grl_fn
 
 if ! declare -F po_resolve_staged_drop_label >/dev/null; then
   echo "ERROR: po_resolve_staged_drop_label not loaded" >&2

--- a/local-watcher/test/sr_marker_state_test.sh
+++ b/local-watcher/test/sr_marker_state_test.sh
@@ -57,6 +57,18 @@ eval "$(extract_function "$MODULE_SH" "sr_load_marker")"
 eval "$(extract_function "$MODULE_SH" "sr_save_marker")"
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$MODULE_SH" "sr_fetch_candidates")"
+# Issue #521: sr_fetch_candidates は Issue 一覧取得を grl_issue_snapshot_or_live 経由へ差し替え、
+# 超集合参照時の client 絞り込みに sr_snapshot_client_filter を呼ぶ。GH_API_SNAPSHOT_ENABLED
+# 未設定（既定 false）では wrapper が従来の gh issue list へ委譲する（snapshot inactive）ため、
+# 後段の gh/timeout stub がそのまま観測される（byte 等価）。両ヘルパーを抽出リストに追随させる。
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$MODULE_SH" "sr_snapshot_client_filter")"
+GRL_MOD_T="$SCRIPT_DIR/../bin/modules/api-rate-guard.sh"
+for _grl_fn in grl_snapshot_dir grl_snapshot_active grl_snapshot_issues grl_issue_snapshot_or_live; do
+  # shellcheck disable=SC1090,SC2086
+  eval "$(extract_function "$GRL_MOD_T" "$_grl_fn")"
+done
+unset _grl_fn
 
 for fn in sr_marker_path sr_load_marker sr_save_marker sr_fetch_candidates; do
   if ! declare -F "$fn" >/dev/null; then

--- a/local-watcher/test/sr_wiring_test.sh
+++ b/local-watcher/test/sr_wiring_test.sh
@@ -326,7 +326,11 @@ else
 fi
 
 # call site 配線確認: process_failed_recovery 行の後ろに process_stale_pickup_reaper 行がある
-fr_line=$(grep -n '^process_failed_recovery ||' "$WATCHER_SH" | head -1 | cut -d: -f1)
+# Issue #521: failed-recovery は non-essential のため縮退 gate でラップされ、call site は
+# `grl_degrade_should_run "failed-recovery" && { process_failed_recovery || fr_warn ...; }`
+# となった。行頭アンカーを外して wrapped 形の call site も検出する（順序契約の意図は不変）。
+# stale-pickup-reaper は essential のため従来どおり行頭 `process_stale_pickup_reaper ||`。
+fr_line=$(grep -n 'process_failed_recovery ||' "$WATCHER_SH" | head -1 | cut -d: -f1)
 spr_line=$(grep -n '^process_stale_pickup_reaper ||' "$WATCHER_SH" | head -1 | cut -d: -f1)
 if [ -n "$fr_line" ] && [ -n "$spr_line" ] && [ "$spr_line" -gt "$fr_line" ]; then
   echo "PASS: Req 1.1 / NFR 1.2: process_stale_pickup_reaper の call site が process_failed_recovery の後（fr=$fr_line, spr=$spr_line）"

--- a/local-watcher/test/stage_a_verify_round1_defer_test.sh
+++ b/local-watcher/test/stage_a_verify_round1_defer_test.sh
@@ -51,6 +51,11 @@ fi
 # issue-watcher.sh から該当関数 1 個だけを抽出する（インデント無しの単独 `}` まで）。
 # shellcheck disable=SC1090,SC2086
 eval "$(extract_function "$IMPL_PIPELINE_SH" "stage_a_verify_round1_defer")"
+# Issue #521: stage_a_verify_round1_defer は claude-picked-up 除去を grl_retry_label_op 経由へ
+# 差し替えた。GH_API_STATE_RETRY_ENABLED 未設定（既定 false）では wrapper が gh issue edit を
+# 1 回だけ実行し（従来挙動 / gh 出力抑止は wrapper 内）、下記 gh stub がそのまま観測される。
+# shellcheck disable=SC1090,SC2086
+eval "$(extract_function "$SCRIPT_DIR/../bin/modules/api-rate-guard.sh" "grl_retry_label_op")"
 
 if ! declare -F stage_a_verify_round1_defer >/dev/null; then
   echo "ERROR: stage_a_verify_round1_defer not loaded" >&2


### PR DESCRIPTION
## 概要

idd-claude watcher は 1 サイクルで複数プロセッサが独立に GitHub API を叩き、GraphQL 5,000 pt/h を
急速に消費する問題があった。本 PR では (1) サイクル内スナップショット共有、(2) バケット別残量の
可視化、(3) 残量閾値割れ時の WARN と縮退、(4) 状態遷移系ラベル操作の限定リトライ、
(5) GraphQL → REST への負荷分散 の 5 機能を **すべて opt-in / 既定 OFF** で導入し、
rate limit 耐性を高める。全 gate 未設定では挙動が一切変わらない後方互換設計を最優先とした。

## 対応 Issue

Closes #521

## 関連 PR

- 設計 PR: #523（merged）

## 実装内容

- (Req 1) 全 5 機能を `GH_API_*_ENABLED=true` で個別 opt-in。既定 OFF / 不正値は安全側正規化
- (Req 2) 新規 module `api-rate-guard.sh`（prefix `grl_`）+ `watcher-config.sh` に env 12 個追加。
  サイクル冒頭 `grl_snapshot_init` で PR/Issue 一覧を各 1 回取得し、参加 13 module がスナップショット参照
- (Req 3) `grl_buckets_refresh` / `grl_buckets_log` をサイクル終端に配線し固定書式 1 行で残量出力
- (Req 4) `grl_degrade_should_run` で非必須 7 call site を gate。essential（dispatch / 状態遷移 / reaper 等）は常時実行
- (Req 5) `grl_retry_label_op` で resumable-return 3 箇所の `claude-picked-up` 除去を rate-limit 限定リトライ対象へ差し替え
- (Req 6) `grl_rest_prs_for_head` で per-branch PR 存在確認 3 箇所を REST core バケット経由へ差し替え（失敗時 GraphQL fallback）
- (Req 7) README に opt-in 手順・新規 env 12 個の表・バケット可視化ログの読み方・縮退優先順を追記

## 受入基準チェック

- [x] Req 1.1–1.3: gate 未設定で no-op・不正値は安全側正規化 ← snapshot/degrade/retry/rest 各 test gate off ケース + config smoke
- [x] Req 1.4–1.6: 既存 env/ラベル/exit code/新規ラベル変更なし ← diff 確認 + 108 test suite 回帰
- [x] Req 2.1, 2.2: スナップショット冒頭 1 回取得 / 重複再取得なし ← `api_rate_guard_snapshot_test.sh`（PR/Issue list 各 1 回 assert）
- [x] Req 2.3: 個別取得と等価判定 ← `_pr_equiv_test.sh` / `_review_equiv_test.sh` / `_issue_equiv_test.sh`
- [x] Req 2.4: 鮮度クリティカル箇所は個別取得維持 ← `_pr_equiv_test.sh` ケース5（Dispatcher 非参加）
- [x] Req 2.5, 2.6: 取得失敗時 fallback + warn ← `api_rate_guard_snapshot_test.sh` ケース4/5
- [x] Req 3.1–3.4: 終端 1 行ログ / 非消費経路 / 固定書式 / 失敗継続 ← `api_rate_guard_degrade_test.sh`
- [x] Req 4.1–4.6: 閾値 WARN / 非必須 skip / essential 不 skip / env 調整 / skip ログ / 無効時不 skip ← `api_rate_guard_degrade_test.sh`
- [x] Req 5.1–5.6: rate-limit 限定リトライ / 有限 / 孤児化しない / 安全側 / 試行ログ ← `api_rate_guard_retry_test.sh`
- [x] Req 6.1–6.4: REST 差し替え / 等価判定 / 失敗 fallback / 無効時 GraphQL ← `api_rate_guard_rest_test.sh`
- [x] Req 7.1–7.3: README opt-in 手順・env 表・ログ読み方・縮退優先順 ← README「GitHub API Rate Guard (#521)」節

## テスト結果

```
108 テスト passed / 0 failed
shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/watcher-config.sh local-watcher/bin/modules/*.sh → 新規警告 0
bash -n local-watcher/bin/issue-watcher.sh → OK
config 正規化 smoke: 不正値（TRUE / -5 / abc / 0 / on）→ 安全側既定へ正規化を確認
gate-off no-op smoke: 全 gate off で grl_* が gh を 1 度も呼ばず（NFR 1.1）確認
```

新規テスト: `api_rate_guard_snapshot_test.sh` / `_pr_equiv_test.sh` / `_review_equiv_test.sh` /
`_issue_equiv_test.sh` / `api_rate_guard_degrade_test.sh` / `api_rate_guard_retry_test.sh` /
`api_rate_guard_rest_test.sh`（計 7 本追加）。既存テストも含む全 108 本すべて green。

## 実装上の判断

`impl-notes.md` に詳細を記録。レビュワーが知っておくべき主要な design drift:

1. **Issue 超集合 union に `updatedAt` を追加**: stale-pickup-reaper が `updatedAt` を必須参照するため design union を補完した
2. **Issue consumer 3 件は branch パターンで実装**: quota-aware / dependency-resolver / path-overlap の `--label` 形クエリは wrapper と byte 一致しないため、gate off 時は原コマンドを逐語温存する branch パターンを採用（NFR 1.1 優先）
3. **REST offload 対象は 3 箇所（design 記載の 4 ではなく）**: slot-worker-resume.sh:318 は prefix 検索 probe のため REST exact-head 差し替え不可。resume:1017 / stage-checkpoint:192 / :694 の 3 箇所
4. **degrade skip ログは WARN キーワード付き**: Req 4.1 の WARN 要求に沿い `grl_warn` 経由で出力（design literal より 1 token 多い）

## 確認事項 / レビュワーへの依頼

- 最終 PR: tasks.md 全 10 タスク完了のため Closes を採用
- Reviewer（独立 context）の独立レビューは approve 済み（`docs/specs/521-feat-watcher-github-api-rate-limit/review-notes.md` 参照 / `RESULT: approve`）
- 上記「実装上の判断」1–4 の design drift について、Architect 追認が必要な場合は別 Issue / design iteration で対応されたい
- 派生タスク候補（config 起動サマリへの gh-api-guard 状態追記・core/search 縮退閾値対応）は `impl-notes.md` に記録済み
- base: main / baseRefName: main / OK

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
関連 Issue での決定事項の履歴は #521 のコメントを参照してください。