### PR TITLE
spec(#526): 人間レビュー用成果物の HTML 並行生成（.md 正準維持・opt-in）

### DIFF
--- a/docs/specs/526-feat-agents-html-md/design.md
+++ b/docs/specs/526-feat-agents-html-md/design.md
@@ -1,0 +1,324 @@
+# Design Document
+
+## Overview
+
+**Purpose**: 本機能は「人間レビュー用 markdown 成果物（`docs/specs/<番号>-<slug>/` 配下の
+requirements.md / design.md / tasks.md 等）を、生タグではなくレンダリング済み HTML でも確認できる」
+可読性向上を、idd-claude を運用するオペレータ / レビュワーへ提供する。markdown を正準（source of
+truth）に据えたまま、opt-in 有効化時のみ **並行して .html を派生生成**する。
+
+**Users**: idd-claude オペレータ / 人間レビュワーが、設計 PR / 実装 PR のレビュー時に、ローカル
+checkout した worktree 上の `design.html` 等を開いてレビューする workflow で利用する。機械ゲート
+（watcher / 各エージェント）は従来どおり .md のみを契約入力とし、.html に一切依存しない。
+
+**Impact**: 現在の watcher は spec 配下 .md を PM/Architect（design 段）・Developer/Reviewer（impl 段）が
+生成する。本機能は **専用 module（`spec-html.sh`）** を追加し、Slot Runner（`slot-worker.sh`）の
+design 分岐 rc=0 直後と impl 分岐 rc=0 直後の 2 箇所に fail-open hook を挿す。既定（opt-in gate OFF）
+では 1 行も挙動を変えない。
+
+複雑度は「標準（新規 module 1 + call site 2 + config + docs 同期）」。分量は design-principles.md の
+標準バジェット（≤300 行）内に収める。
+
+### Goals
+- opt-in gate（既定 OFF）有効時のみ、対象 .md に対応する .html を並行生成する
+- .md を正準として維持し、機械ゲート / エージェント連携が .html に依存しない状態を保つ
+- 生成失敗を本流から分離し、silent fail を作らず、watcher exit code の意味を変えない
+- 新規ランタイム非依存を貫き、依存 CLI 採用時も未インストールで本流を止めない
+- 成功基準: gate OFF で観測可能挙動が導入前と完全一致し、gate ON で 5 対象 .md の .html が worktree に生成される
+
+### Non-Goals
+- .md の .html 置換（Introduction / Out of Scope に従い扱わない）
+- 機械ゲート入力 .md の内容 / 形式の変更（checkbox / センチネル / `RESULT:` 行 / DSL）
+- PR 本文の HTML 化 / spec 外 markdown の HTML 化 / CSS テーマ作り込み
+- .md ↔ .html 乖離の自動検出・整合強制（本 spec は best-effort 追随のみ）
+- 外部静的ホスティング / GitHub Pages への自動アップロード実装（別 opt-in gate 前提・本 spec 対象外）
+
+## Architecture
+
+### Existing Architecture Analysis
+- **パイプライン構造**: `slot-worker.sh` の `_slot_run_issue` が 1 Issue を design / impl / impl-resume の
+  モード別にディスパッチする。design 分岐は PM→Architect→PjM を 1 claude セッションで走らせ、rc=0 直後に
+  既に **post-architect hook** `tc_run_post_architect_check || true`（Tasks Count Gate / #147）が挿さっている。
+  impl 分岐は `run_impl_pipeline`（`impl-pipeline.sh`）を呼び、rc=0 で完了する。
+- **尊重すべき境界**: module は「関数定義のみ・トップレベル副作用なし」。config（env var 定義・正規化）は
+  `watcher-config.sh`。call site（実行順序）は slot-worker / 本体側に残す。ロガーは module 同居可（`tc_log` 前例）。
+- **維持すべき統合点**: 機械ゲート（tasks.md checkbox / Tasks Count Gate / stage-a-verify センチネル /
+  Reviewer `RESULT:` 行 / per-task checkbox）はすべて .md 限定。本機能はこの契約に一切干渉しない。
+- **技術的負債の回避**: 既存の opt-in gate 慣習（`*_ENABLED=true` 厳密一致 / 不正値は安全側正規化 /
+  fail-open hook `|| true`）を踏襲し、新パターンを持ち込まない。
+
+### Architecture Pattern & Boundary Map
+
+採用パターン: 既存 **post-stage fail-open hook + 専用 gate module**（`tasks-count-gate.sh` と同型）。
+`tc_run_post_architect_check` が design rc=0 直後で tasks.md を再評価するのと同じ配置思想で、
+`shx_run_for_spec_dir` を design / impl の rc=0 直後に挿す。
+
+```mermaid
+flowchart TD
+  subgraph SlotWorker["_slot_run_issue (slot-worker.sh)"]
+    D{"MODE == design?"}
+    D -->|yes| DPM["design claude 実行 PM→Architect→PjM"]
+    DPM -->|rc=0| TC["tc_run_post_architect_check (fail-open)"]
+    TC --> SHXD["shx_run_for_spec_dir ★design 段 hook"]
+    D -->|no| IMPL["run_impl_pipeline"]
+    IMPL -->|rc=0| SHXI["shx_run_for_spec_dir ★impl 段 hook"]
+  end
+  SHXD --> M["spec-html.sh module"]
+  SHXI --> M
+  subgraph M2["spec-html.sh (gate module / prefix shx_)"]
+    G{"shx_enabled?"} -->|no| NOOP["no-op return 0"]
+    G -->|yes| AV{"shx_render_available?"}
+    AV -->|no| SK["warn + skip return 0"]
+    AV -->|yes| EN["shx_target_files: 実在対象.md 列挙"]
+    EN --> R["shx_render_one を各.md に適用 / 失敗は per-file warn で継続"]
+  end
+```
+
+**Architecture Integration**:
+- 採用パターン: post-stage fail-open hook + gate module（既存 Tasks Count Gate の再利用形。学習コスト最小）
+- ドメイン境界: 生成ロジックは `spec-html.sh` に閉じる。call site は slot-worker.sh に 2 行追加のみ
+- 既存パターンの維持: `*_ENABLED` 厳密一致正規化 / fail-open `|| true` / module 同居ロガー / 遅延束縛 global 参照
+- 新規コンポーネントの根拠: 生成は独立責務であり本体 inline を避け module 化（CLAUDE.md §1）。新 prefix `shx_` を割当
+
+### Technology Stack
+
+| Layer | Choice / Version | Role in Feature | Notes |
+|-------|------------------|-----------------|-------|
+| Frontend / CLI | 生成物 .html（静的ファイル） | 人間レビュワーが local checkout で開く | GitHub は任意 .html を描画しない前提 |
+| Backend / Services | bash 4+ module `spec-html.sh` | gate 判定 / 対象列挙 / 生成 orchestrate | 既存 module 群と同基盤 |
+| Data / Storage | worktree 上の `.html` ファイル | 派生物（gitignore で版管理除外・既定案） | 正準は .md |
+| Messaging / Events | なし | — | 新イベントなし |
+| Infrastructure / Runtime | 外部 md→html CLI（既定 `pandoc`、env で差替可） | .md→.html 変換 | 未インストール時は skip+log（Req 5） |
+
+## File Structure Plan
+
+### 新規 / 変更ファイル
+
+```
+local-watcher/bin/
+├── modules/
+│   └── spec-html.sh            # 新規: 本機能 module（prefix shx_）。gate/列挙/生成/ロガー
+├── watcher-config.sh           # 変更: SPEC_HTML_* env var 定義・正規化ブロック追加
+└── issue-watcher.sh            # 変更: REQUIRED_MODULES に "spec-html.sh" を 1 要素追加
+
+local-watcher/bin/modules/
+└── slot-worker.sh              # 変更: design 分岐 rc=0 直後 / impl 分岐 rc=0 直後に
+                                #        `shx_run_for_spec_dir || true` を各 1 行挿入（call site）
+
+local-watcher/test/
+└── spec-html_test.sh           # 新規: extract_function 隔離抽出でユニット検証
+
+.gitignore                      # 変更: `docs/specs/**/*.html` を追加（版管理除外・既定案 / Req 7.2）
+
+README.md                       # 変更: 「オプション機能一覧」に SPEC_HTML_* / 閲覧経路 / setup を追記
+CLAUDE.md                       # 変更: 機能追加ガイドライン §2 prefix 表に `shx_` 行を追加
+```
+
+- `install.sh` / `install-lib.sh` は **変更不要**: `local-watcher/bin/modules/*.sh` を glob 配布するため
+  新 module は自動配布される（`install-lib.sh:1315-1317` の `copy_glob_to_homebin ... "*.sh"`）。
+- `repo-template/` 同期: 本機能は `.claude/agents` / `.claude/rules` を変更しないため byte 一致同期対象外
+  （NFR 4.1/4.2 は vacuously 満たす）。consumer 側 `.gitignore` は install 管理外のため README で opt-in
+  setup として案内する（NFR 4.3）。
+
+## Requirements Traceability
+
+| Requirement | Summary | Component / 配置 |
+|-------------|---------|------------------|
+| 1.1 | gate 非 true は .html 非生成・導入前等価経路 | `shx_enabled` / call site 内部 no-op |
+| 1.2 | gate true で並行生成実行 | `shx_run_for_spec_dir` |
+| 1.3 | 不正値を安全側正規化 + 1 行 log | watcher-config `SPEC_HTML_ENABLED` case 正規化 |
+| 1.4 | 既定で処理順序 / 成果物 / ログ先に副作用なし | call site の `|| true` + gate 早期 return |
+| 2.1 | .md 新規生成時に対応 .html 生成 | design/impl hook → `shx_render_one` |
+| 2.2 | 必須対象 = requirements/design/tasks.md | `SPEC_HTML_TARGETS` 既定値 |
+| 2.3 | 追加対象 = impl-notes/review-notes.md（含める確定） | `SPEC_HTML_TARGETS` 既定値 |
+| 2.4 | .md と同一 dir に識別可能命名で配置 | `shx_html_path`（`<name>.html`） |
+| 2.5 | .md 内容を反映した可読 HTML | `SPEC_HTML_RENDER_CMD`（既定 pandoc gfm） |
+| 3.1 | .md を正準維持・置換しない | module は .html のみ Write（.md 不変） |
+| 3.2 | 機械ゲートは .html 非依存 | 本機能は既存ゲートに 1 行も触れない（設計不変） |
+| 3.3 | エージェント連携は .md 正準入力 | 本機能は agents/rules を変更しない |
+| 3.4 | .html 欠落/破損でも既存パイプライン同一判定 | .html を読む経路が存在しない（設計不変） |
+| 4.1 | .md 更新時に .html 追随再生成 | design/impl 両 hook が毎回上書き再生成 |
+| 4.2 | .html を派生物扱い・手編集を維持しない | `shx_render_one` は無条件上書き |
+| 5.1 | 生成失敗でも .md 完了・本流継続 | `shx_run_for_spec_dir` 常に return 0 + `|| true` |
+| 5.2 | 生成失敗を 1 行以上 log | `shx_warn`（対象ファイル付き） |
+| 5.3 | .html 成否を exit code に反映しない | hook は `|| true`、module は return 0 固定 |
+| 6.1 | 外部送信せずローカル生成 | worktree 内 Write のみ（gh/network 呼ばない） |
+| 6.2 | 外部アップロードは別 opt-in gate | 本 spec 未実装・予約名を README 記載 |
+| 6.3 | 閲覧手段を案内 | README 閲覧経路節 |
+| 7.1 | commit する場合 generated 扱い | 代替案（`.gitattributes linguist-generated`）を確認事項に記載 |
+| 7.2 | commit しない場合 版管理除外 | `.gitignore` `docs/specs/**/*.html`（既定案） |
+
+**NFR Traceability**（NFR は numeric collision 回避のため明示ラベル併記）:
+
+| NFR | Summary | 対応 |
+|-----|---------|------|
+| NFR 1.1/1.2/1.3 | 後方互換（挙動 / env / cron / label 不変） | gate 既定 OFF・既存 env 名不変・新 label/cron なし |
+| NFR 2.1/2.2 | ランタイム非追加 / 依存 CLI は design 判断 + README 明記 | 新規 runtime なし・CLI は opt-in 配下 skip-if-missing |
+| NFR 3.1 | 分岐点をログ判定可能 | `shx_log/warn`（skip理由/対象/成功/失敗） |
+| NFR 4.1/4.2/4.3 | 二重管理整合 | agents/rules 非変更・consumer setup を README 同期 |
+| NFR 5.1 | 未信頼入力の path 検証 | 対象 basename allowlist + NUMBER `^[0-9]+$` 既検証 + quote |
+| NFR 6.1 | 静的解析警告ゼロ | `shellcheck` / `bash -n` 検証タスク |
+| NFR 7.1/7.2 | ドキュメント整合 | 同一 PR で README / CLAUDE.md 更新 |
+
+## Components and Interfaces
+
+### spec-html.sh（gate module / prefix `shx_`）
+
+#### spec-html module
+
+| Field | Detail |
+|-------|--------|
+| Intent | opt-in 有効時に spec 配下対象 .md の .html を並行生成する fail-open orchestrator |
+| Requirements | 1.1-1.4, 2.1-2.5, 4.1-4.2, 5.1-5.3, 6.1, NFR 3.1, NFR 5.1 |
+
+**Responsibilities & Constraints**
+- 主責務: gate 判定 → CLI 可用性判定 → 対象 .md 列挙 → 各 .md を .html へ変換
+- 境界: 生成ロジックのみを所有。call site の実行順序は所有しない。.md は一切書き換えない（read-only 入力）
+- invariants: `shx_run_for_spec_dir` は **常に return 0**（本流の exit code に影響しない / Req 5.3）。
+  gate OFF / CLI 不在 / 生成失敗のいずれでも本流を止めない
+- データ所有権: 生成する `.html` は派生物。手編集は保護せず毎回上書き（Req 4.2）
+
+**Dependencies**
+- Inbound: `slot-worker.sh` `_slot_run_issue`（design/impl rc=0 hook）— 生成トリガ（Criticality: 低 / fail-open）
+- Outbound: なし（他 module を呼ばない）
+- External: `pandoc` 等 md→html CLI（`SPEC_HTML_RENDER_BIN`）— 変換（Criticality: 低 / 不在時 skip）
+- 実行時 global 参照（遅延束縛）: `REPO_DIR` / `SPEC_DIR_REL` / `NUMBER` / `REPO` / `LOG` / `SPEC_HTML_*`
+
+**Contracts**: Service [x] / API [ ] / Event [ ] / Batch [ ] / State [ ]
+
+##### Service Interface
+
+```bash
+# ロガー（module 同居 / prefix "spec-html:" / grep 可能な 3 段 prefix）
+shx_log()  { : ; }   # stdout
+shx_warn() { : ; }   # stderr
+shx_error(){ : ; }   # stderr
+
+# gate 判定: SPEC_HTML_ENABLED == "true" 厳密一致で 0、それ以外 1（副作用なし）
+shx_enabled() -> rc 0|1
+
+# CLI 可用性: command -v "$SPEC_HTML_RENDER_BIN" が真で 0。偽なら shx_warn + 1（Req 5 skip）
+shx_render_available() -> rc 0|1
+
+# 対象 .md 列挙: $SPEC_HTML_TARGETS の basename allowlist のうち spec dir に実在する
+#   regular file のみを 1 行 1 パス（絶対パス）で stdout。存在しないものは黙って除外
+shx_target_files() -> stdout: <abs md path>\n...
+
+# .html パス導出（純粋）: <name>.md -> <name>.html（同一 dir）
+shx_html_path(md_path) -> stdout: <abs html path>
+
+# 1 ファイル変換: SPEC_HTML_RENDER_CMD の {IN}/{OUT} を置換し timeout 付きで実行。
+#   成功 0 / 失敗は shx_warn（対象ファイル名付き）+ 非 0。呼び出し側が吸収する
+shx_render_one(md_path) -> rc 0|non-0
+
+# orchestrator（唯一のエントリ）: gate→available→列挙→各変換。件数を summary log。常に return 0
+shx_run_for_spec_dir() -> rc 0 (always)
+```
+- Preconditions: `REPO_DIR` / `SPEC_DIR_REL` が解決済み（Slot Runner が設定済み）
+- Postconditions: gate ON かつ CLI 可用時、実在対象 .md ごとに .html を生成 or per-file warn を記録
+- Invariants: .md を変更しない / 外部ネットワークを呼ばない（Req 3.1, 6.1）/ return 0 固定
+
+### call site（slot-worker.sh `_slot_run_issue`）
+
+| Field | Detail |
+|-------|--------|
+| Intent | design/impl 完了直後の生成トリガ配線（実行順序の所有） |
+| Requirements | 1.4, 2.1, 4.1, 5.1, 5.3 |
+
+- design 分岐 rc=0 case: `tc_run_post_architect_check || true` の直後に `shx_run_for_spec_dir || true`
+- impl 分岐 `_impl_rc` case 0（`✅ 完了`）: `shx_run_for_spec_dir || true` を 1 行追加
+- 双方 `|| true` で、module が return 0 固定なのと二重に本流非干渉を保証（Req 5.3 / NFR 1.1）
+
+## Data Models
+
+### 命名 / 対象モデル
+- **.html 命名規約**（Req 2.4）: `<basename>.md` → `<basename>.html`（同一 dir）。例: `design.md`→`design.html`。
+  spec dir は既知ファイルのみのため衝突しない。人間が「design の HTML」と即識別できる
+- **対象集合**（Req 2.2, 2.3 / Open Question 確定）: `SPEC_HTML_TARGETS` 既定 =
+  `requirements.md design.md tasks.md impl-notes.md review-notes.md`。必須 3 + 追加 2（含める確定）。
+  各 hook は **実在するもののみ**生成（design 段では impl-notes/review-notes 不在 → 除外・エラーにしない）
+- **生成失敗時の扱い**（Req 5.1, 5.2）: per-file 失敗は当該 .html を生成せず warn を残し次の対象へ継続。
+  orchestrator は成功/失敗件数を summary log（NFR 3.1）。.md 生成物・本流は不変
+
+### env var（watcher-config.sh 追加）
+
+| env var | 既定 | 正規化 | 役割 |
+|---------|------|--------|------|
+| `SPEC_HTML_ENABLED` | `false` | `true` 厳密一致のみ ON / 他は `false`（case） | opt-in gate（Req 1.1, 1.3） |
+| `SPEC_HTML_RENDER_BIN` | `pandoc` | そのまま | 可用性 `command -v` 対象 |
+| `SPEC_HTML_RENDER_CMD` | `pandoc -f gfm -t html5 -s -o {OUT} {IN}` | そのまま | 変換テンプレ（`{IN}`/`{OUT}` 置換） |
+| `SPEC_HTML_TIMEOUT` | `60` | 非整数 / ≤0 は `60` | 1 ファイル変換の timeout 秒 |
+| `SPEC_HTML_TARGETS` | 上記 5 basename | そのまま（space 区切り） | 対象 allowlist |
+
+> `SPEC_HTML_UPLOAD_ENABLED` は **将来の外部アップロード用予約名**（Req 6.2）。本 spec では定義・実装しない
+> （未使用 env を作らない）。採用時は本機能とは独立した別 opt-in gate として追加する旨を README に記載。
+
+## Error Handling
+
+### Error Strategy
+すべて **fail-open**。生成系の失敗は本流（.md 生成 / ラベル遷移 / PR 作成 / ゲート判定）へ伝播させない。
+
+### Error Categories and Responses
+- **CLI 不在（環境エラー）**: `shx_render_available` が false → `shx_warn` 1 行 + orchestrator は return 0。
+  gate ON でも本流を止めない（Req 5 の核心）
+- **1 ファイル変換失敗（System 5xx 相当）**: `shx_render_one` 非 0 → per-file `shx_warn`（対象ファイル名付き / Req 5.2）。
+  他対象は継続。orchestrator は return 0（Req 5.1, 5.3）
+- **未信頼入力（Security / NFR 5.1）**: spec dir path は `NUMBER`（`^[0-9]+$` 既検証）+ 固定 basename allowlist
+  から構成。変数は全 quote。`{IN}`/`{OUT}` 置換値は allowlist 由来の実在 path のみ。任意入力を CLI へ渡さない
+- **gate 不正値（User 設定ミス）**: `SPEC_HTML_ENABLED` の typo 等は case 正規化で `false` に倒し 1 行 log（Req 1.3）
+
+## Testing Strategy
+
+- **Unit Tests**（`spec-html_test.sh` / extract_function 隔離抽出 + `test/lib/test-helpers.sh`）:
+  1. `shx_enabled` — `true` のみ ON / 未設定・空・`True`・`1`・typo は OFF（Req 1.1, 1.3）
+  2. `shx_html_path` — `design.md`→`design.html` 導出（Req 2.4）
+  3. `shx_target_files` — 実在対象のみ列挙 / allowlist 外・不在は除外（Req 2.2, 2.3）
+  4. `shx_render_available` — `SPEC_HTML_RENDER_BIN` を stub コマンドで存在/不在双方（Req 5）
+  5. `shx_run_for_spec_dir` — gate OFF で no-op return 0 / CLI 不在で skip return 0（Req 1.4, 5.1, 5.3）
+- **Integration Tests**（`render` CLI を stub 化した shell-level）:
+  1. gate ON + stub CLI 可用 → 実在対象数だけ `.html` が生成される（Req 2.1, 4.1）
+  2. 1 対象で stub を失敗させても他対象は生成され orchestrator return 0（Req 5.1, 5.2）
+  3. gate OFF で `.html` が 1 つも生成されず .md も不変（Req 1.4, 3.1）
+- **E2E / Smoke**:
+  1. `SPEC_HTML_ENABLED` 未設定の dry-run（対象なし）で `処理対象の Issue なし` 正常終了（NFR 1.1）
+  2. `shellcheck local-watcher/bin/modules/spec-html.sh ...` 新規警告ゼロ・`bash -n` OK（NFR 6.1）
+  3. 本 self-hosting repo で本 spec dir に対し gate ON + pandoc で `.html` が生成され .md 変更なしを確認
+
+## Risks & Mitigations
+
+- **後方互換**: gate 既定 OFF・call site `|| true`・module return 0 固定・新 label/cron/exit code なし →
+  未設定環境は導入前と byte 等価（NFR 1.1-1.3）
+- **依存欠落**: 既定 CLI `pandoc` 未インストールでも gate ON 時 skip+log で本流継続（Req 5 / NFR 2）
+- **未信頼入力**: 固定 basename allowlist + NUMBER 既検証 + 全 quote で path 横断 / 引数注入を予防（NFR 5.1）
+- **二重管理ドリフト**: agents/rules 非変更（`diff -r` は空維持）。README / CLAUDE.md prefix 表を同一 PR 更新（NFR 4, 7）
+- **PR への .html 混入**: HTML 生成は claude セッションの commit / PR 作成 **後**に走り `git add` しないため
+  当該 PR に混入しない。加えて `.gitignore` で後続 `git add -A` の巻き込みも防ぐ（Req 7.2）
+- **worktree 揮発性**: 生成 .html は worktree ローカル。閲覧はローカル checkout 前提（Req 6.1, 6.3）。
+  リモートレビュワーの HTML 閲覧要求がある場合は commit 版管理（確認事項）へ切替
+
+## 確認事項（人間レビュー向け）
+
+以下は Architect が確定案を置いたが、方針として人間承認を要する論点。PjM が PR 本文に転記する。
+
+1. **生成手段（確定案: 外部 CLI `pandoc` 既定 + env 差替可 + skip-if-missing）**: NFR 2.1 は「新規 runtime
+   非追加」を *should* とし、本機能は opt-in 既定 OFF のため未有効化環境に依存を課さない。ゆえに高品質な
+   md→html（見出し/リスト/コード/テーブル反映 / Req 2.5）を得られる pandoc を既定に採用し、`SPEC_HTML_RENDER_CMD`
+   で任意 CLI へ差替可能とした。代替案: (a) bash 完結の自前変換（テーブル/ネスト対応が高コストで乖離温床・不採用）
+   (b) エージェント自身生成（LLM トークン消費・非決定的・commit 混入リスク・不採用）。**依存 CLI 導入の是非**に人間承認を要する
+2. **版管理方針（確定案: `.gitignore` 除外 = Req 7.2）**: 生成を commit/PR 作成後・`git add` なしで走らせ、
+   `.gitignore` で `docs/specs/**/*.html` を除外する。理由: 本流の git 状態に一切触れず非干渉が最強（絶対制約に
+   最適合）・実装最小・self-hosting repo に生成 HTML を溜めない・Req 6.1/7.2 直結。**代替案（commit + Req 7.1）**:
+   `.gitattributes` に `docs/specs/**/*.html linguist-generated=true` を置き diff 折り畳み。利点は「checkout →
+   ファイルを開く」でリモート/ローカル双方が閲覧容易。欠点は生成後に追加 commit+push が必要で本流 git 状態に触れる。
+   **リモートレビュワーの HTML 閲覧要求の有無**で最終選択が変わるため人間判断を要する
+3. **対象成果物集合（確定案: 5 ファイル）**: requirements/design/tasks（必須 Req 2.2）+ impl-notes/review-notes
+   （Req 2.3 の should を「含める」で確定 / PM 推奨）。impl-notes/review-notes は impl 段 hook で生成する
+4. **閲覧経路（確定案: ローカル checkout での worktree 参照）**: README にオペレータ向けの開き方を記載する。
+   PR 本文への「開き方案内」追記の要否は運用判断
+5. **consumer `.gitignore` 反映**: consumer の `.gitignore` は install 管理外のため、opt-in setup として README で
+   1 行追加を案内する（install.sh による自動追記はしない）。install 自動追記が望ましいかは確認事項
+
+## Supporting References
+- pandoc md→html 変換の標準呼び出し（`pandoc -f gfm -t html5 -s -o out.html in.md`）は安定仕様のため
+  Web 検索は行わず既知仕様を採用。exact flag は `SPEC_HTML_RENDER_CMD` で差替可能にし load-bearing にしない
+- 既存 gate module 前例: `local-watcher/bin/modules/tasks-count-gate.sh`（post-architect hook / fail-open / opt-out）

--- a/docs/specs/526-feat-agents-html-md/requirements.md
+++ b/docs/specs/526-feat-agents-html-md/requirements.md
@@ -1,0 +1,213 @@
+# Requirements Document
+
+## Introduction
+
+idd-claude の人間レビュー用成果物（`docs/specs/<番号>-<slug>/` 配下の requirements.md /
+design.md / tasks.md 等）は markdown で保守されるが、生ソースはレンダリング済み HTML より
+人間の認知負荷が高い。一方で agent パイプライン（PM → Architect → Developer → Reviewer）と
+watcher の機械ゲートは markdown を契約フォーマットとして厳格に依存している。本機能は markdown を
+正準（source of truth）に据えたまま、opt-in 有効化時に **並行して .html を派生生成**することで、
+人間レビュワーの可読性のみを底上げする。2026-06-02 に検討された「.md → .html 置換案」は棚上げ済み
+であり（GitHub PR が任意 .html を描画しない / tasks.md 等が機械ゲートの regex・awk 契約入力である /
+メタデータ解釈は既存の型付きアノテーション DSL で取得済み、の 3 点が理由）、本 spec は「置換」では
+なく「並行生成」に限定して当該懸念を構造的に回避する。
+
+## Requirements
+
+### Requirement 1: opt-in 有効化と既定 OFF（no-op 後方互換）
+
+**Objective:** As an idd-claude operator, I want HTML 並行生成を env var による opt-in で有効化したい,
+so that 未有効化リポジトリには一切影響を与えず段階的に導入できる
+
+#### Acceptance Criteria
+
+1. While 本機能の opt-in gate 用 env var（本 spec では仮称 `SPEC_HTML_ENABLED` と表記し、正式名は
+   design で確定）が `true` と完全一致しない（未設定 / 空文字 / `false` / `0` / `True` 等の typo を
+   含む）状態である間, the HTML 並行生成機能 shall .html を一切生成せず、本機能導入前と観測可能挙動が
+   等価な経路へ進む
+2. While 上記 env var が `true` と完全一致している状態である間, the HTML 並行生成機能 shall
+   Requirement 2 以降で定める .html 並行生成を実行する
+3. If 上記 env var に `true` 以外の任意値が設定された状態で起動した場合, the HTML 並行生成機能 shall
+   値を安全側（無効）に正規化し、スキップ理由を 1 行ログに記録する
+4. When 本機能が無効（既定）で watcher / 各エージェントが動作する場合, the HTML 並行生成機能 shall
+   既存の処理順序・生成成果物・ログ出力先に副作用を与えない
+
+### Requirement 2: 対象成果物への .html 並行生成
+
+**Objective:** As a 人間レビュワー, I want 人間レビュー用 markdown 成果物に対応する HTML を並行生成して
+ほしい, so that 生タグではなくレンダリング済みの形で認知負荷を下げて確認できる
+
+#### Acceptance Criteria
+
+1. While 本機能が有効化されている状態である間, when 対象成果物の .md が新規生成された場合, the HTML
+   並行生成機能 shall 当該 .md に対応する .html を生成する
+2. The HTML 並行生成機能 shall 並行生成の必須対象を、対象 spec ディレクトリ
+   `docs/specs/<番号>-<slug>/` 配下の `requirements.md` / `design.md` / `tasks.md` とする
+3. While 本機能が有効化されている状態である間, the HTML 並行生成機能 should 追加対象として同一 spec
+   ディレクトリ配下の `impl-notes.md` / `review-notes.md` の .html も生成する（対象集合の最終確定は
+   Open Questions に従う）
+4. The HTML 並行生成機能 shall 生成した .html を対応する .md と同一ディレクトリに、人間が対応関係を
+   識別できる命名で配置する
+5. The HTML 並行生成機能 shall 生成する .html を、対応 .md の内容（見出し / リスト / コードブロック /
+   テーブル等）を反映した人間可読なレンダリング結果とする
+
+### Requirement 3: .md 正準維持と機械契約の .html 非依存
+
+**Objective:** As an idd-claude operator, I want すべての機械ゲートとエージェント連携が .md のみを契約
+入力とすることを保証したい, so that HTML 導入で既存パイプラインの契約が壊れない
+
+#### Acceptance Criteria
+
+1. The HTML 並行生成機能 shall 対象 .md を正準（source of truth）として維持し、.md を .html で
+   置換しない
+2. The watcher 機械ゲート shall .html の有無・内容に依存せず、契約入力を .md に限定する（tasks.md の
+   checkbox 判定 / Tasks Count Gate / stage-a-verify センチネル / Reviewer の `RESULT:` 行解析 /
+   per-task checkbox 判定を含む）
+3. The エージェント連携（PM / Architect / Developer / Reviewer の入出力および各自己レビューゲート）
+   shall .md を正準入力とし、.html を契約入力にしない
+4. If 対象 .html が欠落または破損している場合, the 既存パイプライン shall 影響を受けず、本機能導入前と
+   同一の判定結果で継続する
+
+### Requirement 4: .md 更新への .html 追随（ドリフト対策）
+
+**Objective:** As a 人間レビュワー, I want .md が更新された際に .html が追随再生成されることを期待する,
+so that レビュー時に古い HTML を参照しない
+
+#### Acceptance Criteria
+
+1. While 本機能が有効化されている状態である間, when 対象 .md が更新（iteration による再生成を含む）
+   された場合, the HTML 並行生成機能 shall 対応する .html を追随再生成する
+2. The HTML 並行生成機能 shall .html を派生物（生成物）として扱い、.html への手編集を正準として
+   維持しない
+
+### Requirement 5: 生成失敗の分離とログ（silent fail 禁止）
+
+**Objective:** As an idd-claude operator, I want HTML 生成の失敗が既存パイプラインを阻害しないことを
+保証したい, so that 派生物生成の失敗で本流が停止しない
+
+#### Acceptance Criteria
+
+1. If .html の生成または追随再生成が失敗した場合, the HTML 並行生成機能 shall 対象 .md の生成 / 更新
+   自体を完了させ、既存パイプライン（ラベル遷移 / PR 作成 / ゲート判定）を継続する
+2. If .html の生成または追随再生成が失敗した場合, the HTML 並行生成機能 shall 失敗の事実と対象
+   ファイルを 1 行以上ログに記録する（silent fail を作らない）
+3. The HTML 並行生成機能 shall .html 生成の成否を既存の watcher exit code へ反映せず、exit code の
+   意味を変更しない
+
+### Requirement 6: 閲覧経路と外部送信の制限
+
+**Objective:** As an idd-claude operator, I want HTML の閲覧手段が明示され、外部サービス送信が既定で
+発生しないことを保証したい, so that 情報漏えいや意図しない外部依存を避けられる
+
+#### Acceptance Criteria
+
+1. The HTML 並行生成機能 shall 生成した .html を追加の外部サービスへ送信・アップロードすることなく
+   ローカルに生成する（既定の閲覧経路はローカル checkout での参照）
+2. Where .html を外部サービス（静的ホスティング等）へアップロードする経路を採用する場合, the 当該経路
+   shall 本機能とは別の opt-in gate 配下でのみ有効化され、既定では外部送信しない
+3. The 本機能のドキュメント shall 人間が .html を開く手段（例: ローカル checkout での参照方法）を案内
+   する
+
+### Requirement 7: PR diff ノイズの抑制
+
+**Objective:** As a 人間レビュワー, I want .html を版管理する場合でも PR diff がノイズにならないことを
+望む, so that レビュー対象の .md 変更に集中できる
+
+#### Acceptance Criteria
+
+1. Where 生成した .html をリポジトリにコミットする方針を採用する場合, the リポジトリ設定 shall 当該
+   .html を生成物（generated）として扱い、PR diff で既定折りたたみ対象になるよう設定する
+2. Where 生成した .html をコミットしない方針を採用する場合, the リポジトリ設定 shall 当該 .html を
+   版管理対象から除外し、PR diff に現れないようにする
+
+## Non-Functional Requirements
+
+### NFR 1: 後方互換性
+
+1. While 本機能の opt-in gate が無効な状態である間, the watcher / 各エージェント shall 本機能導入前と
+   完全に同一の観測可能挙動（既存ラベル遷移 / コメント投稿 / 処理順序 / exit code 意味 / ログ出力先）を
+   維持する
+2. The 本機能 shall 既存 env var（`REPO` / `REPO_DIR` / `LOG_DIR` / `BASE_BRANCH` 等）の名前・意味・
+   既定値を変更しない
+3. The 本機能 shall 既存 cron / launchd 登録文字列およびラベル名を変更しない
+
+### NFR 2: ランタイム / 依存の非追加（選好）
+
+1. The 本機能 should 新規ランタイム（Node.js / Python / Ruby 等）の追加を伴わずに動作する（ランタイム
+   非依存原則）
+2. Where 新規依存 CLI（例: pandoc）の導入が生成手段として必要と判断される場合, the 導入 shall design で
+   明示的に是非を判断し、導入時は README にセットアップ要件を明記する
+
+### NFR 3: 観測可能性
+
+1. The 本機能 shall 主要な分岐点（opt-in スキップ理由 / 対象ファイル / 生成成功 / 追随再生成 / 生成
+   失敗）を運用者がログから判定できる形で記録する
+
+### NFR 4: 二重管理整合（agents / rules / consumer 配布物を編集する場合）
+
+1. Where 本機能の実装が `.claude/agents/*.md` または `.claude/rules/*.md` の変更を伴う場合, the
+   implementation shall 同一 PR 内で root `.claude/{agents,rules}/` と
+   `repo-template/.claude/{agents,rules}/` の双方を byte 一致で更新する
+2. While 上記更新が同一 PR に含まれた状態である間, the verification step shall
+   `diff -r .claude/agents repo-template/.claude/agents` および
+   `diff -r .claude/rules repo-template/.claude/rules` が空であることを確認する
+3. Where 本機能が consumer 配布物（workflow / labels / installer 配布ファイル / `.gitattributes` /
+   `.gitignore` 等）に影響する場合, the implementation shall repo-template 側にも同期反映する
+
+### NFR 5: 未信頼 GitHub 入力の取り扱い
+
+1. Where 本機能が Issue / PR 由来の値（番号 / slug / ブランチ名 / ファイルパス）を扱う場合, the 実装
+   shall 変数展開をクォートし、数値 ID を `^[0-9]+$`・path 構成要素を安全な文字集合で使用直前に検証
+   してからファイル入出力に用いる
+
+### NFR 6: 静的解析品質
+
+1. While 本機能の新規 / 変更ファイル群に対し `shellcheck`（該当する場合 `actionlint`）を実行した状態で
+   ある間, the static analysis result shall 既存の抑止方針（root `.shellcheckrc` 等）下で警告ゼロで
+   完了する
+
+### NFR 7: ドキュメント整合性
+
+1. The 本機能 shall README の「オプション機能一覧」相当の節に、新規 env var 名・既定値・opt-in である旨・
+   既定の閲覧経路を明記する
+2. While 本機能の追加または挙動変更を含む PR が作成された状態である間, the documentation shall 同一 PR
+   内で README / CLAUDE.md / 該当 rule ファイルの該当箇所を同時更新する
+
+## Out of Scope
+
+- .md を .html で置換する案（2026-06-02 に棚上げ済み。本 spec は「並行生成」に限定し、置換は扱わない）
+- 機械ゲート入力としての .md の内容 / 形式の変更（tasks.md の checkbox 記法 / stage-a-verify セン
+  チネル / Reviewer の `RESULT:` 行 / 型付きアノテーション DSL などの契約フォーマット変更）
+- PR 本文の HTML 化（GitHub が既にレンダリングするファイル外成果物のため対象外）
+- spec ディレクトリ外の任意 markdown（README / CLAUDE.md / rules 等）の HTML 化
+- .html の見た目 / CSS テーマ / ブランディングの作り込み
+- .md ↔ .html の内容乖離の自動検出・整合強制（本 spec は best-effort な追随再生成に留める）
+- 外部静的ホスティング / GitHub Pages 等への自動アップロード機構の実装（採用時は別 opt-in gate 前提。
+  本 spec では実装しない）
+- 生成手段（pandoc / エージェント自身生成 / bash 完結）の最終確定（design の領分。本 spec は制約と
+  選好のみ定義する）
+- opt-in gate 用 env var の正式名の確定（本 spec は仮称 `SPEC_HTML_ENABLED` を用い、正式名は design で
+  確定する）
+
+## Open Questions
+
+> 本節は人間レビュー向けの確認事項。設計寄りの判断は Architect（design.md）へ委ねるが、方針を要する
+> 決定は人間承認が必要。
+
+- 生成手段の選択: 新規依存 CLI（pandoc 等）の追加を許容するか / エージェント自身に生成させるか / bash で
+  完結させるか。PM 選好は「ランタイム・新規 CLI 依存の非追加」。最終決定は Architect と人間承認に委ねる
+- 対象成果物の最終集合: `impl-notes.md` / `review-notes.md` を並行生成対象に含めるか（PM 推奨: 含める）。
+  含める場合の生成タイミング（impl PR 段階）を確定するか
+- 閲覧経路の具体策: ローカル checkout での参照で十分か / PR 本文に「開き方案内」を追記するか / 外部静的
+  ホスティングを別 opt-in で用意する需要があるか
+- .html の版管理方針: リポジトリへコミットする（閲覧容易・diff ノイズは generated 扱いで抑制）か、
+  コミットせずローカル生成のみ（`.gitignore` 除外）か。Requirement 7 は両案に対応するが、既定方針の
+  確定が必要
+- opt-in gate 用 env var の正式名（本 spec の仮称 `SPEC_HTML_ENABLED`）を確定する
+- ドリフト自動検出の要否: .md 更新に対し .html が古くなった場合の検出 / 警告を将来必要とするか。本 spec
+  では追随 best-effort のみとし、乖離検出は Out of Scope
+
+## 関連
+
+- Related: なし（本 spec 単独。2026-06-02 の「.md → .html 置換案」棚上げ判断は Introduction /
+  Out of Scope に反映済みで、対応する Issue 番号は本文で参照していない）

--- a/docs/specs/526-feat-agents-html-md/tasks.md
+++ b/docs/specs/526-feat-agents-html-md/tasks.md
@@ -1,0 +1,87 @@
+# Implementation Plan
+
+各タスクは 1 commit 単位で独立完了可能。導入順は「config gate → module → call site 配線 →
+版管理 → ドキュメント → 全体検証」。opt-in gate `SPEC_HTML_ENABLED` は既定 OFF のため、各タスク
+commit 時点で未設定環境の観測可能挙動は導入前と不変（NFR 1.1）。
+
+- [ ] 1. watcher-config.sh に SPEC_HTML_* gate と正規化を追加
+  - `local-watcher/bin/watcher-config.sh` の opt-in gate 群近傍（`AUTO_REBASE_MODE` 等の `case` 正規化前例に倣う）へ
+    `SPEC_HTML_ENABLED`（既定 `false` / `true` 厳密一致のみ ON・他は `case` で `false` に正規化）を追加（Req 1.1, 1.3）
+  - 併せて `SPEC_HTML_RENDER_BIN`（既定 `pandoc`）/ `SPEC_HTML_RENDER_CMD`（既定 `pandoc -f gfm -t html5 -s -o {OUT} {IN}`）/
+    `SPEC_HTML_TIMEOUT`（既定 `60` / 非整数・≤0 は `60` へ正規化）/ `SPEC_HTML_TARGETS`
+    （既定 `requirements.md design.md tasks.md impl-notes.md review-notes.md`）を定義（design env 表と一致）
+  - 既存 env var 名（`REPO` / `REPO_DIR` / `LOG_DIR` / `BASE_BRANCH` 等）は不変（NFR 1.2）。
+    既定有効化フラグの正規化ループには加えない（opt-in 既定 OFF のため / `AUTO_REBASE_MODE` と同扱い）
+  - 正規化のシェルレベル回帰テストを本タスク内に追加（`SPEC_HTML_ENABLED` の `true`/未設定/空/`True`/`1`/typo →
+    ON/OFF 判定、`SPEC_HTML_TIMEOUT` の非整数・負値 → 既定 60。source 後の値検証。安全側 fallback の AC のため同 task 内必須）
+  - _Requirements: 1.1, 1.3_
+
+- [ ] 2. spec-html.sh module を実装し REQUIRED_MODULES へ登録
+  - `local-watcher/bin/modules/spec-html.sh` を新規作成（prefix `shx_` / 関数定義のみ・トップレベル副作用なし /
+    ファイル冒頭に用途・配置先・依存・prefix・family 非該当を明記。`tasks-count-gate.sh` のヘッダ様式を踏襲）
+  - 公開関数を実装（design「Service Interface」準拠）: `shx_log`/`shx_warn`/`shx_error`（prefix `spec-html:` / grep 可能 3 段）、
+    `shx_enabled`（`SPEC_HTML_ENABLED == true` 厳密一致 / Req 1.2）、`shx_render_available`（`command -v "$SPEC_HTML_RENDER_BIN"` /
+    不在で warn+1 / Req 5）、`shx_target_files`（`SPEC_HTML_TARGETS` basename allowlist の実在 regular file のみ絶対パス列挙 / Req 2.2, 2.3）、
+    `shx_html_path`（`<name>.md`→`<name>.html` 純粋 / Req 2.4）、`shx_render_one`（`SPEC_HTML_RENDER_CMD` の `{IN}`/`{OUT}` 置換 +
+    `timeout "$SPEC_HTML_TIMEOUT"` 実行 / 成功時 .html 生成・失敗は対象名付き warn + 非 0 / Req 2.5, 4.2, 5.2）、
+    `shx_run_for_spec_dir`（gate→available→列挙→各 `shx_render_one`→成功/失敗件数 summary log / **常に return 0** / Req 5.1, 5.3, NFR 3.1）
+  - `.md` は read-only 入力とし一切書き換えない（.html のみ Write / Req 3.1）。外部ネットワーク / gh を呼ばない（ローカル生成 / Req 6.1）
+  - 未信頼入力対策: spec dir path は `NUMBER`（`^[0-9]+$` 既検証）+ 固定 basename allowlist から構成し、変数は全 quote、
+    allowlist 外・path 構成要素の異常は列挙から除外（NFR 5.1）
+  - `local-watcher/bin/issue-watcher.sh` の `REQUIRED_MODULES` 配列へ `"spec-html.sh"` を 1 要素追加（slot-worker.sh より前に配置）
+  - `local-watcher/test/spec-html_test.sh` を新規追加（`extract_function` 隔離抽出 + `test/lib/test-helpers.sh` source）。
+    `shx_enabled`（true のみ ON / typo OFF）、`shx_html_path`、`shx_target_files`（実在のみ列挙）、`shx_render_available`（stub コマンド存在/不在）、
+    `shx_run_for_spec_dir`（gate OFF no-op return 0 / CLI 不在 skip return 0 / render stub 失敗でも return 0）を live 依存なしで検証
+    （failure-path / safety fallback の AC のため同 task 内必須）
+  - _Requirements: 1.2, 2.2, 2.3, 2.4, 2.5, 3.1, 4.2, 5.1, 5.2, 5.3, 6.1_
+  - _Depends: 1_
+
+- [ ] 3. slot-worker.sh の design / impl 完了直後に生成 hook を配線
+  - `local-watcher/bin/modules/slot-worker.sh` `_slot_run_issue` の design 分岐 rc=0 case、
+    `tc_run_post_architect_check || true` の **直後**に `shx_run_for_spec_dir || true` を 1 行追加（design 段 / Req 2.1, 4.1）
+  - 同関数 impl 分岐 `_impl_rc` case 0（`✅ ... 完了`）に `shx_run_for_spec_dir || true` を 1 行追加（impl 段 / impl-notes・review-notes を含む / Req 2.1, 4.1）
+  - 双方 `|| true` で fail-open。gate OFF 時は module 早期 return で副作用ゼロ（Req 1.4）。機械ゲート / エージェント連携の .md 契約には一切触れない
+    （.html を読む経路を追加しない = Req 3.2, 3.3, 3.4 を構造的に保証）
+  - 本タスク内にシェルレベル統合テストを追加（`shx_run_for_spec_dir` を stub 化し、gate ON で対象数だけ生成トリガ /
+    gate OFF で no-op / render 失敗が本流戻り値に伝播しないことを、call site 到達順で検証。behavior-changing のため同 task 内必須）
+  - _Requirements: 1.4, 2.1, 3.2, 3.3, 3.4, 4.1_
+  - _Depends: 2_
+
+- [ ] 4. 生成 .html を版管理から除外（既定方針 = .gitignore） (P)
+  - ルート `.gitignore` に `docs/specs/**/*.html` を追加し、生成 .html を版管理対象外にする（Req 7.2）。
+    生成は claude セッションの commit / PR 作成後・`git add` なしで走るため当該 PR に混入しないが、後続 `git add -A` の巻き込みも本除外で防ぐ
+  - commit 版管理（Req 7.1: `.gitattributes` の `linguist-generated`）は **不採用**（design 確認事項 2 参照）。リモート閲覧要求が確定した場合の代替として design に記録済み
+  - consumer の `.gitignore` は install 管理外のため本タスクでは触らず、opt-in setup として README（task 5）で 1 行追加を案内する（NFR 4.3）
+  - _Requirements: 7.2_
+  - _Boundary: .gitignore_
+
+- [ ] 5. README / CLAUDE.md のドキュメント整合 (P)
+  - `README.md`「オプション機能一覧」相当節に、`SPEC_HTML_ENABLED`（既定 false・opt-in）と補助 env（`SPEC_HTML_RENDER_BIN` /
+    `SPEC_HTML_RENDER_CMD` / `SPEC_HTML_TIMEOUT` / `SPEC_HTML_TARGETS`）の一覧・既定値・有効化手順を追記（NFR 7.1）
+  - 閲覧経路（ローカル checkout での worktree 参照方法）と consumer `.gitignore` への 1 行追加、依存 CLI（pandoc）の setup 要件を明記（Req 6.3 / NFR 2.2）
+  - 外部アップロードは本機能とは別の opt-in gate 前提で本 spec 未実装である旨（予約名 `SPEC_HTML_UPLOAD_ENABLED`）を記載（Req 6.2）
+  - `README.md`「ディレクトリ構成」ツリーへ `spec-html.sh` を追加。`CLAUDE.md` 機能追加ガイドライン §2 prefix 表へ `shx_` 行を追加（NFR 7.2）
+  - 本機能は `.claude/agents` / `.claude/rules` を変更しないため `diff -r .claude/agents repo-template/.claude/agents` /
+    `diff -r .claude/rules repo-template/.claude/rules` が空のまま（ドリフト非導入）であることを確認（NFR 4.1, 4.2, 4.3）
+  - _Requirements: 6.2, 6.3_
+  - _Boundary: README.md, CLAUDE.md_
+  - _Depends: 2_
+
+- [ ] 6. 全体整合の検証（no-op 回帰・静的解析・smoke）
+  - gate 既定 OFF で main loop の処理順序・生成成果物・ログ出力先が導入前と一致すること（call site `|| true` 経路が no-op）を統合的に確認（Req 1.1 / NFR 1.1）
+  - `shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/watcher-config.sh local-watcher/bin/modules/*.sh` 新規警告ゼロ・
+    `bash -n local-watcher/bin/issue-watcher.sh` OK を確認（NFR 6.1）
+  - dry-run（対象なし・`SPEC_HTML_ENABLED` 未設定）で `処理対象の Issue なし` 正常終了、`SPEC_HTML_ENABLED=true` + pandoc で本 spec dir の .html 生成 + .md 無変更を smoke 確認
+  - スコープは統合 / smoke / no-op 回帰に限定（各 unit テストは task 1〜3 に同梱済み）
+  - _Requirements: 1.1_
+  - _Depends: 1, 2, 3, 4, 5_
+
+## Verify
+
+本 spec の実装後、watcher（stage-a-verify gate）が再実行すべき verify コマンドを宣言する。
+対象パスは tasks.md commit 時点で存在するもののみ（新規 module / test は glob と各 task 内実行でカバー）。
+
+<!-- stage-a-verify -->
+```sh
+shellcheck local-watcher/bin/issue-watcher.sh local-watcher/bin/watcher-config.sh local-watcher/bin/modules/*.sh && bash -n local-watcher/bin/issue-watcher.sh
+```


### PR DESCRIPTION
## 概要

この PR は **設計レビュー専用** です。実装コードは含まれません。
`docs/specs/526-feat-agents-html-md/` 配下の requirements / design / tasks を merge するための
ゲートです。merge 後、Issue から `awaiting-design-review` ラベルを外すと次回ポーリングで
Developer が自動起動し、実装 PR が別途作成されます。

本設計は「人間レビュー用成果物（`docs/specs/<番号>-<slug>/` 配下の requirements.md /
design.md / tasks.md 等）を、markdown を正準（source of truth）に据えたまま、**opt-in
有効化時のみ並行して .html を派生生成**し人間の可読性を上げる」機能を提案します。

- **opt-in gate**: `SPEC_HTML_ENABLED`（既定 `false`）。`true` 厳密一致のみ ON、不正値は安全側に
  正規化。既定では観測可能挙動が導入前と完全一致（no-op）
- **機械契約は .html に完全非依存**: watcher の全ゲート（tasks.md checkbox / Tasks Count Gate /
  stage-a-verify センチネル / Reviewer `RESULT:` 行 / per-task checkbox）とエージェント連携は
  .md のみを契約入力とし続ける。.html の欠落・破損があっても既存パイプラインの判定は影響を受けない
- **配置**: 専用 module `local-watcher/bin/modules/spec-html.sh`（新規 prefix `shx_`）を追加し、
  `slot-worker.sh` の design 分岐 rc=0 直後 / impl 分岐 rc=0 直後の 2 箇所に
  `shx_run_for_spec_dir || true` という fail-open hook を挿す（既存 Tasks Count Gate と同型パターン）
- **生成手段**: 既定 `pandoc`（`SPEC_HTML_RENDER_CMD` で env 差替可）。未インストール時は
  skip + 1 行 log で本流を止めない（silent fail 禁止）
- **版管理**: 既定案は `.gitignore` 除外（`docs/specs/**/*.html`）。生成は commit / PR 作成後・
  `git add` なしで走るため当該 PR に混入しない

## 対応 Issue

Refs #526

## 含まれる成果物

- `docs/specs/526-feat-agents-html-md/requirements.md` — 要件定義（PM 成果物）
- `docs/specs/526-feat-agents-html-md/design.md` — 設計書（Architect 成果物）
- `docs/specs/526-feat-agents-html-md/tasks.md` — 実装タスク分割（最上位 6 件）

## 関連 Issue / PR

なし

## レビュー観点

- requirements.md の FR / NFR / AC に過不足はないか
  - Req 1: opt-in 有効化と既定 OFF（no-op 後方互換）
  - Req 2: 対象成果物への .html 並行生成（必須 3 + 追加 2）
  - Req 3: .md 正準維持と機械契約の .html 非依存
  - Req 4: .md 更新への .html 追随（ドリフト対策・best-effort）
  - Req 5: 生成失敗の分離とログ（silent fail 禁止・exit code 不変）
  - Req 6: 閲覧経路と外部送信の制限（既定ローカルのみ）
  - Req 7: PR diff ノイズの抑制（版管理方針）
- design.md のモジュール構成・公開 IF が FR をカバーしているか
  - 新規 module `spec-html.sh`（prefix `shx_`）に生成ロジックを集約、call site は slot-worker.sh に
    2 行のみ追加
  - `shx_run_for_spec_dir` は常に `return 0` 固定（fail-open を module 内でも二重保証）
- 既存コードの再利用が検討されているか、重複実装が混じっていないか
  - `tasks-count-gate.sh`（post-architect fail-open hook）と同型パターンを踏襲
- tasks.md の分割粒度が独立コミット可能か（6 タスク: config gate → module → call site 配線 →
  版管理 → ドキュメント → 全体検証）

## 確認事項（人間レビュー向け）

design.md の「確認事項（人間レビュー向け）」節を要約して転記します（詳細・代替案の比較は
design.md 本文参照）:

1. **生成手段（確定案: 外部 CLI `pandoc` 既定 + env 差替可 + skip-if-missing）**: NFR 2.1
   「新規 runtime 非追加」の *should* を踏まえつつ、opt-in 既定 OFF のため未有効化環境には
   依存を課さない前提で pandoc 採用を提案。代替案（bash 完結 / エージェント自身生成）は
   乖離温床・非決定性を理由に不採用とした。**依存 CLI 導入の是非に人間承認を要する**
2. **版管理方針（確定案: `.gitignore` 除外）**: 生成を commit/PR 作成後・`git add` なしで走らせ、
   `.gitignore` で除外する案（本流 git 状態への非干渉が最強）。代替案（`.gitattributes` の
   `linguist-generated` で commit 版管理）はリモートレビュワーの閲覧容易性で優位だが追加
   commit+push が必要。**リモートレビュワーの HTML 閲覧要求の有無で最終選択が変わるため
   人間判断を要する**
3. **対象成果物集合（確定案: 5 ファイル）**: requirements/design/tasks（必須）+
   impl-notes/review-notes（Req 2.3 の should を「含める」で確定 / PM 推奨）。この確定でよいか
4. **閲覧経路（確定案: ローカル checkout での worktree 参照）**: README に開き方を記載する方針。
   PR 本文への「開き方案内」追記の要否は運用判断
5. **consumer `.gitignore` 反映**: consumer 側は install 管理外のため README での案内に留める
   （install.sh 自動追記はしない）方針。自動追記が望ましいかは確認事項

requirements.md の Open Questions（上記と重複しない論点）:

- ドリフト自動検出の要否: .md 更新に対し .html が古くなった場合の検出・警告を将来必要とするか
  （本 spec は追随 best-effort のみとし乖離検出は Out of Scope）

## 次のステップ

- この PR を **merge** したら、Issue から `awaiting-design-review` ラベルを外してください。次回
  ポーリングで Developer が自動起動し、実装 PR が別途作られます
- 設計に問題があれば、直接この PR で commit / suggest-edit / line comment して修正してください
- やり直したい場合は PR を close して、Issue の `awaiting-design-review` ラベルを外してください

## 確認事項（base 検証）

base: main / baseRefName: main / OK（`gh pr view` で検証済み）

---

🤖 この PR は idd-claude ワークフローにより Claude Code が自動生成しました。
設計レビューゲート: PM → Architect が完了した段階です。merge 後に Issue から
`awaiting-design-review` ラベルを外すと実装が自動開始します。
